### PR TITLE
Issue #66 Make OffHeapResourcesConfiguration public

### DIFF
--- a/offheap-resource/src/main/java/org/terracotta/offheapresource/OffHeapResourcesConfiguration.java
+++ b/offheap-resource/src/main/java/org/terracotta/offheapresource/OffHeapResourcesConfiguration.java
@@ -23,11 +23,11 @@ import org.terracotta.entity.ServiceProviderConfiguration;
 import org.terracotta.offheapresource.config.OffheapResourcesType;
 import org.terracotta.offheapresource.config.ResourceType;
 
-class OffHeapResourcesConfiguration implements ServiceProviderConfiguration {
+public class OffHeapResourcesConfiguration implements ServiceProviderConfiguration {
 
   private final OffheapResourcesType xmlConfig;
 
-  OffHeapResourcesConfiguration(OffheapResourcesType xmlConfig) {
+  public OffHeapResourcesConfiguration(OffheapResourcesType xmlConfig) {
     this.xmlConfig = xmlConfig;
   }
 

--- a/offheap-resource/src/main/java/org/terracotta/offheapresource/OffHeapResourcesProvider.java
+++ b/offheap-resource/src/main/java/org/terracotta/offheapresource/OffHeapResourcesProvider.java
@@ -53,7 +53,7 @@ public class OffHeapResourcesProvider implements ServiceProvider {
       if (resources.isEmpty()) {
         long totalSize = 0;
         for (ResourceType r : configuration.getResources()) {
-          long size = convert(r.getValue(), r.getUnit()).longValueExact();
+          long size = longValueExact(convert(r.getValue(), r.getUnit()));
           totalSize += size;
           resources.put(OffHeapResourceIdentifier.identifier(r.getName()), new OffHeapResourceImpl(size));
         }
@@ -100,5 +100,14 @@ public class OffHeapResourcesProvider implements ServiceProvider {
       case PB: return value.shiftLeft(50);
     }
     throw new IllegalArgumentException("Unknown unit " + unit);
+  }
+
+  private static final BigInteger MAX_LONG_PLUS_ONE = BigInteger.valueOf(Long.MAX_VALUE).add(BigInteger.ONE);
+  private static long longValueExact(BigInteger value) {
+    if (value.compareTo(MAX_LONG_PLUS_ONE) < 0) {
+      return value.longValue();
+    } else {
+      throw new ArithmeticException("BigInteger out of long range");
+    }
   }
 }

--- a/offheap-resource/src/test/java/org/terracotta/offheapresource/OffHeapResourcesProviderTest.java
+++ b/offheap-resource/src/test/java/org/terracotta/offheapresource/OffHeapResourcesProviderTest.java
@@ -117,4 +117,43 @@ public class OffHeapResourcesProviderTest {
     provider.clear();
     assertThat(provider.getService(42L, OffHeapResourceIdentifier.identifier("foo")), nullValue());
   }
+
+  @Test
+  public void testResourceTooBig() throws Exception {
+    ResourceType resourceConfig = mock(ResourceType.class);
+    when(resourceConfig.getName()).thenReturn("foo");
+    when(resourceConfig.getUnit()).thenReturn(MemoryUnit.B);
+    when(resourceConfig.getValue()).thenReturn(BigInteger.valueOf(Long.MAX_VALUE).add(BigInteger.ONE));
+
+    OffHeapResourcesConfiguration config = mock(OffHeapResourcesConfiguration.class);
+    when(config.getResources()).thenReturn(Collections.singleton(resourceConfig));
+
+    OffHeapResourcesProvider provider = new OffHeapResourcesProvider();
+    try {
+      provider.initialize(config);
+      fail();
+    } catch (ArithmeticException e) {
+      // expected
+    } finally {
+      provider.clear();
+    }
+  }
+
+  @Test
+  public void testResourceMax() throws Exception {
+    ResourceType resourceConfig = mock(ResourceType.class);
+    when(resourceConfig.getName()).thenReturn("foo");
+    when(resourceConfig.getUnit()).thenReturn(MemoryUnit.B);
+    when(resourceConfig.getValue()).thenReturn(BigInteger.valueOf(Long.MAX_VALUE));
+
+    OffHeapResourcesConfiguration config = mock(OffHeapResourcesConfiguration.class);
+    when(config.getResources()).thenReturn(Collections.singleton(resourceConfig));
+
+    OffHeapResourcesProvider provider = new OffHeapResourcesProvider();
+    try {
+      provider.initialize(config);
+    } finally {
+      provider.clear();
+    }
+  }
 }


### PR DESCRIPTION
This commit makes OffHeapResourcesConfiguration public to permit
programmatic configuration of an OffHeapResourcesProvider to support
Ehcache clustered unit testing.  In addition to the visibility change,
OffHeapResourcesProvider is changed to remove the use of the
BigInteger.longValueExact method to permit running of the unit tests
under Java 1.6.