### PR TITLE
[Fix2] TDB-2310: Close #358: M&M ignores all potential inconsistencies coming from voltron events

### DIFF
--- a/management/cluster-topology/src/main/java/org/terracotta/management/model/cluster/Client.java
+++ b/management/cluster-topology/src/main/java/org/terracotta/management/model/cluster/Client.java
@@ -118,21 +118,21 @@ public final class Client extends AbstractManageableNode<Cluster> {
     return connections.size();
   }
 
-  public Client addConnection(Connection connection) {
+  public boolean addConnection(Connection connection) {
     for (Connection c : connections.values()) {
       if (c.getClientEndpoint().equals(connection.getClientEndpoint())) {
-        throw new IllegalArgumentException("Duplicate connection: " + connection.getId() + ": same endpoint: " + c.getClientEndpoint());
+        return false;
       }
       if (!getLogicalConnectionUid().equals(connection.getLogicalConnectionUid())) {
-        throw new IllegalArgumentException("Connection " + connection + " does not belong to client " + this);
+        return false;
       }
     }
     if (connections.putIfAbsent(connection.getId(), connection) != null) {
-      throw new IllegalArgumentException("Duplicate connection: " + connection.getId());
+      return false;
     } else {
       connection.setParent(this);
+      return true;
     }
-    return this;
   }
 
   public Optional<Connection> getConnection(Context context) {

--- a/management/cluster-topology/src/main/java/org/terracotta/management/model/cluster/Cluster.java
+++ b/management/cluster-topology/src/main/java/org/terracotta/management/model/cluster/Cluster.java
@@ -78,18 +78,18 @@ public final class Cluster implements Contextual {
     return stripeStream().findFirst().get();
   }
 
-  public Cluster addClient(Client client) {
+  public boolean addClient(Client client) {
     for (Client c : clients.values()) {
       if (c.getClientIdentifier().equals(client.getClientIdentifier())) {
-        throw new IllegalArgumentException("Duplicate client: " + client.getClientIdentifier());
+        return false;
       }
     }
     if (clients.putIfAbsent(client.getId(), client) != null) {
-      throw new IllegalArgumentException("Duplicate client: " + client.getId());
+      return false;
     } else {
       client.setParent(this);
+      return true;
     }
-    return this;
   }
 
   public Optional<Client> getClient(Context context) {
@@ -114,13 +114,13 @@ public final class Cluster implements Contextual {
     return client;
   }
 
-  public Cluster addStripe(Stripe stripe) {
+  public boolean addStripe(Stripe stripe) {
     if (stripes.putIfAbsent(stripe.getId(), stripe) != null) {
-      throw new IllegalArgumentException("Duplicate stripe: " + stripe.getId());
+      return false;
     } else {
       stripe.setParent(this);
+      return true;
     }
-    return this;
   }
 
   public Optional<Stripe> getStripe(Context context) {

--- a/management/cluster-topology/src/main/java/org/terracotta/management/model/cluster/Server.java
+++ b/management/cluster-topology/src/main/java/org/terracotta/management/model/cluster/Server.java
@@ -201,18 +201,19 @@ public final class Server extends AbstractNode<Stripe> {
     return serverEntities.values().stream();
   }
 
-  public final Server addServerEntity(ServerEntity serverEntity) {
+  public final boolean addServerEntity(ServerEntity serverEntity) {
     // ServerEntityId are unique per their ID but also per their combination of (type + name)
     for (ServerEntity m : serverEntities.values()) {
       if (m.is(serverEntity.getType(), serverEntity.getName())) {
-        throw new IllegalArgumentException("Duplicate serverEntity: type=" + serverEntity.getType() + ", name=" + serverEntity.getName());
+        return false;
       }
     }
     if (serverEntities.putIfAbsent(serverEntity.getId(), serverEntity) != null) {
-      throw new IllegalArgumentException("Duplicate serverEntity: " + serverEntity.getId());
+      return false;
+    } else {
+      serverEntity.setParent(this);
+      return true; 
     }
-    serverEntity.setParent(this);
-    return this;
   }
 
   public final Optional<ServerEntity> getServerEntity(Context context) {

--- a/management/cluster-topology/src/main/java/org/terracotta/management/model/cluster/Stripe.java
+++ b/management/cluster-topology/src/main/java/org/terracotta/management/model/cluster/Stripe.java
@@ -63,13 +63,13 @@ public final class Stripe extends AbstractNode<Cluster> {
     return servers.size();
   }
 
-  public Stripe addServer(Server server) {
+  public boolean addServer(Server server) {
     if (servers.putIfAbsent(server.getId(), server) != null) {
-      throw new IllegalArgumentException("Duplicate server: " + server.getId());
+      return false;
     } else {
       server.setParent(this);
+      return true;
     }
-    return this;
   }
 
   public Optional<Server> getServer(Context context) {

--- a/management/cluster-topology/src/test/java/org/terracotta/management/model/cluster/AbstractTest.java
+++ b/management/cluster-topology/src/test/java/org/terracotta/management/model/cluster/AbstractTest.java
@@ -59,32 +59,36 @@ public abstract class AbstractTest {
       return c;
     };
 
-    cluster1 = Cluster.create()
-        .addStripe(Stripe.create("stripe-1")
-            .addServer(Server.create("server-1")
-                .setHostName("hostname-1")
-                .setBindAddress("0.0.0.0")
-                .setBindPort(8881)
-                .setState(Server.State.ACTIVE)
-                .addServerEntity(ehcache_server_entity = serverEntitySupplier.get()))
-            .addServer(Server.create("server-2")
-                .setHostName("hostname-2")
-                .setBindAddress("0.0.0.0")
-                .setBindPort(8881)
-                .setState(Server.State.PASSIVE)))
-        .addStripe(Stripe.create("stripe-2")
-            .addServer(Server.create("server-1")
-                .setHostName("hostname-3")
-                .setBindAddress("0.0.0.0")
-                .setBindPort(8881)
-                .setState(Server.State.ACTIVE)
-                .addServerEntity(serverEntitySupplier.get()))
-            .addServer(Server.create("server-2")
-                .setHostName("hostname-4")
-                .setBindAddress("0.0.0.0")
-                .setBindPort(8881)
-                .setState(Server.State.PASSIVE)))
-        .addClient(client = clientSupplier.get());
+    cluster1 = Cluster.create();
+    Stripe stripe11 = Stripe.create("stripe-1");
+    cluster1.addStripe(stripe11);
+    Server server111 = Server.create("server-1")
+        .setHostName("hostname-1")
+        .setBindAddress("0.0.0.0")
+        .setBindPort(8881)
+        .setState(Server.State.ACTIVE);
+    stripe11.addServer(server111);
+    server111.addServerEntity(ehcache_server_entity = serverEntitySupplier.get());
+    stripe11.addServer(Server.create("server-2")
+        .setHostName("hostname-2")
+        .setBindAddress("0.0.0.0")
+        .setBindPort(8881)
+        .setState(Server.State.PASSIVE));
+    Stripe stripe12 = Stripe.create("stripe-2");
+    cluster1.addStripe(stripe12);
+    Server server121 = Server.create("server-1")
+        .setHostName("hostname-3")
+        .setBindAddress("0.0.0.0")
+        .setBindPort(8881)
+        .setState(Server.State.ACTIVE);
+    stripe12.addServer(server121);
+    server121.addServerEntity(serverEntitySupplier.get());
+    stripe12.addServer(Server.create("server-2")
+        .setHostName("hostname-4")
+        .setBindAddress("0.0.0.0")
+        .setBindPort(8881)
+        .setState(Server.State.PASSIVE));
+    cluster1.addClient(client = clientSupplier.get());
 
     client.addConnection(Connection.create(
         "uid",
@@ -96,32 +100,36 @@ public abstract class AbstractTest {
         cluster1.getStripe("stripe-2").get().getServerByName("server-1").get(),
         Endpoint.create("10.10.10.10", 3457)));
 
-    cluster2 = Cluster.create()
-        .addStripe(Stripe.create("stripe-1")
-            .addServer(Server.create("server-1")
-                .setHostName("hostname-1")
-                .setBindAddress("0.0.0.0")
-                .setBindPort(8881)
-                .setState(Server.State.ACTIVE)
-                .addServerEntity(serverEntitySupplier.get()))
-            .addServer(Server.create("server-2")
-                .setHostName("hostname-2")
-                .setBindAddress("0.0.0.0")
-                .setBindPort(8881)
-                .setState(Server.State.PASSIVE)))
-        .addStripe(Stripe.create("stripe-2")
-            .addServer(Server.create("server-1")
-                .setHostName("hostname-3")
-                .setBindAddress("0.0.0.0")
-                .setBindPort(8881)
-                .setState(Server.State.ACTIVE)
-                .addServerEntity(serverEntitySupplier.get()))
-            .addServer(Server.create("server-2")
-                .setHostName("hostname-4")
-                .setBindAddress("0.0.0.0")
-                .setBindPort(8881)
-                .setState(Server.State.PASSIVE)))
-        .addClient(clientSupplier.get());
+    cluster2 = Cluster.create();
+    Stripe stripe21 = Stripe.create("stripe-1");
+    cluster2.addStripe(stripe21);
+    Server server211 = Server.create("server-1")
+        .setHostName("hostname-1")
+        .setBindAddress("0.0.0.0")
+        .setBindPort(8881)
+        .setState(Server.State.ACTIVE);
+    stripe21.addServer(server211);
+    server211.addServerEntity(serverEntitySupplier.get());
+    stripe21.addServer(Server.create("server-2")
+        .setHostName("hostname-2")
+        .setBindAddress("0.0.0.0")
+        .setBindPort(8881)
+        .setState(Server.State.PASSIVE));
+    Stripe stripe22 = Stripe.create("stripe-2");
+    cluster2.addStripe(stripe22);
+    Server server221 = Server.create("server-1")
+        .setHostName("hostname-3")
+        .setBindAddress("0.0.0.0")
+        .setBindPort(8881)
+        .setState(Server.State.ACTIVE);
+    stripe22.addServer(server221);
+    server221.addServerEntity(serverEntitySupplier.get());
+    stripe22.addServer(Server.create("server-2")
+        .setHostName("hostname-4")
+        .setBindAddress("0.0.0.0")
+        .setBindPort(8881)
+        .setState(Server.State.PASSIVE));
+    cluster2.addClient(clientSupplier.get());
 
     Client client2 = cluster2.getClient("12345@127.0.0.1:ehcache:uid").get();
 

--- a/management/cluster-topology/src/test/java/org/terracotta/management/model/cluster/ClusterTest.java
+++ b/management/cluster-topology/src/test/java/org/terracotta/management/model/cluster/ClusterTest.java
@@ -89,16 +89,11 @@ public class ClusterTest extends AbstractTest {
   public void test_add_remove_client() {
     assertEquals(1, cluster1.getClients().size());
 
-    try {
-      cluster1.addClient(Client.create("12345@127.0.0.1:ehcache:uid"));
-      fail();
-    } catch (Exception e) {
-      assertEquals(IllegalArgumentException.class, e.getClass());
-    }
+    assertFalse(cluster1.addClient(Client.create("12345@127.0.0.1:ehcache:uid")));
 
     assertEquals(1, cluster1.getClients().size());
 
-    cluster1.addClient(Client.create("123@127.0.0.1:cluster-client-2:uid"));
+    assertTrue(cluster1.addClient(Client.create("123@127.0.0.1:cluster-client-2:uid")));
 
     assertEquals(2, cluster1.getClients().size());
 
@@ -111,12 +106,7 @@ public class ClusterTest extends AbstractTest {
   public void test_add_remove_stripes() {
     assertEquals(2, cluster1.getStripes().size());
 
-    try {
-      cluster1.addStripe(Stripe.create("stripe-1"));
-      fail();
-    } catch (Exception e) {
-      assertEquals(IllegalArgumentException.class, e.getClass());
-    }
+    assertFalse(cluster1.addStripe(Stripe.create("stripe-1")));
 
     assertEquals(2, cluster1.getStripes().size());
 
@@ -135,12 +125,7 @@ public class ClusterTest extends AbstractTest {
 
     assertEquals(2, stripe.getServers().size());
 
-    try {
-      stripe.addServer(Server.create("server-1"));
-      fail();
-    } catch (Exception e) {
-      assertEquals(IllegalArgumentException.class, e.getClass());
-    }
+    assertFalse(stripe.addServer(Server.create("server-1")));
 
     assertEquals(2, stripe.getServers().size());
 
@@ -159,13 +144,7 @@ public class ClusterTest extends AbstractTest {
 
     assertEquals(2, client.getConnections().size());
 
-    try {
-      client.addConnection(Connection.create("uid", cluster1.getStripe("stripe-1").get().getServerByName("server-1").get(), Endpoint.create("10.10.10.10", 3456)));
-      fail();
-    } catch (Exception e) {
-      assertEquals(IllegalArgumentException.class, e.getClass());
-    }
-
+    assertFalse(client.addConnection(Connection.create("uid", cluster1.getStripe("stripe-1").get().getServerByName("server-1").get(), Endpoint.create("10.10.10.10", 3456))));
     assertEquals(2, client.getConnections().size());
 
     client.addConnection(Connection.create("uid", cluster1.getStripe("stripe-1").get().getServerByName("server-1").get(), Endpoint.create("10.10.10.10", 3458)));
@@ -185,17 +164,12 @@ public class ClusterTest extends AbstractTest {
 
     assertEquals(1, server.getServerEntityCount());
 
-    try {
-      server.addServerEntity(ServerEntity.create(serverContextContainer.getValue(), "org.ehcache.clustered.client.internal.EhcacheClientEntity"));
-      fail();
-    } catch (Exception e) {
-      assertEquals(IllegalArgumentException.class, e.getClass());
-    }
+    assertFalse(server.addServerEntity(ServerEntity.create(serverContextContainer.getValue(), "org.ehcache.clustered.client.internal.EhcacheClientEntity")));
 
     assertEquals(1, server.getServerEntityCount());
 
-    server.addServerEntity(ServerEntity.create("other-cm-4", "org.ehcache.clustered.client.internal.EhcacheClientEntity"));
-    server.addServerEntity(ServerEntity.create("name", "OTHER_TYPE"));
+    assertTrue(server.addServerEntity(ServerEntity.create("other-cm-4", "org.ehcache.clustered.client.internal.EhcacheClientEntity")));
+    assertTrue(server.addServerEntity(ServerEntity.create("name", "OTHER_TYPE")));
 
     assertEquals(3, server.getServerEntityCount());
 

--- a/management/monitoring-service-api/src/main/java/org/terracotta/management/service/monitoring/registry/provider/ClientBinding.java
+++ b/management/monitoring-service-api/src/main/java/org/terracotta/management/service/monitoring/registry/provider/ClientBinding.java
@@ -29,9 +29,13 @@ public class ClientBinding {
 
   volatile ClientIdentifier resolvedClientIdentifier;
 
+  public ClientBinding(ClientDescriptor clientDescriptor) {
+    this(clientDescriptor, null);
+  }
+  
   public ClientBinding(ClientDescriptor clientDescriptor, Object value) {
     this.clientDescriptor = Objects.requireNonNull(clientDescriptor);
-    this.value = Objects.requireNonNull(value);
+    this.value = value;
   }
 
   public ClientDescriptor getClientDescriptor() {

--- a/management/monitoring-service/src/main/java/org/terracotta/management/service/monitoring/DefaultClientMonitoringService.java
+++ b/management/monitoring-service/src/main/java/org/terracotta/management/service/monitoring/DefaultClientMonitoringService.java
@@ -116,13 +116,12 @@ class DefaultClientMonitoringService implements ClientMonitoringService, Topolog
         for (Map.Entry<ClientDescriptor, Context> entry : manageableClients.entrySet()) {
           if (context.contains(entry.getValue())) {
             send(entry.getKey(), message);
-            break;
           }
         }
         break;
 
       default:
-        throw new UnsupportedOperationException(message.getType());
+        LOGGER.warn("[{}] fireMessage({}): message type unsupported", this.consumerId, message.getType());
     }
   }
 
@@ -131,7 +130,7 @@ class DefaultClientMonitoringService implements ClientMonitoringService, Topolog
     try {
       clientCommunicator.sendNoResponse(client, ProxyEntityResponse.messageResponse(Message.class, message));
     } catch (Exception e) {
-      LOGGER.error("Unable to send message " + message + " to client " + client);
+      LOGGER.warn("Unable to send message " + message + " to client " + client);
     }
   }
 

--- a/management/monitoring-service/src/main/java/org/terracotta/management/service/monitoring/DefaultDataListener.java
+++ b/management/monitoring-service/src/main/java/org/terracotta/management/service/monitoring/DefaultDataListener.java
@@ -78,7 +78,7 @@ class DefaultDataListener implements DataListener {
       }
 
       default: {
-        throw new IllegalArgumentException(name);
+        LOGGER.warn("[{}] pushBestEffortsData({}, {}, {}): topic name unsupported", this.consumerId, consumerId, sender.getServerName(), name);
       }
     }
 

--- a/management/monitoring-service/src/main/java/org/terracotta/management/service/monitoring/DefaultManagementService.java
+++ b/management/monitoring-service/src/main/java/org/terracotta/management/service/monitoring/DefaultManagementService.java
@@ -98,6 +98,7 @@ class DefaultManagementService implements ManagementService, TopologyEventListen
     }
 
     if (fullContext == null) {
+      // this method is called from an entity invoke, so throwing is OK
       throw new IllegalArgumentException(context.toString());
     }
 
@@ -154,7 +155,7 @@ class DefaultManagementService implements ManagementService, TopologyEventListen
         break;
 
       default:
-        throw new UnsupportedOperationException(message.getType());
+        LOGGER.warn("[{}] onMessageToSend({}): message type unsupported", this.consumerId, message.getType());
     }
   }
 

--- a/management/monitoring-service/src/main/java/org/terracotta/management/service/monitoring/IStripeMonitoringDataListenerAdapter.java
+++ b/management/monitoring-service/src/main/java/org/terracotta/management/service/monitoring/IStripeMonitoringDataListenerAdapter.java
@@ -46,10 +46,10 @@ final class IStripeMonitoringDataListenerAdapter implements IStripeMonitoring {
 
   @Override
   public boolean addNode(PlatformServer sender, String[] parents, String name, Serializable value) {
-    LOGGER.trace("[{}] addNode({}, {}, {})", consumerId, sender.getServerName(), Arrays.toString(parents), name);
     if (parents == null) {
       parents = new String[0];
     }
+    LOGGER.trace("[{}] addNode({}, {}, {})", consumerId, sender.getServerName(), String.join("/", parents), name);
     String[] path = Arrays.copyOf(parents, parents.length + 1);
     path[parents.length] = name;
     delegate.setState(consumerId, sender, path, value);
@@ -58,10 +58,10 @@ final class IStripeMonitoringDataListenerAdapter implements IStripeMonitoring {
 
   @Override
   public boolean removeNode(PlatformServer sender, String[] parents, String name) {
-    LOGGER.trace("[{}] removeNode({}, {})", consumerId, sender.getServerName(), Arrays.toString(parents));
     if (parents == null) {
       parents = new String[0];
     }
+    LOGGER.trace("[{}] removeNode({}, {})", consumerId, sender.getServerName(), String.join("/", parents));
     String[] path = Arrays.copyOf(parents, parents.length + 1);
     path[parents.length] = name;
     delegate.setState(consumerId, sender, path, null);

--- a/management/monitoring-service/src/main/java/org/terracotta/management/service/monitoring/TopologyService.java
+++ b/management/monitoring-service/src/main/java/org/terracotta/management/service/monitoring/TopologyService.java
@@ -90,7 +90,8 @@ class TopologyService implements PlatformListener {
   TopologyService(FiringService firingService, PlatformConfiguration platformConfiguration) {
     this.firingService = Objects.requireNonNull(firingService);
     this.platformConfiguration = platformConfiguration;
-    this.cluster = Cluster.create().addStripe(stripe = Stripe.create("SINGLE"));
+    this.cluster = Cluster.create();
+    this.cluster.addStripe(stripe = Stripe.create("SINGLE"));
   }
 
   // ================================================
@@ -113,16 +114,16 @@ class TopologyService implements PlatformListener {
         .setVersion(self.getVersion())
         .computeUpTime();
 
-    stripe.addServer(server);
+    if(stripe.addServer(server)) {
+      currentActive = stripe.getServerByName(self.getServerName()).get();
 
-    currentActive = stripe.getServerByName(self.getServerName()).get();
+      topologyEventListeners.forEach(TopologyEventListener::onBecomeActive);
 
-    topologyEventListeners.forEach(TopologyEventListener::onBecomeActive);
+      firingService.fireNotification(new ContextualNotification(server.getContext(), SERVER_JOINED.name()));
 
-    firingService.fireNotification(new ContextualNotification(server.getContext(), SERVER_JOINED.name()));
-
-    // we assume server.getStartTime() == activate time, but this will be fixed after into serverStateChanged() call by platform
-    serverStateChanged(self, new ServerState("ACTIVE", server.getStartTime(), server.getStartTime()));
+      // we assume server.getStartTime() == activate time, but this will be fixed after into serverStateChanged() call by platform
+      serverStateChanged(self, new ServerState("ACTIVE", server.getStartTime(), server.getStartTime())); 
+    }
   }
 
   @Override
@@ -140,24 +141,23 @@ class TopologyService implements PlatformListener {
         .setVersion(platformServer.getVersion())
         .computeUpTime();
 
-    stripe.addServer(server);
-
-    firingService.fireNotification(new ContextualNotification(server.getContext(), SERVER_JOINED.name()));
+    if(stripe.addServer(server)) {
+      firingService.fireNotification(new ContextualNotification(server.getContext(), SERVER_JOINED.name()));      
+    }
   }
 
   @Override
   public synchronized void serverDidLeaveStripe(PlatformServer platformServer) {
     LOGGER.trace("[0] serverDidLeaveStripe({})", platformServer.getServerName());
 
-    Server server = stripe.getServerByName(platformServer.getServerName())
-        .<IllegalStateException>orElseThrow(() -> newIllegalTopologyState("Missing server: " + platformServer.getServerName()));
+    stripe.getServerByName(platformServer.getServerName()).ifPresent(server -> {
+      Context context = server.getContext();
+      server.remove();
 
-    Context context = server.getContext();
-    server.remove();
+      serverEntities.remove(platformServer.getServerName());
 
-    serverEntities.remove(platformServer.getServerName());
-
-    firingService.fireNotification(new ContextualNotification(context, SERVER_LEFT.name()));
+      firingService.fireNotification(new ContextualNotification(context, SERVER_LEFT.name()));
+    });
   }
 
   @Override
@@ -165,42 +165,41 @@ class TopologyService implements PlatformListener {
     LOGGER.trace("[0] serverEntityCreated({}, {})", sender.getServerName(), platformEntity);
 
     if (platformEntity.isActive && !sender.getServerName().equals(getActiveServer().getServerName())) {
-      throw newIllegalTopologyState("Server " + sender.getServerName() + " is not current active server but it created an active entity " + platformEntity);
+      LOGGER.warn("[0] serverEntityCreated({}, {}): Server is not current active server but it created an active entity", sender.getServerName(), platformEntity);
+      return;
     }
 
     if (!platformEntity.isActive && sender.getServerName().equals(getActiveServer().getServerName())) {
-      throw newIllegalTopologyState("Server " + sender.getServerName() + " is the current active server but it created a passive entity " + platformEntity);
+      LOGGER.warn("[0] serverEntityCreated({}, {}): Server is the current active server but it created a passive entity", sender.getServerName(), platformEntity);
+      return;
     }
 
-    Server server = stripe.getServerByName(sender.getServerName())
-        .<IllegalStateException>orElseThrow(() -> newIllegalTopologyState("Missing server: " + sender.getServerName()));
-    ServerEntityIdentifier identifier = ServerEntityIdentifier.create(platformEntity.name, platformEntity.typeName);
-    ServerEntity entity = ServerEntity.create(identifier)
-        .setConsumerId(platformEntity.consumerID);
+    stripe.getServerByName(sender.getServerName()).ifPresent(server -> {
+      ServerEntityIdentifier identifier = ServerEntityIdentifier.create(platformEntity.name, platformEntity.typeName);
+      ServerEntity entity = ServerEntity.create(identifier)
+          .setConsumerId(platformEntity.consumerID);
 
-    server.addServerEntity(entity);
+      if(server.addServerEntity(entity)) {
+        firingService.fireNotification(new ContextualNotification(entity.getContext(), SERVER_ENTITY_CREATED.name()));
 
-    firingService.fireNotification(new ContextualNotification(entity.getContext(), SERVER_ENTITY_CREATED.name()));
+        whenServerEntity(platformEntity.consumerID, sender.getServerName()).complete(entity);
 
-    whenServerEntity(platformEntity.consumerID, sender.getServerName()).complete(entity);
-
-    if (sender.getServerName().equals(platformConfiguration.getServerName())) {
-      topologyEventListeners.forEach(listener -> listener.onEntityCreated(platformEntity.consumerID));
-    }
+        if (sender.getServerName().equals(platformConfiguration.getServerName())) {
+          topologyEventListeners.forEach(listener -> listener.onEntityCreated(platformEntity.consumerID));
+        }  
+      }
+    });
   }
 
   @Override
   public void serverEntityReconfigured(PlatformServer sender, PlatformEntity platformEntity) {
     LOGGER.trace("[0] serverEntityReconfigured({}, {})", sender.getServerName(), platformEntity);
 
-    Server server = stripe.getServerByName(sender.getServerName())
-        .<IllegalStateException>orElseThrow(() -> newIllegalTopologyState("Missing server: " + sender.getServerName()));
-    ServerEntityIdentifier identifier = ServerEntityIdentifier.create(platformEntity.name, platformEntity.typeName);
-
-    ServerEntity entity = server.getServerEntity(identifier)
-        .<IllegalStateException>orElseThrow(() -> newIllegalTopologyState("Missing server entity " + identifier + " on server " + sender.getServerName()));
-
-    firingService.fireNotification(new ContextualNotification(entity.getContext(), SERVER_ENTITY_RECONFIGURED.name()));
+    stripe.getServerByName(sender.getServerName()).ifPresent(server -> {
+      ServerEntityIdentifier identifier = ServerEntityIdentifier.create(platformEntity.name, platformEntity.typeName);
+      server.getServerEntity(identifier)
+          .ifPresent(entity -> firingService.fireNotification(new ContextualNotification(entity.getContext(), SERVER_ENTITY_RECONFIGURED.name())));
+    });
   }
 
   @Override
@@ -208,69 +207,66 @@ class TopologyService implements PlatformListener {
     LOGGER.trace("[0] serverEntityDestroyed({}, {})", sender.getServerName(), platformEntity);
 
     if (platformEntity.isActive && !sender.getServerName().equals(getActiveServer().getServerName())) {
-      throw newIllegalTopologyState("Server " + sender.getServerName() + " is not current active server but it destroyed an active entity " + platformEntity);
+      LOGGER.warn("[0] serverEntityDestroyed({}, {}): Server is not current active server but it destroyed an active entity", sender.getServerName(), platformEntity);
+      return;
     }
 
     if (!platformEntity.isActive && sender.getServerName().equals(getActiveServer().getServerName())) {
-      throw newIllegalTopologyState("Server " + sender.getServerName() + " is the current active server but it destroyed a passive entity " + platformEntity);
+      LOGGER.warn("[0] serverEntityDestroyed({}, {}): Server is the current active server but it destroyed a passive entity", sender.getServerName(), platformEntity);
+      return;
     }
 
-    Server server = stripe.getServerByName(sender.getServerName())
-        .<IllegalStateException>orElseThrow(() -> newIllegalTopologyState("Missing server: " + sender.getServerName()));
+    stripe.getServerByName(sender.getServerName()).ifPresent(server -> {
+      server.getServerEntity(platformEntity.name, platformEntity.typeName).ifPresent(entity -> {
+        Context context = entity.getContext();
+        entity.remove();
 
-    ServerEntity entity = server.getServerEntity(platformEntity.name, platformEntity.typeName)
-        .<IllegalStateException>orElseThrow(() -> newIllegalTopologyState("Missing entity: " + platformEntity + " on server " + sender.getServerName()));
+        serverEntities.get(sender.getServerName()).remove(platformEntity.consumerID);
 
-    Context context = entity.getContext();
-    entity.remove();
+        if (isCurrentServerActive() && sender.getServerName().equals(currentActive.getServerName())) {
+          entityFetches.remove(platformEntity.consumerID);
+        }
 
-    serverEntities.get(sender.getServerName()).remove(platformEntity.consumerID);
+        if (sender.getServerName().equals(platformConfiguration.getServerName())) {
+          topologyEventListeners.forEach(listener -> listener.onEntityDestroyed(platformEntity.consumerID));
+        }
 
-    if (isCurrentServerActive() && sender.getServerName().equals(currentActive.getServerName())) {
-      entityFetches.remove(platformEntity.consumerID);
-    }
-
-    if (sender.getServerName().equals(platformConfiguration.getServerName())) {
-      topologyEventListeners.forEach(listener -> listener.onEntityDestroyed(platformEntity.consumerID));
-    }
-
-    firingService.fireNotification(new ContextualNotification(context, SERVER_ENTITY_DESTROYED.name()));
+        firingService.fireNotification(new ContextualNotification(context, SERVER_ENTITY_DESTROYED.name()));
+      });
+    });
   }
 
   @Override
   public synchronized void clientConnected(PlatformServer currentActive, PlatformConnectedClient platformConnectedClient) {
     LOGGER.trace("[0] clientConnected({})", platformConnectedClient);
 
-    Server server = stripe.getServerByName(currentActive.getServerName())
-        .<IllegalStateException>orElseThrow(() -> newIllegalTopologyState("Missing active server: " + currentActive.getServerName()));
-    
-    ClientIdentifier clientIdentifier = toClientIdentifier(platformConnectedClient);
-    Endpoint endpoint = Endpoint.create(platformConnectedClient.remoteAddress.getHostAddress(), platformConnectedClient.remotePort);
+    stripe.getServerByName(currentActive.getServerName()).ifPresent(server -> {
+      ClientIdentifier clientIdentifier = toClientIdentifier(platformConnectedClient);
+      Endpoint endpoint = Endpoint.create(platformConnectedClient.remoteAddress.getHostAddress(), platformConnectedClient.remotePort);
 
-    Client client = Client.create(clientIdentifier)
-        .setHostName(platformConnectedClient.remoteAddress.getHostName());
-    cluster.addClient(client);
+      Client client = Client.create(clientIdentifier)
+          .setHostName(platformConnectedClient.remoteAddress.getHostName());
 
-    client.addConnection(Connection.create(clientIdentifier.getConnectionUid(), getActiveServer(), endpoint));
+      cluster.addClient(client);
 
-    firingService.fireNotification(new ContextualNotification(server.getContext(), CLIENT_CONNECTED.name(), client.getContext()));
+      if(client.addConnection(Connection.create(clientIdentifier.getConnectionUid(), getActiveServer(), endpoint))) {
+        firingService.fireNotification(new ContextualNotification(server.getContext(), CLIENT_CONNECTED.name(), client.getContext()));
+      }
+    });
   }
 
   @Override
   public synchronized void clientDisconnected(PlatformServer currentActive, PlatformConnectedClient platformConnectedClient) {
     LOGGER.trace("[0] clientDisconnected({})", platformConnectedClient);
 
-    Server server = stripe.getServerByName(currentActive.getServerName())
-        .<IllegalStateException>orElseThrow(() -> newIllegalTopologyState("Missing active server: " + currentActive.getServerName()));
-    
-    ClientIdentifier clientIdentifier = toClientIdentifier(platformConnectedClient);
-    Client client = cluster.getClient(clientIdentifier)
-        .<IllegalStateException>orElseThrow(() -> newIllegalTopologyState("Missing client: " + clientIdentifier));
-    Context clientContext = client.getContext();
-
-    client.remove();
-
-    firingService.fireNotification(new ContextualNotification(server.getContext(), CLIENT_DISCONNECTED.name(), clientContext));
+    stripe.getServerByName(currentActive.getServerName()).ifPresent(server -> {
+      ClientIdentifier clientIdentifier = toClientIdentifier(platformConnectedClient);
+      cluster.getClient(clientIdentifier).ifPresent(client -> {
+        Context clientContext = client.getContext();
+        client.remove();
+        firingService.fireNotification(new ContextualNotification(server.getContext(), CLIENT_DISCONNECTED.name(), clientContext));
+      });
+    });
   }
 
   @Override
@@ -281,21 +277,16 @@ class TopologyService implements PlatformListener {
     ClientIdentifier clientIdentifier = toClientIdentifier(platformConnectedClient);
     Endpoint endpoint = Endpoint.create(platformConnectedClient.remoteAddress.getHostAddress(), platformConnectedClient.remotePort);
 
-    Client client = cluster.getClient(clientIdentifier)
-        .<IllegalStateException>orElseThrow(() -> newIllegalTopologyState("Missing client: " + clientIdentifier));
-
-    Connection connection = client.getConnection(currentActive, endpoint)
-        .<IllegalStateException>orElseThrow(() -> newIllegalTopologyState("Missing connection between server " + currentActive + " and client " + clientIdentifier));
-    ServerEntity entity = currentActive.getServerEntity(platformEntity.name, platformEntity.typeName)
-        .<IllegalStateException>orElseThrow(() -> newIllegalTopologyState("Missing entity: name=" + platformEntity.name + ", type=" + platformEntity.typeName));
-
-    connection.fetchServerEntity(platformEntity.name, platformEntity.typeName);
-
-    firingService.fireNotification(new ContextualNotification(entity.getContext(), SERVER_ENTITY_FETCHED.name(), client.getContext()));
-
-    whenFetchClient(platformEntity.consumerID, clientDescriptor).complete(client);
-
-    topologyEventListeners.forEach(listener -> listener.onFetch(platformEntity.consumerID, clientDescriptor));
+    cluster.getClient(clientIdentifier).ifPresent(client -> {
+      client.getConnection(currentActive, endpoint).ifPresent(connection -> {
+        currentActive.getServerEntity(platformEntity.name, platformEntity.typeName).ifPresent(entity -> {
+          connection.fetchServerEntity(platformEntity.name, platformEntity.typeName);
+          firingService.fireNotification(new ContextualNotification(entity.getContext(), SERVER_ENTITY_FETCHED.name(), client.getContext()));
+          whenFetchClient(platformEntity.consumerID, clientDescriptor).complete(client);
+          topologyEventListeners.forEach(listener -> listener.onFetch(platformEntity.consumerID, clientDescriptor));
+        });
+      });
+    });
   }
 
   @Override
@@ -306,50 +297,45 @@ class TopologyService implements PlatformListener {
     ClientIdentifier clientIdentifier = toClientIdentifier(platformConnectedClient);
     Endpoint endpoint = Endpoint.create(platformConnectedClient.remoteAddress.getHostAddress(), platformConnectedClient.remotePort);
 
-    ServerEntity entity = currentActive.getServerEntity(platformEntity.name, platformEntity.typeName)
-        .<IllegalStateException>orElseThrow(() -> newIllegalTopologyState("Missing entity: name=" + platformEntity.name + ", type=" + platformEntity.typeName));
-
-    Client client = cluster.getClient(clientIdentifier)
-        .<IllegalStateException>orElseThrow(() -> newIllegalTopologyState("Missing client: " + clientIdentifier));
-    Connection connection = client.getConnection(currentActive, endpoint)
-        .<IllegalStateException>orElseThrow(() -> newIllegalTopologyState("Missing connection: " + endpoint + " to server " + currentActive.getServerName() + " from client " + clientIdentifier));
-
-    entityFetches.get(platformEntity.consumerID).remove(clientDescriptor);
-
-    if (connection.unfetchServerEntity(platformEntity.name, platformEntity.typeName)) {
-      firingService.fireNotification(new ContextualNotification(entity.getContext(), SERVER_ENTITY_UNFETCHED.name(), client.getContext()));
-    }
-
-    topologyEventListeners.forEach(listener -> listener.onUnfetch(platformEntity.consumerID, clientDescriptor));
+    currentActive.getServerEntity(platformEntity.name, platformEntity.typeName).ifPresent(entity -> {
+      cluster.getClient(clientIdentifier).ifPresent(client -> {
+        client.getConnection(currentActive, endpoint).ifPresent(connection -> {
+          entityFetches.get(platformEntity.consumerID).remove(clientDescriptor);
+          if (connection.unfetchServerEntity(platformEntity.name, platformEntity.typeName)) {
+            firingService.fireNotification(new ContextualNotification(entity.getContext(), SERVER_ENTITY_UNFETCHED.name(), client.getContext()));
+          }
+          topologyEventListeners.forEach(listener -> listener.onUnfetch(platformEntity.consumerID, clientDescriptor));
+        });
+      });
+    });
   }
 
   @Override
   public synchronized void serverStateChanged(PlatformServer sender, ServerState serverState) {
     LOGGER.trace("[0] serverStateChanged({}, {})", sender.getServerName(), serverState.getState());
 
-    Server server = stripe.getServerByName(sender.getServerName())
-        .<IllegalStateException>orElseThrow(() -> newIllegalTopologyState("Missing server: " + sender.getServerName()));
+    stripe.getServerByName(sender.getServerName()).ifPresent(server -> {
+      Server.State oldState = server.getState();
 
-    Server.State oldState = server.getState();
+      if (oldState == Server.State.ACTIVE && currentActive != null && currentActive.getServerName().equals(server.getServerName())) {
+        // in case of a failover, the server state changed is replayed. So the server is active but will become passive and will become active again
+        // we filter this out
+        return;
+      }
 
-    if (oldState == Server.State.ACTIVE && currentActive != null && currentActive.getServerName().equals(server.getServerName())) {
-      // in case of a failover, the server state changed is replayed. So the server is active but will become passive and will become active again
-      // we filter this out
-      return;
-    }
+      server.setState(Server.State.parse(serverState.getState()));
+      server.setActivateTime(serverState.getActivate());
 
-    server.setState(Server.State.parse(serverState.getState()));
-    server.setActivateTime(serverState.getActivate());
+      if (oldState != server.getState()) {
+        // avoid sending another event to report the same state as before, to avoid duplicates
 
-    if (oldState != server.getState()) {
-      // avoid sending another event to report the same state as before, to avoid duplicates
+        Map<String, String> attrs = new HashMap<>();
+        attrs.put("state", serverState.getState());
+        attrs.put("activateTime", serverState.getActivate() > 0 ? String.valueOf(serverState.getActivate()) : "0");
 
-      Map<String, String> attrs = new HashMap<>();
-      attrs.put("state", serverState.getState());
-      attrs.put("activateTime", serverState.getActivate() > 0 ? String.valueOf(serverState.getActivate()) : "0");
-
-      firingService.fireNotification(new ContextualNotification(server.getContext(), SERVER_STATE_CHANGED.name(), attrs));
-    }
+        firingService.fireNotification(new ContextualNotification(server.getContext(), SERVER_STATE_CHANGED.name(), attrs));
+      }
+    });
   }
 
   // ======================================================================
@@ -520,10 +506,7 @@ class TopologyService implements PlatformListener {
   }
 
   private Server getActiveServer() {
-    if (currentActive == null) {
-      throw newIllegalTopologyState("No active server defined!");
-    }
-    return currentActive;
+    return Objects.requireNonNull(currentActive);
   }
 
   private ExecutionChain<Client> whenFetchClient(long consumerId, ClientDescriptor clientDescriptor) {
@@ -534,10 +517,6 @@ class TopologyService implements PlatformListener {
   private ExecutionChain<ServerEntity> whenServerEntity(long consumerId, String serverName) {
     ConcurrentMap<Long, ExecutionChain<ServerEntity>> entities = serverEntities.computeIfAbsent(serverName, name -> new ConcurrentHashMap<>());
     return entities.computeIfAbsent(consumerId, key -> new ExecutionChain<>());
-  }
-
-  private IllegalStateException newIllegalTopologyState(String message) {
-    return new IllegalStateException("Illegal monitoring topology state: " + message + "\n- currentActive: " + currentActive + "\n- cluster:" + cluster);
   }
 
   private static ClientIdentifier toClientIdentifier(PlatformConnectedClient connection) {

--- a/management/nms-agent-entity/nms-agent-entity-client/src/main/java/org/terracotta/management/entity/nms/agent/client/NmsAgentService.java
+++ b/management/nms-agent-entity/nms-agent-entity-client/src/main/java/org/terracotta/management/entity/nms/agent/client/NmsAgentService.java
@@ -87,12 +87,12 @@ public class NmsAgentService implements Closeable {
         try {
           setCapabilities(registry.getContextContainer(), registry.getCapabilities());
         } catch (InterruptedException e) {
-          LOGGER.error("Failed to register managed object of type " + managedObject.getClass().getName() + ": " + e.getMessage(), e);
+          LOGGER.warn("Failed to register managed object of type " + managedObject.getClass().getName() + ": " + e.getMessage(), e);
           Thread.currentThread().interrupt();
         } catch (ConnectionClosedException e) {
           NmsAgentService.this.close();
         } catch (Exception e) {
-          LOGGER.error("Failed to register managed object of type " + managedObject.getClass().getName() + ": " + e.getMessage(), e);
+          LOGGER.warn("Failed to register managed object of type " + managedObject.getClass().getName() + ": " + e.getMessage(), e);
         }
       }
     }

--- a/management/nms-entity/nms-entity-client/src/main/java/org/terracotta/management/entity/nms/client/DefaultNmsService.java
+++ b/management/nms-entity/nms-entity-client/src/main/java/org/terracotta/management/entity/nms/client/DefaultNmsService.java
@@ -17,7 +17,6 @@ package org.terracotta.management.entity.nms.client;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.terracotta.management.model.Objects;
 import org.terracotta.management.model.call.ContextualReturn;
 import org.terracotta.management.model.call.Parameter;
 import org.terracotta.management.model.cluster.Cluster;
@@ -28,6 +27,7 @@ import org.terracotta.management.model.message.Message;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Queue;
 import java.util.concurrent.BlockingQueue;

--- a/management/testing/integration-tests/src/test/java/org/terracotta/management/integration/tests/BadClientsIT.java
+++ b/management/testing/integration-tests/src/test/java/org/terracotta/management/integration/tests/BadClientsIT.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.management.integration.tests;
+
+import org.junit.Test;
+import org.terracotta.management.entity.sample.Cache;
+import org.terracotta.management.entity.sample.client.CacheFactory;
+import org.terracotta.management.entity.sample.client.ClientCache;
+
+import java.net.URI;
+import java.util.UUID;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+/**
+ * @author Mathieu Carbou
+ */
+public class BadClientsIT extends AbstractSingleTest {
+
+  @Test
+  public void two_clients_with_same_identifiers_do_not_crash_the_server() throws Exception {
+    URI uri = cluster.getConnectionURI().resolve("/bad-client");
+    String uuid = UUID.randomUUID().toString();
+
+    CacheFactory cacheFactory1 = new CacheFactory(uri);
+    cacheFactory1.init(uuid);
+    Cache foo1 = cacheFactory1.getCache("foo");
+
+    long count = nmsService.readTopology().clientStream()
+        .filter(client -> client.getClientIdentifier().getConnectionUid().equals(uuid))
+        .count();
+    assertThat(count, equalTo(1L));
+
+    // create another client that will have the same client identifier
+    CacheFactory cacheFactory2 = new CacheFactory(uri);
+    cacheFactory2.init(uuid);
+    ClientCache foo2 = (ClientCache) cacheFactory1.getCache("foo");
+
+    count = nmsService.readTopology().clientStream()
+        .filter(client -> client.getClientIdentifier().getConnectionUid().equals(uuid))
+        .count();
+    assertThat(count, equalTo(1L));
+
+    count = nmsService.readTopology().clientStream()
+        .filter(client -> client.getClientIdentifier().getName().equals("bad-client"))
+        .count();
+    assertThat(count, equalTo(1L));
+
+    foo1.put("key", "val");
+    assertThat(foo2.get("key"), equalTo("val"));
+
+    foo2.close();
+    cacheFactory2.getConnection().close();
+    
+    do {
+      count = nmsService.readTopology().clientStream()
+          .filter(client -> client.getClientIdentifier().getConnectionUid().equals(uuid))
+          .count();
+    } while (!Thread.currentThread().isInterrupted() && count != 0);
+    assertThat(count, equalTo(0L));
+
+    cacheFactory1.getConnection().close();
+  }
+
+}

--- a/management/testing/integration-tests/src/test/resources/logback-ext.xml
+++ b/management/testing/integration-tests/src/test/resources/logback-ext.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright Terracotta, Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<included>
+  <logger name="org.terracotta.management" level="TRACE"/>
+</included>

--- a/management/testing/sample-entity/src/main/java/org/terracotta/management/entity/sample/client/CacheFactory.java
+++ b/management/testing/sample-entity/src/main/java/org/terracotta/management/entity/sample/client/CacheFactory.java
@@ -63,10 +63,17 @@ public class CacheFactory implements Closeable {
   }
 
   public void init() throws ConnectionException, ExecutionException, InterruptedException, TimeoutException {
+    init(null);
+  }
+
+  public void init(String uuid) throws ConnectionException, ExecutionException, InterruptedException, TimeoutException {
     // connects to server
     Properties properties = new Properties();
     properties.setProperty(ConnectionPropertyNames.CONNECTION_NAME, uri.getPath().substring(1));
     properties.setProperty(ConnectionPropertyNames.CONNECTION_TIMEOUT, "5000");
+    if(uuid != null) {
+      properties.setProperty(ConnectionPropertyNames.CONNECTION_UUID, uuid);
+    }
     this.connection = ConnectionFactory.connect(uri, properties);
     this.cacheEntityFactory = new CacheEntityFactory(connection);
     this.management.init(connection);

--- a/management/testing/sample-entity/src/test/java/org/terracotta/management/entity/sample/CacheEntityFeaturesTest.java
+++ b/management/testing/sample-entity/src/test/java/org/terracotta/management/entity/sample/CacheEntityFeaturesTest.java
@@ -90,7 +90,13 @@ public class CacheEntityFeaturesTest extends AbstractTest {
 
     remove(1, "clients", "client1");
 
-    assertThat(size(0, "clients"), equalTo(0));
+    // async events (client communicator)
+    int size = size(0, "clients");
+    while (size != 0 && !Thread.currentThread().isInterrupted()) {
+      size = size(0, "clients");
+    }
+    assertThat(size, equalTo(0));
+
     assertThat(size(1, "clients"), equalTo(0));
 
     assertThat(get(0, "clients", "client1"), is(nullValue()));


### PR DESCRIPTION
This PR makes M&M supports bad clients with the same identifiers, and also bad sequence order sent from voltron.

By supporting, I mean that if something inconsistent is found, then the call is ignored.

Side effects:

1. the topology will only see 1 client
2. if a second client connect with the same client identifier as a first connected client, then both client will be able to send their notification and stats and they will have the same exact origin.
3. management calls will be received by these 2 clients BUT the NMS will only receive the first answer
4. if one of the client disconnects, it will be removed from the topology and if the other clients are sending stats or notifs, they will be ignored. Management calls won't be possible also
5. NMS only sees 1 client