### PR TITLE
lazily initialize metadata to be able to create struct 'aliases'

### DIFF
--- a/runnel/src/main/java/org/terracotta/runnel/metadata/Metadata.java
+++ b/runnel/src/main/java/org/terracotta/runnel/metadata/Metadata.java
@@ -27,12 +27,19 @@ import java.util.Map;
  */
 public class Metadata {
 
-  private final Map<String, Field> fieldsByName;
+  private final List<? extends Field> metadata;
+  private Map<String, Field> fieldsByName;
 
   public Metadata(List<? extends Field> metadata) {
-    fieldsByName = new HashMap<String, Field>();
-    for (Field field : metadata) {
-      fieldsByName.put(field.name(), field);
+    this.metadata = metadata;
+  }
+
+  private void initFields(List<? extends Field> metadata) {
+    if (fieldsByName == null) {
+      fieldsByName = new HashMap<String, Field>(metadata.size(), 1.0F);
+      for (Field field : metadata) {
+        fieldsByName.put(field.name(), field);
+      }
     }
   }
 
@@ -45,6 +52,7 @@ public class Metadata {
   }
 
   public Map<Integer, Field> buildFieldsByIndexMap() {
+    initFields(metadata);
     Map<Integer, Field> map = new HashMap<Integer, Field>();
     for (Field field : fieldsByName.values()) {
       map.put(field.index(), field);
@@ -53,6 +61,7 @@ public class Metadata {
   }
 
   Field getFieldByName(String name) {
+    initFields(metadata);
     return fieldsByName.get(name);
   }
 

--- a/runnel/src/test/java/org/terracotta/runnel/StructBuilderTest.java
+++ b/runnel/src/test/java/org/terracotta/runnel/StructBuilderTest.java
@@ -131,4 +131,20 @@ public class StructBuilderTest {
     StructBuilder.newStructBuilder().enm("a", 2, ENM).enm("b", 3, ENM);
   }
 
+  /**
+   * Check that when calling StructBuilder.build(), then modifying the builder again then
+   * building a second struct, we do end up with two identical structs.
+   *
+   * Ugly, but that's the quick way to solve the struct loop struct1 -> struct2 -> struct1 problem.
+   */
+  @Test
+  public void checkLazyStructAliasesWork() throws Exception {
+    StructBuilder structBuilder = StructBuilder.newStructBuilder();
+
+    Struct lazilyInitializedStruct = structBuilder.build();
+    Struct struct = structBuilder.int32("a", 2).int32("b", 3).build();
+
+    lazilyInitializedStruct.encoder().int32("a", 1).int32("b", -1).encode();
+    struct.encoder().int32("a", 1).int32("b", -1).encode();
+  }
 }


### PR DESCRIPTION
This feature is needed to be able to configure structs of structs with loops, e.g.:
```
struct a:
 struct b 10

struct b:
 struct c 10

struct c:
 struct a 10
```