### PR TITLE
Fixed header style that was in javadoc style, to avoid the IDE reformat

### DIFF
--- a/client-communicator-support/src/main/java/org/terracotta/clientcommunicator/support/ClientCommunicatorClientManager.java
+++ b/client-communicator-support/src/main/java/org/terracotta/clientcommunicator/support/ClientCommunicatorClientManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/client-communicator-support/src/main/java/org/terracotta/clientcommunicator/support/ClientCommunicatorClientManagerImpl.java
+++ b/client-communicator-support/src/main/java/org/terracotta/clientcommunicator/support/ClientCommunicatorClientManagerImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/client-communicator-support/src/main/java/org/terracotta/clientcommunicator/support/ClientCommunicatorMessageFactory.java
+++ b/client-communicator-support/src/main/java/org/terracotta/clientcommunicator/support/ClientCommunicatorMessageFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/client-communicator-support/src/main/java/org/terracotta/clientcommunicator/support/ClientCommunicatorMessageHandler.java
+++ b/client-communicator-support/src/main/java/org/terracotta/clientcommunicator/support/ClientCommunicatorMessageHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/client-communicator-support/src/main/java/org/terracotta/clientcommunicator/support/ClientCommunicatorRequest.java
+++ b/client-communicator-support/src/main/java/org/terracotta/clientcommunicator/support/ClientCommunicatorRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/client-communicator-support/src/main/java/org/terracotta/clientcommunicator/support/ClientCommunicatorRequestCodec.java
+++ b/client-communicator-support/src/main/java/org/terracotta/clientcommunicator/support/ClientCommunicatorRequestCodec.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/client-communicator-support/src/main/java/org/terracotta/clientcommunicator/support/ClientCommunicatorRequestType.java
+++ b/client-communicator-support/src/main/java/org/terracotta/clientcommunicator/support/ClientCommunicatorRequestType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/client-communicator-support/src/main/java/org/terracotta/clientcommunicator/support/ClientCommunicatorServerManager.java
+++ b/client-communicator-support/src/main/java/org/terracotta/clientcommunicator/support/ClientCommunicatorServerManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/client-communicator-support/src/main/java/org/terracotta/clientcommunicator/support/ClientCommunicatorServerManagerImpl.java
+++ b/client-communicator-support/src/main/java/org/terracotta/clientcommunicator/support/ClientCommunicatorServerManagerImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/client-communicator-support/src/test/java/org/terracotta/clientcommunicator/support/ClientCommunicatorRequestCodecTest.java
+++ b/client-communicator-support/src/test/java/org/terracotta/clientcommunicator/support/ClientCommunicatorRequestCodecTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/concurrent-map-entity/client/src/main/java/org/terracotta/entity/map/TerracottaClusteredMap.java
+++ b/concurrent-map-entity/client/src/main/java/org/terracotta/entity/map/TerracottaClusteredMap.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/concurrent-map-entity/client/src/main/java/org/terracotta/entity/map/TerracottaClusteredMapClientService.java
+++ b/concurrent-map-entity/client/src/main/java/org/terracotta/entity/map/TerracottaClusteredMapClientService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/concurrent-map-entity/client/src/main/java/org/terracotta/entity/map/ValueCodec.java
+++ b/concurrent-map-entity/client/src/main/java/org/terracotta/entity/map/ValueCodec.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/concurrent-map-entity/client/src/main/java/org/terracotta/entity/map/ValueCodecFactory.java
+++ b/concurrent-map-entity/client/src/main/java/org/terracotta/entity/map/ValueCodecFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/concurrent-map-entity/common/src/main/java/org/terracotta/entity/map/common/BooleanResponse.java
+++ b/concurrent-map-entity/common/src/main/java/org/terracotta/entity/map/common/BooleanResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/concurrent-map-entity/common/src/main/java/org/terracotta/entity/map/common/ClearOperation.java
+++ b/concurrent-map-entity/common/src/main/java/org/terracotta/entity/map/common/ClearOperation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/concurrent-map-entity/common/src/main/java/org/terracotta/entity/map/common/ClusteredMapCodec.java
+++ b/concurrent-map-entity/common/src/main/java/org/terracotta/entity/map/common/ClusteredMapCodec.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/concurrent-map-entity/common/src/main/java/org/terracotta/entity/map/common/ConcurrentClusteredMap.java
+++ b/concurrent-map-entity/common/src/main/java/org/terracotta/entity/map/common/ConcurrentClusteredMap.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/concurrent-map-entity/common/src/main/java/org/terracotta/entity/map/common/ConditionalRemoveOperation.java
+++ b/concurrent-map-entity/common/src/main/java/org/terracotta/entity/map/common/ConditionalRemoveOperation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/concurrent-map-entity/common/src/main/java/org/terracotta/entity/map/common/ConditionalReplaceOperation.java
+++ b/concurrent-map-entity/common/src/main/java/org/terracotta/entity/map/common/ConditionalReplaceOperation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/concurrent-map-entity/common/src/main/java/org/terracotta/entity/map/common/ContainsKeyOperation.java
+++ b/concurrent-map-entity/common/src/main/java/org/terracotta/entity/map/common/ContainsKeyOperation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/concurrent-map-entity/common/src/main/java/org/terracotta/entity/map/common/ContainsValueOperation.java
+++ b/concurrent-map-entity/common/src/main/java/org/terracotta/entity/map/common/ContainsValueOperation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/concurrent-map-entity/common/src/main/java/org/terracotta/entity/map/common/EntrySetOperation.java
+++ b/concurrent-map-entity/common/src/main/java/org/terracotta/entity/map/common/EntrySetOperation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/concurrent-map-entity/common/src/main/java/org/terracotta/entity/map/common/EntrySetResponse.java
+++ b/concurrent-map-entity/common/src/main/java/org/terracotta/entity/map/common/EntrySetResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/concurrent-map-entity/common/src/main/java/org/terracotta/entity/map/common/GetOperation.java
+++ b/concurrent-map-entity/common/src/main/java/org/terracotta/entity/map/common/GetOperation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/concurrent-map-entity/common/src/main/java/org/terracotta/entity/map/common/KeySetOperation.java
+++ b/concurrent-map-entity/common/src/main/java/org/terracotta/entity/map/common/KeySetOperation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/concurrent-map-entity/common/src/main/java/org/terracotta/entity/map/common/KeySetResponse.java
+++ b/concurrent-map-entity/common/src/main/java/org/terracotta/entity/map/common/KeySetResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/concurrent-map-entity/common/src/main/java/org/terracotta/entity/map/common/MapOperation.java
+++ b/concurrent-map-entity/common/src/main/java/org/terracotta/entity/map/common/MapOperation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/concurrent-map-entity/common/src/main/java/org/terracotta/entity/map/common/MapResponse.java
+++ b/concurrent-map-entity/common/src/main/java/org/terracotta/entity/map/common/MapResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/concurrent-map-entity/common/src/main/java/org/terracotta/entity/map/common/MapValueResponse.java
+++ b/concurrent-map-entity/common/src/main/java/org/terracotta/entity/map/common/MapValueResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/concurrent-map-entity/common/src/main/java/org/terracotta/entity/map/common/NullResponse.java
+++ b/concurrent-map-entity/common/src/main/java/org/terracotta/entity/map/common/NullResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/concurrent-map-entity/common/src/main/java/org/terracotta/entity/map/common/OperationCodec.java
+++ b/concurrent-map-entity/common/src/main/java/org/terracotta/entity/map/common/OperationCodec.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/concurrent-map-entity/common/src/main/java/org/terracotta/entity/map/common/PrimitiveCodec.java
+++ b/concurrent-map-entity/common/src/main/java/org/terracotta/entity/map/common/PrimitiveCodec.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/concurrent-map-entity/common/src/main/java/org/terracotta/entity/map/common/PutAllOperation.java
+++ b/concurrent-map-entity/common/src/main/java/org/terracotta/entity/map/common/PutAllOperation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/concurrent-map-entity/common/src/main/java/org/terracotta/entity/map/common/PutIfAbsentOperation.java
+++ b/concurrent-map-entity/common/src/main/java/org/terracotta/entity/map/common/PutIfAbsentOperation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/concurrent-map-entity/common/src/main/java/org/terracotta/entity/map/common/PutIfPresentOperation.java
+++ b/concurrent-map-entity/common/src/main/java/org/terracotta/entity/map/common/PutIfPresentOperation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/concurrent-map-entity/common/src/main/java/org/terracotta/entity/map/common/PutOperation.java
+++ b/concurrent-map-entity/common/src/main/java/org/terracotta/entity/map/common/PutOperation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/concurrent-map-entity/common/src/main/java/org/terracotta/entity/map/common/RemoveOperation.java
+++ b/concurrent-map-entity/common/src/main/java/org/terracotta/entity/map/common/RemoveOperation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/concurrent-map-entity/common/src/main/java/org/terracotta/entity/map/common/ResponseCodec.java
+++ b/concurrent-map-entity/common/src/main/java/org/terracotta/entity/map/common/ResponseCodec.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/concurrent-map-entity/common/src/main/java/org/terracotta/entity/map/common/SizeOperation.java
+++ b/concurrent-map-entity/common/src/main/java/org/terracotta/entity/map/common/SizeOperation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/concurrent-map-entity/common/src/main/java/org/terracotta/entity/map/common/SizeResponse.java
+++ b/concurrent-map-entity/common/src/main/java/org/terracotta/entity/map/common/SizeResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/concurrent-map-entity/common/src/main/java/org/terracotta/entity/map/common/ValueCollectionResponse.java
+++ b/concurrent-map-entity/common/src/main/java/org/terracotta/entity/map/common/ValueCollectionResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/concurrent-map-entity/common/src/main/java/org/terracotta/entity/map/common/ValueWrapper.java
+++ b/concurrent-map-entity/common/src/main/java/org/terracotta/entity/map/common/ValueWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/concurrent-map-entity/common/src/main/java/org/terracotta/entity/map/common/ValuesOperation.java
+++ b/concurrent-map-entity/common/src/main/java/org/terracotta/entity/map/common/ValuesOperation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/concurrent-map-entity/integration-tests/src/test/java/ClusteredConcurrentMapPassthroughTest.java
+++ b/concurrent-map-entity/integration-tests/src/test/java/ClusteredConcurrentMapPassthroughTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/concurrent-map-entity/server/src/main/java/org/terracotta/entity/map/server/ActiveTerracottaClusteredMap.java
+++ b/concurrent-map-entity/server/src/main/java/org/terracotta/entity/map/server/ActiveTerracottaClusteredMap.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/concurrent-map-entity/server/src/main/java/org/terracotta/entity/map/server/ClusteredMapSyncCodec.java
+++ b/concurrent-map-entity/server/src/main/java/org/terracotta/entity/map/server/ClusteredMapSyncCodec.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/concurrent-map-entity/server/src/main/java/org/terracotta/entity/map/server/PassiveTerracottaClusteredMap.java
+++ b/concurrent-map-entity/server/src/main/java/org/terracotta/entity/map/server/PassiveTerracottaClusteredMap.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/concurrent-map-entity/server/src/main/java/org/terracotta/entity/map/server/SyncOperation.java
+++ b/concurrent-map-entity/server/src/main/java/org/terracotta/entity/map/server/SyncOperation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/concurrent-map-entity/server/src/main/java/org/terracotta/entity/map/server/TerracottaClusteredMapService.java
+++ b/concurrent-map-entity/server/src/main/java/org/terracotta/entity/map/server/TerracottaClusteredMapService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/healthchecker-entity/api/src/main/java/org/terracotta/healthchecker/HealthCheck.java
+++ b/healthchecker-entity/api/src/main/java/org/terracotta/healthchecker/HealthCheck.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/healthchecker-entity/api/src/main/java/org/terracotta/healthchecker/HealthCheckerFactory.java
+++ b/healthchecker-entity/api/src/main/java/org/terracotta/healthchecker/HealthCheckerFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/healthchecker-entity/api/src/main/java/org/terracotta/healthchecker/TimeoutListener.java
+++ b/healthchecker-entity/api/src/main/java/org/terracotta/healthchecker/TimeoutListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/healthchecker-entity/api/src/main/java/org/terracotta/healthchecker/TimeoutManager.java
+++ b/healthchecker-entity/api/src/main/java/org/terracotta/healthchecker/TimeoutManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/healthchecker-entity/api/src/test/java/org/terracotta/healthchecker/HealthCheckerFactoryTest.java
+++ b/healthchecker-entity/api/src/test/java/org/terracotta/healthchecker/HealthCheckerFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/healthchecker-entity/client-impl/src/main/java/org/terracotta/healthchecker/HealthCheckClientService.java
+++ b/healthchecker-entity/client-impl/src/main/java/org/terracotta/healthchecker/HealthCheckClientService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/healthchecker-entity/client-impl/src/main/java/org/terracotta/healthchecker/HealthCheckerClient.java
+++ b/healthchecker-entity/client-impl/src/main/java/org/terracotta/healthchecker/HealthCheckerClient.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/healthchecker-entity/common/src/main/java/org/terracotta/healthchecker/HealthCheckReq.java
+++ b/healthchecker-entity/common/src/main/java/org/terracotta/healthchecker/HealthCheckReq.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/healthchecker-entity/common/src/main/java/org/terracotta/healthchecker/HealthCheckRsp.java
+++ b/healthchecker-entity/common/src/main/java/org/terracotta/healthchecker/HealthCheckRsp.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/healthchecker-entity/common/src/main/java/org/terracotta/healthchecker/HealthCheckerCodec.java
+++ b/healthchecker-entity/common/src/main/java/org/terracotta/healthchecker/HealthCheckerCodec.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/healthchecker-entity/server-impl/src/main/java/org/terracotta/healthchecker/HealthCheckServerEntityService.java
+++ b/healthchecker-entity/server-impl/src/main/java/org/terracotta/healthchecker/HealthCheckServerEntityService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/healthchecker-entity/server-impl/src/main/java/org/terracotta/healthchecker/HealthCheckerServer.java
+++ b/healthchecker-entity/server-impl/src/main/java/org/terracotta/healthchecker/HealthCheckerServer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/cluster-messaging/src/main/java/org/terracotta/management/model/message/DefaultMessage.java
+++ b/management/cluster-messaging/src/main/java/org/terracotta/management/model/message/DefaultMessage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/cluster-messaging/src/main/java/org/terracotta/management/model/message/Message.java
+++ b/management/cluster-messaging/src/main/java/org/terracotta/management/model/message/Message.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/cluster-topology/src/main/java/org/terracotta/management/model/cluster/AbstractNode.java
+++ b/management/cluster-topology/src/main/java/org/terracotta/management/model/cluster/AbstractNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/cluster-topology/src/main/java/org/terracotta/management/model/cluster/Client.java
+++ b/management/cluster-topology/src/main/java/org/terracotta/management/model/cluster/Client.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/cluster-topology/src/main/java/org/terracotta/management/model/cluster/Cluster.java
+++ b/management/cluster-topology/src/main/java/org/terracotta/management/model/cluster/Cluster.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/cluster-topology/src/main/java/org/terracotta/management/model/cluster/Connection.java
+++ b/management/cluster-topology/src/main/java/org/terracotta/management/model/cluster/Connection.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/cluster-topology/src/main/java/org/terracotta/management/model/cluster/Contextual.java
+++ b/management/cluster-topology/src/main/java/org/terracotta/management/model/cluster/Contextual.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/cluster-topology/src/main/java/org/terracotta/management/model/cluster/Endpoint.java
+++ b/management/cluster-topology/src/main/java/org/terracotta/management/model/cluster/Endpoint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/cluster-topology/src/main/java/org/terracotta/management/model/cluster/ManagementRegistry.java
+++ b/management/cluster-topology/src/main/java/org/terracotta/management/model/cluster/ManagementRegistry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/cluster-topology/src/main/java/org/terracotta/management/model/cluster/Node.java
+++ b/management/cluster-topology/src/main/java/org/terracotta/management/model/cluster/Node.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/cluster-topology/src/main/java/org/terracotta/management/model/cluster/Server.java
+++ b/management/cluster-topology/src/main/java/org/terracotta/management/model/cluster/Server.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/cluster-topology/src/main/java/org/terracotta/management/model/cluster/ServerEntity.java
+++ b/management/cluster-topology/src/main/java/org/terracotta/management/model/cluster/ServerEntity.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/cluster-topology/src/main/java/org/terracotta/management/model/cluster/ServerState.java
+++ b/management/cluster-topology/src/main/java/org/terracotta/management/model/cluster/ServerState.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/cluster-topology/src/main/java/org/terracotta/management/model/cluster/Stripe.java
+++ b/management/cluster-topology/src/main/java/org/terracotta/management/model/cluster/Stripe.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/cluster-topology/src/test/java/org/terracotta/management/model/cluster/AbstractTest.java
+++ b/management/cluster-topology/src/test/java/org/terracotta/management/model/cluster/AbstractTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/cluster-topology/src/test/java/org/terracotta/management/model/cluster/ClusterTest.java
+++ b/management/cluster-topology/src/test/java/org/terracotta/management/model/cluster/ClusterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/management-api/src/main/java/org/terracotta/voltron/management/ManagementService.java
+++ b/management/management-api/src/main/java/org/terracotta/voltron/management/ManagementService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/management-api/src/main/java/org/terracotta/voltron/management/MessageDeliveryInfrastructureService.java
+++ b/management/management-api/src/main/java/org/terracotta/voltron/management/MessageDeliveryInfrastructureService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/management-api/src/main/java/org/terracotta/voltron/management/RegistryService.java
+++ b/management/management-api/src/main/java/org/terracotta/voltron/management/RegistryService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/management-api/src/main/java/org/terracotta/voltron/management/common/providers/ActionProvider.java
+++ b/management/management-api/src/main/java/org/terracotta/voltron/management/common/providers/ActionProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/management-api/src/main/java/org/terracotta/voltron/management/common/providers/ManagementProvider.java
+++ b/management/management-api/src/main/java/org/terracotta/voltron/management/common/providers/ManagementProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/management-api/src/main/java/org/terracotta/voltron/management/common/providers/StatisticsProvider.java
+++ b/management/management-api/src/main/java/org/terracotta/voltron/management/common/providers/StatisticsProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/management-api/src/main/java/org/terracotta/voltron/management/consumer/CapabilityConsumer.java
+++ b/management/management-api/src/main/java/org/terracotta/voltron/management/consumer/CapabilityConsumer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/management-api/src/main/java/org/terracotta/voltron/management/consumer/MessageConsumer.java
+++ b/management/management-api/src/main/java/org/terracotta/voltron/management/consumer/MessageConsumer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/management-api/src/main/java/org/terracotta/voltron/management/consumer/MessageConsumerListener.java
+++ b/management/management-api/src/main/java/org/terracotta/voltron/management/consumer/MessageConsumerListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/management-api/src/main/java/org/terracotta/voltron/management/consumer/MessageListener.java
+++ b/management/management-api/src/main/java/org/terracotta/voltron/management/consumer/MessageListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/management-api/src/main/java/org/terracotta/voltron/management/consumer/PreviousMessageAckPendingException.java
+++ b/management/management-api/src/main/java/org/terracotta/voltron/management/consumer/PreviousMessageAckPendingException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/management-api/src/main/java/org/terracotta/voltron/management/consumer/ProviderConsumer.java
+++ b/management/management-api/src/main/java/org/terracotta/voltron/management/consumer/ProviderConsumer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/management-api/src/main/java/org/terracotta/voltron/management/producer/MessageProducer.java
+++ b/management/management-api/src/main/java/org/terracotta/voltron/management/producer/MessageProducer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/management-api/src/main/java/org/terracotta/voltron/management/producer/RegistryProducer.java
+++ b/management/management-api/src/main/java/org/terracotta/voltron/management/producer/RegistryProducer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/management-api/src/main/java/org/terracotta/voltron/management/producer/registry/ManagedEntityRegistry.java
+++ b/management/management-api/src/main/java/org/terracotta/voltron/management/producer/registry/ManagedEntityRegistry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/management-api/src/main/java/org/terracotta/voltron/management/producer/registry/ManagedObjectRegistry.java
+++ b/management/management-api/src/main/java/org/terracotta/voltron/management/producer/registry/ManagedObjectRegistry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/management-entity/management-entity-client/src/main/java/org/terracotta/management/entity/client/ManagementAgentEntity.java
+++ b/management/management-entity/management-entity-client/src/main/java/org/terracotta/management/entity/client/ManagementAgentEntity.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/management-entity/management-entity-client/src/main/java/org/terracotta/management/entity/client/ManagementAgentEntityClientService.java
+++ b/management/management-entity/management-entity-client/src/main/java/org/terracotta/management/entity/client/ManagementAgentEntityClientService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/management-entity/management-entity-client/src/main/java/org/terracotta/management/entity/client/ManagementAgentEntityFactory.java
+++ b/management/management-entity/management-entity-client/src/main/java/org/terracotta/management/entity/client/ManagementAgentEntityFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/management-entity/management-entity-client/src/main/java/org/terracotta/management/entity/client/ManagementAgentService.java
+++ b/management/management-entity/management-entity-client/src/main/java/org/terracotta/management/entity/client/ManagementAgentService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/management-entity/management-entity-common/src/main/java/org/terracotta/management/entity/ManagementAgent.java
+++ b/management/management-entity/management-entity-common/src/main/java/org/terracotta/management/entity/ManagementAgent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/management-entity/management-entity-common/src/main/java/org/terracotta/management/entity/ManagementAgentConfig.java
+++ b/management/management-entity/management-entity-common/src/main/java/org/terracotta/management/entity/ManagementAgentConfig.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/management-entity/management-entity-common/src/main/java/org/terracotta/management/entity/Version.java
+++ b/management/management-entity/management-entity-common/src/main/java/org/terracotta/management/entity/Version.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/management-entity/management-entity-server/src/main/java/org/terracotta/management/entity/server/ManagementAgentEntityServerService.java
+++ b/management/management-entity/management-entity-server/src/main/java/org/terracotta/management/entity/server/ManagementAgentEntityServerService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/management-entity/management-entity-server/src/main/java/org/terracotta/management/entity/server/ManagementAgentImpl.java
+++ b/management/management-entity/management-entity-server/src/main/java/org/terracotta/management/entity/server/ManagementAgentImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/management-entity/management-entity-server/src/main/java/org/terracotta/management/entity/server/ManagementAgentServerEntity.java
+++ b/management/management-entity/management-entity-server/src/main/java/org/terracotta/management/entity/server/ManagementAgentServerEntity.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/management-entity/management-entity-server/src/main/java/org/terracotta/management/entity/server/Utils.java
+++ b/management/management-entity/management-entity-server/src/main/java/org/terracotta/management/entity/server/Utils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/management-entity/management-entity-tests/src/test/java/org/terracotta/management/entity/ManagementAgentServiceTest.java
+++ b/management/management-entity/management-entity-tests/src/test/java/org/terracotta/management/entity/ManagementAgentServiceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/management-entity/management-entity-tests/src/test/java/org/terracotta/management/entity/MyManagementProvider.java
+++ b/management/management-entity/management-entity-tests/src/test/java/org/terracotta/management/entity/MyManagementProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/management-entity/management-entity-tests/src/test/java/org/terracotta/management/entity/MyObject.java
+++ b/management/management-entity/management-entity-tests/src/test/java/org/terracotta/management/entity/MyObject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/management-model/src/main/java/org/terracotta/management/model/Objects.java
+++ b/management/management-model/src/main/java/org/terracotta/management/model/Objects.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/management-model/src/main/java/org/terracotta/management/model/call/ContextualReturn.java
+++ b/management/management-model/src/main/java/org/terracotta/management/model/call/ContextualReturn.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/management-model/src/main/java/org/terracotta/management/model/call/Parameter.java
+++ b/management/management-model/src/main/java/org/terracotta/management/model/call/Parameter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/management-model/src/main/java/org/terracotta/management/model/capabilities/Capability.java
+++ b/management/management-model/src/main/java/org/terracotta/management/model/capabilities/Capability.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/management-model/src/main/java/org/terracotta/management/model/capabilities/DefaultCapability.java
+++ b/management/management-model/src/main/java/org/terracotta/management/model/capabilities/DefaultCapability.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/management-model/src/main/java/org/terracotta/management/model/capabilities/StatisticsCapability.java
+++ b/management/management-model/src/main/java/org/terracotta/management/model/capabilities/StatisticsCapability.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/management-model/src/main/java/org/terracotta/management/model/capabilities/context/CapabilityContext.java
+++ b/management/management-model/src/main/java/org/terracotta/management/model/capabilities/context/CapabilityContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/management-model/src/main/java/org/terracotta/management/model/capabilities/descriptors/CallDescriptor.java
+++ b/management/management-model/src/main/java/org/terracotta/management/model/capabilities/descriptors/CallDescriptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/management-model/src/main/java/org/terracotta/management/model/capabilities/descriptors/Descriptor.java
+++ b/management/management-model/src/main/java/org/terracotta/management/model/capabilities/descriptors/Descriptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/management-model/src/main/java/org/terracotta/management/model/capabilities/descriptors/Settings.java
+++ b/management/management-model/src/main/java/org/terracotta/management/model/capabilities/descriptors/Settings.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/management-model/src/main/java/org/terracotta/management/model/capabilities/descriptors/StatisticDescriptor.java
+++ b/management/management-model/src/main/java/org/terracotta/management/model/capabilities/descriptors/StatisticDescriptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/management-model/src/main/java/org/terracotta/management/model/capabilities/descriptors/StatisticDescriptorCategory.java
+++ b/management/management-model/src/main/java/org/terracotta/management/model/capabilities/descriptors/StatisticDescriptorCategory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/management-model/src/main/java/org/terracotta/management/model/cluster/ClientIdentifier.java
+++ b/management/management-model/src/main/java/org/terracotta/management/model/cluster/ClientIdentifier.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/management-model/src/main/java/org/terracotta/management/model/context/Context.java
+++ b/management/management-model/src/main/java/org/terracotta/management/model/context/Context.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/management-model/src/main/java/org/terracotta/management/model/context/ContextContainer.java
+++ b/management/management-model/src/main/java/org/terracotta/management/model/context/ContextContainer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/management-model/src/main/java/org/terracotta/management/model/notification/ContextualNotification.java
+++ b/management/management-model/src/main/java/org/terracotta/management/model/notification/ContextualNotification.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/management-model/src/main/java/org/terracotta/management/model/stats/AbstractStatistic.java
+++ b/management/management-model/src/main/java/org/terracotta/management/model/stats/AbstractStatistic.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/management-model/src/main/java/org/terracotta/management/model/stats/AbstractStatisticHistory.java
+++ b/management/management-model/src/main/java/org/terracotta/management/model/stats/AbstractStatisticHistory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/management-model/src/main/java/org/terracotta/management/model/stats/ContextualStatistics.java
+++ b/management/management-model/src/main/java/org/terracotta/management/model/stats/ContextualStatistics.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/management-model/src/main/java/org/terracotta/management/model/stats/MemoryUnit.java
+++ b/management/management-model/src/main/java/org/terracotta/management/model/stats/MemoryUnit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/management-model/src/main/java/org/terracotta/management/model/stats/NumberUnit.java
+++ b/management/management-model/src/main/java/org/terracotta/management/model/stats/NumberUnit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/management-model/src/main/java/org/terracotta/management/model/stats/Sample.java
+++ b/management/management-model/src/main/java/org/terracotta/management/model/stats/Sample.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/management-model/src/main/java/org/terracotta/management/model/stats/Statistic.java
+++ b/management/management-model/src/main/java/org/terracotta/management/model/stats/Statistic.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/management-model/src/main/java/org/terracotta/management/model/stats/StatisticHistory.java
+++ b/management/management-model/src/main/java/org/terracotta/management/model/stats/StatisticHistory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/management-model/src/main/java/org/terracotta/management/model/stats/StatisticType.java
+++ b/management/management-model/src/main/java/org/terracotta/management/model/stats/StatisticType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/management-model/src/main/java/org/terracotta/management/model/stats/history/AverageHistory.java
+++ b/management/management-model/src/main/java/org/terracotta/management/model/stats/history/AverageHistory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/management-model/src/main/java/org/terracotta/management/model/stats/history/CounterHistory.java
+++ b/management/management-model/src/main/java/org/terracotta/management/model/stats/history/CounterHistory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/management-model/src/main/java/org/terracotta/management/model/stats/history/DurationHistory.java
+++ b/management/management-model/src/main/java/org/terracotta/management/model/stats/history/DurationHistory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/management-model/src/main/java/org/terracotta/management/model/stats/history/RateHistory.java
+++ b/management/management-model/src/main/java/org/terracotta/management/model/stats/history/RateHistory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/management-model/src/main/java/org/terracotta/management/model/stats/history/RatioHistory.java
+++ b/management/management-model/src/main/java/org/terracotta/management/model/stats/history/RatioHistory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/management-model/src/main/java/org/terracotta/management/model/stats/history/SizeHistory.java
+++ b/management/management-model/src/main/java/org/terracotta/management/model/stats/history/SizeHistory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/management-model/src/main/java/org/terracotta/management/model/stats/primitive/Average.java
+++ b/management/management-model/src/main/java/org/terracotta/management/model/stats/primitive/Average.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/management-model/src/main/java/org/terracotta/management/model/stats/primitive/Counter.java
+++ b/management/management-model/src/main/java/org/terracotta/management/model/stats/primitive/Counter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/management-model/src/main/java/org/terracotta/management/model/stats/primitive/Duration.java
+++ b/management/management-model/src/main/java/org/terracotta/management/model/stats/primitive/Duration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/management-model/src/main/java/org/terracotta/management/model/stats/primitive/Rate.java
+++ b/management/management-model/src/main/java/org/terracotta/management/model/stats/primitive/Rate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/management-model/src/main/java/org/terracotta/management/model/stats/primitive/Ratio.java
+++ b/management/management-model/src/main/java/org/terracotta/management/model/stats/primitive/Ratio.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/management-model/src/main/java/org/terracotta/management/model/stats/primitive/Size.java
+++ b/management/management-model/src/main/java/org/terracotta/management/model/stats/primitive/Size.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/management-model/src/test/java/org/terracotta/management/model/cluster/ClientIdentifierTest.java
+++ b/management/management-model/src/test/java/org/terracotta/management/model/cluster/ClientIdentifierTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/management-model/src/test/java/org/terracotta/management/model/cluster/SerializationTest.java
+++ b/management/management-model/src/test/java/org/terracotta/management/model/cluster/SerializationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/management-registry/src/main/java/org/terracotta/management/registry/AbstractManagementProvider.java
+++ b/management/management-registry/src/main/java/org/terracotta/management/registry/AbstractManagementProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/management-registry/src/main/java/org/terracotta/management/registry/AbstractManagementRegistry.java
+++ b/management/management-registry/src/main/java/org/terracotta/management/registry/AbstractManagementRegistry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/management-registry/src/main/java/org/terracotta/management/registry/CallQuery.java
+++ b/management/management-registry/src/main/java/org/terracotta/management/registry/CallQuery.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/management-registry/src/main/java/org/terracotta/management/registry/CapabilityManagement.java
+++ b/management/management-registry/src/main/java/org/terracotta/management/registry/CapabilityManagement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/management-registry/src/main/java/org/terracotta/management/registry/CapabilityManagementSupport.java
+++ b/management/management-registry/src/main/java/org/terracotta/management/registry/CapabilityManagementSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/management-registry/src/main/java/org/terracotta/management/registry/DefaultCallQuery.java
+++ b/management/management-registry/src/main/java/org/terracotta/management/registry/DefaultCallQuery.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/management-registry/src/main/java/org/terracotta/management/registry/DefaultCallQueryBuilder.java
+++ b/management/management-registry/src/main/java/org/terracotta/management/registry/DefaultCallQueryBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/management-registry/src/main/java/org/terracotta/management/registry/DefaultCapabilityManagement.java
+++ b/management/management-registry/src/main/java/org/terracotta/management/registry/DefaultCapabilityManagement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/management-registry/src/main/java/org/terracotta/management/registry/DefaultResultSet.java
+++ b/management/management-registry/src/main/java/org/terracotta/management/registry/DefaultResultSet.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/management-registry/src/main/java/org/terracotta/management/registry/DefaultStatisticQuery.java
+++ b/management/management-registry/src/main/java/org/terracotta/management/registry/DefaultStatisticQuery.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/management-registry/src/main/java/org/terracotta/management/registry/DefaultStatisticQueryBuilder.java
+++ b/management/management-registry/src/main/java/org/terracotta/management/registry/DefaultStatisticQueryBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/management-registry/src/main/java/org/terracotta/management/registry/ManagementProvider.java
+++ b/management/management-registry/src/main/java/org/terracotta/management/registry/ManagementProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/management-registry/src/main/java/org/terracotta/management/registry/ManagementRegistry.java
+++ b/management/management-registry/src/main/java/org/terracotta/management/registry/ManagementRegistry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/management-registry/src/main/java/org/terracotta/management/registry/Query.java
+++ b/management/management-registry/src/main/java/org/terracotta/management/registry/Query.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/management-registry/src/main/java/org/terracotta/management/registry/QueryBuilder.java
+++ b/management/management-registry/src/main/java/org/terracotta/management/registry/QueryBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/management-registry/src/main/java/org/terracotta/management/registry/ResultSet.java
+++ b/management/management-registry/src/main/java/org/terracotta/management/registry/ResultSet.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/management-registry/src/main/java/org/terracotta/management/registry/StatisticQuery.java
+++ b/management/management-registry/src/main/java/org/terracotta/management/registry/StatisticQuery.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/management-registry/src/main/java/org/terracotta/management/registry/action/AbstractActionManagementProvider.java
+++ b/management/management-registry/src/main/java/org/terracotta/management/registry/action/AbstractActionManagementProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/management-registry/src/main/java/org/terracotta/management/registry/action/Exposed.java
+++ b/management/management-registry/src/main/java/org/terracotta/management/registry/action/Exposed.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/management-registry/src/main/java/org/terracotta/management/registry/action/ExposedObject.java
+++ b/management/management-registry/src/main/java/org/terracotta/management/registry/action/ExposedObject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/management-registry/src/main/java/org/terracotta/management/registry/action/Named.java
+++ b/management/management-registry/src/main/java/org/terracotta/management/registry/action/Named.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/management-registry/src/main/java/org/terracotta/management/registry/action/RequiredContext.java
+++ b/management/management-registry/src/main/java/org/terracotta/management/registry/action/RequiredContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/management-registry/src/main/java/org/terracotta/management/registry/collect/StatisticCollector.java
+++ b/management/management-registry/src/main/java/org/terracotta/management/registry/collect/StatisticCollector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/management-registry/src/main/java/org/terracotta/management/registry/collect/StatisticCollectorProvider.java
+++ b/management/management-registry/src/main/java/org/terracotta/management/registry/collect/StatisticCollectorProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/management-registry/src/test/java/org/terracotta/management/provider/action/ActionProviderTest.java
+++ b/management/management-registry/src/test/java/org/terracotta/management/provider/action/ActionProviderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/management-registry/src/test/java/org/terracotta/management/provider/action/MyManagementProvider.java
+++ b/management/management-registry/src/test/java/org/terracotta/management/provider/action/MyManagementProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/management-registry/src/test/java/org/terracotta/management/provider/action/MyObject.java
+++ b/management/management-registry/src/test/java/org/terracotta/management/provider/action/MyObject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/management-registry/src/test/java/org/terracotta/management/registry/ManagementRegistryTest.java
+++ b/management/management-registry/src/test/java/org/terracotta/management/registry/ManagementRegistryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/management-service/src/main/java/org/terracotta/management/service/ManagementServiceConfiguration.java
+++ b/management/management-service/src/main/java/org/terracotta/management/service/ManagementServiceConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/management-service/src/main/java/org/terracotta/management/service/ManagementServiceProvider.java
+++ b/management/management-service/src/main/java/org/terracotta/management/service/ManagementServiceProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/management-service/src/main/java/org/terracotta/management/service/ManagementServiceProviderConfigParser.java
+++ b/management/management-service/src/main/java/org/terracotta/management/service/ManagementServiceProviderConfigParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/management-service/src/main/java/org/terracotta/management/service/ManagementServiceProviderConfiguration.java
+++ b/management/management-service/src/main/java/org/terracotta/management/service/ManagementServiceProviderConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/management-service/src/main/java/org/terracotta/management/service/buffer/PartitionedRingBuffer.java
+++ b/management/management-service/src/main/java/org/terracotta/management/service/buffer/PartitionedRingBuffer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/management-service/src/main/java/org/terracotta/management/service/buffer/impl/MultiPartitionLockFreeRingBuffer.java
+++ b/management/management-service/src/main/java/org/terracotta/management/service/buffer/impl/MultiPartitionLockFreeRingBuffer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/management-service/src/main/java/org/terracotta/management/service/buffer/impl/SinglePartitionLockFreeRingBuffer.java
+++ b/management/management-service/src/main/java/org/terracotta/management/service/buffer/impl/SinglePartitionLockFreeRingBuffer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/management-service/src/main/java/org/terracotta/management/service/buffer/impl/SinglePartitionSafeRingBuffer.java
+++ b/management/management-service/src/main/java/org/terracotta/management/service/buffer/impl/SinglePartitionSafeRingBuffer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/management-service/src/main/java/org/terracotta/management/service/impl/Constants.java
+++ b/management/management-service/src/main/java/org/terracotta/management/service/impl/Constants.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/management-service/src/main/java/org/terracotta/management/service/impl/DefaultManagementService.java
+++ b/management/management-service/src/main/java/org/terracotta/management/service/impl/DefaultManagementService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/management-service/src/main/java/org/terracotta/management/service/impl/DefaultMessageConsumer.java
+++ b/management/management-service/src/main/java/org/terracotta/management/service/impl/DefaultMessageConsumer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/management-service/src/main/java/org/terracotta/management/service/impl/DefaultMessageDeliveryInfrastructure.java
+++ b/management/management-service/src/main/java/org/terracotta/management/service/impl/DefaultMessageDeliveryInfrastructure.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/management-service/src/main/java/org/terracotta/management/service/impl/DefaultMessageProducer.java
+++ b/management/management-service/src/main/java/org/terracotta/management/service/impl/DefaultMessageProducer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/management-service/src/test/java/org/terracotta/management/service/TestConstants.java
+++ b/management/management-service/src/test/java/org/terracotta/management/service/TestConstants.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/management-service/src/test/java/org/terracotta/management/service/TestMessageCallback.java
+++ b/management/management-service/src/test/java/org/terracotta/management/service/TestMessageCallback.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/management-service/src/test/java/org/terracotta/management/service/buffer/BaseBufferTest.java
+++ b/management/management-service/src/test/java/org/terracotta/management/service/buffer/BaseBufferTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/management-service/src/test/java/org/terracotta/management/service/buffer/BaseByteArrayBufferTest.java
+++ b/management/management-service/src/test/java/org/terracotta/management/service/buffer/BaseByteArrayBufferTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/management-service/src/test/java/org/terracotta/management/service/buffer/BaseStatisticsBufferTest.java
+++ b/management/management-service/src/test/java/org/terracotta/management/service/buffer/BaseStatisticsBufferTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/management-service/src/test/java/org/terracotta/management/service/buffer/ProducerOrConsumerSimulator.java
+++ b/management/management-service/src/test/java/org/terracotta/management/service/buffer/ProducerOrConsumerSimulator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/management-service/src/test/java/org/terracotta/management/service/buffer/impl/ByteArrayLocklessBufferTest.java
+++ b/management/management-service/src/test/java/org/terracotta/management/service/buffer/impl/ByteArrayLocklessBufferTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/management-service/src/test/java/org/terracotta/management/service/buffer/impl/ByteArrayPooledRingBufferTest.java
+++ b/management/management-service/src/test/java/org/terracotta/management/service/buffer/impl/ByteArrayPooledRingBufferTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/management-service/src/test/java/org/terracotta/management/service/buffer/impl/ByteArraySafeBufferTest.java
+++ b/management/management-service/src/test/java/org/terracotta/management/service/buffer/impl/ByteArraySafeBufferTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/management-service/src/test/java/org/terracotta/management/service/buffer/impl/StatisticsLocklessBufferTest.java
+++ b/management/management-service/src/test/java/org/terracotta/management/service/buffer/impl/StatisticsLocklessBufferTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/management-service/src/test/java/org/terracotta/management/service/buffer/impl/StatisticsPooledRingBufferTest.java
+++ b/management/management-service/src/test/java/org/terracotta/management/service/buffer/impl/StatisticsPooledRingBufferTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/management-service/src/test/java/org/terracotta/management/service/buffer/impl/StatisticsSafeBufferTest.java
+++ b/management/management-service/src/test/java/org/terracotta/management/service/buffer/impl/StatisticsSafeBufferTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/management-service/src/test/java/org/terracotta/management/service/impl/DefaultManagementServiceConsumerTest.java
+++ b/management/management-service/src/test/java/org/terracotta/management/service/impl/DefaultManagementServiceConsumerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/management-service/src/test/java/org/terracotta/management/service/impl/DefaultManagementServiceProducerTest.java
+++ b/management/management-service/src/test/java/org/terracotta/management/service/impl/DefaultManagementServiceProducerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/management-service/src/test/java/org/terracotta/management/service/impl/DefaultManagementServiceTest.java
+++ b/management/management-service/src/test/java/org/terracotta/management/service/impl/DefaultManagementServiceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/monitoring-service/src/main/java/org/terracotta/management/service/monitoring/BoundedEvictingPriorityQueue.java
+++ b/management/monitoring-service/src/main/java/org/terracotta/management/service/monitoring/BoundedEvictingPriorityQueue.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/monitoring-service/src/main/java/org/terracotta/management/service/monitoring/BoundedPriorityQueue.java
+++ b/management/monitoring-service/src/main/java/org/terracotta/management/service/monitoring/BoundedPriorityQueue.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/monitoring-service/src/main/java/org/terracotta/management/service/monitoring/IMonitoringConsumer.java
+++ b/management/monitoring-service/src/main/java/org/terracotta/management/service/monitoring/IMonitoringConsumer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/monitoring-service/src/main/java/org/terracotta/management/service/monitoring/MonitoringConfigParser.java
+++ b/management/monitoring-service/src/main/java/org/terracotta/management/service/monitoring/MonitoringConfigParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/monitoring-service/src/main/java/org/terracotta/management/service/monitoring/MonitoringConsumerConfiguration.java
+++ b/management/monitoring-service/src/main/java/org/terracotta/management/service/monitoring/MonitoringConsumerConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/monitoring-service/src/main/java/org/terracotta/management/service/monitoring/MonitoringService.java
+++ b/management/monitoring-service/src/main/java/org/terracotta/management/service/monitoring/MonitoringService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/monitoring-service/src/main/java/org/terracotta/management/service/monitoring/MonitoringServiceConfiguration.java
+++ b/management/monitoring-service/src/main/java/org/terracotta/management/service/monitoring/MonitoringServiceConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/monitoring-service/src/main/java/org/terracotta/management/service/monitoring/MonitoringServiceProvider.java
+++ b/management/monitoring-service/src/main/java/org/terracotta/management/service/monitoring/MonitoringServiceProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/monitoring-service/src/main/java/org/terracotta/management/service/monitoring/Mutation.java
+++ b/management/monitoring-service/src/main/java/org/terracotta/management/service/monitoring/Mutation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/monitoring-service/src/main/java/org/terracotta/management/service/monitoring/TreeMutation.java
+++ b/management/monitoring-service/src/main/java/org/terracotta/management/service/monitoring/TreeMutation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/monitoring-service/src/main/java/org/terracotta/management/service/monitoring/Utils.java
+++ b/management/monitoring-service/src/main/java/org/terracotta/management/service/monitoring/Utils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/monitoring-service/src/test/java/org/terracotta/management/service/monitoring/BoundedPriorityQueueTest.java
+++ b/management/monitoring-service/src/test/java/org/terracotta/management/service/monitoring/BoundedPriorityQueueTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/monitoring-service/src/test/java/org/terracotta/management/service/monitoring/MonitoringConfigParserTestTest.java
+++ b/management/monitoring-service/src/test/java/org/terracotta/management/service/monitoring/MonitoringConfigParserTestTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/monitoring-service/src/test/java/org/terracotta/management/service/monitoring/MonitoringServiceTest.java
+++ b/management/monitoring-service/src/test/java/org/terracotta/management/service/monitoring/MonitoringServiceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/samples/hello-world-entity/src/main/java/org/terracotta/management/entity/helloworld/HelloWorld.java
+++ b/management/samples/hello-world-entity/src/main/java/org/terracotta/management/entity/helloworld/HelloWorld.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/samples/hello-world-entity/src/main/java/org/terracotta/management/entity/helloworld/client/HelloWorldEntity.java
+++ b/management/samples/hello-world-entity/src/main/java/org/terracotta/management/entity/helloworld/client/HelloWorldEntity.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/samples/hello-world-entity/src/main/java/org/terracotta/management/entity/helloworld/client/HelloWorldEntityClientService.java
+++ b/management/samples/hello-world-entity/src/main/java/org/terracotta/management/entity/helloworld/client/HelloWorldEntityClientService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/samples/hello-world-entity/src/main/java/org/terracotta/management/entity/helloworld/client/HelloWorldEntityFactory.java
+++ b/management/samples/hello-world-entity/src/main/java/org/terracotta/management/entity/helloworld/client/HelloWorldEntityFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/samples/hello-world-entity/src/main/java/org/terracotta/management/entity/helloworld/client/management/ExposedHelloWorldEntity.java
+++ b/management/samples/hello-world-entity/src/main/java/org/terracotta/management/entity/helloworld/client/management/ExposedHelloWorldEntity.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/samples/hello-world-entity/src/main/java/org/terracotta/management/entity/helloworld/client/management/HelloWorldManagementProvider.java
+++ b/management/samples/hello-world-entity/src/main/java/org/terracotta/management/entity/helloworld/client/management/HelloWorldManagementProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/samples/hello-world-entity/src/main/java/org/terracotta/management/entity/helloworld/client/management/HelloWorldManagementRegistry.java
+++ b/management/samples/hello-world-entity/src/main/java/org/terracotta/management/entity/helloworld/client/management/HelloWorldManagementRegistry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/samples/hello-world-entity/src/main/java/org/terracotta/management/entity/helloworld/server/HelloWorldEntity.java
+++ b/management/samples/hello-world-entity/src/main/java/org/terracotta/management/entity/helloworld/server/HelloWorldEntity.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/samples/hello-world-entity/src/main/java/org/terracotta/management/entity/helloworld/server/HelloWorldEntityServerService.java
+++ b/management/samples/hello-world-entity/src/main/java/org/terracotta/management/entity/helloworld/server/HelloWorldEntityServerService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/samples/hello-world-entity/src/main/java/org/terracotta/management/entity/helloworld/server/HelloWorldImpl.java
+++ b/management/samples/hello-world-entity/src/main/java/org/terracotta/management/entity/helloworld/server/HelloWorldImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/samples/hello-world-entity/src/test/java/org/terracotta/management/entity/helloworld/HelloWorldTest.java
+++ b/management/samples/hello-world-entity/src/test/java/org/terracotta/management/entity/helloworld/HelloWorldTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/samples/monitoring-tree-consumer/src/main/java/org/terracotta/management/entity/monitoringconsumer/MonitoringConsumer.java
+++ b/management/samples/monitoring-tree-consumer/src/main/java/org/terracotta/management/entity/monitoringconsumer/MonitoringConsumer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/samples/monitoring-tree-consumer/src/main/java/org/terracotta/management/entity/monitoringconsumer/client/MonitoringConsumerEntity.java
+++ b/management/samples/monitoring-tree-consumer/src/main/java/org/terracotta/management/entity/monitoringconsumer/client/MonitoringConsumerEntity.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/samples/monitoring-tree-consumer/src/main/java/org/terracotta/management/entity/monitoringconsumer/client/MonitoringConsumerEntityClientService.java
+++ b/management/samples/monitoring-tree-consumer/src/main/java/org/terracotta/management/entity/monitoringconsumer/client/MonitoringConsumerEntityClientService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/samples/monitoring-tree-consumer/src/main/java/org/terracotta/management/entity/monitoringconsumer/client/MonitoringConsumerEntityFactory.java
+++ b/management/samples/monitoring-tree-consumer/src/main/java/org/terracotta/management/entity/monitoringconsumer/client/MonitoringConsumerEntityFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/samples/monitoring-tree-consumer/src/main/java/org/terracotta/management/entity/monitoringconsumer/server/MonitoringConsumerEntity.java
+++ b/management/samples/monitoring-tree-consumer/src/main/java/org/terracotta/management/entity/monitoringconsumer/server/MonitoringConsumerEntity.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/samples/monitoring-tree-consumer/src/main/java/org/terracotta/management/entity/monitoringconsumer/server/MonitoringConsumerEntityServerService.java
+++ b/management/samples/monitoring-tree-consumer/src/main/java/org/terracotta/management/entity/monitoringconsumer/server/MonitoringConsumerEntityServerService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/samples/monitoring-tree-consumer/src/main/java/org/terracotta/management/entity/monitoringconsumer/server/MonitoringConsumerImpl.java
+++ b/management/samples/monitoring-tree-consumer/src/main/java/org/terracotta/management/entity/monitoringconsumer/server/MonitoringConsumerImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/samples/monitoring-tree-consumer/src/test/java/org/terracotta/management/entity/monitoringconsumer/MonitoringConsumerTest.java
+++ b/management/samples/monitoring-tree-consumer/src/test/java/org/terracotta/management/entity/monitoringconsumer/MonitoringConsumerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/sequence-generator/src/main/java/org/terracotta/management/sequence/BoundaryFlakeSequence.java
+++ b/management/sequence-generator/src/main/java/org/terracotta/management/sequence/BoundaryFlakeSequence.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/sequence-generator/src/main/java/org/terracotta/management/sequence/BoundaryFlakeSequenceGenerator.java
+++ b/management/sequence-generator/src/main/java/org/terracotta/management/sequence/BoundaryFlakeSequenceGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/sequence-generator/src/main/java/org/terracotta/management/sequence/Defaults.java
+++ b/management/sequence-generator/src/main/java/org/terracotta/management/sequence/Defaults.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/sequence-generator/src/main/java/org/terracotta/management/sequence/IntCyclicRangeCounter.java
+++ b/management/sequence-generator/src/main/java/org/terracotta/management/sequence/IntCyclicRangeCounter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/sequence-generator/src/main/java/org/terracotta/management/sequence/NodeIdSource.java
+++ b/management/sequence-generator/src/main/java/org/terracotta/management/sequence/NodeIdSource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/sequence-generator/src/main/java/org/terracotta/management/sequence/Sequence.java
+++ b/management/sequence-generator/src/main/java/org/terracotta/management/sequence/Sequence.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/sequence-generator/src/main/java/org/terracotta/management/sequence/SequenceGenerator.java
+++ b/management/sequence-generator/src/main/java/org/terracotta/management/sequence/SequenceGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/sequence-generator/src/main/java/org/terracotta/management/sequence/TimeSource.java
+++ b/management/sequence-generator/src/main/java/org/terracotta/management/sequence/TimeSource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/sequence-generator/src/main/java/org/terracotta/management/sequence/perf/PerfTest.java
+++ b/management/sequence-generator/src/main/java/org/terracotta/management/sequence/perf/PerfTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/sequence-generator/src/test/java/org/terracotta/management/sequence/BoundaryFlakeSequenceGeneratorTest.java
+++ b/management/sequence-generator/src/test/java/org/terracotta/management/sequence/BoundaryFlakeSequenceGeneratorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/sequence-generator/src/test/java/org/terracotta/management/sequence/IntCyclicRangeCounterTest.java
+++ b/management/sequence-generator/src/test/java/org/terracotta/management/sequence/IntCyclicRangeCounterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/sequence-generator/src/test/java/org/terracotta/management/sequence/MyNodeIdSource.java
+++ b/management/sequence-generator/src/test/java/org/terracotta/management/sequence/MyNodeIdSource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/sequence-generator/src/test/java/org/terracotta/management/sequence/MyTimeSource.java
+++ b/management/sequence-generator/src/test/java/org/terracotta/management/sequence/MyTimeSource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/management/sequence-generator/src/test/java/org/terracotta/management/sequence/Runner.java
+++ b/management/sequence-generator/src/test/java/org/terracotta/management/sequence/Runner.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/offheap-resource/src/main/java/org/terracotta/offheapresource/OffHeapResource.java
+++ b/offheap-resource/src/main/java/org/terracotta/offheapresource/OffHeapResource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/offheap-resource/src/main/java/org/terracotta/offheapresource/OffHeapResourceConfigurationParser.java
+++ b/offheap-resource/src/main/java/org/terracotta/offheapresource/OffHeapResourceConfigurationParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/offheap-resource/src/main/java/org/terracotta/offheapresource/OffHeapResourceIdentifier.java
+++ b/offheap-resource/src/main/java/org/terracotta/offheapresource/OffHeapResourceIdentifier.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/offheap-resource/src/main/java/org/terracotta/offheapresource/OffHeapResourceImpl.java
+++ b/offheap-resource/src/main/java/org/terracotta/offheapresource/OffHeapResourceImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/offheap-resource/src/main/java/org/terracotta/offheapresource/OffHeapResources.java
+++ b/offheap-resource/src/main/java/org/terracotta/offheapresource/OffHeapResources.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/offheap-resource/src/main/java/org/terracotta/offheapresource/OffHeapResourcesConfiguration.java
+++ b/offheap-resource/src/main/java/org/terracotta/offheapresource/OffHeapResourcesConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/offheap-resource/src/main/java/org/terracotta/offheapresource/OffHeapResourcesProvider.java
+++ b/offheap-resource/src/main/java/org/terracotta/offheapresource/OffHeapResourcesProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/offheap-resource/src/main/java/org/terracotta/offheapresource/PhysicalMemory.java
+++ b/offheap-resource/src/main/java/org/terracotta/offheapresource/PhysicalMemory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/offheap-resource/src/test/java/org/terracotta/offheapresource/OffHeapResourceConfigurationParserTest.java
+++ b/offheap-resource/src/test/java/org/terracotta/offheapresource/OffHeapResourceConfigurationParserTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/offheap-resource/src/test/java/org/terracotta/offheapresource/OffHeapResourceIdentifierTest.java
+++ b/offheap-resource/src/test/java/org/terracotta/offheapresource/OffHeapResourceIdentifierTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/offheap-resource/src/test/java/org/terracotta/offheapresource/OffHeapResourceTest.java
+++ b/offheap-resource/src/test/java/org/terracotta/offheapresource/OffHeapResourceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/offheap-resource/src/test/java/org/terracotta/offheapresource/OffHeapResourcesProviderTest.java
+++ b/offheap-resource/src/test/java/org/terracotta/offheapresource/OffHeapResourcesProviderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/pom.xml
+++ b/pom.xml
@@ -167,6 +167,9 @@
           </keywords>
           <aggregate>true</aggregate>
           <header>header.txt</header>
+          <mapping>
+            <java>SLASHSTAR_STYLE</java>
+          </mapping>
           <excludes>
             <exclude>**/README</exclude>
             <exclude>src/test/resources/**</exclude>

--- a/proxy/src/main/java/org/terracotta/voltron/proxy/Async.java
+++ b/proxy/src/main/java/org/terracotta/voltron/proxy/Async.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/proxy/src/main/java/org/terracotta/voltron/proxy/ClientId.java
+++ b/proxy/src/main/java/org/terracotta/voltron/proxy/ClientId.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/proxy/src/main/java/org/terracotta/voltron/proxy/Codec.java
+++ b/proxy/src/main/java/org/terracotta/voltron/proxy/Codec.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/proxy/src/main/java/org/terracotta/voltron/proxy/CommonProxyFactory.java
+++ b/proxy/src/main/java/org/terracotta/voltron/proxy/CommonProxyFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/proxy/src/main/java/org/terracotta/voltron/proxy/MethodDescriptor.java
+++ b/proxy/src/main/java/org/terracotta/voltron/proxy/MethodDescriptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/proxy/src/main/java/org/terracotta/voltron/proxy/ProxyMessageCodec.java
+++ b/proxy/src/main/java/org/terracotta/voltron/proxy/ProxyMessageCodec.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/proxy/src/main/java/org/terracotta/voltron/proxy/SerializationCodec.java
+++ b/proxy/src/main/java/org/terracotta/voltron/proxy/SerializationCodec.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/proxy/src/main/java/org/terracotta/voltron/proxy/client/ClientProxyFactory.java
+++ b/proxy/src/main/java/org/terracotta/voltron/proxy/client/ClientProxyFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/proxy/src/main/java/org/terracotta/voltron/proxy/client/ProxyEndpointDelegate.java
+++ b/proxy/src/main/java/org/terracotta/voltron/proxy/client/ProxyEndpointDelegate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/proxy/src/main/java/org/terracotta/voltron/proxy/client/ProxyEntityClientService.java
+++ b/proxy/src/main/java/org/terracotta/voltron/proxy/client/ProxyEntityClientService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/proxy/src/main/java/org/terracotta/voltron/proxy/client/VoltronProxyInvocationHandler.java
+++ b/proxy/src/main/java/org/terracotta/voltron/proxy/client/VoltronProxyInvocationHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/proxy/src/main/java/org/terracotta/voltron/proxy/client/messages/MessageListener.java
+++ b/proxy/src/main/java/org/terracotta/voltron/proxy/client/messages/MessageListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/proxy/src/main/java/org/terracotta/voltron/proxy/client/messages/ServerMessageAware.java
+++ b/proxy/src/main/java/org/terracotta/voltron/proxy/client/messages/ServerMessageAware.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/proxy/src/main/java/org/terracotta/voltron/proxy/server/ProxiedServerEntity.java
+++ b/proxy/src/main/java/org/terracotta/voltron/proxy/server/ProxiedServerEntity.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/proxy/src/main/java/org/terracotta/voltron/proxy/server/ProxyInvoker.java
+++ b/proxy/src/main/java/org/terracotta/voltron/proxy/server/ProxyInvoker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/proxy/src/main/java/org/terracotta/voltron/proxy/server/ProxyServerEntityService.java
+++ b/proxy/src/main/java/org/terracotta/voltron/proxy/server/ProxyServerEntityService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/proxy/src/main/java/org/terracotta/voltron/proxy/server/messages/MessageFiring.java
+++ b/proxy/src/main/java/org/terracotta/voltron/proxy/server/messages/MessageFiring.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/proxy/src/main/java/org/terracotta/voltron/proxy/server/messages/ProxyEntityMessage.java
+++ b/proxy/src/main/java/org/terracotta/voltron/proxy/server/messages/ProxyEntityMessage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/proxy/src/main/java/org/terracotta/voltron/proxy/server/messages/ProxyEntityResponse.java
+++ b/proxy/src/main/java/org/terracotta/voltron/proxy/server/messages/ProxyEntityResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/proxy/src/test/java/org/terracotta/voltron/proxy/CommonProxyFactoryTest.java
+++ b/proxy/src/test/java/org/terracotta/voltron/proxy/CommonProxyFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/proxy/src/test/java/org/terracotta/voltron/proxy/EndToEndTest.java
+++ b/proxy/src/test/java/org/terracotta/voltron/proxy/EndToEndTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/proxy/src/test/java/org/terracotta/voltron/proxy/client/ClientProxyFactoryTest.java
+++ b/proxy/src/test/java/org/terracotta/voltron/proxy/client/ClientProxyFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/proxy/src/test/java/org/terracotta/voltron/proxy/client/VoltronProxyInvocationHandlerTest.java
+++ b/proxy/src/test/java/org/terracotta/voltron/proxy/client/VoltronProxyInvocationHandlerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Terracotta, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
... to avoid the IDE to reformat the header each type by adding `<p>`

The problem is that reformatting a class or modifying causes the IDE to reformat the javadoc. The issue is that the license headers were in javadoc style, so they all get reformatted also.

Added to `maven-license-plugin`:

```
          <mapping>
            <java>SLASHSTAR_STYLE</java>
          </mapping>
```