### PR TITLE
Close #273: Filtering out statistics that are unsupported and returned -1

### DIFF
--- a/management/management-registry/src/main/java/org/terracotta/management/registry/DefaultStatisticQuery.java
+++ b/management/management-registry/src/main/java/org/terracotta/management/registry/DefaultStatisticQuery.java
@@ -71,7 +71,12 @@ public class DefaultStatisticQuery implements StatisticQuery {
       Map<String, Number> statistics = new HashMap<String, Number>();
       for (ManagementProvider<?> managementProvider : managementProviders) {
         if (managementProvider.supports(context)) {
-          statistics.putAll(managementProvider.collectStatistics(context, statisticNames));
+          for (Map.Entry<String, Number> entry : managementProvider.collectStatistics(context, statisticNames).entrySet()) {
+            if (entry.getValue().doubleValue() >= 0) {
+              statistics.put(entry.getKey(), entry.getValue());
+            }
+          }
+
         }
       }
       contextualStatistics.put(context, new ContextualStatistics(capabilityName, context, statistics));


### PR DESCRIPTION
It's done globally in the stat query system.

This PR takes as hypothesis that normal stats / counters that are sent will never be negative values of course. Because -1 is filtered out.