### PR TITLE
Fix equals/hashcode in management model

### DIFF
--- a/management/cluster-topology/src/main/java/org/terracotta/management/model/cluster/AbstractManageableNode.java
+++ b/management/cluster-topology/src/main/java/org/terracotta/management/model/cluster/AbstractManageableNode.java
@@ -46,4 +46,21 @@ public abstract class AbstractManageableNode<P extends Contextual> extends Abstr
     return managementRegistry != null;
   }
 
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    if (!super.equals(o)) return false;
+
+    AbstractManageableNode<?> that = (AbstractManageableNode<?>) o;
+
+    return managementRegistry != null ? managementRegistry.equals(that.managementRegistry) : that.managementRegistry == null;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = super.hashCode();
+    result = 31 * result + (managementRegistry != null ? managementRegistry.hashCode() : 0);
+    return result;
+  }
 }

--- a/management/cluster-topology/src/main/java/org/terracotta/management/model/cluster/Cluster.java
+++ b/management/cluster-topology/src/main/java/org/terracotta/management/model/cluster/Cluster.java
@@ -18,6 +18,7 @@ package org.terracotta.management.model.cluster;
 import org.terracotta.management.model.context.Context;
 import org.terracotta.management.model.context.Contextual;
 
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
@@ -222,8 +223,8 @@ public final class Cluster implements Contextual {
 
   public Map<String, Object> toMap() {
     Map<String, Object> map = new LinkedHashMap<String, Object>();
-    map.put("stripes", stripeStream().sorted((o1, o2) -> o1.getId().compareTo(o2.getId())).map(Stripe::toMap).collect(Collectors.toList()));
-    map.put("clients", clientStream().sorted((o1, o2) -> o1.getId().compareTo(o2.getId())).map(Client::toMap).collect(Collectors.toList()));
+    map.put("stripes", stripeStream().sorted(Comparator.comparing(AbstractNode::getId)).map(Stripe::toMap).collect(Collectors.toList()));
+    map.put("clients", clientStream().sorted(Comparator.comparing(AbstractNode::getId)).map(Client::toMap).collect(Collectors.toList()));
     return map;
   }
 

--- a/management/cluster-topology/src/main/java/org/terracotta/management/model/cluster/Connection.java
+++ b/management/cluster-topology/src/main/java/org/terracotta/management/model/cluster/Connection.java
@@ -112,29 +112,25 @@ public final class Connection extends AbstractNode<Client> {
   public boolean equals(Object o) {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
-    // we do not consider super because it would include the connection id in the hashcode, which is not "predictatable"
-    // and can be different whether we opened/closed several connections in our different tests
-    //if (!super.equals(o)) return false;
+    if (!super.equals(o)) return false;
 
     Connection that = (Connection) o;
 
     if (!serverEntityIds.equals(that.serverEntityIds)) return false;
     if (!clientEndpoint.equals(that.clientEndpoint)) return false;
-    if (stripeId != null ? !stripeId.equals(that.stripeId) : that.stripeId != null) return false;
-    return serverId != null ? serverId.equals(that.serverId) : that.serverId == null;
-
+    if (!stripeId.equals(that.stripeId)) return false;
+    if (!serverId.equals(that.serverId)) return false;
+    return logicalConnectionUid.equals(that.logicalConnectionUid);
   }
 
   @Override
   public int hashCode() {
-    // we do not consider super because it would include the connection id in the hashcode, which is not "predictatable"
-    // and can be different whether we opened/closed several connections in our different tests
-    //int result = super.hashCode();
-    int result = 0;
+    int result = super.hashCode();
     result = 31 * result + serverEntityIds.hashCode();
     result = 31 * result + clientEndpoint.hashCode();
-    result = 31 * result + (stripeId != null ? stripeId.hashCode() : 0);
-    result = 31 * result + (serverId != null ? serverId.hashCode() : 0);
+    result = 31 * result + stripeId.hashCode();
+    result = 31 * result + serverId.hashCode();
+    result = 31 * result + logicalConnectionUid.hashCode();
     return result;
   }
 

--- a/management/cluster-topology/src/main/java/org/terracotta/management/model/cluster/Server.java
+++ b/management/cluster-topology/src/main/java/org/terracotta/management/model/cluster/Server.java
@@ -167,7 +167,7 @@ public final class Server extends AbstractNode<Stripe> {
   }
 
   public Server setState(State state) {
-    this.state = state;
+    this.state = Objects.requireNonNull(state);
     return this;
   }
 
@@ -288,7 +288,7 @@ public final class Server extends AbstractNode<Stripe> {
     if (startTime != server.startTime) return false;
     if (activateTime != server.activateTime) return false;
     if (!serverEntities.equals(server.serverEntities)) return false;
-    if (serverName != null ? !serverName.equals(server.serverName) : server.serverName != null) return false;
+    if (!serverName.equals(server.serverName)) return false;
     if (hostName != null ? !hostName.equals(server.hostName) : server.hostName != null) return false;
     if (hostAddress != null ? !hostAddress.equals(server.hostAddress) : server.hostAddress != null) return false;
     if (bindAddress != null ? !bindAddress.equals(server.bindAddress) : server.bindAddress != null) return false;
@@ -302,7 +302,7 @@ public final class Server extends AbstractNode<Stripe> {
   public int hashCode() {
     int result = super.hashCode();
     result = 31 * result + serverEntities.hashCode();
-    result = 31 * result + (serverName != null ? serverName.hashCode() : 0);
+    result = 31 * result + serverName.hashCode();
     result = 31 * result + (hostName != null ? hostName.hashCode() : 0);
     result = 31 * result + (hostAddress != null ? hostAddress.hashCode() : 0);
     result = 31 * result + (bindAddress != null ? bindAddress.hashCode() : 0);

--- a/management/cluster-topology/src/main/java/org/terracotta/management/model/cluster/ServerEntity.java
+++ b/management/cluster-topology/src/main/java/org/terracotta/management/model/cluster/ServerEntity.java
@@ -109,6 +109,7 @@ public final class ServerEntity extends AbstractManageableNode<Server> {
 
     ServerEntity that = (ServerEntity) o;
 
+    if (consumerId != that.consumerId) return false;
     return identifier.equals(that.identifier);
   }
 
@@ -116,6 +117,7 @@ public final class ServerEntity extends AbstractManageableNode<Server> {
   public int hashCode() {
     int result = super.hashCode();
     result = 31 * result + identifier.hashCode();
+    result = 31 * result + (int) (consumerId ^ (consumerId >>> 32));
     return result;
   }
 


### PR DESCRIPTION
There was several equals/hashcode bugs preventing the detection of a change between an old topology and a new topology, especially in the management registry data