### PR TITLE
Support for restartability: clear any entity placeholder states that can have been set when server becomes active

### DIFF
--- a/management/monitoring-service/src/main/java/org/terracotta/management/service/monitoring/DefaultActiveEntityMonitoringService.java
+++ b/management/monitoring-service/src/main/java/org/terracotta/management/service/monitoring/DefaultActiveEntityMonitoringService.java
@@ -34,13 +34,13 @@ import java.util.Objects;
 public class DefaultActiveEntityMonitoringService extends AbstractEntityMonitoringService implements ActiveEntityMonitoringService {
 
   private final TopologyService topologyService;
-  private final EventService eventService;
+  private final FiringService firingService;
   private final String serverName;
 
-  DefaultActiveEntityMonitoringService(long consumerId, TopologyService topologyService, EventService eventService) {
+  DefaultActiveEntityMonitoringService(long consumerId, TopologyService topologyService, FiringService firingService) {
     super(consumerId);
     this.topologyService = Objects.requireNonNull(topologyService);
-    this.eventService = Objects.requireNonNull(eventService);
+    this.firingService = Objects.requireNonNull(firingService);
     this.serverName = topologyService.getCurrentServerName();
   }
 
@@ -57,7 +57,7 @@ public class DefaultActiveEntityMonitoringService extends AbstractEntityMonitori
     logger.trace("[{}] pushNotification({})", getConsumerId(), notification);
     topologyService.getEntityContext(serverName, getConsumerId()).ifPresent(context -> {
       notification.setContext(notification.getContext().with(context));
-      eventService.fireNotification(notification);
+      firingService.fireNotification(notification);
     });
   }
 
@@ -70,14 +70,14 @@ public class DefaultActiveEntityMonitoringService extends AbstractEntityMonitori
         topologyService.getEntityContext(serverName, getConsumerId())
             .ifPresent(context -> statistic.setContext(statistic.getContext().with(context)));
       }
-      eventService.fireStatistics(statistics);
+      firingService.fireStatistics(statistics);
     }
   }
 
   @Override
   public void answerManagementCall(String managementCallIdentifier, ContextualReturn<?> contextualReturn) {
     logger.trace("[{}] answerManagementCall({}, executed={}, error={})", getConsumerId(), managementCallIdentifier, contextualReturn.hasExecuted(), contextualReturn.errorThrown());
-    eventService.fireManagementCallAnswer(managementCallIdentifier, contextualReturn);
+    firingService.fireManagementCallAnswer(managementCallIdentifier, contextualReturn);
   }
 
   @Override

--- a/management/monitoring-service/src/main/java/org/terracotta/management/service/monitoring/DefaultConsumerManagementRegistry.java
+++ b/management/monitoring-service/src/main/java/org/terracotta/management/service/monitoring/DefaultConsumerManagementRegistry.java
@@ -35,7 +35,7 @@ import java.util.Objects;
 /**
  * @author Mathieu Carbou
  */
-class DefaultConsumerManagementRegistry extends DefaultManagementRegistry implements ConsumerManagementRegistry, EntityListener {
+class DefaultConsumerManagementRegistry extends DefaultManagementRegistry implements ConsumerManagementRegistry, TopologyEventListener {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(DefaultConsumerManagementRegistry.class);
 
@@ -88,6 +88,10 @@ class DefaultConsumerManagementRegistry extends DefaultManagementRegistry implem
       }
     }
     return false;
+  }
+
+  @Override
+  public void onBecomeActive() {
   }
 
   @Override

--- a/management/monitoring-service/src/main/java/org/terracotta/management/service/monitoring/DefaultDataListener.java
+++ b/management/monitoring-service/src/main/java/org/terracotta/management/service/monitoring/DefaultDataListener.java
@@ -41,12 +41,12 @@ class DefaultDataListener implements DataListener {
 
   private final long consumerId;
   private final TopologyService topologyService;
-  private final EventService eventService;
+  private final FiringService firingService;
 
-  DefaultDataListener(long consumerId, TopologyService topologyService, EventService eventService) {
+  DefaultDataListener(long consumerId, TopologyService topologyService, FiringService firingService) {
     this.consumerId = consumerId;
     this.topologyService = Objects.requireNonNull(topologyService);
-    this.eventService = Objects.requireNonNull(eventService);
+    this.firingService = Objects.requireNonNull(firingService);
   }
 
   // ===========================================================================
@@ -68,7 +68,7 @@ class DefaultDataListener implements DataListener {
         }
         topologyService.getEntityContext(sender.getServerName(), consumerId).ifPresent(context -> {
           notification.setContext(notification.getContext().with(context));
-          eventService.fireNotification(notification);
+          firingService.fireNotification(notification);
         });
         break;
       }
@@ -82,7 +82,7 @@ class DefaultDataListener implements DataListener {
           topologyService.getEntityContext(sender.getServerName(), cid)
               .ifPresent(context -> statistic.setContext(statistic.getContext().with(context)));
         }
-        eventService.fireStatistics(statistics);
+        firingService.fireStatistics(statistics);
         break;
       }
 
@@ -106,7 +106,7 @@ class DefaultDataListener implements DataListener {
       // handles data coming from DefaultMonitoringService.answerManagementCall()
       String managementCallIdentifier = path[2];
       ContextualReturn<?> answer = (ContextualReturn<?>) data;
-      eventService.fireManagementCallAnswer(managementCallIdentifier, answer);
+      firingService.fireManagementCallAnswer(managementCallIdentifier, answer);
     }
   }
 

--- a/management/monitoring-service/src/main/java/org/terracotta/management/service/monitoring/DefaultFiringService.java
+++ b/management/monitoring-service/src/main/java/org/terracotta/management/service/monitoring/DefaultFiringService.java
@@ -37,9 +37,9 @@ import java.util.concurrent.Executors;
 /**
  * @author Mathieu Carbou
  */
-class DefaultEventService implements EventService, Closeable {
+class DefaultFiringService implements FiringService, Closeable {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(DefaultEventService.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(DefaultFiringService.class);
 
   private final SequenceGenerator sequenceGenerator;
   private final PlatformConfiguration platformConfiguration;
@@ -51,7 +51,7 @@ class DefaultEventService implements EventService, Closeable {
   // temporary there to simulate an entity callback with IEntityMessenger
   private final ExecutorService executorService = Executors.newSingleThreadExecutor();
 
-  DefaultEventService(SequenceGenerator sequenceGenerator, PlatformConfiguration platformConfiguration, SharedManagementRegistry sharedManagementRegistry, Map<Long, DefaultManagementService> managementServices, Map<Long, DefaultClientMonitoringService> clientMonitoringServices) {
+  DefaultFiringService(SequenceGenerator sequenceGenerator, PlatformConfiguration platformConfiguration, SharedManagementRegistry sharedManagementRegistry, Map<Long, DefaultManagementService> managementServices, Map<Long, DefaultClientMonitoringService> clientMonitoringServices) {
     this.sequenceGenerator = Objects.requireNonNull(sequenceGenerator);
     this.platformConfiguration = Objects.requireNonNull(platformConfiguration);
     this.sharedManagementRegistry = Objects.requireNonNull(sharedManagementRegistry);

--- a/management/monitoring-service/src/main/java/org/terracotta/management/service/monitoring/DefaultManagementService.java
+++ b/management/monitoring-service/src/main/java/org/terracotta/management/service/monitoring/DefaultManagementService.java
@@ -45,12 +45,12 @@ import java.util.concurrent.ConcurrentSkipListSet;
 /**
  * @author Mathieu Carbou
  */
-class DefaultManagementService implements ManagementService, EntityListener {
+class DefaultManagementService implements ManagementService, TopologyEventListener {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(DefaultManagementService.class);
 
   private final long consumerId;
-  private final EventService eventService;
+  private final FiringService firingService;
   private final ClientCommunicator clientCommunicator;
   private final SequenceGenerator sequenceGenerator;
   private final TopologyService topologyService;
@@ -59,10 +59,10 @@ class DefaultManagementService implements ManagementService, EntityListener {
   private volatile ReadWriteBuffer<Message> buffer;
   private volatile ContextualNotification full;
 
-  DefaultManagementService(long consumerId, TopologyService topologyService, EventService eventService, ClientCommunicator clientCommunicator, SequenceGenerator sequenceGenerator) {
+  DefaultManagementService(long consumerId, TopologyService topologyService, FiringService firingService, ClientCommunicator clientCommunicator, SequenceGenerator sequenceGenerator) {
     this.consumerId = consumerId;
     this.topologyService = Objects.requireNonNull(topologyService);
-    this.eventService = Objects.requireNonNull(eventService);
+    this.firingService = Objects.requireNonNull(firingService);
     this.clientCommunicator = Objects.requireNonNull(clientCommunicator);
     this.sequenceGenerator = Objects.requireNonNull(sequenceGenerator);
   }
@@ -116,8 +116,12 @@ class DefaultManagementService implements ManagementService, EntityListener {
     }
 
     track(caller, managementCallIdentifier);
-    eventService.fireManagementCallRequest(managementCallIdentifier, new ContextualCall<>(fullContext, capabilityName, methodName, returnType, parameters));
+    firingService.fireManagementCallRequest(managementCallIdentifier, new ContextualCall<>(fullContext, capabilityName, methodName, returnType, parameters));
     return managementCallIdentifier;
+  }
+
+  @Override
+  public void onBecomeActive() {
   }
 
   @Override

--- a/management/monitoring-service/src/main/java/org/terracotta/management/service/monitoring/FiringService.java
+++ b/management/monitoring-service/src/main/java/org/terracotta/management/service/monitoring/FiringService.java
@@ -25,7 +25,7 @@ import org.terracotta.management.model.stats.ContextualStatistics;
  *
  * @author Mathieu Carbou
  */
-interface EventService {
+interface FiringService {
   void fireNotification(ContextualNotification notification);
 
   void fireStatistics(ContextualStatistics[] statistics);

--- a/management/monitoring-service/src/main/java/org/terracotta/management/service/monitoring/TopologyEventListener.java
+++ b/management/monitoring-service/src/main/java/org/terracotta/management/service/monitoring/TopologyEventListener.java
@@ -20,24 +20,16 @@ import org.terracotta.entity.ClientDescriptor;
 /**
  * @author Mathieu Carbou
  */
-class EntityListenerAdapter implements EntityListener {
-  @Override
-  public void onFetch(long consumerId, ClientDescriptor clientDescriptor) {
+interface TopologyEventListener {
 
-  }
+  void onBecomeActive();
 
-  @Override
-  public void onUnfetch(long consumerId, ClientDescriptor clientDescriptor) {
+  void onFetch(long consumerId, ClientDescriptor clientDescriptor);
 
-  }
+  void onUnfetch(long consumerId, ClientDescriptor clientDescriptor);
 
-  @Override
-  public void onEntityDestroyed(long consumerId) {
+  void onEntityDestroyed(long consumerId);
 
-  }
+  void onEntityFailover(long consumerId);
 
-  @Override
-  public void onEntityFailover(long consumerId) {
-
-  }
 }

--- a/management/monitoring-service/src/main/java/org/terracotta/management/service/monitoring/TopologyEventListenerAdapter.java
+++ b/management/monitoring-service/src/main/java/org/terracotta/management/service/monitoring/TopologyEventListenerAdapter.java
@@ -20,13 +20,29 @@ import org.terracotta.entity.ClientDescriptor;
 /**
  * @author Mathieu Carbou
  */
-interface EntityListener {
+class TopologyEventListenerAdapter implements TopologyEventListener {
+  @Override
+  public void onFetch(long consumerId, ClientDescriptor clientDescriptor) {
 
-  void onFetch(long consumerId, ClientDescriptor clientDescriptor);
+  }
 
-  void onUnfetch(long consumerId, ClientDescriptor clientDescriptor);
+  @Override
+  public void onUnfetch(long consumerId, ClientDescriptor clientDescriptor) {
 
-  void onEntityDestroyed(long consumerId);
+  }
 
-  void onEntityFailover(long consumerId);
+  @Override
+  public void onEntityDestroyed(long consumerId) {
+
+  }
+
+  @Override
+  public void onEntityFailover(long consumerId) {
+
+  }
+
+  @Override
+  public void onBecomeActive() {
+
+  }
 }

--- a/management/testing/integration-tests/pom.xml
+++ b/management/testing/integration-tests/pom.xml
@@ -64,16 +64,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-core</artifactId>
-      <version>1.3</version>
-    </dependency>
-    <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
       <version>${logback.version}</version>

--- a/management/testing/integration-tests/src/test/java/org/terracotta/management/integration/tests/AbstractTest.java
+++ b/management/testing/integration-tests/src/test/java/org/terracotta/management/integration/tests/AbstractTest.java
@@ -66,7 +66,7 @@ public abstract class AbstractTest {
   protected TmsAgentService tmsAgentService;
 
   @Rule
-  public Timeout timeout = Timeout.seconds(60);
+  public Timeout timeout = Timeout.seconds(90);
 
   protected final void commonSetUp(Cluster cluster) throws Exception {
     this.cluster = cluster;
@@ -76,8 +76,8 @@ public abstract class AbstractTest {
 
     connectManagementClients(cluster.getConnectionURI());
 
-    addWebappNode(cluster.getConnectionURI().resolve("pet-clinic"));
-    addWebappNode(cluster.getConnectionURI().resolve("pet-clinic"));
+    addWebappNode(cluster.getConnectionURI().resolve("/pet-clinic"));
+    addWebappNode(cluster.getConnectionURI().resolve("/pet-clinic"));
 
     getCaches("pets");
     getCaches("clients");

--- a/management/testing/integration-tests/src/test/java/org/terracotta/management/integration/tests/FailoverIT.java
+++ b/management/testing/integration-tests/src/test/java/org/terracotta/management/integration/tests/FailoverIT.java
@@ -33,7 +33,7 @@ import static org.junit.Assert.assertThat;
  * @author Mathieu Carbou
  */
 @Ignore // TODO activate
-public class FailoverTest extends AbstractHATest {
+public class FailoverIT extends AbstractHATest {
 
   @Test
   public void failover_management() throws Exception {

--- a/management/testing/integration-tests/src/test/java/org/terracotta/management/integration/tests/HAIT.java
+++ b/management/testing/integration-tests/src/test/java/org/terracotta/management/integration/tests/HAIT.java
@@ -39,7 +39,7 @@ import static org.junit.Assert.assertThat;
  * @author Mathieu Carbou
  */
 @Ignore // TODO activate
-public class HATest extends AbstractHATest {
+public class HAIT extends AbstractHATest {
 
   @Test
   public void topology_includes_passives() throws Exception {

--- a/management/testing/integration-tests/src/test/java/org/terracotta/management/integration/tests/StartupIT.java
+++ b/management/testing/integration-tests/src/test/java/org/terracotta/management/integration/tests/StartupIT.java
@@ -36,7 +36,7 @@ import static org.junit.Assert.assertThat;
  * @author Mathieu Carbou
  */
 @Ignore // TODO activate
-public class StartupTest extends AbstractHATest {
+public class StartupIT extends AbstractHATest {
 
   @Before
   @Override

--- a/management/testing/sample-entity/src/main/java/org/terracotta/management/entity/sample/server/PassiveCacheServerEntity.java
+++ b/management/testing/sample-entity/src/main/java/org/terracotta/management/entity/sample/server/PassiveCacheServerEntity.java
@@ -67,11 +67,11 @@ class PassiveCacheServerEntity extends PassiveProxiedServerEntity<Cache, CacheSy
 
   @Override
   public void startSyncConcurrencyKey(int concurrencyKey) {
-    LOGGER.trace("[{}] startSyncConcurrencyKey({})", concurrencyKey);
+    LOGGER.trace("[{}] startSyncConcurrencyKey({})", cache.getName(), concurrencyKey);
   }
 
   @Override
   public void endSyncConcurrencyKey(int concurrencyKey) {
-    LOGGER.trace("[{}] endSyncConcurrencyKey({})", concurrencyKey);
+    LOGGER.trace("[{}] endSyncConcurrencyKey({})", cache.getName(), concurrencyKey);
   }
 }


### PR DESCRIPTION
- renamed service that fires messages to `FiringService`
- renamed interface to listen for topo events to `TopologyEventListener`
- separated the maps to store monitoring services created by passive and active entities
- cleanup all potential states that have been created within the monitoring services before the first call to `serverBecomeActive()`

This will fix restartability issues