### PR TITLE
Version updates and fixes to HealthChecker

### DIFF
--- a/healthchecker-entity/api/src/main/java/org/terracotta/healthchecker/HealthCheckerFactory.java
+++ b/healthchecker-entity/api/src/main/java/org/terracotta/healthchecker/HealthCheckerFactory.java
@@ -29,6 +29,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terracotta.connection.Connection;
 import org.terracotta.connection.entity.EntityRef;
+import org.terracotta.exception.ConnectionClosedException;
 import org.terracotta.exception.EntityNotFoundException;
 import org.terracotta.exception.EntityNotProvidedException;
 import org.terracotta.exception.EntityVersionMismatchException;
@@ -164,7 +165,7 @@ public class HealthCheckerFactory {
         root.close();
       } catch (IOException ioe) {
 //  anything todo here?
-      } catch (IllegalStateException state) {
+      } catch (ConnectionClosedException state) {
 //  already closed        
       }
       fireTimeoutListeners();

--- a/healthchecker-entity/client-impl/src/main/java/org/terracotta/healthchecker/HealthCheckerClient.java
+++ b/healthchecker-entity/client-impl/src/main/java/org/terracotta/healthchecker/HealthCheckerClient.java
@@ -25,7 +25,6 @@ import org.terracotta.entity.EntityClientEndpoint;
 import org.terracotta.entity.EntityResponse;
 import org.terracotta.entity.InvokeFuture;
 import org.terracotta.entity.MessageCodecException;
-import org.terracotta.exception.EntityException;
 
 /**
  *
@@ -73,8 +72,10 @@ public class HealthCheckerClient implements HealthCheck {
         try {
 //  not intended for use but implemented in case a future use arises
           return invoke.get().toString();
-        } catch (EntityException ee) {
-          throw new ExecutionException(ee);
+        } catch (InterruptedException interrupt) {
+          throw interrupt;
+        } catch (Throwable t) {
+          throw new ExecutionException(t);
         }
       }
 
@@ -82,8 +83,10 @@ public class HealthCheckerClient implements HealthCheck {
       public String get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
         try {
           return invoke.getWithTimeout(timeout, unit).toString();
-        } catch (EntityException ee) {
-          throw new ExecutionException(ee);
+        } catch (InterruptedException interrupt) {
+          throw interrupt;
+        } catch (Throwable t) {
+          throw new ExecutionException(t);
         }
       } 
     };

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
     <terracotta-apis.version>1.2.0-pre16</terracotta-apis.version>
     <tcconfig.version>10.2.0-pre16</tcconfig.version>
     <passthrough-testing.version>1.2.0-pre16</passthrough-testing.version>
-    <terracotta-core.version>5.2.0-pre16</terracotta-core.version>
+    <terracotta-core.version>5.2.0-pre17</terracotta-core.version>
     <statistics.version>1.4.3</statistics.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -28,10 +28,10 @@
     <maven-forge-plugin.version>1.2.16</maven-forge-plugin.version>
     <slf4j.version>1.7.7</slf4j.version>
     <logback.version>1.1.3</logback.version>
-    <terracotta-apis.version>1.2.0-pre15</terracotta-apis.version>
-    <tcconfig.version>10.2.0-pre15</tcconfig.version>
-    <passthrough-testing.version>1.2.0-pre15</passthrough-testing.version>
-    <terracotta-core.version>5.2.0-pre15</terracotta-core.version>
+    <terracotta-apis.version>1.2.0-pre16</terracotta-apis.version>
+    <tcconfig.version>10.2.0-pre16</tcconfig.version>
+    <passthrough-testing.version>1.2.0-pre16</passthrough-testing.version>
+    <terracotta-core.version>5.2.0-pre16</terracotta-core.version>
     <statistics.version>1.4.3</statistics.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>


### PR DESCRIPTION
Some downstream testing noticed some problems in HealthChecker due to its assumptions regarding how we handle closed connections (which were formalized in pre16).

Addressed those concerns and updated to latest releases.