### PR TITLE
several bugfixes for @Async usage

### DIFF
--- a/proxy/src/main/java/org/terracotta/voltron/proxy/Async.java
+++ b/proxy/src/main/java/org/terracotta/voltron/proxy/Async.java
@@ -17,6 +17,8 @@
 
 package org.terracotta.voltron.proxy;
 
+import org.terracotta.entity.InvocationBuilder;
+
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -32,8 +34,21 @@ public @interface Async {
   Ack value() default Ack.NONE;
 
   enum Ack {
-    NONE,
-    RECEIVED,
+    NONE {
+      @Override
+      public void applyTo(InvocationBuilder builder) {
+        // no-op
+      }
+    },
+
+    RECEIVED {
+      @Override
+      public void applyTo(InvocationBuilder builder) {
+        builder.ackReceived();
+      }
+    };
+
+    public abstract void applyTo(InvocationBuilder builder);
   }
 
 

--- a/proxy/src/main/java/org/terracotta/voltron/proxy/CommonProxyFactory.java
+++ b/proxy/src/main/java/org/terracotta/voltron/proxy/CommonProxyFactory.java
@@ -32,8 +32,8 @@ import static java.util.Collections.unmodifiableMap;
  * @author Alex Snaps
  */
 public class CommonProxyFactory {
-  private static final Comparator<Method> METHOD_COMPARATOR = new Comparator<Method>() {
-    public int compare(final Method m1, final Method m2) {
+  private static final Comparator<MethodDescriptor> METHOD_COMPARATOR = new Comparator<MethodDescriptor>() {
+    public int compare(final MethodDescriptor m1, final MethodDescriptor m2) {
       return m1.toGenericString().compareTo(m2.toGenericString());
     }
   };
@@ -54,12 +54,12 @@ public class CommonProxyFactory {
     return unmodifiableMap(inversion);
   }
 
-  public static Map<Byte, Method> createMethodMappings(final Class<?> proxyType) {
-    SortedSet<Method> methods = getSortedMethods(proxyType);
+  public static Map<Byte, MethodDescriptor> createMethodMappings(final Class<?> proxyType) {
+    SortedSet<MethodDescriptor> methods = getSortedMethods(proxyType);
 
-    final HashMap<Byte, Method> map = new HashMap<Byte, Method>();
+    final HashMap<Byte, MethodDescriptor> map = new HashMap<Byte, MethodDescriptor>();
     byte index = 0;
-    for (final Method method : methods) {
+    for (final MethodDescriptor method : methods) {
       map.put(index++, method);
     }
     return map;
@@ -68,10 +68,10 @@ public class CommonProxyFactory {
   public static Map<Class<?>, Byte> createResponseTypeMappings(Class<?> proxyType, Class<?> ... events) {
     final HashMap<Class<?>, Byte> map = new HashMap<Class<?>, Byte>();
     byte index = 0;
-    for (Method m : getSortedMethods(proxyType)) {
-      Class<?> returnType = m.getReturnType();
-      if (!map.containsKey(returnType)) {
-        map.put(returnType, index++);
+    for (MethodDescriptor m : getSortedMethods(proxyType)) {
+      Class<?> responseType = m.getMessageType();
+      if (!map.containsKey(responseType)) {
+        map.put(responseType, index++);
       }
     }
     for (Class<?> eventType : getSortedTypes(events)) {
@@ -82,8 +82,8 @@ public class CommonProxyFactory {
     return unmodifiableMap(map);
   }
 
-  private static SortedSet<Method> getSortedMethods(final Class<?> type) {
-    SortedSet<Method> methods = new TreeSet<Method>(METHOD_COMPARATOR);
+  static SortedSet<MethodDescriptor> getSortedMethods(final Class<?> type) {
+    SortedSet<MethodDescriptor> methods = new TreeSet<MethodDescriptor>(METHOD_COMPARATOR);
 
     final Method[] declaredMethods = type.getDeclaredMethods();
 
@@ -91,7 +91,10 @@ public class CommonProxyFactory {
       throw new IllegalArgumentException("Can't proxy that many methods on a single instance!");
     }
 
-    methods.addAll(asList(declaredMethods));
+    for (Method declaredMethod : declaredMethods) {
+      methods.add(MethodDescriptor.of(declaredMethod));
+    }
+
     if (methods.size() != declaredMethods.length) {
       throw new AssertionError("Ouch... looks like that didn't work!");
     }

--- a/proxy/src/main/java/org/terracotta/voltron/proxy/MethodDescriptor.java
+++ b/proxy/src/main/java/org/terracotta/voltron/proxy/MethodDescriptor.java
@@ -1,0 +1,146 @@
+/*
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ * http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Connection API.
+ *
+ * The Initial Developer of the Covered Software is
+ * Terracotta, Inc., a Software AG company
+ */
+package org.terracotta.voltron.proxy;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Array;
+import java.lang.reflect.GenericArrayType;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.lang.reflect.TypeVariable;
+import java.lang.reflect.WildcardType;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+
+/**
+ * @author Mathieu Carbou
+ */
+public final class MethodDescriptor {
+
+  private final boolean async;
+  private final Class<?> messageType;
+  private final Method method;
+  private final Async.Ack ack;
+
+  private MethodDescriptor(Method method) {
+    this.method = method;
+    Async asyncAnnot = method.getAnnotation(Async.class);
+    async = asyncAnnot != null;
+    if (async) {
+      // @Async required a Future
+      if (method.getReturnType() != Future.class) {
+        throw new IllegalStateException("@Async requires a Future as a return type on method: " + method);
+      }
+      ack = asyncAnnot.value();
+      Type returnType = method.getGenericReturnType();
+      messageType = returnType instanceof Class<?> ?
+          Object.class : // this is the case where a Future is returned with no given generic type
+          determineRawType(((ParameterizedType) returnType).getActualTypeArguments()[0]);
+    } else {
+      ack = Async.Ack.NONE;
+      messageType = method.getReturnType();
+    }
+  }
+
+  public Async.Ack getAck() {
+    return ack;
+  }
+
+  public boolean isAsync() {
+    return async;
+  }
+
+  public Class<?> getMessageType() {
+    return messageType;
+  }
+
+  public static MethodDescriptor of(Method method) {
+    return new MethodDescriptor(method);
+  }
+
+  public String toGenericString() {
+    return method.toGenericString();
+  }
+
+  @Override
+  public String toString() {
+    return toGenericString();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    MethodDescriptor that = (MethodDescriptor) o;
+    return method.equals(that.method);
+  }
+
+  @Override
+  public int hashCode() {
+    return method.hashCode();
+  }
+
+  public Class<?>[] getParameterTypes() {
+    return method.getParameterTypes();
+  }
+
+  public Annotation[][] getParameterAnnotations() {
+    return method.getParameterAnnotations();
+  }
+
+  public Object invoke(Object target, Object... args) throws IllegalAccessException, IllegalArgumentException, InvocationTargetException {
+    Object ret = method.invoke(target, args);
+    if (async) {
+      try {
+        ret = ((Future<?>) ret).get();
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        throw new InvocationTargetException(e);
+      } catch (ExecutionException e) {
+        throw new InvocationTargetException(e.getCause());
+      }
+    }
+    return ret;
+  }
+
+  public Method getMethod() {
+    return method;
+  }
+
+  private static Class<?> determineRawType(Type type) {
+    if (type instanceof Class<?>) {
+      return (Class<?>) type;
+    }
+    if (type instanceof ParameterizedType) {
+      return determineRawType(((ParameterizedType) type).getRawType());
+    }
+    if (type instanceof WildcardType) {
+      return determineRawType(((WildcardType) type).getUpperBounds()[0]);
+    }
+    if (type instanceof GenericArrayType) {
+      Class<?> rawComponentType = determineRawType(((GenericArrayType) type).getGenericComponentType());
+      return Array.newInstance(rawComponentType, 0).getClass();
+    }
+    if (type instanceof TypeVariable<?>) {
+      return determineRawType(((TypeVariable) type).getBounds()[0]);
+    }
+    throw new IllegalStateException("Unsupported type: " + type);
+  }
+
+}

--- a/proxy/src/main/java/org/terracotta/voltron/proxy/ProxyMessageCodec.java
+++ b/proxy/src/main/java/org/terracotta/voltron/proxy/ProxyMessageCodec.java
@@ -20,7 +20,6 @@ package org.terracotta.voltron.proxy;
 import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
-import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.Map;
 import org.terracotta.entity.MessageCodec;
@@ -34,7 +33,7 @@ import org.terracotta.voltron.proxy.server.messages.ProxyEntityResponse;
 public class ProxyMessageCodec implements MessageCodec<ProxyEntityMessage, ProxyEntityResponse> {
 
   private final Codec codec;
-  private final Map<Byte, Method> methodMappings;
+  private final Map<Byte, MethodDescriptor> methodMappings;
   private final Map<Class<?>, Byte> responseMappings;
   
   public ProxyMessageCodec(Codec codec, Class<?> proxyType, Class<?> ... eventTypes) {
@@ -61,7 +60,7 @@ public class ProxyMessageCodec implements MessageCodec<ProxyEntityMessage, Proxy
   }
 
   public ProxyEntityMessage deserialize(final byte[] bytes) {
-    final Method method = decodeMethod(bytes[0]);
+    final MethodDescriptor method = decodeMethod(bytes[0]);
     return new ProxyEntityMessage(method, decodeArgs(bytes, method.getParameterTypes()));
   }
 
@@ -73,8 +72,8 @@ public class ProxyMessageCodec implements MessageCodec<ProxyEntityMessage, Proxy
     throw new UnsupportedOperationException("Not supported yet.");
   }
 
-  private Method decodeMethod(final byte b) {
-    final Method method = methodMappings.get(b);
+  private MethodDescriptor decodeMethod(final byte b) {
+    final MethodDescriptor method = methodMappings.get(b);
     if(method == null) {
       throw new AssertionError();
     }

--- a/proxy/src/main/java/org/terracotta/voltron/proxy/client/VoltronProxyInvocationHandler.java
+++ b/proxy/src/main/java/org/terracotta/voltron/proxy/client/VoltronProxyInvocationHandler.java
@@ -127,8 +127,7 @@ class VoltronProxyInvocationHandler implements InvocationHandler {
           .invoke();
       return new ProxiedInvokeFuture(future, decodeTo, codec);
     } else {
-      byte[] bytes = builder.invoke().get();
-      return codec.decode(Arrays.copyOfRange(bytes, 1, bytes.length), method.getReturnType());
+      return codec.decode(stripHeader(builder.invoke().get()), method.getReturnType());
     }
   }
 
@@ -205,8 +204,7 @@ class VoltronProxyInvocationHandler implements InvocationHandler {
 
     public Object get() throws InterruptedException, ExecutionException {
       try {
-        byte[] result = future.get();
-        return codec.decode(Arrays.copyOfRange(result, 1, result.length), (Class<?>)decodeTo);
+        return codec.decode(stripHeader(future.get()), (Class<?>)decodeTo);
       } catch (EntityException e) {
         throw new ExecutionException(e);
       }
@@ -214,10 +212,15 @@ class VoltronProxyInvocationHandler implements InvocationHandler {
 
     public Object get(final long timeout, final TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
       try {
-        return codec.decode(future.getWithTimeout(timeout, unit), (Class<?>)decodeTo);
+        return codec.decode(stripHeader(future.getWithTimeout(timeout, unit)), (Class<?>)decodeTo);
       } catch (EntityException e) {
         throw new ExecutionException(e);
       }
     }
   }
+
+  private static byte[] stripHeader(byte[] result) {
+    return Arrays.copyOfRange(result, 1, result.length);
+  }
+
 }

--- a/proxy/src/main/java/org/terracotta/voltron/proxy/server/ProxyInvoker.java
+++ b/proxy/src/main/java/org/terracotta/voltron/proxy/server/ProxyInvoker.java
@@ -74,7 +74,7 @@ public class ProxyInvoker<T> {
     try {
       try {
         invocationContext.set(new InvocationContext(clientDescriptor));
-        return ProxyEntityResponse.response(message.returnType(), message.invoke(target, clientDescriptor));
+        return ProxyEntityResponse.response(message.messageType(), message.invoke(target, clientDescriptor));
       } finally {
         invocationContext.remove();
       }

--- a/proxy/src/main/java/org/terracotta/voltron/proxy/server/messages/ProxyEntityMessage.java
+++ b/proxy/src/main/java/org/terracotta/voltron/proxy/server/messages/ProxyEntityMessage.java
@@ -20,10 +20,10 @@ package org.terracotta.voltron.proxy.server.messages;
 import org.terracotta.entity.ClientDescriptor;
 import org.terracotta.entity.EntityMessage;
 import org.terracotta.voltron.proxy.ClientId;
+import org.terracotta.voltron.proxy.MethodDescriptor;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
@@ -31,12 +31,12 @@ import java.util.concurrent.atomic.AtomicBoolean;
  */
 public class ProxyEntityMessage implements EntityMessage {
 
-  private final Method method;
+  private final MethodDescriptor method;
   private final Object[] args;
 
   private final AtomicBoolean consumed = new AtomicBoolean(false);
 
-  public ProxyEntityMessage(final Method method, final Object[] args) {
+  public ProxyEntityMessage(final MethodDescriptor method, final Object[] args) {
     this.method = method;
     this.args = args;
   }
@@ -62,8 +62,8 @@ public class ProxyEntityMessage implements EntityMessage {
     return method.invoke(target, args);
   }
 
-  public Class<?> returnType() {
-    return method.getReturnType();
+  public Class<?> messageType() {
+    return method.getMessageType();
   }
 
 

--- a/proxy/src/test/java/org/terracotta/voltron/proxy/CommonProxyFactoryTest.java
+++ b/proxy/src/test/java/org/terracotta/voltron/proxy/CommonProxyFactoryTest.java
@@ -1,0 +1,88 @@
+/*
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ * http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Connection API.
+ *
+ * The Initial Developer of the Covered Software is
+ * Terracotta, Inc., a Software AG company
+ */
+package org.terracotta.voltron.proxy;
+
+import org.hamcrest.core.Is;
+import org.junit.Test;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.Future;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ * @author Mathieu Carbou
+ */
+public class CommonProxyFactoryTest {
+
+  @Test
+  public void test_raw_type_determined_correctly() throws Throwable {
+    Class<?>[] expected = {
+        String.class, Collection.class, Object.class, Object.class, Object.class,
+        Collection.class, String[].class, List.class, Collection.class, String[].class,
+        Object.class, Object.class};
+
+    // to be sure we test all
+    assertThat(expected.length, equalTo(AsyncEntity.class.getDeclaredMethods().length));
+
+    for (int i = 1; i <= expected.length; i++) {
+      MethodDescriptor methodDescriptor = MethodDescriptor.of(AsyncEntity.class.getMethod("test" + i));
+      assertThat(methodDescriptor.isAsync(), is(true));
+      assertThat(methodDescriptor.getMessageType(), Is.<Class<?>>is(expected[i-1]));
+    }
+
+    for (int i = 1; i <= expected.length; i++) {
+      MethodDescriptor methodDescriptor = MethodDescriptor.of(NonAsyncEntity.class.getMethod("test" + i));
+      assertThat(methodDescriptor.isAsync(), is(false));
+      assertThat(methodDescriptor.getMessageType(), Is.<Class<?>>is(Future.class));
+    }
+  }
+
+  interface AsyncEntity<V> {
+    @Async Future<String> test1();
+    @Async Future<Collection<String>> test2();
+    @Async Future<?> test3();
+    @Async Future<V> test4();
+    @Async <T> Future<T> test5();
+    @Async Future<Collection<V>> test6();
+    @Async Future<String[]> test7();
+    @Async Future<? extends List> test8();
+    @Async Future<? extends Collection<String>> test9();
+    @Async Future<? extends String[]> test10();
+    @Async Future<? extends V> test11();
+    @Async Future test12();
+  }
+
+  interface NonAsyncEntity<V> {
+    Future<String> test1();
+    Future<Collection<String>> test2();
+    Future<?> test3();
+    Future<V> test4();
+    <T> Future<T> test5();
+    Future<Collection<V>> test6();
+    Future<String[]> test7();
+    Future<? extends List> test8();
+    Future<? extends Collection<String>> test9();
+    Future<? extends String[]> test10();
+    Future<? extends V> test11();
+    Future test12();
+  }
+
+}

--- a/proxy/src/test/java/org/terracotta/voltron/proxy/client/ClientProxyFactoryTest.java
+++ b/proxy/src/test/java/org/terracotta/voltron/proxy/client/ClientProxyFactoryTest.java
@@ -90,7 +90,7 @@ public class ClientProxyFactoryTest {
     final InvokeFuture future = mock(InvokeFuture.class);
     when(builder.invoke()).thenReturn(future);
     when(future.get()).thenReturn(messageCodec.serialize(response(Integer.class, 42)));
-    when(future.getWithTimeout(1, TimeUnit.SECONDS)).thenReturn(codec.encode(Integer.class, 43))
+    when(future.getWithTimeout(1, TimeUnit.SECONDS)).thenReturn(messageCodec.serialize(response(Integer.class, 43)))
         .thenThrow(new TimeoutException("Blah!"));
 
     final PassThrough proxy = ClientProxyFactory.createProxy(PassThrough.class, PassThrough.class, endpoint, codec);

--- a/proxy/src/test/java/org/terracotta/voltron/proxy/client/ClientProxyFactoryTest.java
+++ b/proxy/src/test/java/org/terracotta/voltron/proxy/client/ClientProxyFactoryTest.java
@@ -24,6 +24,7 @@ import org.terracotta.entity.EntityClientEndpoint;
 import org.terracotta.entity.InvocationBuilder;
 import org.terracotta.entity.InvokeFuture;
 import org.terracotta.exception.EntityException;
+import org.terracotta.voltron.proxy.Async;
 import org.terracotta.voltron.proxy.ProxyMessageCodec;
 import org.terracotta.voltron.proxy.SerializationCodec;
 import org.terracotta.voltron.proxy.client.messages.MessageListener;
@@ -144,6 +145,7 @@ public class ClientProxyFactoryTest {
 
     Integer sync();
 
+    @Async
     Future<Integer> aSync();
 
   }

--- a/proxy/src/test/java/org/terracotta/voltron/proxy/client/VoltronProxyInvocationHandlerTest.java
+++ b/proxy/src/test/java/org/terracotta/voltron/proxy/client/VoltronProxyInvocationHandlerTest.java
@@ -23,11 +23,11 @@ import org.terracotta.entity.EntityClientEndpoint;
 import org.terracotta.entity.InvocationBuilder;
 import org.terracotta.entity.InvokeFuture;
 import org.terracotta.voltron.proxy.ClientId;
+import org.terracotta.voltron.proxy.MethodDescriptor;
 import org.terracotta.voltron.proxy.ProxyMessageCodec;
 import org.terracotta.voltron.proxy.SerializationCodec;
 import org.terracotta.voltron.proxy.server.messages.ProxyEntityResponse;
 
-import java.lang.reflect.Method;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
@@ -65,10 +65,10 @@ public class VoltronProxyInvocationHandlerTest {
     when(builder.invoke()).thenReturn(future);
     when(future.get()).thenReturn(messageCodec.serialize(ProxyEntityResponse.response(Void.TYPE, null)));
 
-    Map<Method, Byte> methodMappings = invert(createMethodMappings(TestInterface.class));
+    Map<MethodDescriptor, Byte> methodMappings = invert(createMethodMappings(TestInterface.class));
     VoltronProxyInvocationHandler handler = new VoltronProxyInvocationHandler(methodMappings, endpoint, codec, Collections.<Byte, Class<?>>emptyMap());
-    for (Method method : methodMappings.keySet()) {
-      handler.invoke(null, method, new Object[] { "String", new Object() });
+    for (MethodDescriptor method : methodMappings.keySet()) {
+      handler.invoke(null, method.getMethod(), new Object[] { "String", new Object() });
     }
     for (Object[] objects : valuesSeen) {
       assertNull(objects[1]);


### PR DESCRIPTION
- fix: strip header of bytes read for call with timeout
- async mode now requires @Async (and a Future to be returned)  …
- fixed generic type support for returned Future
- Introduced a MethodDescriptor class to better handle the specifics of async and method calls
- Client and Server entities should use the same interface