### PR TITLE
[closes #201] allow creating lazily-initialized structures

### DIFF
--- a/runnel/src/main/java/org/terracotta/runnel/StructBuilder.java
+++ b/runnel/src/main/java/org/terracotta/runnel/StructBuilder.java
@@ -39,10 +39,21 @@ public class StructBuilder {
 
   private final List<Field> fields = new ArrayList<Field>();
   private final Set<String> names = new HashSet<String>();
+  private final List<StructField> aliasStructFields = new ArrayList<StructField>();
   private int lastIndex = -1;
 
   public Struct build() {
+    for (StructField prebuilt : aliasStructFields) {
+      prebuilt.init();
+    }
+    aliasStructFields.clear();
     return new Struct(new StructField("root", -1, fields));
+  }
+
+  public Struct alias() {
+    StructField field = new StructField("root", -1, fields, false);
+    aliasStructFields.add(field);
+    return new Struct(field);
   }
 
   public static StructBuilder newStructBuilder() {

--- a/runnel/src/main/java/org/terracotta/runnel/decoding/fields/StructField.java
+++ b/runnel/src/main/java/org/terracotta/runnel/decoding/fields/StructField.java
@@ -31,9 +31,17 @@ public class StructField extends AbstractField {
   private final Metadata metadata;
 
   public StructField(String name, int index, List<? extends Field> subFields) {
+    this(name, index, subFields, true);
+  }
+
+  public StructField(String name, int index, List<? extends Field> subFields, boolean init) {
     super(name, index);
     this.subFields = subFields;
-    this.metadata = new Metadata(subFields);
+    this.metadata = new Metadata(subFields, init);
+  }
+
+  public void init() {
+    this.metadata.init();
   }
 
   public Metadata getMetadata() {

--- a/runnel/src/main/java/org/terracotta/runnel/metadata/Metadata.java
+++ b/runnel/src/main/java/org/terracotta/runnel/metadata/Metadata.java
@@ -21,16 +21,34 @@ import org.terracotta.runnel.utils.ReadBuffer;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * @author Ludovic Orban
  */
 public class Metadata {
 
+  private final List<? extends Field> metadata;
   private final Map<String, Field> fieldsByName;
 
   public Metadata(List<? extends Field> metadata) {
-    fieldsByName = new HashMap<String, Field>();
+    this(metadata, true);
+  }
+
+  public Metadata(List<? extends Field> metadata, boolean init) {
+    this.metadata = metadata;
+    if (init) {
+      fieldsByName = new HashMap<String, Field>();
+      init();
+    } else {
+      fieldsByName = new ConcurrentHashMap<String, Field>(16, 1.0F, 1);
+    }
+  }
+
+  public void init() {
+    if (!fieldsByName.isEmpty()) {
+      throw new IllegalStateException("Metadata already initialized");
+    }
     for (Field field : metadata) {
       fieldsByName.put(field.name(), field);
     }

--- a/runnel/src/test/java/org/terracotta/runnel/StructBuilderTest.java
+++ b/runnel/src/test/java/org/terracotta/runnel/StructBuilderTest.java
@@ -131,4 +131,14 @@ public class StructBuilderTest {
     StructBuilder.newStructBuilder().enm("a", 2, ENM).enm("b", 3, ENM);
   }
 
+  @Test
+  public void checkLazyStructAliasesWork() throws Exception {
+    StructBuilder structBuilder = StructBuilder.newStructBuilder();
+
+    Struct lazilyInitializedStruct = structBuilder.alias();
+    Struct struct = structBuilder.int32("a", 2).int32("b", 3).build();
+
+    lazilyInitializedStruct.encoder().int32("a", 1).int32("b", -1).encode();
+    struct.encoder().int32("a", 1).int32("b", -1).encode();
+  }
 }


### PR DESCRIPTION
Introduces a new `StructBuilder.alias()` call for this purpose to make sure that once the `Struct` has been created, everything in the struct has been initialized and using it is thread-safe.