### PR TITLE
Mark these types and constructors as public

### DIFF
--- a/concurrent-map-entity/client/src/main/java/org/terracotta/entity/map/TerracottaClusteredMap.java
+++ b/concurrent-map-entity/client/src/main/java/org/terracotta/entity/map/TerracottaClusteredMap.java
@@ -52,7 +52,7 @@ import java.util.Set;
 import static org.terracotta.entity.map.ValueCodecFactory.getCodecForClass;
 
 @SuppressWarnings("unchecked")
-class TerracottaClusteredMap<K, V> implements ConcurrentClusteredMap<K, V> {
+public class TerracottaClusteredMap<K, V> implements ConcurrentClusteredMap<K, V> {
 
   private final EntityClientEndpoint<MapOperation, MapResponse> endpoint;
 
@@ -61,7 +61,7 @@ class TerracottaClusteredMap<K, V> implements ConcurrentClusteredMap<K, V> {
   private ValueCodec<K> keyValueCodec;
   private ValueCodec<V> valueValueCodec;
 
-  TerracottaClusteredMap(EntityClientEndpoint<MapOperation, MapResponse> endpoint) {
+  public TerracottaClusteredMap(EntityClientEndpoint<MapOperation, MapResponse> endpoint) {
     this.endpoint = endpoint;
   }
 

--- a/concurrent-map-entity/server/src/main/java/org/terracotta/entity/map/server/ActiveTerracottaClusteredMap.java
+++ b/concurrent-map-entity/server/src/main/java/org/terracotta/entity/map/server/ActiveTerracottaClusteredMap.java
@@ -50,7 +50,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
 
-class ActiveTerracottaClusteredMap implements ActiveServerEntity<MapOperation, MapResponse>  {
+public class ActiveTerracottaClusteredMap implements ActiveServerEntity<MapOperation, MapResponse>  {
 
   private static final int CONCURRENCY_KEY = 42;
 
@@ -70,8 +70,6 @@ class ActiveTerracottaClusteredMap implements ActiveServerEntity<MapOperation, M
   public void disconnected(ClientDescriptor clientDescriptor) {
   }
 
-  // Note that we suppress deprecation since we have the size method.
-  @SuppressWarnings("deprecation")
   @Override
   public MapResponse invoke(ClientDescriptor clientDescriptor, MapOperation input) {
     MapResponse response;


### PR DESCRIPTION
-these were package-private but some downstream tests want access to them so they should be marked as public