### PR TITLE
#191: Support of new upcoming voltron changes for failover

### DIFF
--- a/management/monitoring-service/src/main/java/org/terracotta/management/service/monitoring/DefaultClientMonitoringService.java
+++ b/management/monitoring-service/src/main/java/org/terracotta/management/service/monitoring/DefaultClientMonitoringService.java
@@ -101,6 +101,8 @@ class DefaultClientMonitoringService implements ClientMonitoringService, Topolog
 
   @Override
   public void onBecomeActive() {
+    LOGGER.trace("[{}] onBecomeActive()", this.consumerId);
+    clear();
   }
 
   @Override
@@ -119,13 +121,16 @@ class DefaultClientMonitoringService implements ClientMonitoringService, Topolog
   public void onEntityDestroyed(long consumerId) {
     if (consumerId == this.consumerId) {
       LOGGER.trace("[{}] onEntityDestroyed()", this.consumerId);
-      manageableClients.clear();
+      clear();
     }
   }
 
   @Override
   public void onEntityFailover(long consumerId) {
-    onEntityDestroyed(consumerId);
+    if (consumerId == this.consumerId) {
+      LOGGER.trace("[{}] onEntityFailover()", this.consumerId);
+      clear();
+    }
   }
 
   void fireMessage(Message message) {
@@ -153,6 +158,10 @@ class DefaultClientMonitoringService implements ClientMonitoringService, Topolog
     } catch (Exception e) {
       LOGGER.error("Unable to send message " + message + " to client " + client);
     }
+  }
+
+  private void clear() {
+    manageableClients.clear();
   }
 
 }

--- a/management/monitoring-service/src/main/java/org/terracotta/management/service/monitoring/DefaultConsumerManagementRegistry.java
+++ b/management/monitoring-service/src/main/java/org/terracotta/management/service/monitoring/DefaultConsumerManagementRegistry.java
@@ -92,6 +92,8 @@ class DefaultConsumerManagementRegistry extends DefaultManagementRegistry implem
 
   @Override
   public void onBecomeActive() {
+    LOGGER.trace("[{}] onBecomeActive()", consumerId);
+    clear();
   }
 
   @Override
@@ -106,14 +108,21 @@ class DefaultConsumerManagementRegistry extends DefaultManagementRegistry implem
   public void onEntityDestroyed(long consumerId) {
     if (consumerId == this.consumerId) {
       LOGGER.trace("[{}] onEntityDestroyed()", consumerId);
-      managementProviders.forEach(ManagementProvider::close);
-      managementProviders.clear();
+      clear();
     }
   }
 
   @Override
   public void onEntityFailover(long consumerId) {
-    onEntityDestroyed(consumerId);
+    if (consumerId == this.consumerId) {
+      LOGGER.trace("[{}] onEntityFailover()", consumerId);
+      clear();
+    }
   }
 
+  private void clear() {
+    managementProviders.forEach(ManagementProvider::close);
+    managementProviders.clear();
+    previouslyExposed.clear();
+  }
 }

--- a/management/monitoring-service/src/main/java/org/terracotta/management/service/monitoring/DefaultManagementService.java
+++ b/management/monitoring-service/src/main/java/org/terracotta/management/service/monitoring/DefaultManagementService.java
@@ -122,6 +122,8 @@ class DefaultManagementService implements ManagementService, TopologyEventListen
 
   @Override
   public void onBecomeActive() {
+    LOGGER.trace("[{}] onBecomeActive()", this.consumerId);
+    clear();
   }
 
   @Override
@@ -140,14 +142,16 @@ class DefaultManagementService implements ManagementService, TopologyEventListen
   public void onEntityDestroyed(long consumerId) {
     if (consumerId == this.consumerId) {
       LOGGER.trace("[{}] onEntityDestroyed()", this.consumerId);
-      managementCallRequests.clear();
-      buffer = null;
+      clear();
     }
   }
 
   @Override
   public void onEntityFailover(long consumerId) {
-    onEntityDestroyed(consumerId);
+    if (consumerId == this.consumerId) {
+      LOGGER.trace("[{}] onEntityFailover()", this.consumerId);
+      clear();
+    }
   }
 
   void fireMessage(Message message) {
@@ -201,6 +205,14 @@ class DefaultManagementService implements ManagementService, TopologyEventListen
     managementCallRequests
         .computeIfAbsent(caller, clientDescriptor -> new ConcurrentSkipListSet<>())
         .add(managementCallIdentifier);
+  }
+
+  private void clear() {
+    managementCallRequests.clear();
+    full = null;
+    if (buffer != null) {
+      buffer.clear();
+    }
   }
 
 }

--- a/management/testing/integration-tests/src/test/java/org/terracotta/management/integration/tests/TopologyIT.java
+++ b/management/testing/integration-tests/src/test/java/org/terracotta/management/integration/tests/TopologyIT.java
@@ -42,13 +42,7 @@ public class TopologyIT extends AbstractSingleTest {
     Cluster cluster = tmsAgentService.readTopology();
     String currentTopo = toJson(cluster.toMap()).toString();
     String actual = removeRandomValues(currentTopo);
-
-
     String expected = readJson("topology.json").toString();
-
-    System.out.println("This is the actual topology : " + actual);
-    System.out.println("This is the expected topology : " + expected);
-    // and compare
     assertEquals(expected, actual);
   }
 


### PR DESCRIPTION
These changes support re-using some monitoring services, or cleaning before reusing. This is required to be compat' with the new voltron changes in master.

See: https://github.com/Terracotta-OSS/terracotta-core/issues/409

With these changes, failover can work, BUT, we still do see the replay phase (isActive=false) and thus we cannot detect that there has been a failover.

Also, with current tc-core and galvan master, Failover tests will block when terminating the active. O opened a ticket here: https://github.com/Terracotta-OSS/terracotta-core/issues/410.
Thus, tests times out, and we see no exception.