### PR TITLE
[DO NOT MERGE] Fix #345 - Add a rich object reporter for state collection

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,7 @@
     <module>runnel</module>
     <module>management</module>
     <module>client-message-tracker</module>
+    <module>state-format</module>
   </modules>
 
   <dependencyManagement>

--- a/state-format/pom.xml
+++ b/state-format/pom.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright Terracotta, Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.terracotta</groupId>
+    <artifactId>platform-root</artifactId>
+    <version>5.3-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+  
+  <artifactId>state-format</artifactId>
+  <packaging>jar</packaging>
+  <name>state-format</name>
+
+  <properties>
+    <java.version>1.8</java.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+        <groupId>org.terracotta</groupId>
+      <artifactId>packaging-support</artifactId>
+      <version>${terracotta-apis.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+        <groupId>org.terracotta</groupId>
+      <artifactId>entity-common-api</artifactId>
+      <version>${terracotta-apis.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+        <groupId>org.terracotta</groupId>
+      <artifactId>entity-server-api</artifactId>
+      <version>${terracotta-apis.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.terracotta.internal</groupId>
+      <artifactId>tc-messaging</artifactId>
+      <version>${terracotta-core.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>2.8.5</version>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.12</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-core</artifactId>
+      <version>1.3</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>2.19</version>
+        <configuration>
+            <argLine>-Xmx2G -Djava.awt.headless=true</argLine>
+        </configuration>
+      </plugin>
+    </plugins>
+    </build>
+</project>

--- a/state-format/src/main/java/com/tc/state/ObjectStateReporter.java
+++ b/state-format/src/main/java/com/tc/state/ObjectStateReporter.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.tc.state;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.io.IOException;
+import org.terracotta.entity.StateDumpCollector;
+
+/**
+ *
+ */
+public class ObjectStateReporter {
+  private final StateDumpCollector collector;
+  private final ObjectMapper mapper;
+  private final ObjectNode object;
+
+  public ObjectStateReporter(StateDumpCollector collector) {
+    this.collector = collector;
+    this.mapper = new ObjectMapper();
+    this.object = mapper.createObjectNode();
+  }
+  
+  public ObjectNode getBaseObject() {
+    return object;
+  }
+  
+  public void finish() {
+    try {
+      collector.addState(StateDumpCollector.JSON_STATE_KEY, mapper.writerWithDefaultPrettyPrinter().writeValueAsString(this.object));
+    } catch (IOException ioe) {
+      collector.addState("error", ioe.getMessage());
+    }
+  }
+}

--- a/state-format/src/main/java/com/tc/state/ReportingServiceProvider.java
+++ b/state-format/src/main/java/com/tc/state/ReportingServiceProvider.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.tc.state;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.tc.classloader.BuiltinService;
+import com.tc.text.PrettyPrinter;
+import java.util.Collection;
+import java.util.Collections;
+import org.terracotta.entity.PlatformConfiguration;
+import org.terracotta.entity.ServiceConfiguration;
+import org.terracotta.entity.ServiceProvider;
+import org.terracotta.entity.ServiceProviderCleanupException;
+import org.terracotta.entity.ServiceProviderConfiguration;
+
+
+/**
+ *
+ */
+@BuiltinService
+public class ReportingServiceProvider implements ServiceProvider {
+
+  @Override
+  public boolean initialize(ServiceProviderConfiguration spc, PlatformConfiguration pc) {
+    return true;
+  }
+
+  @Override
+  public <T> T getService(long l, ServiceConfiguration<T> sc) {
+    if (com.tc.text.PrettyPrinter.class.isAssignableFrom(sc.getServiceType())) {
+      ObjectMapper mapper = new ObjectMapper();
+      ArrayNode array = mapper.createArrayNode();
+      return (T)new com.tc.text.PrettyPrinter() {
+        @Override
+        public PrettyPrinter println(Object o) {
+          array.addPOJO(o);
+          return this;
+        }
+
+        @Override
+        public void flush() {
+          
+        }
+
+        @Override
+        public String toString() {
+          try {
+            return mapper.writerWithDefaultPrettyPrinter().writeValueAsString(array);
+          } catch (JsonProcessingException jp) {
+            jp.printStackTrace();
+            return "";
+          }
+        }
+      };
+    }
+    return null;
+  }
+
+  @Override
+  public Collection<Class<?>> getProvidedServiceTypes() {
+    return Collections.singleton(PrettyPrinter.class);
+  }
+
+  @Override
+  public void prepareForSynchronization() throws ServiceProviderCleanupException {
+
+  }
+  
+}

--- a/state-format/src/main/resources/META-INF/services/org.terracotta.entity.ServiceProvider
+++ b/state-format/src/main/resources/META-INF/services/org.terracotta.entity.ServiceProvider
@@ -1,0 +1,1 @@
+com.tc.state.ReportingServiceProvider

--- a/state-format/src/test/java/com/tc/state/ObjectStateReporterTest.java
+++ b/state-format/src/test/java/com/tc/state/ObjectStateReporterTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.tc.state;
+
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.terracotta.entity.StateDumpCollector;
+/**
+ *
+ */
+public class ObjectStateReporterTest {
+  
+  public ObjectStateReporterTest() {
+  }
+  
+  @BeforeClass
+  public static void setUpClass() {
+  }
+  
+  @AfterClass
+  public static void tearDownClass() {
+  }
+  
+  @Before
+  public void setUp() {
+  }
+  
+  @After
+  public void tearDown() {
+  }
+
+  @Test
+  public void testCheckFormatting() throws Throwable {
+    ObjectStateReporter reporter = new ObjectStateReporter(new StateDumpCollector() {
+      @Override
+      public StateDumpCollector subStateDumpCollector(String string) {
+        throw new UnsupportedOperationException("Not supported yet.");
+      }
+
+      @Override
+      public void addState(String string, String string1) {
+        Assert.assertEquals(StateDumpCollector.JSON_STATE_KEY, string);
+        System.out.println(string1);
+      }
+    });
+    
+    ObjectNode node = reporter.getBaseObject();
+    node.put("test", 1);
+    node.put("testString", "check");
+    ObjectNode sub = node.with("subNode");
+    sub.put("subIsHere", true);
+    ArrayNode array = sub.withArray("array");
+    for (int x=0;x<5;x++) {
+      array.add(x);
+    }
+    reporter.finish();
+  }
+}


### PR DESCRIPTION
The value of this approach is we are using a well known object mapping API to provide JSON output.  The JSON output will be included in the string output of a full state collection of the server.  JSON is human readable for consumption by an administrator.  The output is also machine parsable in case the platform would like to reformat the data into some other output.