### PR TITLE
Issue #62 Make OffHeapResource a CommonComponent

### DIFF
--- a/offheap-resource/pom.xml
+++ b/offheap-resource/pom.xml
@@ -24,6 +24,11 @@
       <version>10.0-SNAPSHOT</version>
     </dependency>
     <dependency>
+      <groupId>org.terracotta</groupId>
+      <artifactId>packaging-support</artifactId>
+      <version>${terracotta-apis.version}</version>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>

--- a/offheap-resource/src/main/java/org/terracotta/offheapresource/OffHeapResource.java
+++ b/offheap-resource/src/main/java/org/terracotta/offheapresource/OffHeapResource.java
@@ -1,23 +1,6 @@
-/*
- * The contents of this file are subject to the Terracotta Public License Version
- * 2.0 (the "License"); You may not use this file except in compliance with the
- * License. You may obtain a copy of the License at
- *
- * http://terracotta.org/legal/terracotta-public-license.
- *
- * Software distributed under the License is distributed on an "AS IS" basis,
- * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
- * the specific language governing rights and limitations under the License.
- *
- * The Covered Software is OffHeap Resource.
- *
- * The Initial Developer of the Covered Software is
- * Terracotta, Inc., a Software AG company
- */
-
 package org.terracotta.offheapresource;
 
-import java.util.concurrent.atomic.AtomicLong;
+import com.tc.classloader.CommonComponent;
 
 /**
  * Represents an offheap resource, providing a reservation system that can be
@@ -26,23 +9,8 @@ import java.util.concurrent.atomic.AtomicLong;
  * Reservation and release calls perform no allocations, and therefore rely on
  * the cooperation of callers to achieve control over the 'real' resource usage.
  */
-public class OffHeapResource {
-
-  private final AtomicLong remaining;
-
-  /**
-   * Creates a resource of the given initial size.
-   *
-   * @param size size of the resource
-   * @throws IllegalArgumentException if the size is negative
-   */
-  OffHeapResource(long size) throws IllegalArgumentException {
-    if (size < 0) {
-      throw new IllegalArgumentException("Resource size cannot be negative");
-    } else {
-      this.remaining = new AtomicLong(size);
-    }
-  }
+@CommonComponent
+public interface OffHeapResource {
 
   /**
    * Reserves the given amount of this resource.
@@ -55,18 +23,7 @@ public class OffHeapResource {
    * @return {@code true} if the reservation succeeded
    * @throws IllegalArgumentException if the reservation size is negative
    */
-  public boolean reserve(long size) throws IllegalArgumentException {
-    if (size < 0) {
-      throw new IllegalArgumentException("Reservation size cannot be negative");
-    } else {
-      for (long current = remaining.get(); current >= size; current = remaining.get()) {
-        if (remaining.compareAndSet(current, current - size)) {
-          return true;
-        }
-      }
-      return false;
-    }
-  }
+  boolean reserve(long size) throws IllegalArgumentException;
 
   /**
    * Releases the given amount of resource back to this pool.
@@ -74,20 +31,12 @@ public class OffHeapResource {
    * @param size release size
    * @throws IllegalArgumentException if the release size is negative
    */
-  public void release(long size) throws IllegalArgumentException {
-    if (size < 0) {
-      throw new IllegalArgumentException("Released size cannot be negative");
-    } else {
-      remaining.addAndGet(size);
-    }
-  }
+  void release(long size) throws IllegalArgumentException;
 
   /**
    * Returns the size of the remaining resource that can be reserved.
    *
    * @return the remaining resource size
    */
-  public long available() {
-    return remaining.get();
-  }
+  long available();
 }

--- a/offheap-resource/src/main/java/org/terracotta/offheapresource/OffHeapResourceIdentifier.java
+++ b/offheap-resource/src/main/java/org/terracotta/offheapresource/OffHeapResourceIdentifier.java
@@ -19,10 +19,12 @@ package org.terracotta.offheapresource;
 
 import org.terracotta.entity.ServiceConfiguration;
 
+import com.tc.classloader.CommonComponent;
+
 /**
- *
- * @author cdennis
+ * Provides identification of a server-defined off-heap resource.
  */
+@CommonComponent
 public final class OffHeapResourceIdentifier implements ServiceConfiguration<OffHeapResource> {
 
   private final String name;

--- a/offheap-resource/src/main/java/org/terracotta/offheapresource/OffHeapResourceImpl.java
+++ b/offheap-resource/src/main/java/org/terracotta/offheapresource/OffHeapResourceImpl.java
@@ -1,0 +1,81 @@
+/*
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ * http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is OffHeap Resource.
+ *
+ * The Initial Developer of the Covered Software is
+ * Terracotta, Inc., a Software AG company
+ */
+
+package org.terracotta.offheapresource;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * An implementation of {@link OffHeapResource}.
+ */
+class OffHeapResourceImpl implements OffHeapResource {
+
+  private final AtomicLong remaining;
+
+  /**
+   * Creates a resource of the given initial size.
+   *
+   * @param size size of the resource
+   * @throws IllegalArgumentException if the size is negative
+   */
+  OffHeapResourceImpl(long size) throws IllegalArgumentException {
+    if (size < 0) {
+      throw new IllegalArgumentException("Resource size cannot be negative");
+    } else {
+      this.remaining = new AtomicLong(size);
+    }
+  }
+
+  /**
+   * {@inheritDoc}
+   * @throws IllegalArgumentException {@inheritDoc}
+   */
+  @Override
+  public boolean reserve(long size) throws IllegalArgumentException {
+    if (size < 0) {
+      throw new IllegalArgumentException("Reservation size cannot be negative");
+    } else {
+      for (long current = remaining.get(); current >= size; current = remaining.get()) {
+        if (remaining.compareAndSet(current, current - size)) {
+          return true;
+        }
+      }
+      return false;
+    }
+  }
+
+  /**
+   * {@inheritDoc}
+   * @throws IllegalArgumentException {@inheritDoc}
+   */
+  @Override
+  public void release(long size) throws IllegalArgumentException {
+    if (size < 0) {
+      throw new IllegalArgumentException("Released size cannot be negative");
+    } else {
+      remaining.addAndGet(size);
+    }
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public long available() {
+    return remaining.get();
+  }
+}

--- a/offheap-resource/src/main/java/org/terracotta/offheapresource/OffHeapResourcesProvider.java
+++ b/offheap-resource/src/main/java/org/terracotta/offheapresource/OffHeapResourcesProvider.java
@@ -55,7 +55,7 @@ public class OffHeapResourcesProvider implements ServiceProvider {
         for (ResourceType r : configuration.getResources()) {
           long size = convert(r.getValue(), r.getUnit()).longValueExact();
           totalSize += size;
-          resources.put(OffHeapResourceIdentifier.identifier(r.getName()), new OffHeapResource(size));
+          resources.put(OffHeapResourceIdentifier.identifier(r.getName()), new OffHeapResourceImpl(size));
         }
         Long physicalMemory = PhysicalMemory.totalPhysicalMemory();
         if (physicalMemory != null && totalSize > physicalMemory) {

--- a/offheap-resource/src/test/java/org/terracotta/offheapresource/OffHeapResourceTest.java
+++ b/offheap-resource/src/test/java/org/terracotta/offheapresource/OffHeapResourceTest.java
@@ -27,7 +27,7 @@ public class OffHeapResourceTest {
   @Test
   public void testNegativeResourceSize() {
     try {
-      new OffHeapResource(-1);
+      new OffHeapResourceImpl(-1);
       fail("Expected IllegalArgumentException");
     } catch (IllegalArgumentException e) {
       //expected;
@@ -36,14 +36,14 @@ public class OffHeapResourceTest {
 
   @Test
   public void testZeroSizeResourceIsUseless() {
-    OffHeapResource ohr = new OffHeapResource(0);
+    OffHeapResource ohr = new OffHeapResourceImpl(0);
     assertThat(ohr.reserve(1), is(false));
     assertThat(ohr.available(), is(0L));
   }
 
   @Test
   public void testAllocationReducesSize() {
-    OffHeapResource ohr = new OffHeapResource(20);
+    OffHeapResource ohr = new OffHeapResourceImpl(20);
     assertThat(ohr.available(), is(20L));
     assertThat(ohr.reserve(10), is(true));
     assertThat(ohr.available(), is(10L));
@@ -51,7 +51,7 @@ public class OffHeapResourceTest {
 
   @Test
   public void testNegativeAllocationFails() {
-    OffHeapResource ohr = new OffHeapResource(20);
+    OffHeapResource ohr = new OffHeapResourceImpl(20);
     try {
       ohr.reserve(-1);
       fail("Expected IllegalArgumentException");
@@ -62,7 +62,7 @@ public class OffHeapResourceTest {
 
   @Test
   public void testAllocationWhenExhaustedFails() {
-    OffHeapResource ohr = new OffHeapResource(20);
+    OffHeapResource ohr = new OffHeapResourceImpl(20);
     ohr.reserve(20);
     assertThat(ohr.reserve(1), is(false));
     assertThat(ohr.available(), is(0L));
@@ -70,7 +70,7 @@ public class OffHeapResourceTest {
 
   @Test
   public void testFreeIncreasesSize() {
-    OffHeapResource ohr = new OffHeapResource(20);
+    OffHeapResource ohr = new OffHeapResourceImpl(20);
     ohr.reserve(20);
     assertThat(ohr.available(), is(0L));
     ohr.release(10);
@@ -79,7 +79,7 @@ public class OffHeapResourceTest {
 
   @Test
   public void testNegativeFreeFails() {
-    OffHeapResource ohr = new OffHeapResource(20);
+    OffHeapResource ohr = new OffHeapResourceImpl(20);
     ohr.reserve(10);
     try {
       ohr.release(-10);


### PR DESCRIPTION
When performing a org.terracotta.entity.ServiceRegistry.getService call
against OffHeapResource, the configured resources can not be found
due to a difference in the ClassLoaders being used.  Adding the
@CommonComponent annotation to OffHeapResource causes the common
ClassLoader to be used for OffHeapResource so the service-created
instances can be found.  Since OffHeapResourceIdentifier class
references are also used during OffHeapResource lookup (instanceof),
this class is also marked with @CommonComponent.

This commit separates the OffHeapResource interface from its
implementation to avoid an issue during instantiation after application
of the @CommonComponent annotation.