### PR TITLE
Removing takeBuffer() from monitoring entity consumer

### DIFF
--- a/management/management-entity/management-entity-tests/src/test/java/org/terracotta/management/entity/management/ManagementAgentServiceTest.java
+++ b/management/management-entity/management-entity-tests/src/test/java/org/terracotta/management/entity/management/ManagementAgentServiceTest.java
@@ -153,7 +153,7 @@ public class ManagementAgentServiceTest {
       assertEquals(registry.getContextContainer(), children.get("contextContainer"));
 
       assertThat(consumer.readBuffer("client-notifications", Serializable[].class)[1], equalTo(notif));
-      assertThat(consumer.takeBuffer("client-statistics", Serializable[].class)[1], equalTo(new ContextualStatistics[]{stat, stat}));
+      assertThat(consumer.readBuffer("client-statistics", Serializable[].class)[1], equalTo(new ContextualStatistics[]{stat, stat}));
 
       runManagementCallFromAnotherClient(clientIdentifier);
     }

--- a/management/monitoring-service-entity/src/main/java/org/terracotta/management/entity/monitoring/MonitoringService.java
+++ b/management/monitoring-service-entity/src/main/java/org/terracotta/management/entity/monitoring/MonitoringService.java
@@ -43,5 +43,4 @@ public interface MonitoringService {
 
   <T> T readBuffer(String name, Class<T> type);
 
-  <T> T takeBuffer(String name, Class<T> type);
 }

--- a/management/monitoring-service-entity/src/main/java/org/terracotta/management/entity/monitoring/server/MonitoringServiceImpl.java
+++ b/management/monitoring-service-entity/src/main/java/org/terracotta/management/entity/monitoring/server/MonitoringServiceImpl.java
@@ -27,8 +27,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
 /**
  * @author Mathieu Carbou
@@ -90,20 +88,6 @@ class MonitoringServiceImpl implements MonitoringService {
   @Override
   public <T> T readBuffer(String name, Class<T> type) {
     return Optional.ofNullable(buffers.get(name)).map(ReadOnlyBuffer::read).map(type::cast).orElse(null);
-  }
-
-  @Override
-  public <T> T takeBuffer(String name, Class<T> type) {
-    return Optional.ofNullable(buffers.get(name)).map(buffer -> {
-      try {
-        return buffer.take(1, TimeUnit.MINUTES);
-      } catch (InterruptedException e) {
-        Thread.currentThread().interrupt();
-        throw new RuntimeException(e);
-      } catch (TimeoutException e) {
-        throw new RuntimeException(e);
-      }
-    }).map(type::cast).orElse(null);
   }
 
   private static String[] concat(String[] parents, String name) {


### PR DESCRIPTION
Removing takeBuffer() from monitoring entity consumer