### PR TITLE
Support for Entity.reconfigure() and Added config option in TmsAgent Entity to set a stripe name

### DIFF
--- a/management/cluster-topology/src/main/java/org/terracotta/management/model/cluster/Stripe.java
+++ b/management/cluster-topology/src/main/java/org/terracotta/management/model/cluster/Stripe.java
@@ -144,7 +144,7 @@ public final class Stripe extends AbstractNode<Cluster> {
   public void remove() {
     Cluster parent = getParent();
     if (parent != null) {
-      parent.removeClient(getId());
+      parent.removeStripe(getId());
     }
   }
 

--- a/management/monitoring-service/src/main/java/org/terracotta/management/service/monitoring/IStripeMonitoringPlatformListenerAdapter.java
+++ b/management/monitoring-service/src/main/java/org/terracotta/management/service/monitoring/IStripeMonitoringPlatformListenerAdapter.java
@@ -152,14 +152,6 @@ final class IStripeMonitoringPlatformListenerAdapter implements IStripeMonitorin
     switch (parents[parents.length - 1]) {
 
       case "entities": {
-        // ignore removeNode() if fetches are in progress on active server
-        if (sender.getServerName().equals(currentActive)) {
-          for (PlatformClientFetchedEntity fetch : fetches.values()) {
-            if (fetch.entityIdentifier.equals(name)) {
-              return false;
-            }
-          }
-        }
         Map<String, PlatformEntity> serverEntities = entities.get(sender.getServerName());
         PlatformEntity entity = serverEntities.remove(name);
         if (entity != null) {

--- a/management/monitoring-service/src/main/java/org/terracotta/management/service/monitoring/IStripeMonitoringPlatformListenerAdapter.java
+++ b/management/monitoring-service/src/main/java/org/terracotta/management/service/monitoring/IStripeMonitoringPlatformListenerAdapter.java
@@ -93,21 +93,14 @@ final class IStripeMonitoringPlatformListenerAdapter implements IStripeMonitorin
 
         case "entities": {
           PlatformEntity platformEntity = (PlatformEntity) value;
-          requireNonNull(entities.get(sender.getServerName()), "Inconsistent monitoring tree: server did not joined stripe first: " + sender.getServerName())
+          PlatformEntity previous = requireNonNull(entities.get(sender.getServerName()), "Inconsistent monitoring tree: server did not joined stripe first: " + sender.getServerName())
               .put(name, platformEntity);
-          // Workaround for https://github.com/Terracotta-OSS/terracotta-core/issues/405
           if (platformEntity.isActive || !sender.getServerName().equals(currentActive)) {
-            delegate.serverEntityCreated(sender, platformEntity);
-          } else {
-            // event about a passive entity on an active server
-            // this is illegal, but platform was previously sending
-            // us some combinations like that in case of a failover
-            // when passive server become active and replays events
-            // regarding its old passive entities.
-            // Now, in new tc-core versions, we do not receive such
-            // events anymore so we are unable to keep track of failover
-            // transition for entities (https://github.com/Terracotta-OSS/terracotta-core/issues/405)
-            LOGGER.warn("Ignoring platform event for passive entity {} created on new active server {} after a failover", platformEntity, sender.getServerName());
+            if (previous == null) {
+              delegate.serverEntityCreated(sender, platformEntity);
+            } else {
+              delegate.serverEntityReconfigured(sender, platformEntity);
+            }
           }
           return true;
         }
@@ -159,6 +152,14 @@ final class IStripeMonitoringPlatformListenerAdapter implements IStripeMonitorin
     switch (parents[parents.length - 1]) {
 
       case "entities": {
+        // ignore removeNode() if fetches are in progress on active server
+        if (sender.getServerName().equals(currentActive)) {
+          for (PlatformClientFetchedEntity fetch : fetches.values()) {
+            if (fetch.entityIdentifier.equals(name)) {
+              return false;
+            }
+          }
+        }
         Map<String, PlatformEntity> serverEntities = entities.get(sender.getServerName());
         PlatformEntity entity = serverEntities.remove(name);
         if (entity != null) {

--- a/management/monitoring-service/src/main/java/org/terracotta/management/service/monitoring/Notification.java
+++ b/management/monitoring-service/src/main/java/org/terracotta/management/service/monitoring/Notification.java
@@ -20,6 +20,7 @@ package org.terracotta.management.service.monitoring;
  */
 enum Notification {
   SERVER_ENTITY_CREATED,
+  SERVER_ENTITY_RECONFIGURED,
   SERVER_ENTITY_DESTROYED,
 
   SERVER_ENTITY_FETCHED,

--- a/management/monitoring-service/src/main/java/org/terracotta/management/service/monitoring/PlatformListener.java
+++ b/management/monitoring-service/src/main/java/org/terracotta/management/service/monitoring/PlatformListener.java
@@ -36,6 +36,8 @@ interface PlatformListener {
 
   void serverEntityCreated(PlatformServer sender, PlatformEntity entity);
 
+  void serverEntityReconfigured(PlatformServer sender, PlatformEntity entity);
+
   void serverEntityDestroyed(PlatformServer sender, PlatformEntity entity);
 
   void serverStateChanged(PlatformServer sender, ServerState state);

--- a/management/testing/integration-tests/src/test/java/org/terracotta/management/integration/tests/AbstractTest.java
+++ b/management/testing/integration-tests/src/test/java/org/terracotta/management/integration/tests/AbstractTest.java
@@ -172,7 +172,8 @@ public abstract class AbstractTest {
     // create a tms entity
     TmsAgentEntityFactory tmsAgentEntityFactory = new TmsAgentEntityFactory(managementConnection, getClass().getSimpleName());
     TmsAgentEntity tmsAgentEntity = tmsAgentEntityFactory.retrieveOrCreate(new TmsAgentConfig()
-        .setMaximumUnreadMessages(1024 * 1024));
+        .setMaximumUnreadMessages(1024 * 1024)
+        .setStripeName("SINGLE"));
     this.tmsAgentService = new DefaultTmsAgentService(tmsAgentEntity);
     this.tmsAgentService.setOperationTimeout(60, TimeUnit.SECONDS);
   }

--- a/management/testing/integration-tests/src/test/java/org/terracotta/management/integration/tests/ReconfigureEntityIT.java
+++ b/management/testing/integration-tests/src/test/java/org/terracotta/management/integration/tests/ReconfigureEntityIT.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.management.integration.tests;
+
+import org.junit.FixMethodOrder;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.junit.runners.MethodSorters;
+import org.terracotta.management.entity.sample.client.CacheEntityFactory;
+import org.terracotta.management.model.cluster.Cluster;
+import org.terracotta.management.model.message.Message;
+import org.terracotta.management.model.notification.ContextualNotification;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
+/**
+ * @author Mathieu Carbou
+ */
+@RunWith(JUnit4.class)
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+public class ReconfigureEntityIT extends AbstractSingleTest {
+
+  @Test
+  public void reconfigure_entity() throws Exception {
+    // client 0 and 1 are both connected to the same server. For each client
+    // local cache 'clients' is connected to server entity pet-clinic/clients, which reads/writes server map pet-clinic/clients
+    // local cache 'pets' is connected to server entity pet-clinic/pets, which reads/writes server map pet-clinic/pets
+
+    put(0, "clients", "client1", "Mathieu");
+    put(0, "pets", "pet1", "Cubitus");
+
+    assertThat(get(0, "clients", "client1"), equalTo("Mathieu"));
+    assertThat(get(0, "pets", "pet1"), equalTo("Cubitus"));
+    assertThat(get(1, "clients", "client1"), equalTo("Mathieu"));
+    assertThat(get(1, "pets", "pet1"), equalTo("Cubitus"));
+
+    assertThat(size(0, "clients"), equalTo(1));
+    assertThat(size(0, "pets"), equalTo(1));
+
+    // clear local caches
+    caches.get("clients").get(0).clear();
+    caches.get("pets").get(0).clear();
+    assertThat(size(0, "clients"), equalTo(0));
+    assertThat(size(0, "pets"), equalTo(0));
+
+    // we will reconfigure the pet-clinic/pets entity so that it connects to pet-clinic/clients
+    // so both entities points now to the same map
+    CacheEntityFactory factory0 = new CacheEntityFactory(webappNodes.get(0).getConnection());
+    factory0.reconfigure("pet-clinic/pets", "pet-clinic/clients");
+
+    // now we should be able to get pets values from clients cache and vis versa
+    assertThat(get(0, "pets", "client1"), equalTo("Mathieu"));
+    assertThat(size(0, "pets"), equalTo(1));
+
+    // and just for fun, ensure we can still pass values from client to client
+    put(1, "clients", "client2", "Anthony");
+    // but get the values from the pets cache ;-)
+    assertThat(get(0, "pets", "client2"), equalTo("Anthony"));
+  }
+
+  @Test
+  public void topology_after_reconfigure() throws Exception {
+    Cluster cluster = tmsAgentService.readTopology();
+    String currentTopo = toJson(cluster.toMap()).toString();
+    String actual = removeRandomValues(currentTopo);
+    String expected = readJson("topology-before-reconfigure.json").toString();
+    System.out.println(actual);
+    assertEquals(expected, actual);
+
+    CacheEntityFactory factory0 = new CacheEntityFactory(webappNodes.get(0).getConnection());
+    factory0.reconfigure("pet-clinic/pets", "pet-clinic/clients");
+
+    cluster = tmsAgentService.readTopology();
+    currentTopo = toJson(cluster.toMap()).toString();
+    actual = removeRandomValues(currentTopo);
+    expected = readJson("topology-reconfigured.json").toString();
+    System.out.println(actual);
+    assertEquals(expected, actual);
+  }
+
+  @Test
+  public void notification_after_reconfigure() throws Exception {
+    tmsAgentService.readMessages();
+
+    CacheEntityFactory factory0 = new CacheEntityFactory(webappNodes.get(0).getConnection());
+    factory0.reconfigure("pet-clinic/pets", "pet-clinic/clients");
+
+    List<Message> messages = tmsAgentService.readMessages();
+    List<ContextualNotification> notifs = messages.stream()
+        .filter(message -> message.getType().equals("NOTIFICATION"))
+        .flatMap(message -> message.unwrap(ContextualNotification.class).stream())
+        .collect(Collectors.toList());
+
+    String currentJson = toJson(notifs).toString();
+    String actual = removeRandomValues(currentJson);
+    String expected = readJson("notifications-after-reconfigure.json").toString();
+
+    assertEquals(expected, actual);
+  }
+
+}

--- a/management/testing/integration-tests/src/test/java/org/terracotta/management/integration/tests/StripeNamedIT.java
+++ b/management/testing/integration-tests/src/test/java/org/terracotta/management/integration/tests/StripeNamedIT.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.management.integration.tests;
+
+import org.junit.Test;
+import org.terracotta.connection.Connection;
+import org.terracotta.connection.ConnectionFactory;
+import org.terracotta.connection.ConnectionPropertyNames;
+import org.terracotta.management.entity.tms.TmsAgentConfig;
+import org.terracotta.management.entity.tms.client.DefaultTmsAgentService;
+import org.terracotta.management.entity.tms.client.TmsAgentEntity;
+import org.terracotta.management.entity.tms.client.TmsAgentEntityFactory;
+import org.terracotta.management.entity.tms.client.TmsAgentService;
+
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+/**
+ * @author Mathieu Carbou
+ */
+public class StripeNamedIT extends AbstractSingleTest {
+
+  @Test
+  public void stripe_can_be_named() throws Exception {
+    // connects to server
+    Properties properties = new Properties();
+    properties.setProperty(ConnectionPropertyNames.CONNECTION_NAME, getClass().getSimpleName());
+    properties.setProperty(ConnectionPropertyNames.CONNECTION_TIMEOUT, "5000");
+    Connection managementConnection = ConnectionFactory.connect(voltron.getConnectionURI(), properties);
+
+    // create a tms entity
+    TmsAgentEntityFactory tmsAgentEntityFactory = new TmsAgentEntityFactory(managementConnection, getClass().getSimpleName() + "-2");
+    TmsAgentEntity tmsAgentEntity = tmsAgentEntityFactory.retrieveOrCreate(new TmsAgentConfig()
+        .setMaximumUnreadMessages(1024 * 1024)
+        .setStripeName("MY SUPER STRIPE"));
+    TmsAgentService tmsAgentService = new DefaultTmsAgentService(tmsAgentEntity);
+    tmsAgentService.setOperationTimeout(60, TimeUnit.SECONDS);
+
+    assertThat(tmsAgentService.readTopology().getSingleStripe().getName(), equalTo("MY SUPER STRIPE"));
+  }
+
+}

--- a/management/testing/integration-tests/src/test/resources/notifications-after-reconfigure.json
+++ b/management/testing/integration-tests/src/test/resources/notifications-after-reconfigure.json
@@ -1,0 +1,75 @@
+[
+  {
+    "attributes": {},
+    "context": {
+      "consumerId": "3",
+      "alias": "pet-clinic/pets",
+      "type": "ServerCache",
+      "stripeId": "SINGLE",
+      "serverId": "testServer0",
+      "serverName": "testServer0",
+      "entityId": "pet-clinic/pets:org.terracotta.management.entity.sample.client.CacheEntity",
+      "entityName": "pet-clinic/pets",
+      "entityType": "org.terracotta.management.entity.sample.client.CacheEntity"
+    },
+    "type": "SERVER_CACHE_DESTROYED"
+  },
+  {
+    "attributes": {},
+    "context": {
+      "consumerId": "3",
+      "alias": "pet-clinic/clients",
+      "type": "ServerCache",
+      "stripeId": "SINGLE",
+      "serverId": "testServer0",
+      "serverName": "testServer0",
+      "entityId": "pet-clinic/pets:org.terracotta.management.entity.sample.client.CacheEntity",
+      "entityName": "pet-clinic/pets",
+      "entityType": "org.terracotta.management.entity.sample.client.CacheEntity"
+    },
+    "type": "SERVER_CACHE_CREATED"
+  },
+  {
+    "attributes": {},
+    "context": {
+      "consumerId": "3",
+      "alias": "0@127.0.0.1:pet-clinic:<uuid>",
+      "type": "ClientState",
+      "stripeId": "SINGLE",
+      "serverId": "testServer0",
+      "serverName": "testServer0",
+      "entityId": "pet-clinic/pets:org.terracotta.management.entity.sample.client.CacheEntity",
+      "entityName": "pet-clinic/pets",
+      "entityType": "org.terracotta.management.entity.sample.client.CacheEntity"
+    },
+    "type": "CLIENT_ATTACHED"
+  },
+  {
+    "attributes": {},
+    "context": {
+      "consumerId": "3",
+      "alias": "0@127.0.0.1:pet-clinic:<uuid>",
+      "type": "ClientState",
+      "stripeId": "SINGLE",
+      "serverId": "testServer0",
+      "serverName": "testServer0",
+      "entityId": "pet-clinic/pets:org.terracotta.management.entity.sample.client.CacheEntity",
+      "entityName": "pet-clinic/pets",
+      "entityType": "org.terracotta.management.entity.sample.client.CacheEntity"
+    },
+    "type": "CLIENT_ATTACHED"
+  },
+  {
+    "attributes": {},
+    "context": {
+      "stripeId": "SINGLE",
+      "serverId": "testServer0",
+      "serverName": "testServer0",
+      "entityId": "pet-clinic/pets:org.terracotta.management.entity.sample.client.CacheEntity",
+      "entityName": "pet-clinic/pets",
+      "entityType": "org.terracotta.management.entity.sample.client.CacheEntity",
+      "consumerId": "3"
+    },
+    "type": "SERVER_ENTITY_RECONFIGURED"
+  }
+]

--- a/management/testing/integration-tests/src/test/resources/topology-before-reconfigure.json
+++ b/management/testing/integration-tests/src/test/resources/topology-before-reconfigure.json
@@ -1,0 +1,842 @@
+{
+  "stripes": [
+    {
+      "id": "SINGLE",
+      "name": "SINGLE",
+      "servers": [
+        {
+          "id": "testServer0",
+          "serverEntities": [
+            {
+              "id": "ManagementAgent:org.terracotta.management.entity.management.client.ManagementAgentEntity",
+              "type": "org.terracotta.management.entity.management.client.ManagementAgentEntity",
+              "name": "ManagementAgent",
+              "consumerId": 2,
+              "managementRegistry": null
+            },
+            {
+              "id": "ReconfigureEntityIT:org.terracotta.management.entity.tms.client.TmsAgentEntity",
+              "type": "org.terracotta.management.entity.tms.client.TmsAgentEntity",
+              "name": "ReconfigureEntityIT",
+              "consumerId": 1,
+              "managementRegistry": {
+                "contextContainer": {
+                  "consumerId": "1",
+                  "subContexts": []
+                },
+                "capabilities": [
+                  {
+                    "name": "OffHeapResourceSettings",
+                    "context": [
+                      {
+                        "name": "consumerId",
+                        "required": true
+                      },
+                      {
+                        "name": "type",
+                        "required": true
+                      },
+                      {
+                        "name": "alias",
+                        "required": true
+                      }
+                    ],
+                    "descriptors": [
+                      {
+                        "consumerId": "1",
+                        "alias": "primary-server-resource",
+                        "type": "OffHeapResource",
+                        "capacity": 67108864,
+                        "availableAtTime": 67108864
+                      },
+                      {
+                        "type": "OffHeapResourceSettingsManagementProvider",
+                        "time": 0
+                      }
+                    ]
+                  },
+                  {
+                    "name": "OffHeapResourceStatistics",
+                    "context": [
+                      {
+                        "name": "consumerId",
+                        "required": true
+                      },
+                      {
+                        "name": "type",
+                        "required": true
+                      },
+                      {
+                        "name": "alias",
+                        "required": true
+                      }
+                    ],
+                    "descriptors": [
+                      {
+                        "name": "OffHeapResource:AllocatedMemory",
+                        "type": "SIZE"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "StatisticCollectorCapability",
+                    "context": [
+                      {
+                        "name": "consumerId",
+                        "required": true
+                      }
+                    ],
+                    "descriptors": [
+                      {
+                        "name": "startStatisticCollector",
+                        "returnType": "void",
+                        "parameters": [
+                          {
+                            "name": "interval",
+                            "type": "long"
+                          },
+                          {
+                            "name": "unit",
+                            "type": "java.util.concurrent.TimeUnit"
+                          }
+                        ]
+                      },
+                      {
+                        "name": "stopStatisticCollector",
+                        "returnType": "void",
+                        "parameters": []
+                      }
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "id": "pet-clinic/clients:org.terracotta.management.entity.sample.client.CacheEntity",
+              "type": "org.terracotta.management.entity.sample.client.CacheEntity",
+              "name": "pet-clinic/clients",
+              "consumerId": 4,
+              "managementRegistry": {
+                "contextContainer": {
+                  "consumerId": "4",
+                  "subContexts": []
+                },
+                "capabilities": [
+                  {
+                    "name": "ClientStateSettings",
+                    "context": [
+                      {
+                        "name": "consumerId",
+                        "required": true
+                      },
+                      {
+                        "name": "type",
+                        "required": true
+                      },
+                      {
+                        "name": "alias",
+                        "required": true
+                      }
+                    ],
+                    "descriptors": [
+                      {
+                        "consumerId": "4",
+                        "alias": "0@127.0.0.1:pet-clinic:<uuid>",
+                        "type": "ClientState",
+                        "attached": true
+                      },
+                      {
+                        "consumerId": "4",
+                        "alias": "0@127.0.0.1:pet-clinic:<uuid>",
+                        "type": "ClientState",
+                        "attached": true
+                      }
+                    ]
+                  },
+                  {
+                    "name": "ServerCacheCalls",
+                    "context": [
+                      {
+                        "name": "consumerId",
+                        "required": true
+                      },
+                      {
+                        "name": "cacheName",
+                        "required": true
+                      }
+                    ],
+                    "descriptors": [
+                      {
+                        "name": "clear",
+                        "returnType": "void",
+                        "parameters": []
+                      },
+                      {
+                        "name": "get",
+                        "returnType": "java.lang.String",
+                        "parameters": [
+                          {
+                            "name": "key",
+                            "type": "java.lang.String"
+                          }
+                        ]
+                      },
+                      {
+                        "name": "put",
+                        "returnType": "void",
+                        "parameters": [
+                          {
+                            "name": "key",
+                            "type": "java.lang.String"
+                          },
+                          {
+                            "name": "value",
+                            "type": "java.lang.String"
+                          }
+                        ]
+                      },
+                      {
+                        "name": "size",
+                        "returnType": "int",
+                        "parameters": []
+                      }
+                    ]
+                  },
+                  {
+                    "name": "ServerCacheSettings",
+                    "context": [
+                      {
+                        "name": "consumerId",
+                        "required": true
+                      },
+                      {
+                        "name": "type",
+                        "required": true
+                      },
+                      {
+                        "name": "alias",
+                        "required": true
+                      }
+                    ],
+                    "descriptors": [
+                      {
+                        "consumerId": "4",
+                        "alias": "pet-clinic/clients",
+                        "type": "ServerCache",
+                        "size": 0
+                      },
+                      {
+                        "type": "ServerCacheSettings",
+                        "time": 0
+                      }
+                    ]
+                  },
+                  {
+                    "name": "ServerCacheStatistics",
+                    "context": [
+                      {
+                        "name": "consumerId",
+                        "required": true
+                      },
+                      {
+                        "name": "type",
+                        "required": true
+                      },
+                      {
+                        "name": "alias",
+                        "required": true
+                      }
+                    ],
+                    "descriptors": [
+                      {
+                        "name": "Cluster:ClearCount",
+                        "type": "COUNTER"
+                      },
+                      {
+                        "name": "Cluster:HitCount",
+                        "type": "COUNTER"
+                      },
+                      {
+                        "name": "Cluster:MissCount",
+                        "type": "COUNTER"
+                      },
+                      {
+                        "name": "Cluster:PutCount",
+                        "type": "COUNTER"
+                      },
+                      {
+                        "name": "ServerCache:Size",
+                        "type": "SIZE"
+                      }
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "id": "pet-clinic/pets:org.terracotta.management.entity.sample.client.CacheEntity",
+              "type": "org.terracotta.management.entity.sample.client.CacheEntity",
+              "name": "pet-clinic/pets",
+              "consumerId": 3,
+              "managementRegistry": {
+                "contextContainer": {
+                  "consumerId": "3",
+                  "subContexts": []
+                },
+                "capabilities": [
+                  {
+                    "name": "ClientStateSettings",
+                    "context": [
+                      {
+                        "name": "consumerId",
+                        "required": true
+                      },
+                      {
+                        "name": "type",
+                        "required": true
+                      },
+                      {
+                        "name": "alias",
+                        "required": true
+                      }
+                    ],
+                    "descriptors": [
+                      {
+                        "consumerId": "3",
+                        "alias": "0@127.0.0.1:pet-clinic:<uuid>",
+                        "type": "ClientState",
+                        "attached": true
+                      },
+                      {
+                        "consumerId": "3",
+                        "alias": "0@127.0.0.1:pet-clinic:<uuid>",
+                        "type": "ClientState",
+                        "attached": true
+                      }
+                    ]
+                  },
+                  {
+                    "name": "ServerCacheCalls",
+                    "context": [
+                      {
+                        "name": "consumerId",
+                        "required": true
+                      },
+                      {
+                        "name": "cacheName",
+                        "required": true
+                      }
+                    ],
+                    "descriptors": [
+                      {
+                        "name": "clear",
+                        "returnType": "void",
+                        "parameters": []
+                      },
+                      {
+                        "name": "get",
+                        "returnType": "java.lang.String",
+                        "parameters": [
+                          {
+                            "name": "key",
+                            "type": "java.lang.String"
+                          }
+                        ]
+                      },
+                      {
+                        "name": "put",
+                        "returnType": "void",
+                        "parameters": [
+                          {
+                            "name": "key",
+                            "type": "java.lang.String"
+                          },
+                          {
+                            "name": "value",
+                            "type": "java.lang.String"
+                          }
+                        ]
+                      },
+                      {
+                        "name": "size",
+                        "returnType": "int",
+                        "parameters": []
+                      }
+                    ]
+                  },
+                  {
+                    "name": "ServerCacheSettings",
+                    "context": [
+                      {
+                        "name": "consumerId",
+                        "required": true
+                      },
+                      {
+                        "name": "type",
+                        "required": true
+                      },
+                      {
+                        "name": "alias",
+                        "required": true
+                      }
+                    ],
+                    "descriptors": [
+                      {
+                        "consumerId": "3",
+                        "alias": "pet-clinic/pets",
+                        "type": "ServerCache",
+                        "size": 0
+                      },
+                      {
+                        "type": "ServerCacheSettings",
+                        "time": 0
+                      }
+                    ]
+                  },
+                  {
+                    "name": "ServerCacheStatistics",
+                    "context": [
+                      {
+                        "name": "consumerId",
+                        "required": true
+                      },
+                      {
+                        "name": "type",
+                        "required": true
+                      },
+                      {
+                        "name": "alias",
+                        "required": true
+                      }
+                    ],
+                    "descriptors": [
+                      {
+                        "name": "Cluster:ClearCount",
+                        "type": "COUNTER"
+                      },
+                      {
+                        "name": "Cluster:HitCount",
+                        "type": "COUNTER"
+                      },
+                      {
+                        "name": "Cluster:MissCount",
+                        "type": "COUNTER"
+                      },
+                      {
+                        "name": "Cluster:PutCount",
+                        "type": "COUNTER"
+                      },
+                      {
+                        "name": "ServerCache:Size",
+                        "type": "SIZE"
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "serverName": "testServer0",
+          "hostName": "<hostname>",
+          "hostAddress": "127.0.0.1",
+          "bindAddress": "0.0.0.0",
+          "bindPort": 0,
+          "groupPort": 0,
+          "state": "ACTIVE",
+          "version": "<version>",
+          "buildId": "Build ID",
+          "startTime": 0,
+          "upTimeSec": 0,
+          "activateTime": 0
+        }
+      ]
+    }
+  ],
+  "clients": [
+    {
+      "id": "0@127.0.0.1:ReconfigureEntityIT:<uuid>",
+      "pid": 0,
+      "hostAddress": "127.0.0.1",
+      "name": "ReconfigureEntityIT",
+      "logicalConnectionUid": "<uuid>",
+      "vmId": "0@127.0.0.1",
+      "clientId": "0@127.0.0.1:ReconfigureEntityIT:<uuid>",
+      "hostName": "<hostname>",
+      "tags": [],
+      "connections": [
+        {
+          "id": "<uuid>:SINGLE:testServer0:127.0.0.1:0",
+          "logicalConnectionUid": "<uuid>",
+          "clientEndpoint": {
+            "address": "127.0.0.1",
+            "port": 0
+          },
+          "stripeId": "SINGLE",
+          "serverId": "testServer0",
+          "serverEntityIds": {
+            "ReconfigureEntityIT:org.terracotta.management.entity.tms.client.TmsAgentEntity": 1
+          }
+        }
+      ],
+      "managementRegistry": null
+    },
+    {
+      "id": "0@127.0.0.1:pet-clinic:<uuid>",
+      "pid": 0,
+      "hostAddress": "127.0.0.1",
+      "name": "pet-clinic",
+      "logicalConnectionUid": "<uuid>",
+      "vmId": "0@127.0.0.1",
+      "clientId": "0@127.0.0.1:pet-clinic:<uuid>",
+      "hostName": "<hostname>",
+      "tags": [
+        "caches",
+        "pet-clinic"
+      ],
+      "connections": [
+        {
+          "id": "<uuid>:SINGLE:testServer0:127.0.0.1:0",
+          "logicalConnectionUid": "<uuid>",
+          "clientEndpoint": {
+            "address": "127.0.0.1",
+            "port": 0
+          },
+          "stripeId": "SINGLE",
+          "serverId": "testServer0",
+          "serverEntityIds": {
+            "ManagementAgent:org.terracotta.management.entity.management.client.ManagementAgentEntity": 1,
+            "pet-clinic/clients:org.terracotta.management.entity.sample.client.CacheEntity": 1,
+            "pet-clinic/pets:org.terracotta.management.entity.sample.client.CacheEntity": 1
+          }
+        }
+      ],
+      "managementRegistry": {
+        "contextContainer": {
+          "appName": "pet-clinic",
+          "subContexts": []
+        },
+        "capabilities": [
+          {
+            "name": "CacheCalls",
+            "context": [
+              {
+                "name": "appName",
+                "required": true
+              },
+              {
+                "name": "cacheName",
+                "required": true
+              }
+            ],
+            "descriptors": [
+              {
+                "name": "clear",
+                "returnType": "void",
+                "parameters": []
+              },
+              {
+                "name": "get",
+                "returnType": "java.lang.String",
+                "parameters": [
+                  {
+                    "name": "key",
+                    "type": "java.lang.String"
+                  }
+                ]
+              },
+              {
+                "name": "put",
+                "returnType": "void",
+                "parameters": [
+                  {
+                    "name": "key",
+                    "type": "java.lang.String"
+                  },
+                  {
+                    "name": "value",
+                    "type": "java.lang.String"
+                  }
+                ]
+              },
+              {
+                "name": "size",
+                "returnType": "int",
+                "parameters": []
+              }
+            ]
+          },
+          {
+            "name": "CacheSettings",
+            "context": [
+              {
+                "name": "appName",
+                "required": true
+              },
+              {
+                "name": "cacheName",
+                "required": true
+              }
+            ],
+            "descriptors": [
+              {
+                "appName": "pet-clinic",
+                "cacheName": "pets",
+                "size": 0
+              },
+              {
+                "appName": "pet-clinic",
+                "cacheName": "clients",
+                "size": 0
+              }
+            ]
+          },
+          {
+            "name": "CacheStatistics",
+            "context": [
+              {
+                "name": "appName",
+                "required": true
+              },
+              {
+                "name": "cacheName",
+                "required": true
+              }
+            ],
+            "descriptors": [
+              {
+                "name": "Cache:ClearCount",
+                "type": "COUNTER"
+              },
+              {
+                "name": "Cache:HitCount",
+                "type": "COUNTER"
+              },
+              {
+                "name": "Cache:MissCount",
+                "type": "COUNTER"
+              },
+              {
+                "name": "ClientCache:Size",
+                "type": "SIZE"
+              }
+            ]
+          },
+          {
+            "name": "ManagementAgentService",
+            "context": [],
+            "descriptors": []
+          },
+          {
+            "name": "StatisticCollectorCapability",
+            "context": [
+              {
+                "name": "appName",
+                "required": true
+              }
+            ],
+            "descriptors": [
+              {
+                "name": "startStatisticCollector",
+                "returnType": "void",
+                "parameters": [
+                  {
+                    "name": "interval",
+                    "type": "long"
+                  },
+                  {
+                    "name": "unit",
+                    "type": "java.util.concurrent.TimeUnit"
+                  }
+                ]
+              },
+              {
+                "name": "stopStatisticCollector",
+                "returnType": "void",
+                "parameters": []
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "0@127.0.0.1:pet-clinic:<uuid>",
+      "pid": 0,
+      "hostAddress": "127.0.0.1",
+      "name": "pet-clinic",
+      "logicalConnectionUid": "<uuid>",
+      "vmId": "0@127.0.0.1",
+      "clientId": "0@127.0.0.1:pet-clinic:<uuid>",
+      "hostName": "<hostname>",
+      "tags": [
+        "caches",
+        "pet-clinic"
+      ],
+      "connections": [
+        {
+          "id": "<uuid>:SINGLE:testServer0:127.0.0.1:0",
+          "logicalConnectionUid": "<uuid>",
+          "clientEndpoint": {
+            "address": "127.0.0.1",
+            "port": 0
+          },
+          "stripeId": "SINGLE",
+          "serverId": "testServer0",
+          "serverEntityIds": {
+            "ManagementAgent:org.terracotta.management.entity.management.client.ManagementAgentEntity": 1,
+            "pet-clinic/clients:org.terracotta.management.entity.sample.client.CacheEntity": 1,
+            "pet-clinic/pets:org.terracotta.management.entity.sample.client.CacheEntity": 1
+          }
+        }
+      ],
+      "managementRegistry": {
+        "contextContainer": {
+          "appName": "pet-clinic",
+          "subContexts": []
+        },
+        "capabilities": [
+          {
+            "name": "CacheCalls",
+            "context": [
+              {
+                "name": "appName",
+                "required": true
+              },
+              {
+                "name": "cacheName",
+                "required": true
+              }
+            ],
+            "descriptors": [
+              {
+                "name": "clear",
+                "returnType": "void",
+                "parameters": []
+              },
+              {
+                "name": "get",
+                "returnType": "java.lang.String",
+                "parameters": [
+                  {
+                    "name": "key",
+                    "type": "java.lang.String"
+                  }
+                ]
+              },
+              {
+                "name": "put",
+                "returnType": "void",
+                "parameters": [
+                  {
+                    "name": "key",
+                    "type": "java.lang.String"
+                  },
+                  {
+                    "name": "value",
+                    "type": "java.lang.String"
+                  }
+                ]
+              },
+              {
+                "name": "size",
+                "returnType": "int",
+                "parameters": []
+              }
+            ]
+          },
+          {
+            "name": "CacheSettings",
+            "context": [
+              {
+                "name": "appName",
+                "required": true
+              },
+              {
+                "name": "cacheName",
+                "required": true
+              }
+            ],
+            "descriptors": [
+              {
+                "appName": "pet-clinic",
+                "cacheName": "pets",
+                "size": 0
+              },
+              {
+                "appName": "pet-clinic",
+                "cacheName": "clients",
+                "size": 0
+              }
+            ]
+          },
+          {
+            "name": "CacheStatistics",
+            "context": [
+              {
+                "name": "appName",
+                "required": true
+              },
+              {
+                "name": "cacheName",
+                "required": true
+              }
+            ],
+            "descriptors": [
+              {
+                "name": "Cache:ClearCount",
+                "type": "COUNTER"
+              },
+              {
+                "name": "Cache:HitCount",
+                "type": "COUNTER"
+              },
+              {
+                "name": "Cache:MissCount",
+                "type": "COUNTER"
+              },
+              {
+                "name": "ClientCache:Size",
+                "type": "SIZE"
+              }
+            ]
+          },
+          {
+            "name": "ManagementAgentService",
+            "context": [],
+            "descriptors": []
+          },
+          {
+            "name": "StatisticCollectorCapability",
+            "context": [
+              {
+                "name": "appName",
+                "required": true
+              }
+            ],
+            "descriptors": [
+              {
+                "name": "startStatisticCollector",
+                "returnType": "void",
+                "parameters": [
+                  {
+                    "name": "interval",
+                    "type": "long"
+                  },
+                  {
+                    "name": "unit",
+                    "type": "java.util.concurrent.TimeUnit"
+                  }
+                ]
+              },
+              {
+                "name": "stopStatisticCollector",
+                "returnType": "void",
+                "parameters": []
+              }
+            ]
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/management/testing/integration-tests/src/test/resources/topology-reconfigured.json
+++ b/management/testing/integration-tests/src/test/resources/topology-reconfigured.json
@@ -1,0 +1,842 @@
+{
+  "stripes": [
+    {
+      "id": "SINGLE",
+      "name": "SINGLE",
+      "servers": [
+        {
+          "id": "testServer0",
+          "serverEntities": [
+            {
+              "id": "ManagementAgent:org.terracotta.management.entity.management.client.ManagementAgentEntity",
+              "type": "org.terracotta.management.entity.management.client.ManagementAgentEntity",
+              "name": "ManagementAgent",
+              "consumerId": 2,
+              "managementRegistry": null
+            },
+            {
+              "id": "ReconfigureEntityIT:org.terracotta.management.entity.tms.client.TmsAgentEntity",
+              "type": "org.terracotta.management.entity.tms.client.TmsAgentEntity",
+              "name": "ReconfigureEntityIT",
+              "consumerId": 1,
+              "managementRegistry": {
+                "contextContainer": {
+                  "consumerId": "1",
+                  "subContexts": []
+                },
+                "capabilities": [
+                  {
+                    "name": "OffHeapResourceSettings",
+                    "context": [
+                      {
+                        "name": "consumerId",
+                        "required": true
+                      },
+                      {
+                        "name": "type",
+                        "required": true
+                      },
+                      {
+                        "name": "alias",
+                        "required": true
+                      }
+                    ],
+                    "descriptors": [
+                      {
+                        "consumerId": "1",
+                        "alias": "primary-server-resource",
+                        "type": "OffHeapResource",
+                        "capacity": 67108864,
+                        "availableAtTime": 67108864
+                      },
+                      {
+                        "type": "OffHeapResourceSettingsManagementProvider",
+                        "time": 0
+                      }
+                    ]
+                  },
+                  {
+                    "name": "OffHeapResourceStatistics",
+                    "context": [
+                      {
+                        "name": "consumerId",
+                        "required": true
+                      },
+                      {
+                        "name": "type",
+                        "required": true
+                      },
+                      {
+                        "name": "alias",
+                        "required": true
+                      }
+                    ],
+                    "descriptors": [
+                      {
+                        "name": "OffHeapResource:AllocatedMemory",
+                        "type": "SIZE"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "StatisticCollectorCapability",
+                    "context": [
+                      {
+                        "name": "consumerId",
+                        "required": true
+                      }
+                    ],
+                    "descriptors": [
+                      {
+                        "name": "startStatisticCollector",
+                        "returnType": "void",
+                        "parameters": [
+                          {
+                            "name": "interval",
+                            "type": "long"
+                          },
+                          {
+                            "name": "unit",
+                            "type": "java.util.concurrent.TimeUnit"
+                          }
+                        ]
+                      },
+                      {
+                        "name": "stopStatisticCollector",
+                        "returnType": "void",
+                        "parameters": []
+                      }
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "id": "pet-clinic/clients:org.terracotta.management.entity.sample.client.CacheEntity",
+              "type": "org.terracotta.management.entity.sample.client.CacheEntity",
+              "name": "pet-clinic/clients",
+              "consumerId": 4,
+              "managementRegistry": {
+                "contextContainer": {
+                  "consumerId": "4",
+                  "subContexts": []
+                },
+                "capabilities": [
+                  {
+                    "name": "ClientStateSettings",
+                    "context": [
+                      {
+                        "name": "consumerId",
+                        "required": true
+                      },
+                      {
+                        "name": "type",
+                        "required": true
+                      },
+                      {
+                        "name": "alias",
+                        "required": true
+                      }
+                    ],
+                    "descriptors": [
+                      {
+                        "consumerId": "4",
+                        "alias": "0@127.0.0.1:pet-clinic:<uuid>",
+                        "type": "ClientState",
+                        "attached": true
+                      },
+                      {
+                        "consumerId": "4",
+                        "alias": "0@127.0.0.1:pet-clinic:<uuid>",
+                        "type": "ClientState",
+                        "attached": true
+                      }
+                    ]
+                  },
+                  {
+                    "name": "ServerCacheCalls",
+                    "context": [
+                      {
+                        "name": "consumerId",
+                        "required": true
+                      },
+                      {
+                        "name": "cacheName",
+                        "required": true
+                      }
+                    ],
+                    "descriptors": [
+                      {
+                        "name": "clear",
+                        "returnType": "void",
+                        "parameters": []
+                      },
+                      {
+                        "name": "get",
+                        "returnType": "java.lang.String",
+                        "parameters": [
+                          {
+                            "name": "key",
+                            "type": "java.lang.String"
+                          }
+                        ]
+                      },
+                      {
+                        "name": "put",
+                        "returnType": "void",
+                        "parameters": [
+                          {
+                            "name": "key",
+                            "type": "java.lang.String"
+                          },
+                          {
+                            "name": "value",
+                            "type": "java.lang.String"
+                          }
+                        ]
+                      },
+                      {
+                        "name": "size",
+                        "returnType": "int",
+                        "parameters": []
+                      }
+                    ]
+                  },
+                  {
+                    "name": "ServerCacheSettings",
+                    "context": [
+                      {
+                        "name": "consumerId",
+                        "required": true
+                      },
+                      {
+                        "name": "type",
+                        "required": true
+                      },
+                      {
+                        "name": "alias",
+                        "required": true
+                      }
+                    ],
+                    "descriptors": [
+                      {
+                        "consumerId": "4",
+                        "alias": "pet-clinic/clients",
+                        "type": "ServerCache",
+                        "size": 0
+                      },
+                      {
+                        "type": "ServerCacheSettings",
+                        "time": 0
+                      }
+                    ]
+                  },
+                  {
+                    "name": "ServerCacheStatistics",
+                    "context": [
+                      {
+                        "name": "consumerId",
+                        "required": true
+                      },
+                      {
+                        "name": "type",
+                        "required": true
+                      },
+                      {
+                        "name": "alias",
+                        "required": true
+                      }
+                    ],
+                    "descriptors": [
+                      {
+                        "name": "Cluster:ClearCount",
+                        "type": "COUNTER"
+                      },
+                      {
+                        "name": "Cluster:HitCount",
+                        "type": "COUNTER"
+                      },
+                      {
+                        "name": "Cluster:MissCount",
+                        "type": "COUNTER"
+                      },
+                      {
+                        "name": "Cluster:PutCount",
+                        "type": "COUNTER"
+                      },
+                      {
+                        "name": "ServerCache:Size",
+                        "type": "SIZE"
+                      }
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "id": "pet-clinic/pets:org.terracotta.management.entity.sample.client.CacheEntity",
+              "type": "org.terracotta.management.entity.sample.client.CacheEntity",
+              "name": "pet-clinic/pets",
+              "consumerId": 3,
+              "managementRegistry": {
+                "contextContainer": {
+                  "consumerId": "3",
+                  "subContexts": []
+                },
+                "capabilities": [
+                  {
+                    "name": "ClientStateSettings",
+                    "context": [
+                      {
+                        "name": "consumerId",
+                        "required": true
+                      },
+                      {
+                        "name": "type",
+                        "required": true
+                      },
+                      {
+                        "name": "alias",
+                        "required": true
+                      }
+                    ],
+                    "descriptors": [
+                      {
+                        "consumerId": "3",
+                        "alias": "0@127.0.0.1:pet-clinic:<uuid>",
+                        "type": "ClientState",
+                        "attached": true
+                      },
+                      {
+                        "consumerId": "3",
+                        "alias": "0@127.0.0.1:pet-clinic:<uuid>",
+                        "type": "ClientState",
+                        "attached": true
+                      }
+                    ]
+                  },
+                  {
+                    "name": "ServerCacheCalls",
+                    "context": [
+                      {
+                        "name": "consumerId",
+                        "required": true
+                      },
+                      {
+                        "name": "cacheName",
+                        "required": true
+                      }
+                    ],
+                    "descriptors": [
+                      {
+                        "name": "clear",
+                        "returnType": "void",
+                        "parameters": []
+                      },
+                      {
+                        "name": "get",
+                        "returnType": "java.lang.String",
+                        "parameters": [
+                          {
+                            "name": "key",
+                            "type": "java.lang.String"
+                          }
+                        ]
+                      },
+                      {
+                        "name": "put",
+                        "returnType": "void",
+                        "parameters": [
+                          {
+                            "name": "key",
+                            "type": "java.lang.String"
+                          },
+                          {
+                            "name": "value",
+                            "type": "java.lang.String"
+                          }
+                        ]
+                      },
+                      {
+                        "name": "size",
+                        "returnType": "int",
+                        "parameters": []
+                      }
+                    ]
+                  },
+                  {
+                    "name": "ServerCacheSettings",
+                    "context": [
+                      {
+                        "name": "consumerId",
+                        "required": true
+                      },
+                      {
+                        "name": "type",
+                        "required": true
+                      },
+                      {
+                        "name": "alias",
+                        "required": true
+                      }
+                    ],
+                    "descriptors": [
+                      {
+                        "consumerId": "3",
+                        "alias": "pet-clinic/clients",
+                        "type": "ServerCache",
+                        "size": 0
+                      },
+                      {
+                        "type": "ServerCacheSettings",
+                        "time": 0
+                      }
+                    ]
+                  },
+                  {
+                    "name": "ServerCacheStatistics",
+                    "context": [
+                      {
+                        "name": "consumerId",
+                        "required": true
+                      },
+                      {
+                        "name": "type",
+                        "required": true
+                      },
+                      {
+                        "name": "alias",
+                        "required": true
+                      }
+                    ],
+                    "descriptors": [
+                      {
+                        "name": "Cluster:ClearCount",
+                        "type": "COUNTER"
+                      },
+                      {
+                        "name": "Cluster:HitCount",
+                        "type": "COUNTER"
+                      },
+                      {
+                        "name": "Cluster:MissCount",
+                        "type": "COUNTER"
+                      },
+                      {
+                        "name": "Cluster:PutCount",
+                        "type": "COUNTER"
+                      },
+                      {
+                        "name": "ServerCache:Size",
+                        "type": "SIZE"
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "serverName": "testServer0",
+          "hostName": "<hostname>",
+          "hostAddress": "127.0.0.1",
+          "bindAddress": "0.0.0.0",
+          "bindPort": 0,
+          "groupPort": 0,
+          "state": "ACTIVE",
+          "version": "<version>",
+          "buildId": "Build ID",
+          "startTime": 0,
+          "upTimeSec": 0,
+          "activateTime": 0
+        }
+      ]
+    }
+  ],
+  "clients": [
+    {
+      "id": "0@127.0.0.1:ReconfigureEntityIT:<uuid>",
+      "pid": 0,
+      "hostAddress": "127.0.0.1",
+      "name": "ReconfigureEntityIT",
+      "logicalConnectionUid": "<uuid>",
+      "vmId": "0@127.0.0.1",
+      "clientId": "0@127.0.0.1:ReconfigureEntityIT:<uuid>",
+      "hostName": "<hostname>",
+      "tags": [],
+      "connections": [
+        {
+          "id": "<uuid>:SINGLE:testServer0:127.0.0.1:0",
+          "logicalConnectionUid": "<uuid>",
+          "clientEndpoint": {
+            "address": "127.0.0.1",
+            "port": 0
+          },
+          "stripeId": "SINGLE",
+          "serverId": "testServer0",
+          "serverEntityIds": {
+            "ReconfigureEntityIT:org.terracotta.management.entity.tms.client.TmsAgentEntity": 1
+          }
+        }
+      ],
+      "managementRegistry": null
+    },
+    {
+      "id": "0@127.0.0.1:pet-clinic:<uuid>",
+      "pid": 0,
+      "hostAddress": "127.0.0.1",
+      "name": "pet-clinic",
+      "logicalConnectionUid": "<uuid>",
+      "vmId": "0@127.0.0.1",
+      "clientId": "0@127.0.0.1:pet-clinic:<uuid>",
+      "hostName": "<hostname>",
+      "tags": [
+        "caches",
+        "pet-clinic"
+      ],
+      "connections": [
+        {
+          "id": "<uuid>:SINGLE:testServer0:127.0.0.1:0",
+          "logicalConnectionUid": "<uuid>",
+          "clientEndpoint": {
+            "address": "127.0.0.1",
+            "port": 0
+          },
+          "stripeId": "SINGLE",
+          "serverId": "testServer0",
+          "serverEntityIds": {
+            "ManagementAgent:org.terracotta.management.entity.management.client.ManagementAgentEntity": 1,
+            "pet-clinic/clients:org.terracotta.management.entity.sample.client.CacheEntity": 1,
+            "pet-clinic/pets:org.terracotta.management.entity.sample.client.CacheEntity": 1
+          }
+        }
+      ],
+      "managementRegistry": {
+        "contextContainer": {
+          "appName": "pet-clinic",
+          "subContexts": []
+        },
+        "capabilities": [
+          {
+            "name": "CacheCalls",
+            "context": [
+              {
+                "name": "appName",
+                "required": true
+              },
+              {
+                "name": "cacheName",
+                "required": true
+              }
+            ],
+            "descriptors": [
+              {
+                "name": "clear",
+                "returnType": "void",
+                "parameters": []
+              },
+              {
+                "name": "get",
+                "returnType": "java.lang.String",
+                "parameters": [
+                  {
+                    "name": "key",
+                    "type": "java.lang.String"
+                  }
+                ]
+              },
+              {
+                "name": "put",
+                "returnType": "void",
+                "parameters": [
+                  {
+                    "name": "key",
+                    "type": "java.lang.String"
+                  },
+                  {
+                    "name": "value",
+                    "type": "java.lang.String"
+                  }
+                ]
+              },
+              {
+                "name": "size",
+                "returnType": "int",
+                "parameters": []
+              }
+            ]
+          },
+          {
+            "name": "CacheSettings",
+            "context": [
+              {
+                "name": "appName",
+                "required": true
+              },
+              {
+                "name": "cacheName",
+                "required": true
+              }
+            ],
+            "descriptors": [
+              {
+                "appName": "pet-clinic",
+                "cacheName": "pets",
+                "size": 0
+              },
+              {
+                "appName": "pet-clinic",
+                "cacheName": "clients",
+                "size": 0
+              }
+            ]
+          },
+          {
+            "name": "CacheStatistics",
+            "context": [
+              {
+                "name": "appName",
+                "required": true
+              },
+              {
+                "name": "cacheName",
+                "required": true
+              }
+            ],
+            "descriptors": [
+              {
+                "name": "Cache:ClearCount",
+                "type": "COUNTER"
+              },
+              {
+                "name": "Cache:HitCount",
+                "type": "COUNTER"
+              },
+              {
+                "name": "Cache:MissCount",
+                "type": "COUNTER"
+              },
+              {
+                "name": "ClientCache:Size",
+                "type": "SIZE"
+              }
+            ]
+          },
+          {
+            "name": "ManagementAgentService",
+            "context": [],
+            "descriptors": []
+          },
+          {
+            "name": "StatisticCollectorCapability",
+            "context": [
+              {
+                "name": "appName",
+                "required": true
+              }
+            ],
+            "descriptors": [
+              {
+                "name": "startStatisticCollector",
+                "returnType": "void",
+                "parameters": [
+                  {
+                    "name": "interval",
+                    "type": "long"
+                  },
+                  {
+                    "name": "unit",
+                    "type": "java.util.concurrent.TimeUnit"
+                  }
+                ]
+              },
+              {
+                "name": "stopStatisticCollector",
+                "returnType": "void",
+                "parameters": []
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "0@127.0.0.1:pet-clinic:<uuid>",
+      "pid": 0,
+      "hostAddress": "127.0.0.1",
+      "name": "pet-clinic",
+      "logicalConnectionUid": "<uuid>",
+      "vmId": "0@127.0.0.1",
+      "clientId": "0@127.0.0.1:pet-clinic:<uuid>",
+      "hostName": "<hostname>",
+      "tags": [
+        "caches",
+        "pet-clinic"
+      ],
+      "connections": [
+        {
+          "id": "<uuid>:SINGLE:testServer0:127.0.0.1:0",
+          "logicalConnectionUid": "<uuid>",
+          "clientEndpoint": {
+            "address": "127.0.0.1",
+            "port": 0
+          },
+          "stripeId": "SINGLE",
+          "serverId": "testServer0",
+          "serverEntityIds": {
+            "ManagementAgent:org.terracotta.management.entity.management.client.ManagementAgentEntity": 1,
+            "pet-clinic/clients:org.terracotta.management.entity.sample.client.CacheEntity": 1,
+            "pet-clinic/pets:org.terracotta.management.entity.sample.client.CacheEntity": 1
+          }
+        }
+      ],
+      "managementRegistry": {
+        "contextContainer": {
+          "appName": "pet-clinic",
+          "subContexts": []
+        },
+        "capabilities": [
+          {
+            "name": "CacheCalls",
+            "context": [
+              {
+                "name": "appName",
+                "required": true
+              },
+              {
+                "name": "cacheName",
+                "required": true
+              }
+            ],
+            "descriptors": [
+              {
+                "name": "clear",
+                "returnType": "void",
+                "parameters": []
+              },
+              {
+                "name": "get",
+                "returnType": "java.lang.String",
+                "parameters": [
+                  {
+                    "name": "key",
+                    "type": "java.lang.String"
+                  }
+                ]
+              },
+              {
+                "name": "put",
+                "returnType": "void",
+                "parameters": [
+                  {
+                    "name": "key",
+                    "type": "java.lang.String"
+                  },
+                  {
+                    "name": "value",
+                    "type": "java.lang.String"
+                  }
+                ]
+              },
+              {
+                "name": "size",
+                "returnType": "int",
+                "parameters": []
+              }
+            ]
+          },
+          {
+            "name": "CacheSettings",
+            "context": [
+              {
+                "name": "appName",
+                "required": true
+              },
+              {
+                "name": "cacheName",
+                "required": true
+              }
+            ],
+            "descriptors": [
+              {
+                "appName": "pet-clinic",
+                "cacheName": "pets",
+                "size": 0
+              },
+              {
+                "appName": "pet-clinic",
+                "cacheName": "clients",
+                "size": 0
+              }
+            ]
+          },
+          {
+            "name": "CacheStatistics",
+            "context": [
+              {
+                "name": "appName",
+                "required": true
+              },
+              {
+                "name": "cacheName",
+                "required": true
+              }
+            ],
+            "descriptors": [
+              {
+                "name": "Cache:ClearCount",
+                "type": "COUNTER"
+              },
+              {
+                "name": "Cache:HitCount",
+                "type": "COUNTER"
+              },
+              {
+                "name": "Cache:MissCount",
+                "type": "COUNTER"
+              },
+              {
+                "name": "ClientCache:Size",
+                "type": "SIZE"
+              }
+            ]
+          },
+          {
+            "name": "ManagementAgentService",
+            "context": [],
+            "descriptors": []
+          },
+          {
+            "name": "StatisticCollectorCapability",
+            "context": [
+              {
+                "name": "appName",
+                "required": true
+              }
+            ],
+            "descriptors": [
+              {
+                "name": "startStatisticCollector",
+                "returnType": "void",
+                "parameters": [
+                  {
+                    "name": "interval",
+                    "type": "long"
+                  },
+                  {
+                    "name": "unit",
+                    "type": "java.util.concurrent.TimeUnit"
+                  }
+                ]
+              },
+              {
+                "name": "stopStatisticCollector",
+                "returnType": "void",
+                "parameters": []
+              }
+            ]
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/management/testing/sample-entity/src/main/java/org/terracotta/management/entity/sample/client/CacheEntityFactory.java
+++ b/management/testing/sample-entity/src/main/java/org/terracotta/management/entity/sample/client/CacheEntityFactory.java
@@ -26,7 +26,7 @@ import org.terracotta.exception.EntityVersionMismatchException;
 /**
  * @author Mathieu Carbou
  */
-class CacheEntityFactory {
+public class CacheEntityFactory {
 
   private final Connection connection;
 
@@ -34,12 +34,12 @@ class CacheEntityFactory {
     this.connection = connection;
   }
 
-  public CacheEntity retrieveOrCreate(String entityName) {
+  public CacheEntity retrieveOrCreate(String entityName, String cacheName) {
     try {
       return retrieve(entityName);
     } catch (EntityNotFoundException e) {
       try {
-        return create(entityName);
+        return create(entityName, cacheName);
       } catch (EntityAlreadyExistsException f) {
         throw new AssertionError(e);
       }
@@ -54,21 +54,28 @@ class CacheEntityFactory {
     }
   }
 
-  public CacheEntity create(final String identifier) throws EntityAlreadyExistsException {
-    EntityRef<CacheEntity, String> ref = getEntityRef(identifier);
+  public CacheEntity create(String entityName, String cacheName) throws EntityAlreadyExistsException {
+    EntityRef<CacheEntity, String> ref = getEntityRef(entityName);
     try {
-      ref.create(identifier);
+      ref.create(cacheName);
       return ref.fetchEntity();
-    } catch (EntityNotProvidedException | EntityVersionMismatchException | EntityNotFoundException e) {
-      throw new AssertionError(e);
-    } catch (EntityConfigurationException e) {
+    } catch (EntityNotProvidedException | EntityVersionMismatchException | EntityNotFoundException | EntityConfigurationException e) {
       throw new AssertionError(e);
     }
   }
 
-  private EntityRef<CacheEntity, String> getEntityRef(String entityName) {
+  public void reconfigure(String entityName, String cacheName) throws EntityAlreadyExistsException {
+    EntityRef<CacheEntity, String> ref = getEntityRef(entityName);
     try {
-      return connection.getEntityRef(CacheEntity.class, 1, entityName);
+      ref.reconfigure(cacheName);
+    } catch (EntityNotProvidedException | EntityNotFoundException | EntityConfigurationException e) {
+      throw new AssertionError(e);
+    }
+  }
+
+  private EntityRef<CacheEntity, String> getEntityRef(String identifier) {
+    try {
+      return connection.getEntityRef(CacheEntity.class, 1, identifier);
     } catch (EntityNotProvidedException e) {
       throw new AssertionError(e);
     }

--- a/management/testing/sample-entity/src/main/java/org/terracotta/management/entity/sample/client/CacheFactory.java
+++ b/management/testing/sample-entity/src/main/java/org/terracotta/management/entity/sample/client/CacheFactory.java
@@ -74,7 +74,8 @@ public class CacheFactory implements Closeable {
 
   public Cache getCache(String name) {
     return caches.computeIfAbsent(name, s -> {
-      CacheEntity cacheEntity = cacheEntityFactory.retrieveOrCreate(uri.getPath().substring(1) + "/" + name);
+      String entityName = uri.getPath().substring(1) + "/" + name;
+      CacheEntity cacheEntity = cacheEntityFactory.retrieveOrCreate(entityName, entityName);
       ClientCache clientCache = new ClientCache(name, cacheEntity);
 
       // add a cache to the local registry for stat and calls and send a notification

--- a/management/tms-entity/tms-entity-common/src/main/java/org/terracotta/management/entity/tms/TmsAgentConfig.java
+++ b/management/tms-entity/tms-entity-common/src/main/java/org/terracotta/management/entity/tms/TmsAgentConfig.java
@@ -16,6 +16,7 @@
 package org.terracotta.management.entity.tms;
 
 import java.io.Serializable;
+import java.util.Objects;
 
 /**
  * @author Mathieu Carbou
@@ -28,6 +29,7 @@ public final class TmsAgentConfig implements Serializable {
   public static final String ENTITY_TYPE = "org.terracotta.management.entity.tms.client.TmsAgentEntity";
 
   private int maximumUnreadMessages = 1024 * 1024;
+  private String stripeName = "SINGLE";
 
   public int getMaximumUnreadMessages() {
     return maximumUnreadMessages;
@@ -38,9 +40,21 @@ public final class TmsAgentConfig implements Serializable {
     return this;
   }
 
-  @Override
-  public String toString() {
-    return "TmsAgentConfig{" + "maximumUnreadMessages=" + maximumUnreadMessages + '}';
+  public String getStripeName() {
+    return stripeName;
   }
 
+  public TmsAgentConfig setStripeName(String stripeName) {
+    this.stripeName = Objects.requireNonNull(stripeName);
+    return this;
+  }
+
+  @Override
+  public String toString() {
+    final StringBuilder sb = new StringBuilder("TmsAgentConfig{");
+    sb.append("maximumUnreadMessages=").append(maximumUnreadMessages);
+    sb.append(", stripeName='").append(stripeName).append('\'');
+    sb.append('}');
+    return sb.toString();
+  }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -30,8 +30,8 @@
     <logback.version>1.1.3</logback.version>
     <terracotta-apis.version>1.2.0-pre9</terracotta-apis.version>
     <tcconfig.version>10.2.0-pre9</tcconfig.version>
-    <passthrough-testing.version>1.2.0-pre10</passthrough-testing.version>
-    <terracotta-core.version>5.2.0-pre10</terracotta-core.version>
+    <passthrough-testing.version>1.2.0-pre11</passthrough-testing.version>
+    <terracotta-core.version>5.2.0-pre11</terracotta-core.version>
     <statistics.version>1.4.3</statistics.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -30,8 +30,8 @@
     <logback.version>1.1.3</logback.version>
     <terracotta-apis.version>1.2.0-pre9</terracotta-apis.version>
     <tcconfig.version>10.2.0-pre9</tcconfig.version>
-    <passthrough-testing.version>1.2.0-pre9</passthrough-testing.version>
-    <terracotta-core.version>5.2.0-pre9</terracotta-core.version>
+    <passthrough-testing.version>1.2.0-pre10</passthrough-testing.version>
+    <terracotta-core.version>5.2.0-pre10</terracotta-core.version>
     <statistics.version>1.4.3</statistics.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/voltron-proxy/voltron-proxy-server/src/main/java/org/terracotta/voltron/proxy/server/ProxyInvoker.java
+++ b/voltron-proxy/voltron-proxy-server/src/main/java/org/terracotta/voltron/proxy/server/ProxyInvoker.java
@@ -122,6 +122,10 @@ class ProxyInvoker<T> implements MessageFiring {
     clients.remove(descriptor);
   }
 
+  public Set<ClientDescriptor> getClients() {
+    return clients;
+  }
+
   private void handleExceptionOnSend(MessageCodecException ex) {
     throw new RuntimeException(ex);
   }


### PR DESCRIPTION
Several additions:

__1. Set a stripe name to Tms Agent__

You can now do:

```
TmsAgentEntity tmsAgentEntity = tmsAgentEntityFactory.retrieveOrCreate(new TmsAgentConfig()
        .setMaximumUnreadMessages(1024 * 1024)
        .setStripeName("MY SUPER STRIPE"));
```

This will return a cluster object with the right stripe name :-) And simplify your code... You know where ;-)

__2. I also upgraded to -pre10__

__3. Support for reconfigure()__

@jd0-sag and @myronkscott did a change in tc-core to remove the `removeNode(entity)` call. When they will have done the fix, we will be able to remove the following code in `IStripeMonitoringPlatformListenerAdapter`:

```
        // ignore removeNode() if fetches are in progress on active server
        if (sender.getServerName().equals(currentActive)) {
          for (PlatformClientFetchedEntity fetch : fetches.values()) {
            if (fetch.entityIdentifier.equals(name)) {
              return false;
            }
          }
        }
```

This code is compatible for now and in the future so it is safe to commit for now so that you are unlocked and we will be able to upgrade to new platform versions transparently.

UPDATE: @anthonydahanne : done in commit 78f6976c2dd3f47f869a1e4cfeff1cc40e375dda