### PR TITLE
CallQuery.execute() not throwing any exception and catch call errors

### DIFF
--- a/management/management-registry/src/main/java/org/terracotta/management/registry/DefaultCallQuery.java
+++ b/management/management-registry/src/main/java/org/terracotta/management/registry/DefaultCallQuery.java
@@ -77,10 +77,6 @@ public class DefaultCallQuery<T> implements CallQuery<T> {
     Map<Context, ContextualReturn<T>> contextualResults = new LinkedHashMap<Context, ContextualReturn<T>>(contexts.size());
     Collection<ManagementProvider<?>> managementProviders = capabilityManagement.getManagementProvidersByCapability(capabilityName);
 
-    if (managementProviders.isEmpty()) {
-      throw new IllegalArgumentException("Bad capability: " + capabilityName);
-    }
-
     for (Context context : contexts) {
       ContextualReturn<T> result = ContextualReturn.notExecuted(capabilityName, context, methodName);
       for (ManagementProvider<?> managementProvider : managementProviders) {
@@ -90,6 +86,8 @@ public class DefaultCallQuery<T> implements CallQuery<T> {
             result = ContextualReturn.of(capabilityName, context, methodName, managementProvider.callAction(context, methodName, returnType, parameters));
           } catch (ExecutionException e) {
             result = ContextualReturn.error(capabilityName, context, methodName, e);
+          } catch (Exception e) {
+            result = ContextualReturn.error(capabilityName, context, methodName, new ExecutionException(e.getMessage(), e));
           }
           break;
         }

--- a/management/management-registry/src/test/java/org/terracotta/management/registry/DefaultCallQueryTest.java
+++ b/management/management-registry/src/test/java/org/terracotta/management/registry/DefaultCallQueryTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.management.registry;
+
+import org.junit.Test;
+import org.terracotta.management.model.call.ContextualReturn;
+import org.terracotta.management.model.call.Parameter;
+import org.terracotta.management.model.context.Context;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.concurrent.ExecutionException;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Anthony Dahanne
+ */
+public class DefaultCallQueryTest {
+
+  @Test
+  public void execute_handles_unexpected_exceptions() throws Exception {
+    final Context context = Context.create("key", "val");
+    Parameter[] parameters = new Parameter[]{new Parameter("toto")};
+    Collection<Context> contexts = new ArrayList<Context>() {{
+      add(context);
+    }};
+
+    //necessary mock
+    ManagementProvider<?> managementProvider = mock(ManagementProvider.class);
+    when(managementProvider.supports(context)).thenReturn(true);
+    RuntimeException runtimeException = new RuntimeException("Oups, that was not supposed to happen !");
+    when(managementProvider.callAction(context, "myMethodName", String.class, parameters)).thenThrow(runtimeException);
+
+    CapabilityManagementSupport capabilityManagementSupport = mock(CapabilityManagementSupport.class);
+    Collection<ManagementProvider<?>> managementProviders = new ArrayList<ManagementProvider<?>>();
+    managementProviders.add(managementProvider);
+    when(capabilityManagementSupport.getManagementProvidersByCapability("myCapabilityName")).thenReturn(managementProviders);
+
+    DefaultCallQuery<String> defaultCallQuery = new DefaultCallQuery<String>(capabilityManagementSupport, "myCapabilityName", "myMethodName", String.class, parameters, contexts);
+    ResultSet executeResults = defaultCallQuery.execute();
+
+    ContextualReturn singleResult = (ContextualReturn) executeResults.getSingleResult();
+    try {
+      singleResult.getValue();
+      fail();
+    } catch (Exception e) {
+      assertThat(e, is(instanceOf(ExecutionException.class)));
+      assertThat(e.getMessage(), equalTo("Oups, that was not supposed to happen !"));
+    }
+
+  }
+
+
+}


### PR DESCRIPTION
will be followed by a PR in ehcache3 also, and needs to be integrated into ehcache (release required ?)