### PR TITLE
[Fix2] TDB-2403: Makes M&M more reliable against voltron inconsistencies

### DIFF
--- a/management/monitoring-service/pom.xml
+++ b/management/monitoring-service/pom.xml
@@ -100,6 +100,12 @@
         </exclusion>
       </exclusions>
     </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <version>${logback.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/management/monitoring-service/src/main/java/org/terracotta/management/service/monitoring/DefaultActiveEntityMonitoringService.java
+++ b/management/monitoring-service/src/main/java/org/terracotta/management/service/monitoring/DefaultActiveEntityMonitoringService.java
@@ -25,8 +25,11 @@ import org.terracotta.management.model.context.ContextContainer;
 import org.terracotta.management.model.notification.ContextualNotification;
 import org.terracotta.management.model.stats.ContextualStatistics;
 
+import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * @author Mathieu Carbou
@@ -46,7 +49,10 @@ public class DefaultActiveEntityMonitoringService extends AbstractEntityMonitori
 
   @Override
   public void exposeManagementRegistry(ContextContainer contextContainer, Capability... capabilities) {
-    logger.trace("[{}] exposeManagementRegistry({})", getConsumerId(), contextContainer);
+    if(logger.isTraceEnabled()) {
+      List<String> names = Stream.of(capabilities).map(Capability::getName).collect(Collectors.toList());
+      logger.trace("[{}] exposeManagementRegistry({})", getConsumerId(), names);
+    }
     ManagementRegistry registry = ManagementRegistry.create(contextContainer);
     registry.addCapabilities(capabilities);
     topologyService.willSetEntityManagementRegistry(getConsumerId(), serverName, registry);

--- a/management/monitoring-service/src/main/java/org/terracotta/management/service/monitoring/DefaultClientMonitoringService.java
+++ b/management/monitoring-service/src/main/java/org/terracotta/management/service/monitoring/DefaultClientMonitoringService.java
@@ -31,9 +31,12 @@ import org.terracotta.management.model.stats.ContextualStatistics;
 import org.terracotta.voltron.proxy.ProxyEntityResponse;
 
 import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * @author Mathieu Carbou
@@ -80,7 +83,10 @@ class DefaultClientMonitoringService implements ClientMonitoringService, Topolog
 
   @Override
   public void exposeManagementRegistry(ClientDescriptor from, ContextContainer contextContainer, Capability... capabilities) {
-    LOGGER.trace("[{}] exposeManagementRegistry({}, {})", consumerId, from, contextContainer);
+    if(LOGGER.isTraceEnabled()) {
+      List<String> names = Stream.of(capabilities).map(Capability::getName).collect(Collectors.toList());
+      LOGGER.trace("[{}] exposeManagementRegistry({}, {})", consumerId, from, names);
+    }
     ManagementRegistry newRegistry = ManagementRegistry.create(contextContainer);
     newRegistry.addCapabilities(capabilities);
     topologyService.willSetClientManagementRegistry(consumerId, from, newRegistry)

--- a/management/monitoring-service/src/main/java/org/terracotta/management/service/monitoring/DefaultEntityManagementRegistry.java
+++ b/management/monitoring-service/src/main/java/org/terracotta/management/service/monitoring/DefaultEntityManagementRegistry.java
@@ -22,8 +22,8 @@ import org.terracotta.management.model.context.ContextContainer;
 import org.terracotta.management.model.notification.ContextualNotification;
 import org.terracotta.management.registry.CapabilityManagement;
 import org.terracotta.management.registry.DefaultCapabilityManagement;
-import org.terracotta.management.registry.ManagementProvider;
 import org.terracotta.management.registry.ExposedObject;
+import org.terracotta.management.registry.ManagementProvider;
 import org.terracotta.management.service.monitoring.registry.provider.AbstractEntityManagementProvider;
 import org.terracotta.management.service.monitoring.registry.provider.MonitoringServiceAware;
 
@@ -64,6 +64,13 @@ class DefaultEntityManagementRegistry implements EntityManagementRegistry, Topol
 
     topologyService.addTopologyEventListener(this);
     sharedManagementRegistry.addManagementService(this);
+  }
+
+  @Override
+  public void onBecomeActive() {
+    if (monitoringService instanceof DefaultPassiveEntityMonitoringService) {
+      close();
+    }
   }
 
   @Override

--- a/management/monitoring-service/src/main/java/org/terracotta/management/service/monitoring/DefaultPassiveEntityMonitoringService.java
+++ b/management/monitoring-service/src/main/java/org/terracotta/management/service/monitoring/DefaultPassiveEntityMonitoringService.java
@@ -26,7 +26,10 @@ import org.terracotta.management.model.notification.ContextualNotification;
 import org.terracotta.management.model.stats.ContextualStatistics;
 import org.terracotta.monitoring.IMonitoringProducer;
 
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.terracotta.management.service.monitoring.DefaultDataListener.TOPIC_SERVER_ENTITY_NOTIFICATION;
 import static org.terracotta.management.service.monitoring.DefaultDataListener.TOPIC_SERVER_ENTITY_STATISTICS;
@@ -46,7 +49,10 @@ class DefaultPassiveEntityMonitoringService extends AbstractEntityMonitoringServ
 
   @Override
   public void exposeManagementRegistry(ContextContainer contextContainer, Capability... capabilities) {
-    logger.trace("[{}] exposeManagementRegistry({})", getConsumerId(), contextContainer);
+    if(logger.isTraceEnabled()) {
+      List<String> names = Stream.of(capabilities).map(Capability::getName).collect(Collectors.toList());
+      logger.trace("[{}] exposeManagementRegistry({})", getConsumerId(), names);
+    }
     ManagementRegistry registry = ManagementRegistry.create(contextContainer);
     registry.addCapabilities(capabilities);
     monitoringProducer.addNode(new String[0], "registry", registry);

--- a/management/monitoring-service/src/main/java/org/terracotta/management/service/monitoring/MonitoringServiceProvider.java
+++ b/management/monitoring-service/src/main/java/org/terracotta/management/service/monitoring/MonitoringServiceProvider.java
@@ -24,7 +24,6 @@ import org.terracotta.entity.ServiceProvider;
 import org.terracotta.entity.ServiceProviderCleanupException;
 import org.terracotta.entity.ServiceProviderConfiguration;
 import org.terracotta.entity.StateDumpCollector;
-import org.terracotta.entity.StateDumpable;
 import org.terracotta.management.model.context.Context;
 import org.terracotta.management.model.context.ContextContainer;
 import org.terracotta.management.model.stats.ContextualStatistics;
@@ -40,9 +39,6 @@ import java.io.Closeable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
 
 /**
  * @author Mathieu Carbou
@@ -174,6 +170,7 @@ public class MonitoringServiceProvider implements ServiceProvider, Closeable {
           // add a collector service, not started by default, but that can be started through a remote management call
           StatisticCollector statisticCollector = statisticService.createStatisticCollector(statistics -> monitoringService.pushStatistics(statistics.toArray(new ContextualStatistics[statistics.size()])));
           registry.register(statisticCollector);
+          registry.refresh();
         }
 
         @Override

--- a/management/monitoring-service/src/test/java/org/terracotta/management/service/monitoring/VoltronMonitoringServiceTest.java
+++ b/management/monitoring-service/src/test/java/org/terracotta/management/service/monitoring/VoltronMonitoringServiceTest.java
@@ -330,7 +330,7 @@ public class VoltronMonitoringServiceTest {
     };
     EntityManagementRegistry passiveRegistry = passiveServiceProvider.getService(3, new ManagementRegistryConfiguration(mock(ServiceRegistry.class), false) {
       @Override
-      public  IMonitoringProducer getMonitoringProducer() {
+      public IMonitoringProducer getMonitoringProducer() {
         return monitoringProducer;
       }
     });
@@ -371,11 +371,16 @@ public class VoltronMonitoringServiceTest {
   public void test_notifs_and_stats() throws Exception {
     test_fetch_entity();
 
+    activePlatformListener.serverDidJoinStripe(passive);
+    activePlatformListener.addNode(passive, ENTITIES_PATH, "entity-1", new PlatformEntity("entityType", "entityName-1", 1, false));
+
+    messages();
+    
     clientMonitoringService.pushNotification(new FakeDesc("1-1"), new ContextualNotification(Context.empty(), "TYPE-1"));
     clientMonitoringService.pushStatistics(new FakeDesc("1-1"), new ContextualStatistics("capability", Context.empty(), Collections.emptyMap()));
 
-    activeDataListener.pushBestEffortsData(active, TOPIC_SERVER_ENTITY_NOTIFICATION, new ContextualNotification(Context.empty(), "TYPE-2"));
-    activeDataListener.pushBestEffortsData(active, TOPIC_SERVER_ENTITY_STATISTICS, new ContextualStatistics[]{new ContextualStatistics("capability", Context.empty(), Collections.emptyMap())});
+    activeDataListener.pushBestEffortsData(passive, TOPIC_SERVER_ENTITY_NOTIFICATION, new ContextualNotification(Context.empty(), "TYPE-2"));
+    activeDataListener.pushBestEffortsData(passive, TOPIC_SERVER_ENTITY_STATISTICS, new ContextualStatistics[]{new ContextualStatistics("capability", Context.empty(), Collections.emptyMap())});
 
     List<Message> messages = messages();
     assertThat(messageTypes(messages), equalTo(Arrays.asList("NOTIFICATION", "STATISTICS", "NOTIFICATION", "STATISTICS")));
@@ -384,7 +389,7 @@ public class VoltronMonitoringServiceTest {
         notificationContexts(messages),
         equalTo(Arrays.asList(
             Context.create(Client.KEY, "111@127.0.0.1:name:uuid-1"),
-            managementService.readTopology().getSingleStripe().getActiveServerEntity("entityName-1", "entityType").get().getContext())));
+            managementService.readTopology().getSingleStripe().getServer("server-2").get().getServerEntity("entityName-1", "entityType").get().getContext())));
   }
 
   @Test

--- a/management/monitoring-service/src/test/resources/logback.xml
+++ b/management/monitoring-service/src/test/resources/logback.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright Terracotta, Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<configuration scan="false" scanPeriod="20 seconds" debug="false">
+
+  <contextListener class="ch.qos.logback.classic.jul.LevelChangePropagator">
+    <resetJUL>true</resetJUL>
+  </contextListener>
+
+  <property name="CONSOLE_LOG_PATTERN" value="${CONSOLE_LOG_PATTERN:-%d{yyyy-MM-dd HH:mm:ss.SSS} ${LOG_LEVEL_PATTERN:-%5p} ${PID:- } --- [%15.15t] %-40.40logger{39}: %m%n${LOG_EXCEPTION_CONVERSION_WORD:-%ex{full}}}"/>
+
+  <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>${CONSOLE_LOG_PATTERN}</pattern>
+      <charset>utf8</charset>
+    </encoder>
+  </appender>
+
+  <!--<logger name="com.terracottatech" level="INFO"/>-->
+  <!--<logger name="org.terracotta" level="TRACE"/>-->
+  <logger name="org.terracotta.management" level="TRACE"/>
+
+  <root level="INFO">
+    <appender-ref ref="CONSOLE"/>
+  </root>
+
+</configuration>

--- a/offheap-resource/src/main/java/org/terracotta/offheapresource/OffHeapResourcesProvider.java
+++ b/offheap-resource/src/main/java/org/terracotta/offheapresource/OffHeapResourcesProvider.java
@@ -108,15 +108,20 @@ public class OffHeapResourcesProvider implements OffHeapResources, ManageableSer
     registry.addManagementProvider(new OffHeapResourceSettingsManagementProvider());
     registry.addManagementProvider(new OffHeapResourceStatisticsManagementProvider());
 
-    for (OffHeapResourceIdentifier identifier : getAllIdentifiers()) {
-      LOGGER.trace("[{}] onManagementRegistryCreated() - Exposing OffHeapResource:{}", registry.getMonitoringService().getConsumerId(), identifier.getName());
-      OffHeapResourceBinding managementBinding = getOffHeapResource(identifier).getManagementBinding();
-      registry.register(managementBinding);
+    Set<OffHeapResourceIdentifier> identifiers = getAllIdentifiers();
+    if(!identifiers.isEmpty()) {
+      for (OffHeapResourceIdentifier identifier : identifiers) {
+        LOGGER.trace("[{}] onManagementRegistryCreated() - Exposing OffHeapResource:{}", registry.getMonitoringService().getConsumerId(), identifier.getName());
+        OffHeapResourceBinding managementBinding = getOffHeapResource(identifier).getManagementBinding();
+        registry.register(managementBinding);
+      }
+      registry.refresh(); 
     }
   }
 
   @Override
   public void onManagementRegistryClose(EntityManagementRegistry registry) {
+    LOGGER.trace("[{}] onManagementRegistryClose()", registry.getMonitoringService().getConsumerId());
     registries.remove(registry);
   }
 


### PR DESCRIPTION
- better support of passive entities placeholders that are not cleaned up by platform when server becomes active
- filter out any event coming from active in DefaultDataListener (DefaultDataListener should only receive passive events but was receiving events from the passive placeholders created on a server before it becomes active)