### PR TITLE
Fixing CI build on master: management could be initialized twice 

### DIFF
--- a/management/monitoring-service/src/main/java/org/terracotta/management/service/monitoring/TopologyService.java
+++ b/management/monitoring-service/src/main/java/org/terracotta/management/service/monitoring/TopologyService.java
@@ -175,7 +175,9 @@ class TopologyService implements PlatformListener {
 
     firingService.fireNotification(new ContextualNotification(entity.getContext(), SERVER_ENTITY_CREATED.name()));
 
-    topologyEventListeners.forEach(listener -> listener.onEntityCreated(platformEntity.consumerID));
+    if (sender.getServerName().equals(platformConfiguration.getServerName())) {
+      topologyEventListeners.forEach(listener -> listener.onEntityCreated(platformEntity.consumerID));
+    }
   }
 
   @Override
@@ -203,7 +205,9 @@ class TopologyService implements PlatformListener {
       fetches.remove(platformEntity.consumerID);
     }
 
-    topologyEventListeners.forEach(listener -> listener.onEntityDestroyed(platformEntity.consumerID));
+    if (sender.getServerName().equals(platformConfiguration.getServerName())) {
+      topologyEventListeners.forEach(listener -> listener.onEntityDestroyed(platformEntity.consumerID));
+    }
 
     firingService.fireNotification(new ContextualNotification(context, SERVER_ENTITY_DESTROYED.name()));
   }

--- a/management/testing/integration-tests/src/test/java/org/terracotta/management/integration/tests/PassiveStartupIT.java
+++ b/management/testing/integration-tests/src/test/java/org/terracotta/management/integration/tests/PassiveStartupIT.java
@@ -87,7 +87,9 @@ public class PassiveStartupIT extends AbstractHATest {
         .map(contextualNotification -> contextualNotification.getAttributes().get("state"))
         .forEach(states::add);
 
-    while (!Thread.currentThread().isInterrupted() && !(states.contains("SYNCHRONIZING") && states.contains("PASSIVE"))) {
+    while (!Thread.currentThread().isInterrupted()
+        && !(states.contains("SYNCHRONIZING") && states.contains("PASSIVE"))
+        && !notifs.stream().anyMatch(contextualNotification -> contextualNotification.getType().equals("SYNC_END"))) {
       tmsAgentService.readMessages().stream()
           .filter(message -> message.getType().equals("NOTIFICATION"))
           .flatMap(message -> message.unwrap(ContextualNotification.class).stream())

--- a/management/testing/integration-tests/src/test/java/org/terracotta/management/integration/tests/PassiveTopologyIT.java
+++ b/management/testing/integration-tests/src/test/java/org/terracotta/management/integration/tests/PassiveTopologyIT.java
@@ -23,12 +23,10 @@ import org.terracotta.management.model.cluster.Server;
 import org.terracotta.management.model.notification.ContextualNotification;
 import org.terracotta.management.registry.collect.StatisticConfiguration;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
-import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.hasItems;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;

--- a/management/testing/sample-entity/src/main/java/org/terracotta/management/entity/sample/server/ActiveCacheServerEntity.java
+++ b/management/testing/sample-entity/src/main/java/org/terracotta/management/entity/sample/server/ActiveCacheServerEntity.java
@@ -45,15 +45,6 @@ class ActiveCacheServerEntity extends ActiveProxiedServerEntity<Cache, CacheSync
   }
 
   @Override
-  public void createNew() {
-    super.createNew();
-    LOGGER.trace("[{}] createNew()", cache.getName());
-    if (management.init()) {
-      management.serverCacheCreated(cache);
-    }
-  }
-
-  @Override
   public void destroy() {
     LOGGER.trace("[{}] destroy()", cache.getName());
     management.serverCacheDestroyed(cache);

--- a/management/testing/sample-entity/src/main/java/org/terracotta/management/entity/sample/server/CacheEntityServerService.java
+++ b/management/testing/sample-entity/src/main/java/org/terracotta/management/entity/sample/server/CacheEntityServerService.java
@@ -59,9 +59,8 @@ public class CacheEntityServerService extends ProxyServerEntityService<Cache, St
       @Override
       public void onCreated() {
         LOGGER.trace("[{}] onCreated()", identifier);
-        if(management.init()) {
-          management.serverCacheCreated(cache);
-        }
+        management.init();
+        management.serverCacheCreated(cache);
       }
     });
 

--- a/management/testing/sample-entity/src/main/java/org/terracotta/management/entity/sample/server/management/Management.java
+++ b/management/testing/sample-entity/src/main/java/org/terracotta/management/entity/sample/server/management/Management.java
@@ -41,8 +41,6 @@ public class Management {
   private final ConsumerManagementRegistry managementRegistry;
   private final String cacheName;
 
-  private boolean initialized;
-
   public Management(String cacheName, ServiceRegistry serviceRegistry, boolean active) {
     this.cacheName = cacheName;
     EntityMonitoringService monitoringService;
@@ -70,16 +68,10 @@ public class Management {
   }
 
   // workaround for https://github.com/Terracotta-OSS/terracotta-core/issues/426
-  public synchronized boolean init() {
-    if (!initialized) {
-      if (managementRegistry != null) {
-        LOGGER.trace("[{}] init()", cacheName);
-        managementRegistry.refresh(); // send to voltron the registry at entity init
-      }
-      initialized = true;
-      return true;
-    } else {
-      return false;
+  public synchronized void init() {
+    if (managementRegistry != null) {
+      LOGGER.trace("[{}] init()", cacheName);
+      managementRegistry.refresh(); // send to voltron the registry at entity init
     }
   }
 


### PR DESCRIPTION
`PassiveTopologyIT.notification_on_entity_creation_and_destruction`

https://terracotta-oss.ci.cloudbees.com/job/terracotta-platform/234/console

The ordering of notifications can change