### PR TITLE
Bump to latest Terracotta .1-pre2 release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -250,6 +250,26 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>1.4.1</version>
+        <executions>
+          <execution>
+            <id>enforce-java</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <requireJavaVersion>
+                  <version>[1.8,)</version>
+                </requireJavaVersion>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -30,9 +30,9 @@
     <logback.version>1.1.3</logback.version>
     <terracotta-apis.version>1.1.0</terracotta-apis.version>
     <tcconfig.version>10.1.0</tcconfig.version>
-    <passthrough-testing.version>1.1.1-pre1</passthrough-testing.version>
-    <terracotta-core.version>5.1.1-pre1</terracotta-core.version>
-    <galvan.version>1.1.1-pre1</galvan.version>
+    <passthrough-testing.version>1.1.1-pre2</passthrough-testing.version>
+    <terracotta-core.version>5.1.1-pre2</terracotta-core.version>
+    <galvan.version>1.1.1-pre2</galvan.version>
     <statistics.version>1.4.1</statistics.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>


### PR DESCRIPTION
This includes enforcing the use of Java 8 for this build as the failsafe plugin does not work with toolchains.