### PR TITLE
Ignoring collision / perf test

### DIFF
--- a/management/sequence-generator/pom.xml
+++ b/management/sequence-generator/pom.xml
@@ -43,9 +43,6 @@
         <version>2.19</version>
         <configuration>
           <argLine>
-            -server
-            -Xmx512M
-            -Xms512M
             -Dorg.terracotta.management.sequence.NodeIdSource=org.terracotta.management.sequence.MyNodeIdSource
             -Dorg.terracotta.management.sequence.TimeSource=org.terracotta.management.sequence.MyTimeSource
           </argLine>

--- a/management/sequence-generator/src/test/java/org/terracotta/management/sequence/BoundaryFlakeSequenceGeneratorTest.java
+++ b/management/sequence-generator/src/test/java/org/terracotta/management/sequence/BoundaryFlakeSequenceGeneratorTest.java
@@ -16,6 +16,7 @@
 
 package org.terracotta.management.sequence;
 
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -105,6 +106,7 @@ public class BoundaryFlakeSequenceGeneratorTest {
   }
 
   @Test
+  @Ignore
   public void test_no_collisions() throws InterruptedException {
     final BoundaryFlakeSequenceGenerator generator = new BoundaryFlakeSequenceGenerator(TimeSource.SYSTEM, NodeIdSource.MAC_PID);
     final Collection<Sequence> bag = new ConcurrentSkipListSet<Sequence>();


### PR DESCRIPTION
Avoid requiring more memory to run test within the IDE