### PR TITLE
Decoder reuse when sharing common message base

### DIFF
--- a/runnel/src/main/java/org/terracotta/runnel/Struct.java
+++ b/runnel/src/main/java/org/terracotta/runnel/Struct.java
@@ -48,6 +48,10 @@ public class Struct {
     return new StructDecoder(root, new ReadBuffer(byteBuffer));
   }
 
+  public StructDecoder fromDecoder(StructDecoder otherDecoder) {
+    return new StructDecoder(root, otherDecoder);
+  }
+
   public void dump(ByteBuffer byteBuffer, PrintStream out) {
     Map<Integer, Field> fieldsByInteger = root.getMetadata().buildFieldsByIndexMap();
 

--- a/runnel/src/main/java/org/terracotta/runnel/decoding/StructDecoder.java
+++ b/runnel/src/main/java/org/terracotta/runnel/decoding/StructDecoder.java
@@ -49,6 +49,12 @@ public class StructDecoder implements PrimitiveDecodingSupport {
     this.fieldDecoder = structField.getMetadata().fieldDecoder(this.readBuffer);
   }
 
+  public StructDecoder(StructField structField, StructDecoder sourceDecoder) {
+    this.parent = null;
+    this.readBuffer = sourceDecoder.readBuffer;
+    this.fieldDecoder = structField.getMetadata().fieldDecoder(sourceDecoder.fieldDecoder);
+  }
+
   @Override
   public Boolean bool(String name) {
     return fieldDecoder.decodeValue(name, BoolField.class);

--- a/runnel/src/main/java/org/terracotta/runnel/metadata/FieldDecoder.java
+++ b/runnel/src/main/java/org/terracotta/runnel/metadata/FieldDecoder.java
@@ -39,6 +39,14 @@ public class FieldDecoder {
     this.readBuffer = readBuffer;
   }
 
+  FieldDecoder(Metadata metadata, FieldDecoder sourceDecoder) {
+    this.metadata = metadata;
+    this.readBuffer = sourceDecoder.readBuffer;
+    this.lastIndex = sourceDecoder.lastIndex;
+    this.readAheadIndex = sourceDecoder.readAheadIndex;
+    sourceDecoder.lastIndex = Integer.MAX_VALUE;
+  }
+
   public StructArrayDecoder decodeStructArray(String name, StructDecoder parent) {
     ArrayField field = nextField(name, ArrayField.class, StructField.class);
     if (field == null) {

--- a/runnel/src/main/java/org/terracotta/runnel/metadata/Metadata.java
+++ b/runnel/src/main/java/org/terracotta/runnel/metadata/Metadata.java
@@ -44,6 +44,10 @@ public class Metadata {
     return new FieldDecoder(this, readBuffer);
   }
 
+  public FieldDecoder fieldDecoder(FieldDecoder sourceDecoder) {
+    return new FieldDecoder(this, sourceDecoder);
+  }
+
   public Map<Integer, Field> buildFieldsByIndexMap() {
     Map<Integer, Field> map = new HashMap<Integer, Field>();
     for (Field field : fieldsByName.values()) {


### PR DESCRIPTION
This adds a method to transform a decoder into a different one while
 maintaining read position and reducing new objects creation.
 This is useful when messages share a common structure, such as
  beginning with an operation code for example.