### PR TITLE
Fixed an occasional test hang issue in current management service build.

### DIFF
--- a/management-service/src/test/java/org/terracotta/management/service/TestConstants.java
+++ b/management-service/src/test/java/org/terracotta/management/service/TestConstants.java
@@ -27,6 +27,7 @@ public final class TestConstants {
   public static final int BUFFER_SIZE = 1 << 13;
   public static final int NUM_PARTITIONS_FOR_POOLED = 8;
   public static final int DEFAULT_MESSAGE_SIZE = 128;
+  public static final int TEST_MAX_WAIT_TIME_MILLIS = 300000;
   public static void PAUSE(long millis) {
     try {
       Thread.sleep(millis);


### PR DESCRIPTION
The problem was in the test class that simulates Producer and Consumer of the ring buffer. ProducerOrConsumerSimulator.java, where the consumer was exiting before consuming all messages in rare scenarios.

Also, piggybacked a minor performance optimization that avoided a new every time an item is inserted. This changed some noticeable reduction some small CPU spikes (during GC) during long perf runs.

If this PR is merged, issue-32 and issue-21 can be closed.