### PR TITLE
voltron-proxy: Support serialization of entity config through the installed codec

### DIFF
--- a/coordinator-entity/client/src/main/java/org/terracotta/consensus/entity/client/ClientCoordinationEntityService.java
+++ b/coordinator-entity/client/src/main/java/org/terracotta/consensus/entity/client/ClientCoordinationEntityService.java
@@ -27,16 +27,7 @@ import org.terracotta.consensus.entity.messages.ServerElectionEvent;
 public class ClientCoordinationEntityService extends ProxyEntityClientService<CoordinationClientEntity, Void> {
 
   public ClientCoordinationEntityService() {
-    super(CoordinationClientEntity.class, CoordinationEntity.class, ServerElectionEvent.class);
+    super(CoordinationClientEntity.class, CoordinationEntity.class, Void.TYPE, ServerElectionEvent.class);
   }
 
-  @Override
-  public byte[] serializeConfiguration(final Void aVoid) {
-    return new byte[0];
-  }
-
-  @Override
-  public Void deserializeConfiguration(final byte[] bytes) {
-    return null;
-  }
 }

--- a/coordinator-entity/server/src/main/java/org/terracotta/consensus/entity/CoordinationServerEntityService.java
+++ b/coordinator-entity/server/src/main/java/org/terracotta/consensus/entity/CoordinationServerEntityService.java
@@ -23,21 +23,18 @@ import org.terracotta.entity.BasicServiceConfiguration;
 import org.terracotta.entity.ClientCommunicator;
 import org.terracotta.entity.ClientDescriptor;
 import org.terracotta.entity.ServiceRegistry;
-import org.terracotta.entity.SyncMessageCodec;
 import org.terracotta.voltron.proxy.SerializationCodec;
 import org.terracotta.voltron.proxy.server.ProxyServerEntityService;
-import org.terracotta.voltron.proxy.server.messages.ProxyEntityMessage;
-import org.terracotta.voltron.proxy.server.messages.ProxyEntityResponse;
 
 /**
  * @author Alex Snaps
  */
-public class CoordinationServerEntityService extends ProxyServerEntityService {
+public class CoordinationServerEntityService extends ProxyServerEntityService<Void> {
   
   private static final String ENTITY_CLASS_NAME = "org.terracotta.consensus.entity.client.CoordinationClientEntity";
 
   public CoordinationServerEntityService() {
-    super(CoordinationEntity.class, new SerializationCodec(), ServerElectionEvent.class);
+    super(CoordinationEntity.class, Void.TYPE, new SerializationCodec(), ServerElectionEvent.class);
   }
 
   @Override
@@ -51,11 +48,7 @@ public class CoordinationServerEntityService extends ProxyServerEntityService {
   }
 
   @Override
-  public CoordinationServerEntity createActiveEntity(final ServiceRegistry serviceRegistry, final byte[] bytes) {
-    if (bytes != null && bytes.length > 0) {
-      throw new IllegalArgumentException("No config expected here!");
-    }
-    
+  public CoordinationServerEntity createActiveEntity(final ServiceRegistry serviceRegistry, Void v) {
     ClientCommunicator communicator = serviceRegistry.getService(new BasicServiceConfiguration<ClientCommunicator>(ClientCommunicator.class));
     
     return new CoordinationServerEntity(new LeaderElector<String, ClientDescriptor>(new UuidOfferFactory()), communicator);

--- a/proxy/src/main/java/org/terracotta/voltron/proxy/client/ProxyEntityClientService.java
+++ b/proxy/src/main/java/org/terracotta/voltron/proxy/client/ProxyEntityClientService.java
@@ -21,19 +21,20 @@ public abstract class ProxyEntityClientService<T extends Entity, C> implements E
   private final Class<? super T> type;
   private final Codec codec;
   private final Class<?>[] messageTypes;
+  private final Class<C> configType;
 
-
-  public ProxyEntityClientService(Class<T> clientType, Class<? super T> type, Class<?>... messageTypes) {
-    this(clientType, type, new SerializationCodec(), messageTypes);
+  public ProxyEntityClientService(Class<T> clientType, Class<? super T> type, Class<C> configType, Class<?>... messageTypes) {
+    this(clientType, type, configType, new SerializationCodec(), messageTypes);
   }
 
-  public ProxyEntityClientService(Class<T> clientType, Class<? super T> type) {
-    this(clientType, type, new SerializationCodec());
+  public ProxyEntityClientService(Class<T> clientType, Class<? super T> type, Class<C> configType) {
+    this(clientType, type, configType, new SerializationCodec());
   }
 
-  public ProxyEntityClientService(Class<T> clientType, Class<? super T> type, Codec codec, Class<?>... messageTypes) {
+  public ProxyEntityClientService(Class<T> clientType, Class<? super T> type, Class<C> configType, Codec codec, Class<?>... messageTypes) {
     this.clientType = clientType;
     this.type = type;
+    this.configType = configType;
     this.codec = codec;
     this.messageTypes = messageTypes;
   }
@@ -51,6 +52,22 @@ public abstract class ProxyEntityClientService<T extends Entity, C> implements E
   @Override
   public MessageCodec<ProxyEntityMessage, ProxyEntityResponse> getMessageCodec() {
     return new ProxyMessageCodec(codec, type, messageTypes);
+  }
+
+  @Override
+  public C deserializeConfiguration(byte[] configuration) {
+    if(configType == Void.TYPE) {
+      return null;
+    }
+    return configType.cast(codec.decode(configuration, configType));
+  }
+
+  @Override
+  public byte[] serializeConfiguration(C configuration) {
+    if(configType == Void.TYPE) {
+      return new byte[0];
+    }
+    return codec.encode(configType, configuration);
   }
 
   private static Class<?>[] sum(Class<?> one, Class<?>[] others) {


### PR DESCRIPTION
Support serialization of entity config through the installed codec and supporting default Void config type.
This provides a default serialization behavior to help implementing entities easier.
Behavior can be overridden, as before.
