### PR TITLE
TDB-1849 Runnel: Fix resize in StringDataHolder.encodeString()

### DIFF
--- a/runnel/src/main/java/org/terracotta/runnel/encoding/dataholders/StringDataHolder.java
+++ b/runnel/src/main/java/org/terracotta/runnel/encoding/dataholders/StringDataHolder.java
@@ -45,7 +45,7 @@ public class StringDataHolder extends AbstractDataHolder {
 
 
   private ByteBuffer encodeString(String object) {
-    ByteArrayOutputStream bout = new ByteArrayOutputStream(object.length());
+    ByteArrayOutputStream bout = new ByteArrayOutputStream(2 * object.length() + 1);
     try {
       int length = object.length();
       int i = 0;


### PR DESCRIPTION
Size ByteArrayOutputStream that is used as temporary
byte output while we encode a String. Assume 2n+1 size
to allow for lots of UTF noise.