### PR TITLE
Fix typing on OOOMessageHandler and associated classes

### DIFF
--- a/client-message-tracker/src/main/java/org/terracotta/client/message/tracker/OOOMessageHandlerConfiguration.java
+++ b/client-message-tracker/src/main/java/org/terracotta/client/message/tracker/OOOMessageHandlerConfiguration.java
@@ -15,31 +15,34 @@
  */
 package org.terracotta.client.message.tracker;
 
+import org.terracotta.entity.EntityMessage;
+import org.terracotta.entity.EntityResponse;
 import org.terracotta.entity.ServiceConfiguration;
 
 import com.tc.classloader.CommonComponent;
 
 @CommonComponent
-public class OOOMessageHandlerConfiguration implements ServiceConfiguration<OOOMessageHandler> {
+public class OOOMessageHandlerConfiguration<M extends EntityMessage, R extends EntityResponse> implements ServiceConfiguration<OOOMessageHandler<M, R>> {
 
   private final String entityIdentifier;
-  private final TrackerPolicy TrackerPolicy;
+  private final TrackerPolicy<M> trackerPolicy;
 
-  public OOOMessageHandlerConfiguration(String entityIdentifier, TrackerPolicy TrackerPolicy) {
+  public OOOMessageHandlerConfiguration(String entityIdentifier, TrackerPolicy<M> trackerPolicy) {
     this.entityIdentifier = entityIdentifier;
-    this.TrackerPolicy = TrackerPolicy;
+    this.trackerPolicy = trackerPolicy;
   }
 
   public TrackerPolicy getTrackerPolicy() {
-    return TrackerPolicy;
+    return trackerPolicy;
   }
 
   public String getEntityIdentifier() {
     return entityIdentifier;
   }
 
+  @SuppressWarnings("unchecked")
   @Override
-  public Class<OOOMessageHandler> getServiceType() {
-    return OOOMessageHandler.class;
+  public Class<OOOMessageHandler<M, R>> getServiceType() {
+    return (Class) OOOMessageHandler.class;
   }
 }

--- a/client-message-tracker/src/test/java/org/terracotta/client/message/tracker/OOOMessageHandlerProviderTest.java
+++ b/client-message-tracker/src/test/java/org/terracotta/client/message/tracker/OOOMessageHandlerProviderTest.java
@@ -16,6 +16,8 @@
 package org.terracotta.client.message.tracker;
 
 import org.junit.Test;
+import org.terracotta.entity.EntityMessage;
+import org.terracotta.entity.EntityResponse;
 import org.terracotta.entity.ServiceConfiguration;
 
 import static org.hamcrest.Matchers.not;
@@ -28,11 +30,11 @@ public class OOOMessageHandlerProviderTest {
   @Test
   public void getService() throws Exception {
     OOOMessageHandlerProvider provider =  new OOOMessageHandlerProvider();
-    OOOMessageHandlerConfiguration config = new OOOMessageHandlerConfiguration("foo", mock(TrackerPolicy.class));
-    OOOMessageHandler messageHandler = provider.getService(1L, config);
+    OOOMessageHandlerConfiguration<EntityMessage, EntityResponse> config = new OOOMessageHandlerConfiguration<>("foo", mock(TrackerPolicy.class));
+    OOOMessageHandler<EntityMessage, EntityResponse> messageHandler = provider.getService(1L, config);
     assertThat(provider.getService(2L, config), sameInstance(messageHandler));
 
-    config = new OOOMessageHandlerConfiguration("bar", mock(TrackerPolicy.class));
+    config = new OOOMessageHandlerConfiguration<>("bar", mock(TrackerPolicy.class));
     assertThat(provider.getService(2L, config), not(sameInstance(messageHandler)));
   }
 

--- a/client-message-tracker/src/test/java/org/terracotta/client/message/tracker/demo/DemoActiveEntity.java
+++ b/client-message-tracker/src/test/java/org/terracotta/client/message/tracker/demo/DemoActiveEntity.java
@@ -35,9 +35,9 @@ public class DemoActiveEntity implements ActiveServerEntity {
   private final OOOMessageHandler<EntityMessage, EntityResponse> messageHandler;
 
   public DemoActiveEntity(ServiceRegistry serviceRegistry) throws ServiceException {
-    OOOMessageHandlerConfiguration OOOMessageHandlerConfiguration =
-        new OOOMessageHandlerConfiguration("foo", new DummyTrackerPolicy());
-    messageHandler = serviceRegistry.getService(OOOMessageHandlerConfiguration);
+    OOOMessageHandlerConfiguration<EntityMessage, EntityResponse> messageHandlerConfiguration =
+        new OOOMessageHandlerConfiguration<>("foo", new DummyTrackerPolicy());
+    messageHandler = serviceRegistry.getService(messageHandlerConfiguration);
   }
 
   @Override

--- a/client-message-tracker/src/test/java/org/terracotta/client/message/tracker/demo/DemoPassiveEntity.java
+++ b/client-message-tracker/src/test/java/org/terracotta/client/message/tracker/demo/DemoPassiveEntity.java
@@ -33,9 +33,9 @@ public class DemoPassiveEntity implements PassiveServerEntity {
   private final OOOMessageHandler<EntityMessage, EntityResponse> messageHandler;
 
   public DemoPassiveEntity(ServiceRegistry serviceRegistry) throws ServiceException {
-    OOOMessageHandlerConfiguration OOOMessageHandlerConfiguration =
-        new OOOMessageHandlerConfiguration("foo", new DummyTrackerPolicy());
-    messageHandler = serviceRegistry.getService(OOOMessageHandlerConfiguration);
+    OOOMessageHandlerConfiguration<EntityMessage, EntityResponse> messageHandlerConfiguration =
+        new OOOMessageHandlerConfiguration<>("foo", new DummyTrackerPolicy());
+    messageHandler = serviceRegistry.getService(messageHandlerConfiguration);
   }
 
   @Override


### PR DESCRIPTION
The other solution is to remove the typing from everywhere. I don't think it's needed an implementations can overload methods with a more specific type if needed. 