### PR TITLE
[DO NOT MERGE] QnD stage management code

### DIFF
--- a/coremon/pom.xml
+++ b/coremon/pom.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright Terracotta, Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.terracotta</groupId>
+    <artifactId>platform-root</artifactId>
+    <version>5.4-SNAPSHOT</version>
+    <relativePath>..</relativePath>
+  </parent>
+
+  <artifactId>coremon</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.terracotta</groupId>
+      <artifactId>monitoring-support</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.terracotta.management</groupId>
+      <artifactId>monitoring-service-api</artifactId>
+    </dependency>
+  </dependencies>
+
+
+</project>

--- a/coremon/src/main/java/org/terracotta/coremon/CoreManagementServiceProvider.java
+++ b/coremon/src/main/java/org/terracotta/coremon/CoreManagementServiceProvider.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.coremon;
+
+import com.tc.classloader.BuiltinService;
+import org.terracotta.entity.PlatformConfiguration;
+import org.terracotta.entity.ServiceConfiguration;
+import org.terracotta.entity.ServiceProvider;
+import org.terracotta.entity.ServiceProviderConfiguration;
+import org.terracotta.management.service.monitoring.EntityManagementRegistry;
+import org.terracotta.management.service.monitoring.ManageableServerComponent;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+
+@BuiltinService
+public class CoreManagementServiceProvider implements ServiceProvider, ManageableServerComponent {
+
+  @Override
+  public boolean initialize(ServiceProviderConfiguration serviceProviderConfiguration, PlatformConfiguration platformConfiguration) {
+    return true;
+  }
+
+  @Override
+  public <T> T getService(long consumerID, ServiceConfiguration<T> serviceConfiguration) {
+    Class<T> serviceType = serviceConfiguration.getServiceType();
+    if (serviceType.equals(ManageableServerComponent.class)) {
+      return serviceType.cast(this);
+    }
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Collection<Class<?>> getProvidedServiceTypes() {
+    return Collections.singleton(ManageableServerComponent.class);
+  }
+
+  @Override
+  public void prepareForSynchronization() {
+  }
+
+  @Override
+  public void onManagementRegistryCreated(EntityManagementRegistry registry) {
+    try {
+    registry.addManagementProvider(new StageStatisticsProvider());
+    registry.addManagementProvider(new StageSettingsProvider());
+
+      JmxUtil jmxUtil = new JmxUtil();
+      Map<String, Object> statistics = jmxUtil.getStatistics();
+      for (String key : statistics.keySet()) {
+        if (key.endsWith("queueCount")) {
+          String[] split = key.split("\\.");
+          String stageName = split[0];
+          registry.register(new StageBinding(stageName, jmxUtil));
+        }
+      }
+
+      registry.refresh();
+    } catch (Exception e) {
+      e.printStackTrace();
+    }
+  }
+
+  @Override
+  public void onManagementRegistryClose(EntityManagementRegistry registry) {
+  }
+}

--- a/coremon/src/main/java/org/terracotta/coremon/JmxUtil.java
+++ b/coremon/src/main/java/org/terracotta/coremon/JmxUtil.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.coremon;
+
+import javax.management.MBeanServer;
+import javax.management.ObjectName;
+import java.lang.management.ManagementFactory;
+import java.util.Map;
+
+public class JmxUtil {
+
+  private final MBeanServer mBeanServer = ManagementFactory.getPlatformMBeanServer();
+  private final ObjectName internalTerracottaServerObjectName;
+
+  public JmxUtil() throws Exception {
+    this.internalTerracottaServerObjectName = new ObjectName("org.terracotta:name=TerracottaServer");
+  }
+
+  public Map<String, Object> getStatistics() throws Exception {
+    return (Map<String, Object>) mBeanServer.getAttribute(internalTerracottaServerObjectName, "Statistics");
+  }
+
+}

--- a/coremon/src/main/java/org/terracotta/coremon/StageBinding.java
+++ b/coremon/src/main/java/org/terracotta/coremon/StageBinding.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.coremon;
+
+import org.terracotta.management.service.monitoring.registry.provider.AliasBinding;
+
+public class StageBinding extends AliasBinding {
+
+  private final int queueCount;
+  private final int maxQueueSize;
+
+  public StageBinding(String alias, JmxUtil jmxUtil) throws Exception {
+    super(alias, jmxUtil);
+    this.queueCount = (int) getValue().getStatistics().get(getAlias() + ".queueCount");
+    this.maxQueueSize = (int) getValue().getStatistics().get(getAlias() + ".maxQueueSize");
+  }
+
+  @Override
+  public JmxUtil getValue() {
+    return (JmxUtil) super.getValue();
+  }
+
+  public int getQueueCount() {
+    return queueCount;
+  }
+
+  public int getMaxQueueSize() {
+    return maxQueueSize;
+  }
+
+  public int fetchCurrentQueueSize() {
+    try {
+      return (int) getValue().getStatistics().get(getAlias() + ".currentQueueSize");
+    } catch (Exception e) {
+      return -1;
+    }
+  }
+
+  public long fetchTotalQueuedCount() {
+    try {
+      return (long) getValue().getStatistics().get(getAlias() + ".totalQueuedCount");
+    } catch (Exception e) {
+      return -1L;
+    }
+  }
+}

--- a/coremon/src/main/java/org/terracotta/coremon/StageSettingsProvider.java
+++ b/coremon/src/main/java/org/terracotta/coremon/StageSettingsProvider.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.coremon;
+
+import org.terracotta.management.model.capabilities.descriptors.Settings;
+import org.terracotta.management.model.context.Context;
+import org.terracotta.management.registry.Named;
+import org.terracotta.management.registry.RequiredContext;
+import org.terracotta.management.service.monitoring.registry.provider.AliasBindingManagementProvider;
+
+import java.util.Collection;
+import java.util.Collections;
+
+@Named("StageSettings")
+@RequiredContext({})
+public class StageSettingsProvider extends AliasBindingManagementProvider<StageBinding> {
+
+  public StageSettingsProvider() {
+    super(StageBinding.class);
+  }
+
+
+  @Override
+  protected ExposedRestartStoreBinding internalWrap(Context context, StageBinding managedObject) {
+    return new ExposedRestartStoreBinding(context, managedObject);
+  }
+
+  private static class ExposedRestartStoreBinding extends ExposedAliasBinding<StageBinding> {
+
+    ExposedRestartStoreBinding(Context context, StageBinding binding) {
+      super(context, binding);
+    }
+
+    @Override
+    public Collection<? extends Settings> getDescriptors() {
+      return Collections.singleton(new Settings(getContext())
+          .set("stageQueueCount", getBinding().getQueueCount())
+          .set("stageMaxQueueSize", getBinding().getMaxQueueSize())
+      );
+    }
+  }
+
+}

--- a/coremon/src/main/java/org/terracotta/coremon/StageStatisticsProvider.java
+++ b/coremon/src/main/java/org/terracotta/coremon/StageStatisticsProvider.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.coremon;
+
+import org.terracotta.management.model.context.Context;
+import org.terracotta.management.registry.Named;
+import org.terracotta.management.registry.RequiredContext;
+import org.terracotta.management.registry.collect.StatisticProvider;
+import org.terracotta.management.registry.collect.StatisticRegistry;
+import org.terracotta.management.service.monitoring.registry.provider.AbstractExposedStatistics;
+import org.terracotta.management.service.monitoring.registry.provider.AbstractStatisticsManagementProvider;
+
+@Named("StageStatistics")
+@RequiredContext({@Named("alias")})
+@StatisticProvider
+public class StageStatisticsProvider extends AbstractStatisticsManagementProvider<StageBinding> {
+
+  public StageStatisticsProvider() {
+    super(StageBinding.class);
+  }
+
+  @Override
+  protected AbstractExposedStatistics<StageBinding> internalWrap(Context context, StageBinding managedObject, StatisticRegistry statisticRegistry) {
+    return new StageStatisticsBindingExposedStatistics(context, managedObject, statisticRegistry);
+  }
+
+  private static class StageStatisticsBindingExposedStatistics extends AbstractExposedStatistics<StageBinding> {
+    StageStatisticsBindingExposedStatistics(Context context, StageBinding binding, StatisticRegistry statisticRegistry) {
+      super(context, binding, statisticRegistry);
+
+      getRegistry().registerSize("Stage:CurrentQueueSize", binding::fetchCurrentQueueSize);
+      getRegistry().registerCounter("Stage:TotalQueuedCount", binding::fetchTotalQueuedCount);
+    }
+  }
+}

--- a/coremon/src/main/resources/META-INF/services/org.terracotta.entity.ServiceProvider
+++ b/coremon/src/main/resources/META-INF/services/org.terracotta.entity.ServiceProvider
@@ -1,0 +1,17 @@
+#
+# Copyright Terracotta, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+org.terracotta.coremon.CoreManagementServiceProvider

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
     <terracotta-apis.version>1.4.0-pre7</terracotta-apis.version>
     <terracotta-configuration.version>10.4.0-pre7</terracotta-configuration.version>
     <passthrough-testing.version>1.4.0-pre8</passthrough-testing.version>
-    <terracotta-core.version>5.4.0-pre13</terracotta-core.version>
+    <terracotta-core.version>5.4-SNAPSHOT</terracotta-core.version>
     <statistics.version>1.5.0</statistics.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -52,6 +52,7 @@
     <module>runnel</module>
     <module>management</module>
     <module>client-message-tracker</module>
+    <module>coremon</module>
   </modules>
 
   <dependencyManagement>
@@ -120,6 +121,11 @@
         <groupId>org.terracotta</groupId>
         <artifactId>monitoring-support</artifactId>
         <version>${terracotta-apis.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.terracotta.management</groupId>
+        <artifactId>monitoring-service-api</artifactId>
+        <version>${project.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
This is the kind of SEDA stage monitoring I would like to see. I've relied on JMX to communicate management info between core and platform, which is open for discussion.

This whole PR is only about starting the discussion, BTW. The related core PR is here: https://github.com/Terracotta-OSS/terracotta-core/pull/808

FYI, here is what the JSON'ified topology looks like:

```
            {
            "name" : "StageSettings",
            "context" : [ ],
            "descriptors" : [ {
              "consumerId" : "7",
              "alias" : "active_to_passive_driver_stage",
              "stageQueueCount" : 1,
              "stageMaxQueueSize" : 2147483647
            }, {
              "consumerId" : "7",
              "alias" : "request_processor_stage",
              "stageQueueCount" : 8,
              "stageMaxQueueSize" : 2147483647
            }, {
              "consumerId" : "7",
              "alias" : "l2_state_message_handler_stage",
              "stageQueueCount" : 1,
              "stageMaxQueueSize" : 2147483647
            }, {
              "consumerId" : "7",
              "alias" : "passive_replication_stage",
              "stageQueueCount" : 1,
              "stageMaxQueueSize" : 2147483647
            }, {
              "consumerId" : "7",
              "alias" : "group_handshake_message_stage",
              "stageQueueCount" : 1,
              "stageMaxQueueSize" : 5000
            }, {
              "consumerId" : "7",
              "alias" : "receive_group_message_stage",
              "stageQueueCount" : 1,
              "stageMaxQueueSize" : 5000
            }, {
              "consumerId" : "7",
              "alias" : "group_events_dispatch_stage",
              "stageQueueCount" : 1,
              "stageMaxQueueSize" : 2147483647
            }, {
              "consumerId" : "7",
              "alias" : "single_threaded_fastpath",
              "stageQueueCount" : 1,
              "stageMaxQueueSize" : 2147483647
            }, {
              "consumerId" : "7",
              "alias" : "l2_election_handler_stage",
              "stageQueueCount" : 1,
              "stageMaxQueueSize" : 1024
            }, {
              "consumerId" : "7",
              "alias" : "respond_to_request_stage",
              "stageQueueCount" : 1,
              "stageMaxQueueSize" : 2147483647
            }, {
              "consumerId" : "7",
              "alias" : "voltron_message_stage",
              "stageQueueCount" : 1,
              "stageMaxQueueSize" : 2147483647
            }, {
              "consumerId" : "7",
              "alias" : "passive_replication_ack_stage",
              "stageQueueCount" : 1,
              "stageMaxQueueSize" : 2147483647
            }, {
              "consumerId" : "7",
              "alias" : "platform_information_request",
              "stageQueueCount" : 1,
              "stageMaxQueueSize" : 2147483647
            }, {
              "consumerId" : "7",
              "alias" : "request_processor_during_sync_stage",
              "stageQueueCount" : 4,
              "stageMaxQueueSize" : 2147483647
            }, {
              "consumerId" : "7",
              "alias" : "passive_outgoing_response_stage",
              "stageQueueCount" : 1,
              "stageMaxQueueSize" : 2147483647
            }, {
              "consumerId" : "7",
              "alias" : "l2_state_change_stage",
              "stageQueueCount" : 1,
              "stageMaxQueueSize" : 2147483647
            }, {
              "consumerId" : "7",
              "alias" : "client_handshake_stage",
              "stageQueueCount" : 1,
              "stageMaxQueueSize" : 2147483647
            }, {
              "consumerId" : "7",
              "alias" : "group_discovery_stage",
              "stageQueueCount" : 1,
              "stageMaxQueueSize" : 5000
            } ]
          }, {
            "name" : "StageStatistics",
            "context" : [ {
              "name" : "alias",
              "required" : true
            } ],
            "descriptors" : [ {
              "name" : "Stage:CurrentQueueSize",
              "type" : "SIZE"
            }, {
              "name" : "Stage:TotalQueuedCount",
              "type" : "COUNTER"
            } ]
          }
```