### PR TITLE
bugfix: classpath issue

### DIFF
--- a/proxy/src/main/java/org/terracotta/voltron/proxy/Async.java
+++ b/proxy/src/main/java/org/terracotta/voltron/proxy/Async.java
@@ -17,8 +17,6 @@
 
 package org.terracotta.voltron.proxy;
 
-import org.terracotta.entity.InvocationBuilder;
-
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -34,21 +32,8 @@ public @interface Async {
   Ack value() default Ack.NONE;
 
   enum Ack {
-    NONE {
-      @Override
-      public void applyTo(InvocationBuilder builder) {
-        // no-op
-      }
-    },
-
-    RECEIVED {
-      @Override
-      public void applyTo(InvocationBuilder builder) {
-        builder.ackReceived();
-      }
-    };
-
-    public abstract void applyTo(InvocationBuilder builder);
+    NONE,
+    RECEIVED;
   }
 
 

--- a/proxy/src/main/java/org/terracotta/voltron/proxy/client/VoltronProxyInvocationHandler.java
+++ b/proxy/src/main/java/org/terracotta/voltron/proxy/client/VoltronProxyInvocationHandler.java
@@ -106,7 +106,15 @@ class VoltronProxyInvocationHandler implements InvocationHandler {
         .payload(payload);
 
     if(methodDescriptor.isAsync()) {
-      methodDescriptor.getAck().applyTo(builder);
+      switch (methodDescriptor.getAck()) {
+        case NONE:
+          break;
+        case RECEIVED:
+          builder.ackReceived();
+          break;
+        default:
+          throw new IllegalStateException(methodDescriptor.getAck().name());
+      }
       return new ProxiedInvokeFuture(builder.invoke(), methodDescriptor.getMessageType(), codec);
 
     } else {


### PR DESCRIPTION
@Async is now both used on client side and server side so it should not depend on specific client api

@anthonydahanne @chrisdennis @myronkscott : if you could please review / merge. My previous PR caused a classloader issue because of a changed in the @Async annotation. Since this annot is now used both on server side and client side, we cannot have client-specific code into it.

I tested this fix in our system tests and it pass.

I encountered the following error below.

```
2016-03-08 17:52:08.742  INFO 11904 --- [  XNIO-2 task-7] c.t.m.s.cluster.VoltronProbeService      : probe(terracotta://localhost:9510)
java.lang.NoClassDefFoundError: org/terracotta/entity/InvocationBuilder
	at java.lang.Class.getDeclaredMethods0(Native Method)
	at java.lang.Class.privateGetDeclaredMethods(Class.java:2701)
	at java.lang.Class.privateGetMethodRecursive(Class.java:3048)
	at java.lang.Class.getMethod0(Class.java:3018)
	at java.lang.Class.getMethod(Class.java:1784)
	at java.lang.Class.getEnumConstantsShared(Class.java:3311)
	at java.lang.Class.enumConstantDirectory(Class.java:3341)
	at java.lang.Enum.valueOf(Enum.java:232)
	at sun.reflect.annotation.AnnotationParser.parseEnumValue(AnnotationParser.java:483)
	at sun.reflect.annotation.AnnotationParser.parseMemberValue(AnnotationParser.java:347)
	at java.lang.reflect.Method.getDefaultValue(Method.java:605)
	at sun.reflect.annotation.AnnotationType.<init>(AnnotationType.java:128)
	at sun.reflect.annotation.AnnotationType.getInstance(AnnotationType.java:85)
	at sun.reflect.annotation.AnnotationParser.parseAnnotation2(AnnotationParser.java:266)
	at sun.reflect.annotation.AnnotationParser.parseAnnotations2(AnnotationParser.java:120)
	at sun.reflect.annotation.AnnotationParser.parseAnnotations(AnnotationParser.java:72)
	at java.lang.reflect.Executable.declaredAnnotations(Executable.java:602)
	at java.lang.reflect.Executable.declaredAnnotations(Executable.java:600)
	at java.lang.reflect.Executable.getAnnotation(Executable.java:572)
	at java.lang.reflect.Method.getAnnotation(Method.java:621)
	at org.terracotta.voltron.proxy.MethodDescriptor.<init>(MethodDescriptor.java:43)
	at org.terracotta.voltron.proxy.MethodDescriptor.of(MethodDescriptor.java:74)
	at org.terracotta.voltron.proxy.CommonProxyFactory.getSortedMethods(CommonProxyFactory.java:95)
	at org.terracotta.voltron.proxy.CommonProxyFactory.createMethodMappings(CommonProxyFactory.java:58)
	at org.terracotta.voltron.proxy.ProxyMessageCodec.<init>(ProxyMessageCodec.java:41)
	at org.terracotta.voltron.proxy.server.ProxyServerEntityService.getMessageCodec(ProxyServerEntityService.java:41)
	at com.tc.objectserver.entity.ManagedEntityImpl.<init>(ManagedEntityImpl.java:115)
	at com.tc.objectserver.entity.EntityManagerImpl.createEntity(EntityManagerImpl.java:96)
	at com.tc.objectserver.handler.EntityExistenceHelpers.createEntityReturnWasCached(EntityExistenceHelpers.java:55)
	at com.tc.objectserver.handler.ProcessTransactionHandler.addMessage(ProcessTransactionHandler.java:147)
	at com.tc.objectserver.handler.ProcessTransactionHandler.access$100(ProcessTransactionHandler.java:60)
	at com.tc.objectserver.handler.ProcessTransactionHandler$1.handleEvent(ProcessTransactionHandler.java:83)
	at com.tc.objectserver.handler.ProcessTransactionHandler$1.handleEvent(ProcessTransactionHandler.java:72)
	at com.tc.async.impl.StageQueueImpl$HandledContext.runWithHandler(StageQueueImpl.java:502)
	at com.tc.async.impl.StageImpl$WorkerThread.run(StageImpl.java:197)
Caused by: java.lang.ClassNotFoundException: org.terracotta.entity.InvocationBuilder
	at java.net.URLClassLoader.findClass(URLClassLoader.java:381)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
	at com.tc.classloader.ComponentURLClassLoader.loadClass(ComponentURLClassLoader.java:42)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
	... 35 more
2016-03-08 17:53:04.307  INFO 11904 --- [MessageBroker-1] o.s.w.s.c.WebSocketMessageBrokerStats    : WebSocketSession[1 current WS(1)-HttpStream(0)-HttpPoll(0), 1 total, 0 closed abnormally (0 connect failure, 0 send limit, 0 transport error)], stompSubProtocol[processed CONNECT(1)-CONNECTED(1)-DISCONNECT(0)], stompBrokerRelay[null], inboundChannel[pool size = 6, active threads = 0, queued tasks = 0, completed tasks = 6], outboundChannelpool size = 1, active threads = 0, queued tasks =
```
