### PR TITLE
Bad construction of CLIENT_CONNECTED and CLIENT_DISCONNECTED notifications

### DIFF
--- a/management/monitoring-service/src/main/java/org/terracotta/management/service/monitoring/PlatformListener.java
+++ b/management/monitoring-service/src/main/java/org/terracotta/management/service/monitoring/PlatformListener.java
@@ -42,9 +42,9 @@ interface PlatformListener {
 
   void serverStateChanged(PlatformServer sender, ServerState state);
 
-  void clientConnected(PlatformConnectedClient client);
+  void clientConnected(PlatformServer currentActive, PlatformConnectedClient client);
 
-  void clientDisconnected(PlatformConnectedClient client);
+  void clientDisconnected(PlatformServer currentActive, PlatformConnectedClient client);
 
   void clientFetch(PlatformConnectedClient client, PlatformEntity entity, ClientDescriptor clientDescriptor);
 

--- a/management/testing/integration-tests/src/test/java/org/terracotta/management/integration/tests/PassiveStartupIT.java
+++ b/management/testing/integration-tests/src/test/java/org/terracotta/management/integration/tests/PassiveStartupIT.java
@@ -26,7 +26,7 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.hasItems;
+import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
 /**
@@ -84,7 +84,8 @@ public class PassiveStartupIT extends AbstractHATest {
         .map(contextualNotification -> contextualNotification.getAttributes().get("state"))
         .collect(Collectors.toSet());
 
-    assertThat(states, hasItems("SYNCHRONIZING", "PASSIVE"));
+    assertThat(states.contains("SYNCHRONIZING"), is(true));
+    assertThat(states.contains("PASSIVE"), is(true));
 
     // only 1 server in source: passive server
     ContextualNotification stateChanged = collected.stream().filter(n -> n.getType().equals("SERVER_STATE_CHANGED")).findFirst().get();

--- a/management/testing/integration-tests/src/test/resources/notifications.json
+++ b/management/testing/integration-tests/src/test/resources/notifications.json
@@ -41,9 +41,13 @@
     "type": "SERVER_ENTITY_FETCHED"
   },
   {
-    "attributes": {},
-    "context": {
+    "attributes": {
       "clientId": "0@127.0.0.1:pet-clinic:<uuid>"
+    },
+    "context": {
+      "stripeId": "SINGLE",
+      "serverId": "testServer0",
+      "serverName": "testServer0"
     },
     "type": "CLIENT_CONNECTED"
   },
@@ -85,9 +89,13 @@
     "type": "CLIENT_INIT"
   },
   {
-    "attributes": {},
-    "context": {
+    "attributes": {
       "clientId": "0@127.0.0.1:pet-clinic:<uuid>"
+    },
+    "context": {
+      "stripeId": "SINGLE",
+      "serverId": "testServer0",
+      "serverName": "testServer0"
     },
     "type": "CLIENT_CONNECTED"
   },


### PR DESCRIPTION
`CLIENT_CONNECTED ` and `CLIENT_DISCONNECTED` events were badly constructed. They should have the server as the source  `Context`, like fetch and unfetch events, and they should contain the `clientId` that connected as an attribute.