### PR TITLE
use permanent entity annotation

### DIFF
--- a/healthchecker-entity/server-impl/pom.xml
+++ b/healthchecker-entity/server-impl/pom.xml
@@ -22,6 +22,11 @@
       <artifactId>entity-server-api</artifactId>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+        <groupId>org.terracotta</groupId>
+        <artifactId>packaging-support</artifactId>
+        <scope>provided</scope>
+    </dependency>
   </dependencies>
     <build>
     <plugins>

--- a/healthchecker-entity/server-impl/src/main/java/org/terracotta/healthchecker/HealthCheckServerEntityService.java
+++ b/healthchecker-entity/server-impl/src/main/java/org/terracotta/healthchecker/HealthCheckServerEntityService.java
@@ -18,6 +18,7 @@
  */
 package org.terracotta.healthchecker;
 
+import com.tc.classloader.PermanentEntity;
 import java.util.Collections;
 import java.util.Set;
 import org.terracotta.entity.ActiveServerEntity;
@@ -30,8 +31,9 @@ import org.terracotta.entity.ServiceRegistry;
 import org.terracotta.entity.SyncMessageCodec;
 
 /**
- *
+ *  annotation must match the type, and version below for this to work
  */
+@PermanentEntity(type="org.terracotta.healthchecker.HealthCheck", names={"staticHealthChecker"}, version=1)
 public class HealthCheckServerEntityService implements ServerEntityService<HealthCheckReq, HealthCheckRsp> {
   
   private static final ConcurrencyStrategy CONCURRENCY = new ConcurrencyStrategy() {


### PR DESCRIPTION
healthchecker entity should use annotation support so that the entity setup is captured in source files rather than runtime configuration