### PR TITLE
Close #252: Missing capabilities from monitoring tree after a failover

### DIFF
--- a/management/monitoring-service-api/src/main/java/org/terracotta/management/service/monitoring/EntityEventListener.java
+++ b/management/monitoring-service-api/src/main/java/org/terracotta/management/service/monitoring/EntityEventListener.java
@@ -16,21 +16,32 @@
 package org.terracotta.management.service.monitoring;
 
 import com.tc.classloader.CommonComponent;
-import org.terracotta.management.model.context.ContextContainer;
-import org.terracotta.management.registry.CapabilityManagementSupport;
-
-import java.util.Collection;
+import org.terracotta.entity.ClientDescriptor;
 
 /**
- * Special management registry that aggregates all created entity management registry on a server to run query and management calls on them.
- * <p>
- * {@link CapabilityManagementSupport} is able to route the call to the right exposed object thanks to the {@link org.terracotta.management.model.context.Context} objects passed.
- *
  * @author Mathieu Carbou
  */
 @CommonComponent
-public interface SharedManagementRegistry extends CapabilityManagementSupport {
+public interface EntityEventListener {
 
-  Collection<ContextContainer> getContextContainers();
+  /**
+   * Callback called when platform told the monitoring service that the entity has been created
+   */
+  void onCreated();
+
+  /**
+   * Callback called when platform told the monitoring service that a fetch happened
+   */
+  void onFetch(ClientDescriptor clientDescriptor);
+
+  /**
+   * Callback called when platform told the monitoring service that an unfetch
+   */
+  void onUnfetch(ClientDescriptor clientDescriptor);
+
+  /**
+   * Callback called when platform told the monitoring service that an entity has been destroyed
+   */
+  void onDestroyed();
 
 }

--- a/management/monitoring-service-api/src/main/java/org/terracotta/management/service/monitoring/EntityEventListenerAdapter.java
+++ b/management/monitoring-service-api/src/main/java/org/terracotta/management/service/monitoring/EntityEventListenerAdapter.java
@@ -16,21 +16,30 @@
 package org.terracotta.management.service.monitoring;
 
 import com.tc.classloader.CommonComponent;
-import org.terracotta.management.model.context.ContextContainer;
-import org.terracotta.management.registry.CapabilityManagementSupport;
-
-import java.util.Collection;
+import org.terracotta.entity.ClientDescriptor;
 
 /**
- * Special management registry that aggregates all created entity management registry on a server to run query and management calls on them.
- * <p>
- * {@link CapabilityManagementSupport} is able to route the call to the right exposed object thanks to the {@link org.terracotta.management.model.context.Context} objects passed.
- *
  * @author Mathieu Carbou
  */
 @CommonComponent
-public interface SharedManagementRegistry extends CapabilityManagementSupport {
+public class EntityEventListenerAdapter implements EntityEventListener {
+  @Override
+  public void onCreated() {
 
-  Collection<ContextContainer> getContextContainers();
+  }
 
+  @Override
+  public void onFetch(ClientDescriptor clientDescriptor) {
+
+  }
+
+  @Override
+  public void onUnfetch(ClientDescriptor clientDescriptor) {
+
+  }
+
+  @Override
+  public void onDestroyed() {
+
+  }
 }

--- a/management/monitoring-service-api/src/main/java/org/terracotta/management/service/monitoring/EntityEventService.java
+++ b/management/monitoring-service-api/src/main/java/org/terracotta/management/service/monitoring/EntityEventService.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.management.service.monitoring;
+
+import com.tc.classloader.CommonComponent;
+
+/**
+ * Workaround for https://github.com/Terracotta-OSS/terracotta-core/issues/426.
+ * <p>
+ * This service allows to register a listener for platform events, to know specifically
+ * when platform tells the monitoring service that an entity has been created.
+ * <p>
+ * This tells you when you can initialize or expose any management states into the monitoring service
+ * from a client or entity, especially after a failover because the entity API does not provide the
+ * same ordering of events as for entity creation.
+ *
+ * @author Mathieu Carbou
+ */
+@CommonComponent
+public interface EntityEventService {
+
+  long getConsumerId();
+
+  /**
+   * Adds a listener that will listen for monitoring events for this entity consumer.
+   * Once the consumer is destroyed, the listeners are automatically removed
+   */
+  void addEntityEventListener(EntityEventListener entityEventListener);
+
+}

--- a/management/monitoring-service-api/src/main/java/org/terracotta/management/service/monitoring/ManagementCallExecutor.java
+++ b/management/monitoring-service-api/src/main/java/org/terracotta/management/service/monitoring/ManagementCallExecutor.java
@@ -21,7 +21,10 @@ import org.terracotta.management.model.call.ContextualReturn;
 
 /**
  * Interface passed to a {@link ManagementServiceConfiguration}, that is responsible to execute a management call
- * and set the result by calling {@link EntityMonitoringService#answerManagementCall(String, ContextualReturn)}
+ * and set back the result by calling {@link EntityMonitoringService#answerManagementCall(String, ContextualReturn)}.
+ * <p>
+ * Management call execution can be done directly through the callback, or could also be redirected to the right server
+ * with {@link org.terracotta.entity.IEntityMessenger}
  *
  * @author Mathieu Carbou
  */

--- a/management/monitoring-service-api/src/main/java/org/terracotta/management/service/monitoring/StatisticsService.java
+++ b/management/monitoring-service-api/src/main/java/org/terracotta/management/service/monitoring/StatisticsService.java
@@ -20,6 +20,10 @@ import org.terracotta.context.extended.StatisticsRegistry;
 import org.terracotta.management.registry.collect.StatisticCollector;
 import org.terracotta.management.registry.collect.StatisticConfiguration;
 
+/**
+ * This statistic service is injected into {@link org.terracotta.management.registry.ManagementProvider} objects implementing
+ * {@link org.terracotta.management.service.monitoring.registry.provider.MonitoringServiceAware} when they are added into a {@link ConsumerManagementRegistry}
+ */
 @CommonComponent
 public interface StatisticsService {
   StatisticsRegistry createStatisticsRegistry(Object contextObject);

--- a/management/monitoring-service/src/main/java/org/terracotta/management/service/monitoring/DefaultClientMonitoringService.java
+++ b/management/monitoring-service/src/main/java/org/terracotta/management/service/monitoring/DefaultClientMonitoringService.java
@@ -126,11 +126,7 @@ class DefaultClientMonitoringService implements ClientMonitoringService, Topolog
   }
 
   @Override
-  public void onEntityFailover(long consumerId) {
-    if (consumerId == this.consumerId) {
-      LOGGER.trace("[{}] onEntityFailover()", this.consumerId);
-      clear();
-    }
+  public void onEntityCreated(long consumerId) {
   }
 
   void fireMessage(Message message) {

--- a/management/monitoring-service/src/main/java/org/terracotta/management/service/monitoring/DefaultConsumerManagementRegistry.java
+++ b/management/monitoring-service/src/main/java/org/terracotta/management/service/monitoring/DefaultConsumerManagementRegistry.java
@@ -92,8 +92,8 @@ class DefaultConsumerManagementRegistry extends DefaultManagementRegistry implem
 
   @Override
   public void onBecomeActive() {
-    LOGGER.trace("[{}] onBecomeActive()", consumerId);
-    clear();
+    // do not clear any state because on failover, onBecomeActive() is called after the new active entities are created
+    // so it would clear the providers added by entities at creation time
   }
 
   @Override
@@ -113,14 +113,11 @@ class DefaultConsumerManagementRegistry extends DefaultManagementRegistry implem
   }
 
   @Override
-  public void onEntityFailover(long consumerId) {
-    if (consumerId == this.consumerId) {
-      LOGGER.trace("[{}] onEntityFailover()", consumerId);
-      clear();
-    }
+  public void onEntityCreated(long consumerId) {
   }
 
-  private void clear() {
+  void clear() {
+    LOGGER.trace("[{}] clear()", consumerId);
     managementProviders.forEach(ManagementProvider::close);
     managementProviders.clear();
     previouslyExposed.clear();

--- a/management/monitoring-service/src/main/java/org/terracotta/management/service/monitoring/DefaultEntityEventService.java
+++ b/management/monitoring-service/src/main/java/org/terracotta/management/service/monitoring/DefaultEntityEventService.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.management.service.monitoring;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.terracotta.entity.ClientDescriptor;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+/**
+ * @author Mathieu Carbou
+ */
+public class DefaultEntityEventService implements TopologyEventListener, EntityEventService {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(DefaultEntityEventService.class);
+
+  private final long consumerId;
+  private final List<EntityEventListener> listeners = new CopyOnWriteArrayList<>();
+
+  DefaultEntityEventService(long consumerId) {
+    this.consumerId = consumerId;
+  }
+
+  @Override
+  public void onEntityCreated(long consumerId) {
+    if (consumerId == this.consumerId) {
+      LOGGER.trace("[{}] onEntityCreated()", consumerId);
+      for (EntityEventListener listener : listeners) {
+        listener.onCreated();
+      }
+    }
+  }
+
+  @Override
+  public void onFetch(long consumerId, ClientDescriptor clientDescriptor) {
+    if (consumerId == this.consumerId) {
+      LOGGER.trace("[{}] onFetch({})", consumerId, clientDescriptor);
+      for (EntityEventListener listener : listeners) {
+        listener.onFetch(clientDescriptor);
+      }
+    }
+  }
+
+  @Override
+  public void onUnfetch(long consumerId, ClientDescriptor clientDescriptor) {
+    if (consumerId == this.consumerId) {
+      LOGGER.trace("[{}] onUnfetch({})", consumerId, clientDescriptor);
+      for (EntityEventListener listener : listeners) {
+        listener.onUnfetch(clientDescriptor);
+      }
+    }
+  }
+
+  @Override
+  public void onEntityDestroyed(long consumerId) {
+    if (consumerId == this.consumerId) {
+      LOGGER.trace("[{}] onEntityDestroyed()", consumerId);
+      for (EntityEventListener listener : listeners) {
+        listener.onDestroyed();
+      }
+      clear();
+    }
+  }
+
+  @Override
+  public long getConsumerId() {
+    return consumerId;
+  }
+
+  @Override
+  public void addEntityEventListener(EntityEventListener entityEventListener) {
+    LOGGER.trace("[{}] addEntityEventListener({})", consumerId, entityEventListener.getClass().getName());
+    listeners.add(entityEventListener);
+  }
+
+  @Override
+  public void onBecomeActive() {
+    // do not clear any state because on failover, onBecomeActive() is called after the new active entities are created
+    // so it would clear the listeners added by entities at creation time
+  }
+
+  void clear() {
+    LOGGER.trace("[{}] clear()", consumerId);
+    listeners.clear();
+  }
+
+}

--- a/management/monitoring-service/src/main/java/org/terracotta/management/service/monitoring/DefaultManagementService.java
+++ b/management/monitoring-service/src/main/java/org/terracotta/management/service/monitoring/DefaultManagementService.java
@@ -151,11 +151,7 @@ class DefaultManagementService implements ManagementService, TopologyEventListen
   }
 
   @Override
-  public void onEntityFailover(long consumerId) {
-    if (consumerId == this.consumerId) {
-      LOGGER.trace("[{}] onEntityFailover()", this.consumerId);
-      clear();
-    }
+  public void onEntityCreated(long consumerId) {
   }
 
   void fireMessage(Message message) {

--- a/management/monitoring-service/src/main/java/org/terracotta/management/service/monitoring/IStripeMonitoringPlatformListenerAdapter.java
+++ b/management/monitoring-service/src/main/java/org/terracotta/management/service/monitoring/IStripeMonitoringPlatformListenerAdapter.java
@@ -95,11 +95,19 @@ final class IStripeMonitoringPlatformListenerAdapter implements IStripeMonitorin
           PlatformEntity platformEntity = (PlatformEntity) value;
           requireNonNull(entities.get(sender.getServerName()), "Inconsistent monitoring tree: server did not joined stripe first: " + sender.getServerName())
               .put(name, platformEntity);
-          // an active server is reporting a passive entity: it *can* be that a failover is occurring
-          if (!platformEntity.isActive && sender.getServerName().equals(currentActive)) {
-            delegate.serverEntityFailover(sender, platformEntity);
-          } else {
+          // Workaround for https://github.com/Terracotta-OSS/terracotta-core/issues/405
+          if (platformEntity.isActive || !sender.getServerName().equals(currentActive)) {
             delegate.serverEntityCreated(sender, platformEntity);
+          } else {
+            // event about a passive entity on an active server
+            // this is illegal, but platform was previously sending
+            // us some combinations like that in case of a failover
+            // when passive server become active and replays events
+            // regarding its old passive entities.
+            // Now, in new tc-core versions, we do not receive such
+            // events anymore so we are unable to keep track of failover
+            // transition for entities (https://github.com/Terracotta-OSS/terracotta-core/issues/405)
+            LOGGER.warn("Ignoring platform event for passive entity {} created on new active server {} after a failover", platformEntity, sender.getServerName());
           }
           return true;
         }

--- a/management/monitoring-service/src/main/java/org/terracotta/management/service/monitoring/PlatformListener.java
+++ b/management/monitoring-service/src/main/java/org/terracotta/management/service/monitoring/PlatformListener.java
@@ -38,19 +38,6 @@ interface PlatformListener {
 
   void serverEntityDestroyed(PlatformServer sender, PlatformEntity entity);
 
-  /**
-   * Called when the passive takes over an active.
-   * 1. Passive becomes active
-   * 2. Voltron will "replay" the passive monitoring states (entities)
-   * 3. serverEntityFailover() will be called with these passive entities originating from the new active server
-   * 4. Voltron will then create a new monitoring tree
-   * 5. New active entities are created
-   * 6. serverEntityCreated() will be called with the new active entities
-   * <p>
-   * So this method enables to see the ongoing transitions of entities that were on a passive
-   */
-  void serverEntityFailover(PlatformServer sender, PlatformEntity entity);
-
   void serverStateChanged(PlatformServer sender, ServerState state);
 
   void clientConnected(PlatformConnectedClient client);

--- a/management/monitoring-service/src/main/java/org/terracotta/management/service/monitoring/TopologyEventListener.java
+++ b/management/monitoring-service/src/main/java/org/terracotta/management/service/monitoring/TopologyEventListener.java
@@ -22,14 +22,29 @@ import org.terracotta.entity.ClientDescriptor;
  */
 interface TopologyEventListener {
 
+  /**
+   * Callback called when platform told the monitoring service that a service became active
+   */
   void onBecomeActive();
 
+  /**
+   * Callback called when platform told the monitoring service that a fetch happened
+   */
   void onFetch(long consumerId, ClientDescriptor clientDescriptor);
 
+  /**
+   * Callback called when platform told the monitoring service that an unfetch
+   */
   void onUnfetch(long consumerId, ClientDescriptor clientDescriptor);
 
+  /**
+   * Callback called when platform told the monitoring service that an entity has been destroyed
+   */
   void onEntityDestroyed(long consumerId);
 
-  void onEntityFailover(long consumerId);
+  /**
+   * Callback called when platform told the monitoring service that an entity has been created
+   */
+  void onEntityCreated(long consumerId);
 
 }

--- a/management/monitoring-service/src/main/java/org/terracotta/management/service/monitoring/TopologyEventListenerAdapter.java
+++ b/management/monitoring-service/src/main/java/org/terracotta/management/service/monitoring/TopologyEventListenerAdapter.java
@@ -37,8 +37,7 @@ class TopologyEventListenerAdapter implements TopologyEventListener {
   }
 
   @Override
-  public void onEntityFailover(long consumerId) {
-
+  public void onEntityCreated(long consumerId) {
   }
 
   @Override

--- a/management/testing/integration-tests/src/test/java/org/terracotta/management/integration/tests/HAStatisticsIT.java
+++ b/management/testing/integration-tests/src/test/java/org/terracotta/management/integration/tests/HAStatisticsIT.java
@@ -35,7 +35,7 @@ public class HAStatisticsIT extends AbstractHATest {
   @Test
   public void can_do_remote_management_calls_on_servers() throws Exception {
     try {
-      triggerServerStatComputation();
+      triggerServerStatComputation("Cluster:PutCount");
 
       Set<String> servers = new HashSet<>();
 
@@ -59,7 +59,7 @@ public class HAStatisticsIT extends AbstractHATest {
   public void test_passive_stats() throws Exception {
     try {
       System.out.println("Please be patient... Test can take about 15s...");
-      triggerServerStatComputation();
+      triggerServerStatComputation("Cluster:PutCount");
 
       //System.out.println("put(pet1=Cubitus)");
       put(0, "pets", "pet1", "Cubitus"); // put on both active and passive
@@ -98,35 +98,6 @@ public class HAStatisticsIT extends AbstractHATest {
       e.printStackTrace();
       throw e;
     }
-  }
-
-  private void triggerServerStatComputation() throws Exception {
-    // trigger stats computation and wait for all stats to have been computed at least once
-    tmsAgentService.readTopology().serverStream().forEach(server -> {
-      ServerEntity serverEntity = server
-          .serverEntityStream()
-          .filter(e -> e.getType().equals(TmsAgentConfig.ENTITY_TYPE))
-          .findFirst()
-          .get();
-
-      try {
-        tmsAgentService.updateCollectedStatistics(
-            serverEntity.getContext(),
-            "ServerCacheStatistics",
-            Arrays.asList("Cluster:PutCount")
-        ).waitForReturn();
-      } catch (Exception e) {
-        throw new RuntimeException(e);
-      }
-    });
-
-    queryAllRemoteStatsUntil(stats -> !stats.isEmpty() && !stats
-        .stream()
-        .flatMap(o -> o.getStatistics().values().stream())
-        .map(statistic -> (StatisticHistory<?, ?>) statistic)
-        .filter(statisticHistory -> statisticHistory.getValue().length == 0)
-        .findFirst()
-        .isPresent());
   }
 
 }

--- a/management/testing/integration-tests/src/test/java/org/terracotta/management/integration/tests/ServerCacheManagementIT.java
+++ b/management/testing/integration-tests/src/test/java/org/terracotta/management/integration/tests/ServerCacheManagementIT.java
@@ -114,7 +114,7 @@ public class ServerCacheManagementIT extends AbstractSingleTest {
   @Test
   public void can_receive_server_statistics() throws Exception {
     System.out.println("Please be patient... Test can take about 15s...");
-    triggerServerStatComputation();
+    triggerServerStatComputation("Cluster:HitCount", "Cluster:MissCount", "Cluster:HitRatio", "ServerCache:Size");
 
     put(0, "pets", "pet1", "Cubitus");
     get(1, "pets", "pet1"); // hit
@@ -159,29 +159,6 @@ public class ServerCacheManagementIT extends AbstractSingleTest {
       return test;
     });
 
-  }
-
-  private void triggerServerStatComputation() throws Exception {
-    // trigger stats computation and wait for all stats to have been computed at least once
-    ServerEntity serverEntity = tmsAgentService.readTopology()
-        .activeServerEntityStream()
-        .filter(e -> e.getType().equals(TmsAgentConfig.ENTITY_TYPE))
-        .findFirst()
-        .get();
-
-    tmsAgentService.updateCollectedStatistics(
-        serverEntity.getContext(),
-        "ServerCacheStatistics",
-        Arrays.asList("Cluster:HitCount", "Cluster:MissCount", "Cluster:HitRatio", "ServerCache:Size")
-    ).waitForReturn();
-
-    queryAllRemoteStatsUntil(stats -> !stats.isEmpty() && !stats
-        .stream()
-        .flatMap(o -> o.getStatistics().values().stream())
-        .map(statistic -> (StatisticHistory<?, ?>) statistic)
-        .filter(statisticHistory -> statisticHistory.getValue().length == 0)
-        .findFirst()
-        .isPresent());
   }
 
 }

--- a/management/testing/integration-tests/src/test/java/org/terracotta/management/integration/tests/TopologyIT.java
+++ b/management/testing/integration-tests/src/test/java/org/terracotta/management/integration/tests/TopologyIT.java
@@ -89,9 +89,6 @@ public class TopologyIT extends AbstractSingleTest {
     String actual = removeRandomValues(currentJson);
     String expected = readJson("notifications.json").toString();
 
-    System.out.println("This is the actual topology : " + actual);
-    System.out.println("This is the expected topology : " + expected);
-
     assertEquals(expected, actual);
   }
 

--- a/management/testing/sample-entity/src/main/java/org/terracotta/management/entity/sample/client/CacheFactory.java
+++ b/management/testing/sample-entity/src/main/java/org/terracotta/management/entity/sample/client/CacheFactory.java
@@ -19,6 +19,10 @@ import org.terracotta.connection.Connection;
 import org.terracotta.connection.ConnectionException;
 import org.terracotta.connection.ConnectionFactory;
 import org.terracotta.connection.ConnectionPropertyNames;
+import org.terracotta.connection.entity.EntityRef;
+import org.terracotta.exception.EntityNotFoundException;
+import org.terracotta.exception.EntityNotProvidedException;
+import org.terracotta.exception.PermanentEntityException;
 import org.terracotta.management.entity.sample.Cache;
 import org.terracotta.management.entity.sample.client.management.Management;
 import org.terracotta.management.model.context.ContextContainer;
@@ -88,6 +92,19 @@ public class CacheFactory implements Closeable {
 
       return clientCache;
     });
+  }
+
+  public void destroyCache(String name) {
+    ClientCache clientCache = caches.remove(name);
+    if (clientCache != null) {
+      clientCache.close();
+    }
+    try {
+      EntityRef<CacheEntity, String> ref = connection.getEntityRef(CacheEntity.class, 1, uri.getPath().substring(1) + "/" + name);
+      ref.destroy();
+    } catch (EntityNotProvidedException | PermanentEntityException | EntityNotFoundException e) {
+      throw new RuntimeException(e);
+    }
   }
 
   public Connection getConnection() {

--- a/management/testing/sample-entity/src/main/java/org/terracotta/management/entity/sample/client/ClientCache.java
+++ b/management/testing/sample-entity/src/main/java/org/terracotta/management/entity/sample/client/ClientCache.java
@@ -21,6 +21,7 @@ import org.terracotta.management.entity.sample.Cache;
 import org.terracotta.statistics.StatisticsManager;
 import org.terracotta.statistics.observer.OperationObserver;
 
+import java.io.Closeable;
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -37,7 +38,7 @@ import static org.terracotta.statistics.StatisticBuilder.operation;
 /**
  * @author Mathieu Carbou
  */
-public class ClientCache implements Cache {
+public class ClientCache implements Cache, Closeable {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(ClientCache.class);
 
@@ -159,4 +160,8 @@ public class ClientCache implements Cache {
     data.remove(key, val);
   }
 
+  @Override
+  public void close() {
+    delegate.close();
+  }
 }

--- a/management/testing/sample-entity/src/main/java/org/terracotta/management/entity/sample/server/ActiveCacheServerEntity.java
+++ b/management/testing/sample-entity/src/main/java/org/terracotta/management/entity/sample/server/ActiveCacheServerEntity.java
@@ -17,7 +17,6 @@ package org.terracotta.management.entity.sample.server;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.terracotta.entity.ServiceRegistry;
 import org.terracotta.management.entity.sample.Cache;
 import org.terracotta.management.entity.sample.server.management.Management;
 import org.terracotta.voltron.proxy.server.ActiveProxiedServerEntity;
@@ -35,22 +34,23 @@ class ActiveCacheServerEntity extends ActiveProxiedServerEntity<Cache, CacheSync
   private final ServerCache cache;
   private final ServerCache.Listener listener = (key, value) -> fireMessage(Serializable[].class, new Serializable[]{"remove", key, value}, true);
 
-  ActiveCacheServerEntity(ServerCache cache, ServiceRegistry serviceRegistry) {
+  ActiveCacheServerEntity(ServerCache cache, Management management) {
     super(cache, null);
     this.cache = cache;
 
     // callback clients on eviction
     cache.addListener(listener);
 
-    this.management = new Management(cache.getName(), serviceRegistry, true);
+    this.management = management;
   }
 
   @Override
   public void createNew() {
     super.createNew();
     LOGGER.trace("[{}] createNew()", cache.getName());
-    management.init();
-    management.serverCacheCreated(cache);
+    if (management.init()) {
+      management.serverCacheCreated(cache);
+    }
   }
 
   @Override

--- a/management/testing/sample-entity/src/main/java/org/terracotta/management/entity/sample/server/PassiveCacheServerEntity.java
+++ b/management/testing/sample-entity/src/main/java/org/terracotta/management/entity/sample/server/PassiveCacheServerEntity.java
@@ -17,7 +17,6 @@ package org.terracotta.management.entity.sample.server;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.terracotta.entity.ServiceRegistry;
 import org.terracotta.management.entity.sample.Cache;
 import org.terracotta.management.entity.sample.server.management.Management;
 import org.terracotta.voltron.proxy.server.PassiveProxiedServerEntity;
@@ -32,10 +31,10 @@ class PassiveCacheServerEntity extends PassiveProxiedServerEntity<Cache, CacheSy
   private final Management management;
   private final ServerCache cache;
 
-  PassiveCacheServerEntity(ServerCache cache, ServiceRegistry serviceRegistry) {
+  PassiveCacheServerEntity(ServerCache cache, Management management) {
     super(cache, cache, null);
     this.cache = cache;
-    this.management = new Management(cache.getName(), serviceRegistry, false);
+    this.management = management;
   }
 
   @Override

--- a/management/testing/sample-entity/src/main/java/org/terracotta/management/entity/sample/server/management/Management.java
+++ b/management/testing/sample-entity/src/main/java/org/terracotta/management/entity/sample/server/management/Management.java
@@ -41,6 +41,8 @@ public class Management {
   private final ConsumerManagementRegistry managementRegistry;
   private final String cacheName;
 
+  private boolean initialized;
+
   public Management(String cacheName, ServiceRegistry serviceRegistry, boolean active) {
     this.cacheName = cacheName;
     EntityMonitoringService monitoringService;
@@ -67,11 +69,17 @@ public class Management {
     }
   }
 
-  public void init() {
-    if (managementRegistry != null) {
-      LOGGER.trace("[{}] init()", cacheName);
-
-      managementRegistry.refresh(); // send to voltron the registry at entity init
+  // workaround for https://github.com/Terracotta-OSS/terracotta-core/issues/426
+  public synchronized boolean init() {
+    if (!initialized) {
+      if (managementRegistry != null) {
+        LOGGER.trace("[{}] init()", cacheName);
+        managementRegistry.refresh(); // send to voltron the registry at entity init
+      }
+      initialized = true;
+      return true;
+    } else {
+      return false;
     }
   }
 

--- a/management/tms-entity/tms-entity-server/src/main/java/org/terracotta/management/entity/tms/server/ActiveTmsAgentServerEntity.java
+++ b/management/tms-entity/tms-entity-server/src/main/java/org/terracotta/management/entity/tms/server/ActiveTmsAgentServerEntity.java
@@ -28,16 +28,9 @@ import java.util.concurrent.atomic.AtomicBoolean;
 class ActiveTmsAgentServerEntity extends ActiveProxiedServerEntity<TmsAgent, Void, Void, TmsAgentMessenger> {
 
   private final AtomicBoolean connected = new AtomicBoolean();
-  private final ActiveTmsAgent tmsAgent;
 
   ActiveTmsAgentServerEntity(ActiveTmsAgent tmsAgent) {
     super(tmsAgent, tmsAgent);
-    this.tmsAgent = tmsAgent;
-  }
-
-  @Override
-  public void createNew() {
-    tmsAgent.init();
   }
 
   @Override


### PR DESCRIPTION
See #252. This PR contains:

- Workaround for https://github.com/Terracotta-OSS/terracotta-core/issues/426 (`loadExisting()` ordering issue): entities can now listen for platform events received by monitoring service to know when they can start exposing management stuff.

- Added more javadoc and more tests

- Cleaned up the code related to failover detection on entities since the platform does not send us anymore the transition steps of entities during a failover (`isActive=false` then `isActive=true`)

Note: there is also https://github.com/Terracotta-OSS/terracotta-core/issues/427 (random test failure because of bad ordering in `addNode()` call) fixed by platform team.