### PR TITLE
Close #333 (StateDumpable for M&M) + Voltron upgrade

### DIFF
--- a/management/monitoring-service-api/src/main/java/org/terracotta/management/service/monitoring/registry/provider/AbstractStatisticsManagementProvider.java
+++ b/management/monitoring-service-api/src/main/java/org/terracotta/management/service/monitoring/registry/provider/AbstractStatisticsManagementProvider.java
@@ -44,6 +44,7 @@ public abstract class AbstractStatisticsManagementProvider<T extends AliasBindin
     ((AbstractExposedStatistics<T>) exposedObject).close();
   }
 
+  @SuppressWarnings("unchecked")
   @Override
   public final Collection<? extends Descriptor> getDescriptors() {
     // To keep ordering because these objects end up in an immutable

--- a/management/monitoring-service/src/main/java/org/terracotta/management/service/monitoring/DefaultEntityManagementRegistry.java
+++ b/management/monitoring-service/src/main/java/org/terracotta/management/service/monitoring/DefaultEntityManagementRegistry.java
@@ -134,6 +134,7 @@ class DefaultEntityManagementRegistry implements EntityManagementRegistry, Topol
     return allProviders;
   }
 
+  @SuppressWarnings("unchecked")
   @Override
   public CompletableFuture<Void> register(Object managedObject) {
     LOGGER.trace("[{}] register()", consumerId, managedObject);

--- a/management/nms-entity/nms-entity-client/src/main/java/org/terracotta/management/entity/nms/client/DefaultNmsService.java
+++ b/management/nms-entity/nms-entity-client/src/main/java/org/terracotta/management/entity/nms/client/DefaultNmsService.java
@@ -172,6 +172,7 @@ public class DefaultNmsService implements NmsService {
     return future.get(timeout, TimeUnit.MILLISECONDS);
   }
 
+  @SuppressWarnings("unchecked")
   private static <T> void complete(VoltronManagementCall<T> managementCall, ContextualReturn<?> aReturn) {
     try {
       // we have a value returned

--- a/management/nms-entity/nms-entity-server/src/main/java/org/terracotta/management/entity/nms/server/PassiveNmsServerEntity.java
+++ b/management/nms-entity/nms-entity-server/src/main/java/org/terracotta/management/entity/nms/server/PassiveNmsServerEntity.java
@@ -18,6 +18,7 @@ package org.terracotta.management.entity.nms.server;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terracotta.entity.IEntityMessenger;
+import org.terracotta.entity.StateDumpCollector;
 import org.terracotta.management.entity.nms.Nms;
 import org.terracotta.management.model.call.ContextualCall;
 import org.terracotta.management.model.call.ContextualReturn;
@@ -61,6 +62,11 @@ class PassiveNmsServerEntity extends PassiveProxiedServerEntity implements Nms, 
     super.createNew();
     LOGGER.trace("[{}] createNew()", entityManagementRegistry.getMonitoringService().getConsumerId());
     entityManagementRegistry.refresh();
+  }
+
+  @Override
+  protected void dumpState(StateDumpCollector dump) {
+    dump.addState("consumerId", String.valueOf(entityManagementRegistry.getMonitoringService().getConsumerId()));
   }
 
   // NmsCallback

--- a/management/testing/integration-tests/pom.xml
+++ b/management/testing/integration-tests/pom.xml
@@ -67,13 +67,6 @@
       <artifactId>galvan-support</artifactId>
       <version>${terracotta-core.version}</version>
       <scope>test</scope>
-      <!-- TODO Remove once galvan version is updated - simply check mockito-all is not longer pulled -->
-      <exclusions>
-        <exclusion>
-          <groupId>org.mockito</groupId>
-          <artifactId>mockito-all</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>ch.qos.logback</groupId>

--- a/management/testing/integration-tests/src/test/java/org/terracotta/management/integration/tests/AbstractTest.java
+++ b/management/testing/integration-tests/src/test/java/org/terracotta/management/integration/tests/AbstractTest.java
@@ -211,6 +211,8 @@ public abstract class AbstractTest {
         .replaceAll("\"groupPort\":[0-9]+", "\"groupPort\":0")
         .replaceAll("\"port\":[0-9]+", "\"port\":0")
         .replaceAll("\"activateTime\":[0-9]+", "\"activateTime\":0")
+        .replaceAll("\"availableAtTime\":[0-9]+", "\"availableAtTime\":0")
+        .replaceAll("\"OffHeapResource:AllocatedMemory\":[0-9]+", "\"OffHeapResource:AllocatedMemory\":0")
         .replaceAll("\"time\":[0-9]+", "\"time\":0")
         .replaceAll("\"startTime\":[0-9]+", "\"startTime\":0")
         .replaceAll("\"upTimeSec\":[0-9]+", "\"upTimeSec\":0")

--- a/management/testing/integration-tests/src/test/java/org/terracotta/management/integration/tests/DiagnosticIT.java
+++ b/management/testing/integration-tests/src/test/java/org/terracotta/management/integration/tests/DiagnosticIT.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.management.integration.tests;
+
+import com.terracotta.diagnostic.Diagnostics;
+import org.hamcrest.core.StringContains;
+import org.junit.Assert;
+import org.junit.Test;
+import org.terracotta.connection.Connection;
+import org.terracotta.connection.ConnectionFactory;
+import org.terracotta.connection.ConnectionPropertyNames;
+import org.terracotta.connection.entity.EntityRef;
+
+import java.net.URI;
+import java.util.Properties;
+
+import static org.hamcrest.core.StringContains.containsString;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+/**
+ * @author Mathieu Carbou
+ */
+public class DiagnosticIT extends AbstractSingleTest {
+
+  private static final String PROP_REQUEST_TIMEOUT = "request.timeout";
+  private static final String PROP_REQUEST_TIMEOUTMESSAGE = "request.timeoutMessage";
+
+  @Test
+  public void cluster_state_dump() throws Exception {
+    put(0, "pets", "pet1", "Cubitus");
+
+    Properties properties = new Properties();
+    properties.setProperty(ConnectionPropertyNames.CONNECTION_TIMEOUT, String.valueOf("5000"));
+    properties.setProperty(ConnectionPropertyNames.CONNECTION_NAME, "diagnostic");
+    properties.setProperty(PROP_REQUEST_TIMEOUT, "5000");
+    properties.setProperty(PROP_REQUEST_TIMEOUTMESSAGE, "5000");
+    URI uri = URI.create("diagnostic://" + voltron.getConnectionURI().getAuthority());
+    try (Connection connection = ConnectionFactory.connect(uri, properties)) {
+      EntityRef<Diagnostics, Object, Void> ref = connection.getEntityRef(Diagnostics.class, 1, "root");
+      Diagnostics diagnostics = ref.fetchEntity(null);
+
+      //TODO: improve these assertions
+      // once https://github.com/Terracotta-OSS/terracotta-core/issues/613 and https://github.com/Terracotta-OSS/terracotta-core/pull/601 will be fixed 
+      // and once the state dump format will be improved.
+      String dump = diagnostics.getClusterState();
+      String cluster = nmsService.readTopology().toMap().toString();
+      assertThat(dump, containsString(cluster));
+      
+      // monitoring service provider
+      assertThat(dump, containsString("server="));
+      assertThat(dump, containsString("configurationCount="));
+      assertThat(dump, containsString("manageable=true"));
+      assertThat(dump, containsString("cluster="));
+      
+      // ActiveNmsServerEntity / PassiveNmsServerEntity
+      assertThat(dump, containsString("consumerId="));
+      assertThat(dump, containsString("stripeName="));
+      assertThat(dump, containsString("messageQueueSize="));
+      
+      // OffHeapResourcesProvider
+      assertThat(dump, containsString("capacity="));
+      assertThat(dump, containsString("available="));
+      
+      // ActiveCacheServerEntity / ActiveCacheServerEntity
+      assertThat(dump, containsString("cacheName="));
+      assertThat(dump, containsString("cacheSize="));
+      
+      // MapProvider
+      assertThat(dump, containsString(".caches"));
+      
+      // Common on all active entities
+      assertThat(dump, containsString("instance="));
+      assertThat(dump, containsString("clientCount="));
+      assertThat(dump, containsString(".clients"));
+    }
+  }
+
+}

--- a/management/testing/integration-tests/src/test/resources/passive.json
+++ b/management/testing/integration-tests/src/test/resources/passive.json
@@ -41,7 +41,7 @@
                 "alias": "primary-server-resource",
                 "type": "OffHeapResource",
                 "capacity": 67108864,
-                "availableAtTime": 67108864
+                "availableAtTime": 0
               },
               {
                 "type": "OffHeapResourceSettingsManagementProvider",

--- a/management/testing/integration-tests/src/test/resources/topology-after-failover.json
+++ b/management/testing/integration-tests/src/test/resources/topology-after-failover.json
@@ -40,7 +40,7 @@
                         "alias": "primary-server-resource",
                         "type": "OffHeapResource",
                         "capacity": 67108864,
-                        "availableAtTime": 67108864
+                        "availableAtTime": 0
                       },
                       {
                         "type": "OffHeapResourceSettingsManagementProvider",

--- a/management/testing/integration-tests/src/test/resources/topology-before-reconfigure.json
+++ b/management/testing/integration-tests/src/test/resources/topology-before-reconfigure.json
@@ -47,7 +47,7 @@
                         "alias": "primary-server-resource",
                         "type": "OffHeapResource",
                         "capacity": 67108864,
-                        "availableAtTime": 67108864
+                        "availableAtTime": 0
                       },
                       {
                         "type": "OffHeapResourceSettingsManagementProvider",

--- a/management/testing/integration-tests/src/test/resources/topology-reconfigured.json
+++ b/management/testing/integration-tests/src/test/resources/topology-reconfigured.json
@@ -47,7 +47,7 @@
                         "alias": "primary-server-resource",
                         "type": "OffHeapResource",
                         "capacity": 67108864,
-                        "availableAtTime": 67108864
+                        "availableAtTime": 0
                       },
                       {
                         "type": "OffHeapResourceSettingsManagementProvider",

--- a/management/testing/integration-tests/src/test/resources/topology-renamed.json
+++ b/management/testing/integration-tests/src/test/resources/topology-renamed.json
@@ -47,7 +47,7 @@
                         "alias": "primary-server-resource",
                         "type": "OffHeapResource",
                         "capacity": 67108864,
-                        "availableAtTime": 67108864
+                        "availableAtTime": 0
                       },
                       {
                         "type": "OffHeapResourceSettingsManagementProvider",
@@ -144,7 +144,7 @@
                         "alias": "primary-server-resource",
                         "type": "OffHeapResource",
                         "capacity": 67108864,
-                        "availableAtTime": 67108864
+                        "availableAtTime": 0
                       },
                       {
                         "type": "OffHeapResourceSettingsManagementProvider",

--- a/management/testing/integration-tests/src/test/resources/topology.json
+++ b/management/testing/integration-tests/src/test/resources/topology.json
@@ -47,7 +47,7 @@
                         "alias": "primary-server-resource",
                         "type": "OffHeapResource",
                         "capacity": 67108864,
-                        "availableAtTime": 67108864
+                        "availableAtTime": 0
                       },
                       {
                         "type": "OffHeapResourceSettingsManagementProvider",

--- a/management/testing/sample-entity/src/main/java/org/terracotta/management/entity/sample/server/ActiveCacheServerEntity.java
+++ b/management/testing/sample-entity/src/main/java/org/terracotta/management/entity/sample/server/ActiveCacheServerEntity.java
@@ -18,6 +18,7 @@ package org.terracotta.management.entity.sample.server;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terracotta.entity.ClientDescriptor;
+import org.terracotta.entity.StateDumpCollector;
 import org.terracotta.management.entity.sample.Cache;
 import org.terracotta.management.entity.sample.server.management.Management;
 import org.terracotta.voltron.proxy.server.ActiveProxiedServerEntity;
@@ -106,4 +107,11 @@ class ActiveCacheServerEntity extends ActiveProxiedServerEntity<CacheSync, Void,
 
   @Override
   public int size() {return cache.size();}
+
+  @Override
+  protected void dumpState(StateDumpCollector dump) {
+    dump.addState("cacheName", cache.getName());
+    dump.addState("cacheSize", String.valueOf(cache.size()));
+  }
+
 }

--- a/management/testing/sample-entity/src/main/java/org/terracotta/management/entity/sample/server/CacheEntityServerService.java
+++ b/management/testing/sample-entity/src/main/java/org/terracotta/management/entity/sample/server/CacheEntityServerService.java
@@ -43,6 +43,7 @@ public class CacheEntityServerService extends ProxyServerEntityService<String, C
     setCodec(new SerializationCodec());
   }
 
+  @SuppressWarnings("unchecked")
   @Override
   public ActiveCacheServerEntity createActiveEntity(ServiceRegistry registry, String identifier) throws ConfigurationException {
     LOGGER.trace("createActiveEntity({})", identifier);
@@ -56,6 +57,7 @@ public class CacheEntityServerService extends ProxyServerEntityService<String, C
     }
   }
 
+  @SuppressWarnings("unchecked")
   @Override
   protected PassiveCacheServerEntity createPassiveEntity(ServiceRegistry registry, String identifier) throws ConfigurationException {
     LOGGER.trace("createPassiveEntity({})", identifier);

--- a/management/testing/sample-entity/src/main/java/org/terracotta/management/entity/sample/server/MapProvider.java
+++ b/management/testing/sample-entity/src/main/java/org/terracotta/management/entity/sample/server/MapProvider.java
@@ -24,6 +24,9 @@ import org.terracotta.entity.ServiceProvider;
 import org.terracotta.entity.ServiceProviderCleanupException;
 import org.terracotta.entity.ServiceProviderConfiguration;
 import org.terracotta.entity.StateDumpCollector;
+import org.terracotta.offheapresource.OffHeapResource;
+import org.terracotta.offheapresource.OffHeapResourceIdentifier;
+import org.terracotta.offheapresource.OffHeapResources;
 
 import java.io.Closeable;
 import java.util.Arrays;
@@ -48,6 +51,10 @@ public class MapProvider implements ServiceProvider, Closeable {
 
   @Override
   public boolean initialize(ServiceProviderConfiguration configuration, PlatformConfiguration platformConfiguration) {
+    OffHeapResources offHeapResources = platformConfiguration.getExtendedConfiguration(OffHeapResources.class).iterator().next();
+    OffHeapResource heapResource = offHeapResources.getOffHeapResource(OffHeapResourceIdentifier.identifier("primary-server-resource"));
+    // just to mimic some allocation
+    heapResource.reserve(12 * 1024 * 1024);
     return true;
   }
 
@@ -80,6 +87,10 @@ public class MapProvider implements ServiceProvider, Closeable {
 
   @Override
   public void addStateTo(StateDumpCollector stateDumper) {
-    stateDumper.addState("TrackedMaps", caches.keySet().toString());
+    StateDumpCollector caches = stateDumper.subStateDumpCollector("caches");
+    int c = 0;
+    for (String name : this.caches.keySet()) {
+      caches.addState(String.valueOf(c), name);
+    }
   }
 }

--- a/management/testing/sample-entity/src/main/java/org/terracotta/management/entity/sample/server/PassiveCacheServerEntity.java
+++ b/management/testing/sample-entity/src/main/java/org/terracotta/management/entity/sample/server/PassiveCacheServerEntity.java
@@ -17,6 +17,7 @@ package org.terracotta.management.entity.sample.server;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.terracotta.entity.StateDumpCollector;
 import org.terracotta.management.entity.sample.Cache;
 import org.terracotta.management.entity.sample.server.management.Management;
 import org.terracotta.voltron.proxy.server.PassiveProxiedServerEntity;
@@ -102,4 +103,11 @@ class PassiveCacheServerEntity extends PassiveProxiedServerEntity implements Cac
   public int size() {
     throw new UnsupportedOperationException();
   }
+
+  @Override
+  protected void dumpState(StateDumpCollector stateDumpCollector) {
+    stateDumpCollector.addState("cacheName", cache.getName());
+    stateDumpCollector.addState("cacheSize", String.valueOf(cache.size()));
+  }
+
 }

--- a/management/testing/sample-entity/src/test/java/org/terracotta/management/entity/sample/AbstractTest.java
+++ b/management/testing/sample-entity/src/test/java/org/terracotta/management/entity/sample/AbstractTest.java
@@ -96,7 +96,7 @@ public abstract class AbstractTest {
 
       OffheapResourcesType resources = new OffheapResourcesType();
       ResourceType resource = new ResourceType();
-      resource.setName("primary-resource");
+      resource.setName("primary-server-resource");
       resource.setUnit(MemoryUnit.MB);
       resource.setValue(BigInteger.valueOf(32));
       resources.getResource().add(resource);

--- a/offheap-resource/pom.xml
+++ b/offheap-resource/pom.xml
@@ -101,7 +101,7 @@
               <dependencyResource>
                 <groupId>org.terracotta</groupId>
                 <artifactId>tcconfig-schema</artifactId>
-                <version>${tcconfig.version}</version>
+                <version>${terracotta-configuration.version}</version>
                 <resource>catalog.cat</resource>
               </dependencyResource>
             </catalog>
@@ -110,7 +110,7 @@
             <episode>
               <groupId>org.terracotta</groupId>
               <artifactId>tcconfig-schema</artifactId>
-              <version>${tcconfig.version}</version>
+              <version>${terracotta-configuration.version}</version>
             </episode>
           </episodes>
         </configuration>

--- a/offheap-resource/src/main/java/org/terracotta/offheapresource/OffHeapResourcesProvider.java
+++ b/offheap-resource/src/main/java/org/terracotta/offheapresource/OffHeapResourcesProvider.java
@@ -17,6 +17,8 @@ package org.terracotta.offheapresource;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.terracotta.entity.StateDumpCollector;
+import org.terracotta.entity.StateDumpable;
 import org.terracotta.management.service.monitoring.EntityManagementRegistry;
 import org.terracotta.management.service.monitoring.ManageableServerComponent;
 import org.terracotta.offheapresource.config.MemoryUnit;
@@ -44,7 +46,7 @@ import java.util.concurrent.Callable;
  * allows for the partitioning and control of memory usage by entities
  * consuming this service.
  */
-public class OffHeapResourcesProvider implements OffHeapResources, ManageableServerComponent {
+public class OffHeapResourcesProvider implements OffHeapResources, ManageableServerComponent, StateDumpable {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(OffHeapResourcesProvider.class);
 
@@ -103,6 +105,17 @@ public class OffHeapResourcesProvider implements OffHeapResources, ManageableSer
 
   @Override
   public void onManagementRegistryClose(EntityManagementRegistry registry) {
+  }
+
+  @Override
+  public void addStateTo(StateDumpCollector dump) {
+    for (Map.Entry<OffHeapResourceIdentifier, OffHeapResource> entry : resources.entrySet()) {
+      OffHeapResourceIdentifier identifier = entry.getKey();
+      OffHeapResource resource = entry.getValue();
+      StateDumpCollector offHeapDump = dump.subStateDumpCollector(identifier.getName());
+      offHeapDump.addState("capacity", String.valueOf(resource.capacity()));
+      offHeapDump.addState("available", String.valueOf(resource.available()));
+    }
   }
 
   static BigInteger convert(BigInteger value, MemoryUnit unit) {

--- a/pom.xml
+++ b/pom.xml
@@ -29,11 +29,10 @@
     <maven-forge-plugin.version>1.2.16</maven-forge-plugin.version>
     <slf4j.version>1.7.7</slf4j.version>
     <logback.version>1.1.3</logback.version>
-    <terracotta-apis.version>1.3.0-pre10</terracotta-apis.version>
-    <tcconfig.version>10.3.0-pre10</tcconfig.version>
-    <passthrough-testing.version>1.3.0-pre7</passthrough-testing.version>
-    <!-- TODO If you update the version below, see comment in management/testing/integration-tests/pom.xml and remove me -->
-    <terracotta-core.version>5.3.0-pre11</terracotta-core.version>
+    <terracotta-apis.version>1.3.0-pre11</terracotta-apis.version>
+    <terracotta-configuration.version>10.3.0-pre11</terracotta-configuration.version>
+    <passthrough-testing.version>1.3.0-pre9</passthrough-testing.version>
+    <terracotta-core.version>5.3.0-pre13</terracotta-core.version>
     <statistics.version>1.4.3</statistics.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -80,7 +79,7 @@
       <dependency>
         <groupId>org.terracotta.internal</groupId>
         <artifactId>tc-config-parser</artifactId>
-        <version>${tcconfig.version}</version>
+        <version>${terracotta-configuration.version}</version>
       </dependency>
       <dependency>
         <groupId>org.terracotta</groupId>

--- a/voltron-proxy/voltron-proxy-common/src/main/java/org/terracotta/voltron/proxy/ProxyEntityMessage.java
+++ b/voltron-proxy/voltron-proxy-common/src/main/java/org/terracotta/voltron/proxy/ProxyEntityMessage.java
@@ -60,10 +60,6 @@ public class ProxyEntityMessage implements EntityMessage {
     return method.invoke(target, args);
   }
 
-  public Object invoke(final Object target) throws InvocationTargetException, IllegalAccessException {
-    return method.invoke(target, args);
-  }
-
   public Class<?> messageType() {
     return method.getMessageType();
   }

--- a/voltron-proxy/voltron-proxy-server/src/main/java/org/terracotta/voltron/proxy/server/ActiveProxiedServerEntity.java
+++ b/voltron-proxy/voltron-proxy-server/src/main/java/org/terracotta/voltron/proxy/server/ActiveProxiedServerEntity.java
@@ -20,6 +20,7 @@ import org.terracotta.entity.ClientDescriptor;
 import org.terracotta.entity.EntityUserException;
 import org.terracotta.entity.InvokeContext;
 import org.terracotta.entity.PassiveSynchronizationChannel;
+import org.terracotta.entity.StateDumpCollector;
 import org.terracotta.voltron.proxy.Codec;
 import org.terracotta.voltron.proxy.ProxyEntityMessage;
 import org.terracotta.voltron.proxy.ProxyEntityResponse;
@@ -98,6 +99,24 @@ public abstract class ActiveProxiedServerEntity<S, R, M extends Messenger> imple
     if (messenger != null) {
       messenger.unSchedule();
     }
+  }
+
+  @Override
+  public final void addStateTo(StateDumpCollector stateDumpCollector) {
+    stateDumpCollector.addState("instance", this.toString());
+    // clients, by default for all active entities
+    Collection<ClientDescriptor> clients = getClients();
+    stateDumpCollector.addState("clientCount", String.valueOf(clients.size()));
+    StateDumpCollector clientsDumper = stateDumpCollector.subStateDumpCollector("clients");
+    int i = 0;
+    for (ClientDescriptor client : clients) {
+      clientsDumper.addState(String.valueOf(i++), client.toString());
+    }
+    // custom
+    dumpState(stateDumpCollector);
+  }
+
+  protected void dumpState(StateDumpCollector dump) {
   }
 
   protected void synchronizeKeyToPassive(int concurrencyKey) {

--- a/voltron-proxy/voltron-proxy-server/src/main/java/org/terracotta/voltron/proxy/server/ActiveProxiedServerEntity.java
+++ b/voltron-proxy/voltron-proxy-server/src/main/java/org/terracotta/voltron/proxy/server/ActiveProxiedServerEntity.java
@@ -17,6 +17,8 @@ package org.terracotta.voltron.proxy.server;
 
 import org.terracotta.entity.ActiveServerEntity;
 import org.terracotta.entity.ClientDescriptor;
+import org.terracotta.entity.EntityUserException;
+import org.terracotta.entity.InvokeContext;
 import org.terracotta.entity.PassiveSynchronizationChannel;
 import org.terracotta.voltron.proxy.Codec;
 import org.terracotta.voltron.proxy.ProxyEntityMessage;
@@ -37,13 +39,13 @@ public abstract class ActiveProxiedServerEntity<S, R, M extends Messenger> imple
   private Class<R> reconnectDataType;
 
   @Override
-  public final ProxyEntityResponse invoke(final ClientDescriptor clientDescriptor, final ProxyEntityMessage msg) {
-    switch (msg.getType()) {
+  public ProxyEntityResponse invokeActive(InvokeContext context, ProxyEntityMessage message) throws EntityUserException {
+    switch (message.getType()) {
       case MESSAGE:
       case MESSENGER:
-        return entityInvoker.invoke(msg, clientDescriptor);
+        return entityInvoker.invoke(context, message);
       default:
-        throw new AssertionError(msg.getType());
+        throw new AssertionError(message.getType());
     }
   }
 

--- a/voltron-proxy/voltron-proxy-server/src/main/java/org/terracotta/voltron/proxy/server/PassiveProxiedServerEntity.java
+++ b/voltron-proxy/voltron-proxy-server/src/main/java/org/terracotta/voltron/proxy/server/PassiveProxiedServerEntity.java
@@ -15,6 +15,8 @@
  */
 package org.terracotta.voltron.proxy.server;
 
+import org.terracotta.entity.EntityUserException;
+import org.terracotta.entity.InvokeContext;
 import org.terracotta.entity.PassiveServerEntity;
 import org.terracotta.voltron.proxy.ProxyEntityMessage;
 import org.terracotta.voltron.proxy.ProxyEntityResponse;
@@ -27,15 +29,15 @@ public abstract class PassiveProxiedServerEntity implements PassiveServerEntity<
   private final ProxyInvoker<?> entityInvoker = new ProxyInvoker<>(this);
 
   @Override
-  public void invoke(final ProxyEntityMessage msg) {
-    switch (msg.getType()) {
+  public void invokePassive(InvokeContext context, ProxyEntityMessage message) throws EntityUserException {
+    switch (message.getType()) {
       case SYNC:
       case MESSENGER:
       case MESSAGE:
-        entityInvoker.invoke(msg);
+        entityInvoker.invoke(context, message);
         break;
       default:
-        throw new AssertionError(msg.getType());
+        throw new AssertionError(message.getType());
     }
   }
 

--- a/voltron-proxy/voltron-proxy-server/src/main/java/org/terracotta/voltron/proxy/server/PassiveProxiedServerEntity.java
+++ b/voltron-proxy/voltron-proxy-server/src/main/java/org/terracotta/voltron/proxy/server/PassiveProxiedServerEntity.java
@@ -18,6 +18,7 @@ package org.terracotta.voltron.proxy.server;
 import org.terracotta.entity.EntityUserException;
 import org.terracotta.entity.InvokeContext;
 import org.terracotta.entity.PassiveServerEntity;
+import org.terracotta.entity.StateDumpCollector;
 import org.terracotta.voltron.proxy.ProxyEntityMessage;
 import org.terracotta.voltron.proxy.ProxyEntityResponse;
 
@@ -69,6 +70,15 @@ public abstract class PassiveProxiedServerEntity implements PassiveServerEntity<
   @Override
   public void destroy() {
     // Don't care I think
+  }
+
+  @Override
+  public final void addStateTo(StateDumpCollector stateDumpCollector) {
+    stateDumpCollector.addState("instance", this.toString());
+    dumpState(stateDumpCollector);
+  }
+
+  protected void dumpState(StateDumpCollector stateDumpCollector) {
   }
 
 }

--- a/voltron-proxy/voltron-proxy-server/src/main/java/org/terracotta/voltron/proxy/server/ProxyInvoker.java
+++ b/voltron-proxy/voltron-proxy-server/src/main/java/org/terracotta/voltron/proxy/server/ProxyInvoker.java
@@ -17,8 +17,9 @@ package org.terracotta.voltron.proxy.server;
 
 import org.terracotta.entity.ClientCommunicator;
 import org.terracotta.entity.ClientDescriptor;
-import org.terracotta.entity.MessageCodecException;
 import org.terracotta.entity.EntityUserException;
+import org.terracotta.entity.InvokeContext;
+import org.terracotta.entity.MessageCodecException;
 import org.terracotta.voltron.proxy.ProxyEntityMessage;
 import org.terracotta.voltron.proxy.ProxyEntityResponse;
 
@@ -46,7 +47,8 @@ class ProxyInvoker<T> implements MessageFiring {
     this.target = target;
   }
 
-  ProxyEntityResponse invoke(final ProxyEntityMessage message, final ClientDescriptor clientDescriptor) {
+  ProxyEntityResponse invoke(InvokeContext context, final ProxyEntityMessage message) {
+    ClientDescriptor clientDescriptor = context.getClientDescriptor();
     try {
       invocationContext.set(new InvocationContext(clientDescriptor));
       return ProxyEntityResponse.response(message.getType(), message.messageType(), message.invoke(target, clientDescriptor));
@@ -66,23 +68,6 @@ class ProxyInvoker<T> implements MessageFiring {
       return ProxyEntityResponse.error(entityUserException);
     } finally {
       invocationContext.remove();
-    }
-  }
-
-  void invoke(final ProxyEntityMessage message) {
-    try {
-      message.invoke(target);
-    } catch (IllegalAccessException e) {
-      throw new IllegalArgumentException(e);
-    } catch (InvocationTargetException e) {
-      Throwable target = e.getTargetException();
-      if (target instanceof Error) {
-        throw (Error) target;
-      }
-      if (target instanceof RuntimeException) {
-        throw (RuntimeException) target;
-      }
-      throw new RuntimeException(target.getMessage(), target);
     }
   }
 

--- a/voltron-proxy/voltron-proxy-server/src/test/java/org/terracotta/voltron/proxy/server/EndToEndTest.java
+++ b/voltron-proxy/voltron-proxy-server/src/test/java/org/terracotta/voltron/proxy/server/EndToEndTest.java
@@ -23,6 +23,7 @@ import org.terracotta.entity.EndpointDelegate;
 import org.terracotta.entity.EntityClientEndpoint;
 import org.terracotta.entity.EntityResponse;
 import org.terracotta.entity.InvocationBuilder;
+import org.terracotta.entity.InvokeContext;
 import org.terracotta.entity.InvokeFuture;
 import org.terracotta.entity.MessageCodec;
 import org.terracotta.exception.EntityException;
@@ -272,7 +273,27 @@ public class EndToEndTest {
       final FutureTask<ProxyEntityResponse> futureTask = new FutureTask<ProxyEntityResponse>(new Callable<ProxyEntityResponse>() {
         @Override
         public ProxyEntityResponse call() throws Exception {
-          return proxyInvoker.invoke(message, clientDescriptor);
+          return proxyInvoker.invoke(new InvokeContext() {
+            @Override
+            public ClientDescriptor getClientDescriptor() {
+              return clientDescriptor;
+            }
+
+            @Override
+            public long getCurrentTransactionId() {
+              return 0;
+            }
+
+            @Override
+            public long getOldestTransactionId() {
+              return 0;
+            }
+
+            @Override
+            public boolean isValidClientInformation() {
+              return false;
+            }
+          }, message);
         }
       });
       futureTask.run();


### PR DESCRIPTION
I have left intentionally an uncomplete failing test because to me, the output of the state dump is unreadable and it is not something that we should show to a user in its current state.

There is no indentation, spaces are missing between key=value dumps and it is hard to separate what is a key and what is a value in the dump because some values have string representations with = sign in them

So I suggest we fix these issues first in tc-core before merging this PR and complete the test.

Also, there's a feature missing: plugins should also support implementing `StateDumpable` I think. 
See: https://github.com/Terracotta-OSS/terracotta-core/issues/613

For the moment, as a workaround, I added some code in the monitoring service that will dump all `StateDumpable` plugins.

Also, for ref, see: https://github.com/Terracotta-OSS/terracotta-core/pull/601