### PR TITLE
Supporting all different status comming from voltron

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
     <terracotta-apis.version>1.3.0-pre2</terracotta-apis.version>
     <tcconfig.version>10.3.0-pre3</tcconfig.version>
     <passthrough-testing.version>1.3.0-pre2</passthrough-testing.version>
-    <terracotta-core.version>5.3.0-pre3</terracotta-core.version>
+    <terracotta-core.version>5.3.0-pre4</terracotta-core.version>
     <statistics.version>1.4.3</statistics.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>


### PR DESCRIPTION
This PR:

1. Upgrade tc-core to get the fix for https://github.com/Terracotta-OSS/terracotta-core/issues/550
2. Improves the server state enums to correctly handle different state values coming from voltron from different places (monitoring service and diagnostic port).