### PR TITLE
cannot set a negative time for since

### DIFF
--- a/management/management-registry/src/main/java/org/terracotta/management/registry/DefaultStatisticQueryBuilder.java
+++ b/management/management-registry/src/main/java/org/terracotta/management/registry/DefaultStatisticQueryBuilder.java
@@ -35,7 +35,7 @@ public class DefaultStatisticQueryBuilder implements StatisticQuery.Builder {
   private final long since;
 
   public DefaultStatisticQueryBuilder(CapabilityManagementSupport capabilityManagement, String capabilityName, Collection<String> statisticNames) {
-    this(capabilityManagement, capabilityName, statisticNames, Collections.<Context>emptyList(), Long.MIN_VALUE);
+    this(capabilityManagement, capabilityName, statisticNames, Collections.<Context>emptyList(), 0L);
   }
 
   private DefaultStatisticQueryBuilder(CapabilityManagementSupport capabilityManagement, String capabilityName, Collection<String> statisticNames, Collection<Context> contexts, long since) {


### PR DESCRIPTION
because it will prevent comparison with other time from working (because it creates an overflow).

When we compare, in comparators (a - b), if b in Long.MIN, then 0 - b give a negative number instead of a positive because 0 - Long.MIN is negative.

So comparison does not work.