### PR TITLE
Prevent word tiering

### DIFF
--- a/client-message-tracker/src/test/java/org/terracotta/client/message/tracker/MessageTrackerImplTest.java
+++ b/client-message-tracker/src/test/java/org/terracotta/client/message/tracker/MessageTrackerImplTest.java
@@ -19,6 +19,7 @@ import org.junit.Test;
 import org.terracotta.entity.EntityMessage;
 import org.terracotta.entity.EntityResponse;
 
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
@@ -72,7 +73,7 @@ public class MessageTrackerImplTest {
     EntityResponse response = mock(EntityResponse.class);
     when(trackerPolicy.trackable(message)).thenReturn(true);
 
-    MessageTracker tracker = new MessageTrackerImpl(trackerPolicy);
+    MessageTrackerImpl tracker = new MessageTrackerImpl(trackerPolicy);
     tracker.track(1L, message, response);
     tracker.track(2L, message, response);
     tracker.track(3L, message, response);
@@ -85,16 +86,19 @@ public class MessageTrackerImplTest {
     assertThat(tracker.getTrackedResponse(1L), notNullValue());
     assertThat(tracker.getTrackedResponse(2L), notNullValue());
     assertThat(tracker.getTrackedResponse(3L), notNullValue());
+    assertThat(tracker.getLastReconciledMessageId(), is(1L));
 
     tracker.reconcile(2L);
     assertThat(tracker.getTrackedResponse(1L), nullValue());
     assertThat(tracker.getTrackedResponse(2L), notNullValue());
     assertThat(tracker.getTrackedResponse(3L), notNullValue());
+    assertThat(tracker.getLastReconciledMessageId(), is(2L));
 
     tracker.reconcile(3L);
     assertThat(tracker.getTrackedResponse(1L), nullValue());
     assertThat(tracker.getTrackedResponse(2L), nullValue());
     assertThat(tracker.getTrackedResponse(3L), notNullValue());
+    assertThat(tracker.getLastReconciledMessageId(), is(3L));
   }
 
   @Test


### PR DESCRIPTION
Using a volatile was allowing possible word tiering. Also, using `lastReconciledMessageId` throughout the `reconcile` method instead of a local variable wasn't providing a stable behaviour.

This is now fixed.

However, a data race is still present. I can't evaluate if it's harmful, not knowing the exact threading usage of this class.

Right now I think it is harmless.