### PR TITLE
Update to account for EndpointDelegate API change

### DIFF
--- a/client-communicator-support/src/main/java/org/terracotta/clientcommunicator/support/ClientCommunicatorClientManager.java
+++ b/client-communicator-support/src/main/java/org/terracotta/clientcommunicator/support/ClientCommunicatorClientManager.java
@@ -26,5 +26,5 @@ public interface ClientCommunicatorClientManager<M extends EntityMessage, R exte
      * @param message the received message
      * @param clientCommunicatorMessageHandler an entity handler to process server message
      */
-    void handleClientCommunicatorMessage(byte[] message, ClientCommunicatorMessageHandler clientCommunicatorMessageHandler);
+    void handleClientCommunicatorMessage(R message, ClientCommunicatorMessageHandler clientCommunicatorMessageHandler);
 }

--- a/client-communicator-support/src/main/java/org/terracotta/clientcommunicator/support/ClientCommunicatorClientManagerImpl.java
+++ b/client-communicator-support/src/main/java/org/terracotta/clientcommunicator/support/ClientCommunicatorClientManagerImpl.java
@@ -51,8 +51,9 @@ public class ClientCommunicatorClientManagerImpl<M extends EntityMessage, R exte
     }
 
     @Override
-    public void handleClientCommunicatorMessage(byte[] message, ClientCommunicatorMessageHandler clientCommunicatorMessageHandler) {
-        ClientCommunicatorRequest clientCommunicatorRequest = ClientCommunicatorRequestCodec.deserialize(message);;
+    public void handleClientCommunicatorMessage(R message, ClientCommunicatorMessageHandler clientCommunicatorMessageHandler) {
+      try {
+        ClientCommunicatorRequest clientCommunicatorRequest = ClientCommunicatorRequestCodec.deserialize(clientCommunicatorMessageFactory.extractBytesFromResponse(message));
         switch (clientCommunicatorRequest.getRequestType()) {
             case ACK:
                 clientCommunicatorMessageHandler.handleMessage(clientCommunicatorRequest.getMsgBytes());
@@ -82,6 +83,10 @@ public class ClientCommunicatorClientManagerImpl<M extends EntityMessage, R exte
             default:
                 throw new IllegalArgumentException("unexpected/unknown ClientCommunicatorRequestType: " + clientCommunicatorRequest.getRequestType());
         }
+      } catch (MessageCodecException e) {
+        // This would mean a serious bug in the message factory.
+        throw new RuntimeException(e);
+      }
     }
 }
 

--- a/proxy/src/main/java/org/terracotta/voltron/proxy/client/ProxyEndpointDelegate.java
+++ b/proxy/src/main/java/org/terracotta/voltron/proxy/client/ProxyEndpointDelegate.java
@@ -18,8 +18,10 @@
 package org.terracotta.voltron.proxy.client;
 
 import org.terracotta.entity.EndpointDelegate;
+import org.terracotta.entity.EntityResponse;
 import org.terracotta.voltron.proxy.Codec;
 import org.terracotta.voltron.proxy.client.messages.MessageListener;
+import org.terracotta.voltron.proxy.server.messages.ProxyEntityResponse;
 
 import java.util.Arrays;
 import java.util.Map;
@@ -44,11 +46,11 @@ class ProxyEndpointDelegate implements EndpointDelegate {
   }
 
   @Override
-  public void handleMessage(final byte[] bytes) {
-    final Object message = codec.decode(Arrays.copyOfRange(bytes, 1, bytes.length), eventMappings.get(bytes[0]));
-    final Class<?> aClass = message.getClass();
+  public void handleMessage(EntityResponse messageFromServer) {
+    ProxyEntityResponse response = (ProxyEntityResponse)messageFromServer;
+    final Class<?> aClass = response.getResponseType();
     for (MessageListener messageListener : listeners.get(aClass)) {
-      messageListener.onMessage(message);
+      messageListener.onMessage(response.getResponse());
     }
   }
 

--- a/proxy/src/test/java/org/terracotta/voltron/proxy/EndToEndTest.java
+++ b/proxy/src/test/java/org/terracotta/voltron/proxy/EndToEndTest.java
@@ -99,7 +99,7 @@ public class EndToEndTest {
           }
         });
         voidFutureTask.run();
-        delegate.get().handleMessage(messageCodec.encodeResponse((ProxyEntityResponse) message));
+        delegate.get().handleMessage(message);
         return voidFutureTask;
       }
     }, String.class);


### PR DESCRIPTION
-EndpointDelegate.handleMessage() now takes EntityResponse instead of byte[]

**Note:**  This depends on Terracotta-OSS/terracotta-apis#78