### PR TITLE
refactoring of the monitoring service

### DIFF
--- a/management/management-entity/management-entity-common/src/main/java/org/terracotta/management/entity/ManagementAgent.java
+++ b/management/management-entity/management-entity-common/src/main/java/org/terracotta/management/entity/ManagementAgent.java
@@ -77,6 +77,8 @@ public interface ManagementAgent {
   @Async(Async.Ack.NONE)
   Future<String> call(@ClientId Object clientDescriptor, ClientIdentifier to, Context context, String capabilityName, String methodName, Class<?> returnType, Parameter... parameters);
 
+  //TODO: MATHIEU: Add a method to run the same management call over several clients at once: https://github.com/Terracotta-OSS/terracotta-platform/issues/126
+
   /**
    * Return a result from a received management call
    */

--- a/management/monitoring-service/src/main/java/org/terracotta/management/service/monitoring/MonitoringConfigParser.java
+++ b/management/monitoring-service/src/main/java/org/terracotta/management/service/monitoring/MonitoringConfigParser.java
@@ -50,10 +50,6 @@ public class MonitoringConfigParser implements ServiceConfigParser {
       configuration.setDebug(Boolean.valueOf(fragment.getAttribute("debug")));
     }
 
-    if (fragment.hasAttribute("maximumUnreadMutationsPerConsumer")) {
-      configuration.setMaximumUnreadMutationsPerConsumer(Integer.valueOf(fragment.getAttribute("maximumUnreadMutationsPerConsumer")));
-    }
-
     return configuration;
   }
 

--- a/management/monitoring-service/src/main/java/org/terracotta/management/service/monitoring/MonitoringConsumer.java
+++ b/management/monitoring-service/src/main/java/org/terracotta/management/service/monitoring/MonitoringConsumer.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.management.service.monitoring;
+
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.Spliterators;
+import java.util.function.Consumer;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+import static java.util.Spliterator.DISTINCT;
+import static java.util.Spliterator.IMMUTABLE;
+import static java.util.Spliterator.NONNULL;
+import static java.util.Spliterator.ORDERED;
+import static java.util.Spliterator.SIZED;
+import static java.util.Spliterator.SUBSIZED;
+
+/**
+ * @author Mathieu Carbou
+ */
+abstract class MonitoringConsumer implements IMonitoringConsumer {
+
+  @SuppressWarnings("MismatchedQueryAndUpdateOfCollection")
+  private static final Queue<Mutation> EMPTY_QUEUE = new LinkedList<>();
+
+  private static final Logger LOGGER = Logger.getLogger(MonitoringService.class.getName());
+
+  private final Queue<Mutation> mutationQueue;
+
+  MonitoringConsumer(long callerConsumerID, MonitoringConsumerConfiguration consumerConfiguration) {
+    if (consumerConfiguration.isRecordingMutations()) {
+      //TODO: MATHIEU - PERF: https://github.com/Terracotta-OSS/terracotta-platform/issues/109
+      mutationQueue = new BoundedEvictingPriorityQueue<>(
+          consumerConfiguration.getMaximumUnreadMutations(),
+          mutation -> {
+            if (LOGGER.isLoggable(Level.FINE)) {
+              LOGGER.fine("CONSUMER " + callerConsumerID + ": discarded mutation " + mutation);
+            }
+          });
+    } else {
+      mutationQueue = EMPTY_QUEUE;
+    }
+  }
+
+  @Override
+  public final Stream<Mutation> readMutations() {
+    return StreamSupport.stream(new Spliterators.AbstractSpliterator<Mutation>(mutationQueue.size(), NONNULL | ORDERED | SIZED | SUBSIZED | DISTINCT | IMMUTABLE) {
+      @Override
+      public boolean tryAdvance(Consumer<? super Mutation> action) {
+        if (mutationQueue == EMPTY_QUEUE) {
+          return false;
+        }
+        Mutation mutation = mutationQueue.poll();
+        if (mutation == null) {
+          return false;
+        }
+        action.accept(mutation);
+        return true;
+      }
+    }, false);
+  }
+
+  void record(TreeMutation mutation) {
+    if (mutationQueue != EMPTY_QUEUE) {
+      mutationQueue.offer(mutation);
+    }
+  }
+
+}

--- a/management/monitoring-service/src/main/java/org/terracotta/management/service/monitoring/MonitoringConsumerConfiguration.java
+++ b/management/monitoring-service/src/main/java/org/terracotta/management/service/monitoring/MonitoringConsumerConfiguration.java
@@ -25,13 +25,24 @@ import org.terracotta.entity.ServiceConfiguration;
 public class MonitoringConsumerConfiguration implements ServiceConfiguration<IMonitoringConsumer> {
 
   private boolean recordingMutations;
+  private int maximumUnreadMutations = 1024 * 1024;
 
   public boolean isRecordingMutations() {
     return recordingMutations;
   }
 
-  public MonitoringConsumerConfiguration setRecordingMutations(boolean recordingMutations) {
-    this.recordingMutations = recordingMutations;
+  public MonitoringConsumerConfiguration recordMutations() {
+    this.recordingMutations = true;
+    return this;
+  }
+
+
+  public int getMaximumUnreadMutations() {
+    return maximumUnreadMutations;
+  }
+
+  public MonitoringConsumerConfiguration setMaximumUnreadMutations(int maximumUnreadMutations) {
+    this.maximumUnreadMutations = maximumUnreadMutations;
     return this;
   }
 

--- a/management/monitoring-service/src/main/java/org/terracotta/management/service/monitoring/MonitoringServiceConfiguration.java
+++ b/management/monitoring-service/src/main/java/org/terracotta/management/service/monitoring/MonitoringServiceConfiguration.java
@@ -24,16 +24,6 @@ import org.terracotta.entity.ServiceProviderConfiguration;
 public class MonitoringServiceConfiguration implements ServiceProviderConfiguration {
 
   private boolean debug;
-  private int maximumUnreadMutationsPerConsumer = 1024 * 1024;
-
-  public int getMaximumUnreadMutationsPerConsumer() {
-    return maximumUnreadMutationsPerConsumer;
-  }
-
-  public MonitoringServiceConfiguration setMaximumUnreadMutationsPerConsumer(int maximumUnreadMutationsPerConsumer) {
-    this.maximumUnreadMutationsPerConsumer = maximumUnreadMutationsPerConsumer;
-    return this;
-  }
 
   public boolean isDebug() {
     return debug;

--- a/management/monitoring-service/src/main/resources/org/terracotta/management/service/monitoring/management.xsd
+++ b/management/monitoring-service/src/main/resources/org/terracotta/management/service/monitoring/management.xsd
@@ -23,7 +23,6 @@
             <xs:sequence minOccurs="0" maxOccurs="1">
             </xs:sequence>
             <xs:attribute name="debug" type="xs:boolean" default="false" use="optional"/>
-            <xs:attribute name="maximumUnreadMutationsPerConsumer" type="xs:integer" default="1048576" use="optional"/>
         </xs:complexType>
     </xs:element>
 </xs:schema>

--- a/management/monitoring-service/src/test/java/org/terracotta/management/service/monitoring/MonitoringConfigParserTestTest.java
+++ b/management/monitoring-service/src/test/java/org/terracotta/management/service/monitoring/MonitoringConfigParserTestTest.java
@@ -47,7 +47,7 @@ public class MonitoringConfigParserTestTest {
 
     MonitoringServiceConfiguration configuration = parser.parse(dom.getDocumentElement(), "source");
 
-    assertEquals(50, configuration.getMaximumUnreadMutationsPerConsumer());
+    assertEquals(true, configuration.isDebug());
   }
 
   @Test
@@ -59,7 +59,7 @@ public class MonitoringConfigParserTestTest {
 
     MonitoringServiceConfiguration configuration = parser.parse(dom.getDocumentElement(), "source");
 
-    assertEquals(1048576, configuration.getMaximumUnreadMutationsPerConsumer());
+    assertEquals(false, configuration.isDebug());
   }
 
 }

--- a/management/monitoring-service/src/test/java/org/terracotta/management/service/monitoring/MonitoringServiceTest.java
+++ b/management/monitoring-service/src/test/java/org/terracotta/management/service/monitoring/MonitoringServiceTest.java
@@ -57,7 +57,7 @@ public class MonitoringServiceTest {
   public void setUp() throws Exception {
     serviceProvider.initialize(new MonitoringServiceConfiguration().setDebug(true));
     producer = serviceProvider.getService(0, new BasicServiceConfiguration<>(IMonitoringProducer.class));
-    consumer = serviceProvider.getService(0, new MonitoringConsumerConfiguration().setRecordingMutations(true));
+    consumer = serviceProvider.getService(0, new MonitoringConsumerConfiguration().recordMutations());
   }
 
   @Test

--- a/management/monitoring-service/src/test/resources/sample-config-1.xml
+++ b/management/monitoring-service/src/test/resources/sample-config-1.xml
@@ -20,4 +20,4 @@
   xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'
   xmlns:management="http://www.terracotta.org/config/management"
   xsi:schemaLocation='http://www.terracotta.org/config/management ../../main/resources/org/terracotta/management/service/monitoring/management.xsd'
-  maximumUnreadMutationsPerConsumer="50"/>
+  debug="true"/>

--- a/management/samples/monitoring-tree-consumer/src/main/java/org/terracotta/management/entity/monitoringconsumer/server/MonitoringConsumerEntityServerService.java
+++ b/management/samples/monitoring-tree-consumer/src/main/java/org/terracotta/management/entity/monitoringconsumer/server/MonitoringConsumerEntityServerService.java
@@ -32,7 +32,7 @@ public class MonitoringConsumerEntityServerService extends ProxyServerEntityServ
 
   @Override
   public MonitoringConsumerEntity createActiveEntity(ServiceRegistry registry, Void config) {
-    IMonitoringConsumer monitoringConsumer = registry.getService(new MonitoringConsumerConfiguration().setRecordingMutations(false));
+    IMonitoringConsumer monitoringConsumer = registry.getService(new MonitoringConsumerConfiguration());
     return new MonitoringConsumerEntity(monitoringConsumer);
   }
 


### PR DESCRIPTION
refactoring of the monitoring service
- moved unread notification settings to consumer configuration (this
was a consumer option, not a service-level option)
- renamed recordMutation option in builder
- refactored how mutations are collected, per consumer

This is a preparation work for #108  and new IMonitoringProducer method that will record notifications and statistics