### PR TITLE
Management layer refactoring to support more statistic types

### DIFF
--- a/management/management-model/pom.xml
+++ b/management/management-model/pom.xml
@@ -38,12 +38,15 @@
   </licenses>
 
   <dependencies>
-    <!-- this module can OPTIONALLY be used with management model to help sequencing messages -->
+    <dependency>
+      <groupId>org.terracotta</groupId>
+      <artifactId>statistics</artifactId>
+      <version>${statistics.version}</version>
+    </dependency>
     <dependency>
       <groupId>org.terracotta.management</groupId>
       <artifactId>sequence-generator</artifactId>
       <version>${project.version}</version>
-      <scope>provided</scope>
     </dependency>
 
     <dependency>

--- a/management/management-registry/pom.xml
+++ b/management/management-registry/pom.xml
@@ -43,11 +43,6 @@
       <artifactId>management-model</artifactId>
       <version>${project.version}</version>
     </dependency>
-    <dependency>
-      <groupId>org.terracotta</groupId>
-      <artifactId>statistics</artifactId>
-      <version>${statistics.version}</version>
-    </dependency>
 
     <dependency>
       <groupId>junit</groupId>

--- a/management/management-registry/src/main/java/org/terracotta/management/registry/AbstractManagementProvider.java
+++ b/management/management-registry/src/main/java/org/terracotta/management/registry/AbstractManagementProvider.java
@@ -22,7 +22,9 @@ import org.terracotta.management.model.capabilities.context.CapabilityContext;
 import org.terracotta.management.model.capabilities.descriptors.Descriptor;
 import org.terracotta.management.model.capabilities.descriptors.StatisticDescriptor;
 import org.terracotta.management.model.context.Context;
+import org.terracotta.statistics.registry.Statistic;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
@@ -107,7 +109,7 @@ public abstract class AbstractManagementProvider<T> implements ManagementProvide
   }
 
   @Override
-  public Map<String, Number> collectStatistics(Context context, Collection<String> statisticNames) {
+  public Map<String, Statistic<? extends Serializable>> collectStatistics(Context context, Collection<String> statisticNames) {
     throw new UnsupportedOperationException("Not a statistics provider : " + getCapabilityName());
   }
 

--- a/management/management-registry/src/main/java/org/terracotta/management/registry/DefaultStatisticsExposedObject.java
+++ b/management/management-registry/src/main/java/org/terracotta/management/registry/DefaultStatisticsExposedObject.java
@@ -18,9 +18,13 @@ package org.terracotta.management.registry;
 import org.terracotta.management.model.capabilities.descriptors.StatisticDescriptor;
 import org.terracotta.management.model.context.Context;
 import org.terracotta.management.registry.collect.StatisticRegistry;
+import org.terracotta.statistics.registry.Statistic;
 
+import java.io.Serializable;
 import java.util.Collection;
 import java.util.Map;
+import java.util.Optional;
+import java.util.function.Supplier;
 
 /**
  * @author Mathieu Carbou
@@ -29,25 +33,25 @@ public class DefaultStatisticsExposedObject<T> extends DefaultExposedObject<T> {
 
   protected final StatisticRegistry statisticRegistry;
   
-  public DefaultStatisticsExposedObject(T o, Context context) {
+  public DefaultStatisticsExposedObject(T o, Supplier<Long> timeSource, Context context) {
     super(o, context);
-    statisticRegistry = new StatisticRegistry(o);
+    statisticRegistry = new StatisticRegistry(o, timeSource);
   }
 
-  public DefaultStatisticsExposedObject(T o) {
+  public DefaultStatisticsExposedObject(T o, Supplier<Long> timeSource) {
     super(o);
-    statisticRegistry = new StatisticRegistry(o);
+    statisticRegistry = new StatisticRegistry(o, timeSource);
   }
 
   public StatisticRegistry getStatisticRegistry() {
     return statisticRegistry;
   }
 
-  public Number queryStatistic(String fullStatisticName) {
+  public <T extends Serializable> Optional<Statistic<T>> queryStatistic(String fullStatisticName) {
     return statisticRegistry.queryStatistic(fullStatisticName);
   }
 
-  public Map<String, Number> queryStatistics() {
+  public Map<String, Statistic<? extends Serializable>> queryStatistics() {
     return statisticRegistry.queryStatistics();
   }
 

--- a/management/management-registry/src/main/java/org/terracotta/management/registry/ManagementProvider.java
+++ b/management/management-registry/src/main/java/org/terracotta/management/registry/ManagementProvider.java
@@ -20,7 +20,9 @@ import org.terracotta.management.model.capabilities.Capability;
 import org.terracotta.management.model.capabilities.context.CapabilityContext;
 import org.terracotta.management.model.capabilities.descriptors.Descriptor;
 import org.terracotta.management.model.context.Context;
+import org.terracotta.statistics.registry.Statistic;
 
+import java.io.Serializable;
 import java.util.Collection;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
@@ -80,13 +82,13 @@ public interface ManagementProvider<T> {
   String getCapabilityName();
 
   /**
-   * Collect statistics, if the provider supports this.
+   * Collect new statistic samples, if the provider supports this.
    *
    * @param context        the context.
    * @param statisticNames the statistic names to collect. If empty, collect ALL statistics
    * @return the statistic map, the key being the statistic names.
    */
-  Map<String, Number> collectStatistics(Context context, Collection<String> statisticNames);
+  Map<String, Statistic<? extends Serializable>> collectStatistics(Context context, Collection<String> statisticNames);
 
   /**
    * Call an action, if the provider supports this.

--- a/management/management-registry/src/main/java/org/terracotta/management/registry/ManagementProviderAdapter.java
+++ b/management/management-registry/src/main/java/org/terracotta/management/registry/ManagementProviderAdapter.java
@@ -21,7 +21,9 @@ import org.terracotta.management.model.capabilities.DefaultCapability;
 import org.terracotta.management.model.capabilities.context.CapabilityContext;
 import org.terracotta.management.model.capabilities.descriptors.Descriptor;
 import org.terracotta.management.model.context.Context;
+import org.terracotta.statistics.registry.Statistic;
 
+import java.io.Serializable;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
@@ -74,7 +76,7 @@ public class ManagementProviderAdapter<T> implements ManagementProvider<T> {
   }
 
   @Override
-  public Map<String, Number> collectStatistics(Context context, Collection<String> statisticNames) {
+  public Map<String, Statistic<? extends Serializable>> collectStatistics(Context context, Collection<String> statisticNames) {
     throw new UnsupportedOperationException("Not a statistics provider : " + getCapabilityName());
   }
 

--- a/management/management-registry/src/main/java/org/terracotta/management/registry/collect/StatisticRegistry.java
+++ b/management/management-registry/src/main/java/org/terracotta/management/registry/collect/StatisticRegistry.java
@@ -15,214 +15,37 @@
  */
 package org.terracotta.management.registry.collect;
 
-import org.terracotta.context.ContextManager;
-import org.terracotta.context.TreeNode;
-import org.terracotta.context.extended.OperationStatisticDescriptor;
-import org.terracotta.context.extended.ValueStatisticDescriptor;
-import org.terracotta.context.query.Matcher;
-import org.terracotta.context.query.Matchers;
-import java.util.Objects;
 import org.terracotta.management.model.capabilities.descriptors.StatisticDescriptor;
-import org.terracotta.statistics.OperationStatistic;
-import org.terracotta.statistics.ValueStatistic;
-import org.terracotta.statistics.extended.StatisticType;
+import org.terracotta.statistics.SampledStatistic;
+import org.terracotta.statistics.StatisticType;
 
+import java.io.Serializable;
 import java.util.Collection;
-import java.util.Collections;
-import java.util.EnumSet;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Supplier;
 
-import static org.terracotta.context.query.Matchers.attributes;
-import static org.terracotta.context.query.Matchers.context;
-import static org.terracotta.context.query.Matchers.hasAttribute;
-import static org.terracotta.context.query.Matchers.identifier;
-import static org.terracotta.context.query.Matchers.subclassOf;
-import static org.terracotta.context.query.QueryBuilder.queryBuilder;
-
-/**
- * This class replaces the previous {@link org.terracotta.context.extended.StatisticsRegistry}
- * in the cases where you do not need any sampling and history.
- * <p>
- * This class typically does a sort of mapping between the registrations and the discovered
- * operations or passthrough statistics.
- * <p>
- * This class also supporte the generation of management metadata from the discovered statistics.
- * <p>
- * Non thread-safe.
- *
+/***
  * @author Mathieu Carbou
  */
-public class StatisticRegistry {
+public class StatisticRegistry extends org.terracotta.statistics.registry.StatisticRegistry {
 
-  private static final Object ME = new Object();
-
-  private final Object contextObject;
-  private final Map<String, ValueStatistic<? extends Number>> statistics = new HashMap<String, ValueStatistic<? extends Number>>();
-  private final Map<String, StatisticType> statisticTypes = new HashMap<String, StatisticType>();
+  public StatisticRegistry(Object contextObject, Supplier<Long> timeSource) {
+    super(contextObject, timeSource);
+  }
 
   public StatisticRegistry(Object contextObject) {
-    this.contextObject = Objects.requireNonNull(contextObject);
+    super(contextObject);
   }
 
   public Collection<StatisticDescriptor> getDescriptors() {
-    Set<StatisticDescriptor> descriptors = new HashSet<StatisticDescriptor>(statistics.size());
-    for (Map.Entry<String, ValueStatistic<? extends Number>> entry : statistics.entrySet()) {
+    Set<StatisticDescriptor> descriptors = new HashSet<>(getStatistics().size());
+    for (Map.Entry<String, SampledStatistic<? extends Serializable>> entry : getStatistics().entrySet()) {
       String fullStatName = entry.getKey();
-      StatisticType type = statisticTypes.get(fullStatName);
+      StatisticType type = entry.getValue().type();
       descriptors.add(new StatisticDescriptor(fullStatName, type.name()));
     }
     return descriptors;
-  }
-
-  /**
-   * Query a statistic based on the full statistic name. Returns null if not found.
-   */
-  public Number queryStatistic(String fullStatisticName) {
-    ValueStatistic<? extends Number> statistic = statistics.get(fullStatisticName);
-    return statistic == null ? null : statistic.value();
-  }
-
-  public Map<String, Number> queryStatistics() {
-    Map<String, Number> stats = new HashMap<String, Number>(statistics.size());
-    for (String fullStatName : statistics.keySet()) {
-      Number statistic = queryStatistic(fullStatName);
-      if (statistic != null) {
-        stats.put(fullStatName, statistic);
-      }
-    }
-    return stats;
-  }
-
-  /**
-   * Directly register a SIZE stat with its accessor
-   */
-  public <N extends Number> void registerSize(String fullStatName, ValueStatistic<N> accessor) {
-    registerStatistic(fullStatName, StatisticType.SIZE, accessor);
-  }
-
-  /**
-   * Register one or several SIZE passthrough stats. Stat prefix is taken from the discriminator if any.
-   */
-  public void registerSize(String statNameSuffix, ValueStatisticDescriptor descriptor) {
-    registerStatistic(statNameSuffix, StatisticType.SIZE, descriptor);
-  }
-
-  /**
-   * Register one or several SIZE stats based on the observers found and summarize the outcomes. Stat prefix is taken from the discriminator if any.
-   */
-  public <T extends Enum<T>> void registerSize(String statNameSuffix, OperationStatisticDescriptor<T> descriptor, EnumSet<T> outcomes) {
-    registerStatistic(statNameSuffix, StatisticType.SIZE, descriptor, outcomes);
-  }
-
-  /**
-   * Directly register a COUNTER stat with its accessor
-   */
-  public <N extends Number> void registerCounter(String fullStatName, ValueStatistic<N> accessor) {
-    registerStatistic(fullStatName, StatisticType.COUNTER, accessor);
-  }
-
-  /**
-   * Register one or several COUNTER passthrough stats. Stat prefix is taken from the discriminator.
-   */
-  public void registerCounter(String statNameSuffix, ValueStatisticDescriptor descriptor) {
-    registerStatistic(statNameSuffix, StatisticType.COUNTER, descriptor);
-  }
-
-  /**
-   * Register one or several COUNTER stats based on the observers found and summarize the outcomes. Stat prefix is taken from the discriminator if any.
-   */
-  public <T extends Enum<T>> void registerCounter(String statNameSuffix, OperationStatisticDescriptor<T> descriptor, EnumSet<T> outcomes) {
-    registerStatistic(statNameSuffix, StatisticType.COUNTER, descriptor, outcomes);
-  }
-
-  private <N extends Number> void registerStatistic(String statNameSuffix, StatisticType type, final ValueStatisticDescriptor descriptor) {
-    TreeNode treeNode = ContextManager.nodeFor(contextObject);
-    if(treeNode == null) {
-      return;
-    }
-
-    Set<TreeNode> result = queryBuilder()
-        .descendants()
-        .filter(context(attributes(Matchers.<Map<String, Object>>allOf(
-            hasAttribute("name", descriptor.getObserverName()),
-            hasTags(descriptor.getTags())))))
-        .filter(context(identifier(subclassOf(ValueStatistic.class))))
-        .build().execute(Collections.singleton(treeNode));
-
-    if (!result.isEmpty()) {
-      for (TreeNode node : result) {
-        String discriminator = null;
-
-        Map<String, Object> properties = (Map<String, Object>) node.getContext().attributes().get("properties");
-        if (properties != null && properties.containsKey("discriminator")) {
-          discriminator = properties.get("discriminator").toString();
-        }
-
-        String fullStatName = (discriminator == null ? "" : (discriminator + ":")) + statNameSuffix;
-        ValueStatistic<N> statistic = (ValueStatistic<N>) node.getContext().attributes().get("this");
-
-        registerStatistic(fullStatName, type, statistic);
-      }
-    }
-  }
-
-  private <T extends Enum<T>> void registerStatistic(String statNameSuffix, StatisticType type, final OperationStatisticDescriptor<T> descriptor, final EnumSet<T> outcomes) {
-    TreeNode treeNode = ContextManager.nodeFor(contextObject);
-    if(treeNode == null) {
-      return;
-    }
-
-    Set<TreeNode> result = queryBuilder()
-        .descendants()
-        .filter(context(attributes(Matchers.<Map<String, Object>>allOf(
-            hasAttribute("type", descriptor.getType()),
-            hasAttribute("name", descriptor.getObserverName()),
-            hasTags(descriptor.getTags())))))
-        .filter(context(identifier(subclassOf(OperationStatistic.class))))
-        .build().execute(Collections.singleton(treeNode));
-
-    if (!result.isEmpty()) {
-      for (TreeNode node : result) {
-        String discriminator = null;
-
-        Map<String, Object> properties = (Map<String, Object>) node.getContext().attributes().get("properties");
-        if (properties != null && properties.containsKey("discriminator")) {
-          discriminator = properties.get("discriminator").toString();
-        }
-
-        String fullStatName = (discriminator == null ? "" : (discriminator + ":")) + statNameSuffix;
-        final OperationStatistic<T> statistic = (OperationStatistic<T>) node.getContext().attributes().get("this");
-
-        registerStatistic(fullStatName, type, new ValueStatistic<Number>() {
-          @Override
-          public Number value() {
-            return statistic.sum(outcomes);
-          }
-        });
-      }
-    }
-  }
-
-  private Matcher<Map<String, Object>> hasTags(final Collection<String> tags) {
-    return hasAttribute("tags", new Matcher<Collection<String>>() {
-      @Override
-      protected boolean matchesSafely(Collection<String> object) {
-        return object.containsAll(tags);
-      }
-    });
-  }
-
-  private <N extends Number> void registerStatistic(String fullStatName, StatisticType type, ValueStatistic<N> accessor) {
-    if (statistics.put(fullStatName, accessor) != null) {
-      throw new IllegalArgumentException("Found duplicate statistic " + fullStatName);
-    }
-    statisticTypes.put(fullStatName, type);
-  }
-
-  public static final StatisticRegistry noop() {
-    return new StatisticRegistry(ME);
   }
 }

--- a/management/monitoring-service-api/src/main/java/org/terracotta/management/service/monitoring/registry/provider/AbstractEntityManagementProvider.java
+++ b/management/monitoring-service-api/src/main/java/org/terracotta/management/service/monitoring/registry/provider/AbstractEntityManagementProvider.java
@@ -18,8 +18,9 @@ package org.terracotta.management.service.monitoring.registry.provider;
 import com.tc.classloader.CommonComponent;
 import org.terracotta.management.model.context.Context;
 import org.terracotta.management.registry.AbstractManagementProvider;
-import org.terracotta.management.registry.ManagementProvider;
 import org.terracotta.management.registry.ExposedObject;
+import org.terracotta.management.registry.ManagementProvider;
+import org.terracotta.management.sequence.TimeSource;
 import org.terracotta.management.service.monitoring.EntityMonitoringService;
 
 import java.util.Objects;
@@ -33,6 +34,7 @@ import java.util.concurrent.ExecutionException;
 public abstract class AbstractEntityManagementProvider<T> extends AbstractManagementProvider<T> implements ManagementProvider<T>, MonitoringServiceAware {
 
   private EntityMonitoringService monitoringService;
+  private TimeSource timeSource;
 
   public AbstractEntityManagementProvider(Class<? extends T> managedType) {
     super(managedType);
@@ -44,7 +46,16 @@ public abstract class AbstractEntityManagementProvider<T> extends AbstractManage
   }
 
   protected EntityMonitoringService getMonitoringService() {
-    return Objects.requireNonNull(monitoringService);
+    return monitoringService;
+  }
+
+  @Override
+  public void setTimeSource(TimeSource timeSource) {
+    this.timeSource = Objects.requireNonNull(timeSource);
+  }
+
+  protected TimeSource getTimeSource() {
+    return timeSource;
   }
 
   @Override

--- a/management/monitoring-service-api/src/main/java/org/terracotta/management/service/monitoring/registry/provider/AbstractExposedStatistics.java
+++ b/management/monitoring-service-api/src/main/java/org/terracotta/management/service/monitoring/registry/provider/AbstractExposedStatistics.java
@@ -19,10 +19,13 @@ import com.tc.classloader.CommonComponent;
 import org.terracotta.management.model.capabilities.descriptors.StatisticDescriptor;
 import org.terracotta.management.model.context.Context;
 import org.terracotta.management.registry.collect.StatisticRegistry;
+import org.terracotta.statistics.registry.Statistic;
 
 import java.io.Closeable;
+import java.io.Serializable;
 import java.util.Collection;
 import java.util.Map;
+import java.util.Optional;
 
 @CommonComponent
 public class AbstractExposedStatistics<T extends AliasBinding> extends AliasBindingManagementProvider.ExposedAliasBinding<T> implements Closeable {
@@ -38,16 +41,16 @@ public class AbstractExposedStatistics<T extends AliasBinding> extends AliasBind
   public void close() {
   }
 
-  protected StatisticRegistry getRegistry() {
+  protected StatisticRegistry getStatisticRegistry() {
     return statisticRegistry;
   }
 
   @SuppressWarnings("unchecked")
-  public Number queryStatistic(String fullStatisticName) {
+  public <T extends Serializable> Optional<Statistic<T>> queryStatistic(String fullStatisticName) {
     return statisticRegistry.queryStatistic(fullStatisticName);
   }
 
-  public Map<String, Number> queryStatistics() {
+  public Map<String, Statistic<? extends Serializable>> queryStatistics() {
     return statisticRegistry.queryStatistics();
   }
 

--- a/management/monitoring-service-api/src/main/java/org/terracotta/management/service/monitoring/registry/provider/MonitoringServiceAware.java
+++ b/management/monitoring-service-api/src/main/java/org/terracotta/management/service/monitoring/registry/provider/MonitoringServiceAware.java
@@ -16,9 +16,12 @@
 package org.terracotta.management.service.monitoring.registry.provider;
 
 import com.tc.classloader.CommonComponent;
+import org.terracotta.management.sequence.TimeSource;
 import org.terracotta.management.service.monitoring.EntityMonitoringService;
 
 @CommonComponent
 public interface MonitoringServiceAware {
-  void setMonitoringService(EntityMonitoringService monitoringService);
+  default void setMonitoringService(EntityMonitoringService monitoringService) {}
+
+  default void setTimeSource(TimeSource timeSource) {}
 }

--- a/management/monitoring-service/src/main/java/org/terracotta/management/service/monitoring/DefaultEntityManagementRegistry.java
+++ b/management/monitoring-service/src/main/java/org/terracotta/management/service/monitoring/DefaultEntityManagementRegistry.java
@@ -24,6 +24,7 @@ import org.terracotta.management.registry.CapabilityManagement;
 import org.terracotta.management.registry.DefaultCapabilityManagement;
 import org.terracotta.management.registry.ExposedObject;
 import org.terracotta.management.registry.ManagementProvider;
+import org.terracotta.management.sequence.TimeSource;
 import org.terracotta.management.service.monitoring.registry.provider.AbstractEntityManagementProvider;
 import org.terracotta.management.service.monitoring.registry.provider.MonitoringServiceAware;
 
@@ -48,15 +49,17 @@ class DefaultEntityManagementRegistry implements EntityManagementRegistry, Topol
 
   private final long consumerId;
   private final EntityMonitoringService monitoringService;
+  private final TimeSource timeSource;
   private final ContextContainer contextContainer;
   private final List<ManagementProvider<?>> managementProviders = new CopyOnWriteArrayList<>();
   private final CompletableFuture<?> onEntityPromotionCompleted = new CompletableFuture<>();
   private final CompletableFuture<?> onClose = new CompletableFuture<>();
 
-  DefaultEntityManagementRegistry(long consumerId, EntityMonitoringService monitoringService) {
+  DefaultEntityManagementRegistry(long consumerId, EntityMonitoringService monitoringService, TimeSource timeSource) {
     this.contextContainer = new ContextContainer("consumerId", String.valueOf(consumerId));
     this.consumerId = consumerId;
     this.monitoringService = Objects.requireNonNull(monitoringService);
+    this.timeSource = Objects.requireNonNull(timeSource);
   }
 
   void onEntityPromotionCompleted(Runnable r) {
@@ -90,6 +93,7 @@ class DefaultEntityManagementRegistry implements EntityManagementRegistry, Topol
     if (added) {
       if (provider instanceof MonitoringServiceAware) {
         ((MonitoringServiceAware) provider).setMonitoringService(monitoringService);
+        ((MonitoringServiceAware) provider).setTimeSource(timeSource);
       }
     }
     return added;

--- a/management/monitoring-service/src/main/java/org/terracotta/management/service/monitoring/MonitoringServiceProvider.java
+++ b/management/monitoring-service/src/main/java/org/terracotta/management/service/monitoring/MonitoringServiceProvider.java
@@ -162,7 +162,7 @@ public class MonitoringServiceProvider implements ServiceProvider, Closeable {
         EntityMonitoringService entityMonitoringService = new DefaultEntityMonitoringService(consumerID, monitoringProducer, topologyService, activeEntity);
 
         // create a registry for the entity
-        DefaultEntityManagementRegistry managementRegistry = new DefaultEntityManagementRegistry(consumerID, entityMonitoringService);
+        DefaultEntityManagementRegistry managementRegistry = new DefaultEntityManagementRegistry(consumerID, entityMonitoringService, timeSource);
 
         // make the registry listen for topology events
         topologyService.addTopologyEventListener(managementRegistry);

--- a/management/testing/doc/src/main/java/org/terracotta/management/doc/ReadStatistics.java
+++ b/management/testing/doc/src/main/java/org/terracotta/management/doc/ReadStatistics.java
@@ -26,8 +26,10 @@ import org.terracotta.management.model.cluster.ServerEntity;
 import org.terracotta.management.model.context.Context;
 import org.terracotta.management.model.message.Message;
 import org.terracotta.management.model.stats.ContextualStatistics;
+import org.terracotta.statistics.registry.Statistic;
 
 import java.io.IOException;
+import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
@@ -91,7 +93,7 @@ public class ReadStatistics {
           .flatMap(message -> message.unwrap(ContextualStatistics.class).stream())
           .forEach(statistics -> {
             System.out.println(statistics.getContext());
-            for (Map.Entry<String, Number> entry : statistics.getStatistics().entrySet()) {
+            for (Map.Entry<String, Statistic<? extends Serializable>> entry : statistics.getStatistics().entrySet()) {
               System.out.println(" - " + entry.getKey() + "=" + entry.getValue());
             }
           });

--- a/management/testing/integration-tests/src/test/java/org/terracotta/management/integration/tests/AbstractTest.java
+++ b/management/testing/integration-tests/src/test/java/org/terracotta/management/integration/tests/AbstractTest.java
@@ -16,6 +16,7 @@
 package org.terracotta.management.integration.tests;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -39,10 +40,14 @@ import org.terracotta.management.model.cluster.AbstractManageableNode;
 import org.terracotta.management.model.cluster.ServerEntity;
 import org.terracotta.management.model.notification.ContextualNotification;
 import org.terracotta.management.model.stats.ContextualStatistics;
+import org.terracotta.statistics.ConstantValueStatistic;
+import org.terracotta.statistics.registry.Statistic;
+import org.terracotta.statistics.StatisticType;
 import org.terracotta.testing.rules.Cluster;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.Serializable;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -50,6 +55,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
@@ -83,7 +89,11 @@ public abstract class AbstractTest {
     this.cluster = cluster;
 
     mapper.configure(SerializationFeature.INDENT_OUTPUT, true);
+    mapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
     mapper.addMixIn(CapabilityContext.class, CapabilityContextMixin.class);
+    mapper.addMixIn(Statistic.class, StatisticMixin.class);
+    mapper.addMixIn(ContextualStatistics.class, ContextualStatisticsMixin.class);
+    mapper.addMixIn(ConstantValueStatistic.class, ConstantValueStatisticMixin.class);
 
     connectManagementClient(cluster.getConnectionURI());
 
@@ -168,14 +178,6 @@ public abstract class AbstractTest {
     webappNodes.add(cacheFactory);
   }
 
-  public static abstract class CapabilityContextMixin {
-    @JsonIgnore
-    public abstract Collection<String> getRequiredAttributeNames();
-
-    @JsonIgnore
-    public abstract Collection<CapabilityContext.Attribute> getRequiredAttributes();
-  }
-
   private void connectManagementClient(URI uri) throws Exception {
     // connects to server
     Properties properties = new Properties();
@@ -225,6 +227,7 @@ public abstract class AbstractTest {
         .replaceAll("\"OffHeapResource:AllocatedMemory\":[0-9]+", "\"OffHeapResource:AllocatedMemory\":0")
         .replaceAll("\"time\":[0-9]+", "\"time\":0")
         .replaceAll("\"startTime\":[0-9]+", "\"startTime\":0")
+        .replaceAll("\"timestamp\":[0-9]+", "\"timestamp\":0")
         .replaceAll("\"upTimeSec\":[0-9]+", "\"upTimeSec\":0")
         .replaceAll("\"id\":\"[0-9]+@[^:]*:([^:]*):[^\"]*\",\"pid\":[0-9]+", "\"id\":\"0@127.0.0.1:$1:<uuid>\",\"pid\":0")
         .replaceAll("\"alias\":\"[0-9]+@[^:]*:([^:]*):[^\"]*\",", "\"alias\":\"0@127.0.0.1:$1:<uuid>\",")
@@ -311,4 +314,40 @@ public abstract class AbstractTest {
       throw e;
     }
   }
+
+  public static abstract class CapabilityContextMixin {
+    @JsonIgnore
+    public abstract Collection<String> getRequiredAttributeNames();
+
+    @JsonIgnore
+    public abstract Collection<CapabilityContext.Attribute> getRequiredAttributes();
+  }
+
+  public static abstract class StatisticMixin<T> {
+    @JsonIgnore
+    public abstract boolean isEmpty();
+
+    @JsonIgnore
+    public abstract Optional<T> getLatestSample();
+  }
+
+  public static abstract class ContextualStatisticsMixin {
+    @JsonIgnore
+    public abstract int size();
+
+    @JsonIgnore
+    public abstract boolean isEmpty();
+
+    @JsonIgnore
+    public abstract Map<String, ? extends Serializable> getLatestSamples();
+  }
+
+  public static abstract class ConstantValueStatisticMixin<T> {
+    @JsonProperty
+    public abstract T value();
+
+    @JsonProperty
+    public abstract StatisticType type();
+  }
+
 }

--- a/management/testing/integration-tests/src/test/java/org/terracotta/management/integration/tests/ClientCacheRemoteManagementIT.java
+++ b/management/testing/integration-tests/src/test/java/org/terracotta/management/integration/tests/ClientCacheRemoteManagementIT.java
@@ -21,9 +21,10 @@ import org.terracotta.management.model.cluster.Client;
 import org.terracotta.management.model.cluster.ManagementRegistry;
 import org.terracotta.management.model.context.Context;
 
-import java.util.concurrent.TimeUnit;
-
-import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
@@ -113,8 +114,8 @@ public class ClientCacheRemoteManagementIT extends AbstractSingleTest {
 
     queryAllRemoteStatsUntil(stats -> stats
         .stream()
-        .map(o -> o.getStatistic("Cache:HitCount"))
-        .anyMatch(counter -> counter.longValue() == 1L)); // 1 hit
+        .map(o -> o.<Long>getLatestSample("Cache:HitCount"))
+        .anyMatch(counter -> counter.get() == 1L)); // 1 hit
 
     get(0, "pets", "pet2"); // miss on client 0
     get(1, "pets", "pet2"); // miss on client 0
@@ -124,13 +125,13 @@ public class ClientCacheRemoteManagementIT extends AbstractSingleTest {
 
       test &= stats
           .stream()
-          .map(o -> o.getStatistic("Cache:MissCount"))
-          .anyMatch(counter -> counter.longValue() == 1L); // 1 miss
+          .map(o -> o.<Long>getLatestSample("Cache:MissCount"))
+          .anyMatch(counter -> counter.get() == 1L); // 1 miss
 
       test &= stats
           .stream()
-          .map(o -> o.getStatistic("ClientCache:Size"))
-          .anyMatch(counter -> counter.longValue() == 1L); // size 1 on heap of entity
+          .map(o -> o.<Integer>getLatestSample("ClientCache:Size"))
+          .anyMatch(counter -> counter.get() == 1); // size 1 on heap of entity
 
       return test;
     });

--- a/management/testing/integration-tests/src/test/java/org/terracotta/management/integration/tests/FailoverIT.java
+++ b/management/testing/integration-tests/src/test/java/org/terracotta/management/integration/tests/FailoverIT.java
@@ -99,8 +99,8 @@ public class FailoverIT extends AbstractHATest {
     queryAllRemoteStatsUntil(stats -> stats
         .stream()
         .filter(o -> o.hasStatistic("Cluster:HitCount"))
-        .map(o -> o.getStatistic("Cluster:HitCount"))
-        .anyMatch(sample -> sample.longValue() == 1L)); // 1 hit
+        .map(o -> o.<Long>getLatestSample("Cluster:HitCount"))
+        .anyMatch(sample -> sample.get() == 1L)); // 1 hit
 
     get(1, "pets", "pet2"); // miss
 
@@ -118,14 +118,14 @@ public class FailoverIT extends AbstractHATest {
       test &= stats
           .stream()
           .filter(o -> o.hasStatistic("Cluster:MissCount"))
-          .map(o -> o.getStatistic("Cluster:MissCount"))
-          .anyMatch(sample -> sample.longValue() == 1L); // 1 miss
+          .map(o -> o.<Long>getLatestSample("Cluster:MissCount"))
+          .anyMatch(sample -> sample.get() == 1L); // 1 miss
 
       test &= stats
           .stream()
           .filter(o -> o.hasStatistic("ServerCache:Size"))
-          .map(o -> o.getStatistic("ServerCache:Size"))
-          .anyMatch(sample -> sample.longValue() == 1L); // size 1 on heap of entity
+          .map(o -> o.<Integer>getLatestSample("ServerCache:Size"))
+          .anyMatch(sample -> sample.get() == 1); // size 1 on heap of entity
 
       return test;
     });

--- a/management/testing/integration-tests/src/test/java/org/terracotta/management/integration/tests/HAStatisticsIT.java
+++ b/management/testing/integration-tests/src/test/java/org/terracotta/management/integration/tests/HAStatisticsIT.java
@@ -71,11 +71,11 @@ public class HAStatisticsIT extends AbstractHATest {
             String serverName = stat.getContext().get(Server.NAME_KEY);
             //System.out.println("server: " + serverName);
 
-            Number counter = stat.getStatistic("Cluster:PutCount");
+            long counter = stat.<Long>getLatestSample("Cluster:PutCount").get();
             //System.out.println("counterHistory: " + counterHistory.getLast().getValue());
 
             // if the counter history is not yet 1, return false, we continue looping
-            if (counter.longValue()< 1L) {
+            if (counter < 1L) {
               return false;
 
             } else {

--- a/management/testing/integration-tests/src/test/resources/client-descriptors.json
+++ b/management/testing/integration-tests/src/test/resources/client-descriptors.json
@@ -105,7 +105,7 @@
       },
       {
         "name": "ClientCache:Size",
-        "type": "SIZE"
+        "type": "GAUGE"
       }
     ],
     "name": "CacheStatistics"

--- a/management/testing/integration-tests/src/test/resources/passive.json
+++ b/management/testing/integration-tests/src/test/resources/passive.json
@@ -68,7 +68,7 @@
             "descriptors": [
               {
                 "name": "OffHeapResource:AllocatedMemory",
-                "type": "SIZE"
+                "type": "GAUGE"
               }
             ]
           },
@@ -217,6 +217,10 @@
             ],
             "descriptors": [
               {
+                "name": "Cluster:CacheEntryLength",
+                "type": "TABLE"
+              },
+              {
                 "name": "Cluster:ClearCount",
                 "type": "COUNTER"
               },
@@ -234,7 +238,7 @@
               },
               {
                 "name": "ServerCache:Size",
-                "type": "SIZE"
+                "type": "GAUGE"
               }
             ]
           }
@@ -348,6 +352,10 @@
             ],
             "descriptors": [
               {
+                "name": "Cluster:CacheEntryLength",
+                "type": "TABLE"
+              },
+              {
                 "name": "Cluster:ClearCount",
                 "type": "COUNTER"
               },
@@ -365,7 +373,7 @@
               },
               {
                 "name": "ServerCache:Size",
-                "type": "SIZE"
+                "type": "GAUGE"
               }
             ]
           }

--- a/management/testing/integration-tests/src/test/resources/server-descriptors.json
+++ b/management/testing/integration-tests/src/test/resources/server-descriptors.json
@@ -133,6 +133,10 @@
     },
     "descriptors": [
       {
+        "name": "Cluster:CacheEntryLength",
+        "type": "TABLE"
+      },
+      {
         "name": "Cluster:ClearCount",
         "type": "COUNTER"
       },
@@ -150,7 +154,7 @@
       },
       {
         "name": "ServerCache:Size",
-        "type": "SIZE"
+        "type": "GAUGE"
       }
     ],
     "name": "ServerCacheStatistics"

--- a/management/testing/integration-tests/src/test/resources/stats.json
+++ b/management/testing/integration-tests/src/test/resources/stats.json
@@ -13,9 +13,16 @@
       "entityName": "ServerCacheManagementIT",
       "entityType": "org.terracotta.management.entity.nms.client.NmsEntity"
     },
-    "empty": false,
     "statistics": {
-      "OffHeapResource:AllocatedMemory": 0
+      "OffHeapResource:AllocatedMemory": {
+        "samples": [
+          {
+            "sample": 25165824,
+            "timestamp": 0
+          }
+        ],
+        "type": "GAUGE"
+      }
     }
   },
   {
@@ -32,13 +39,83 @@
       "entityName": "pet-clinic/pets",
       "entityType": "org.terracotta.management.entity.sample.client.CacheEntity"
     },
-    "empty": false,
     "statistics": {
-      "Cluster:HitCount": 1,
-      "Cluster:PutCount": 1,
-      "Cluster:MissCount": 0,
-      "Cluster:ClearCount": 0,
-      "ServerCache:Size": 1
+      "Cluster:HitCount": {
+        "samples": [
+          {
+            "sample": 1,
+            "timestamp": 0
+          }
+        ],
+        "type": "COUNTER"
+      },
+      "Cluster:PutCount": {
+        "samples": [
+          {
+            "sample": 1,
+            "timestamp": 0
+          }
+        ],
+        "type": "COUNTER"
+      },
+      "Cluster:MissCount": {
+        "samples": [
+          {
+            "sample": 0,
+            "timestamp": 0
+          }
+        ],
+        "type": "COUNTER"
+      },
+      "Cluster:ClearCount": {
+        "samples": [
+          {
+            "sample": 0,
+            "timestamp": 0
+          }
+        ],
+        "type": "COUNTER"
+      },
+      "Cluster:CacheEntryLength": {
+        "samples": [
+          {
+            "sample": {
+              "rowCount": 1,
+              "rowLabels": [
+                "pet1"
+              ],
+              "statisticCount": 2,
+              "statisticNames": [
+                "KeyLength",
+                "ValueLength"
+              ],
+              "statistics": {
+                "pet1": [
+                  {
+                    "type": "GAUGE",
+                    "value": 4
+                  },
+                  {
+                    "type": "COUNTER",
+                    "value": 7
+                  }
+                ]
+              }
+            },
+            "timestamp": 0
+          }
+        ],
+        "type": "TABLE"
+      },
+      "ServerCache:Size": {
+        "samples": [
+          {
+            "sample": 1,
+            "timestamp": 0
+          }
+        ],
+        "type": "GAUGE"
+      }
     }
   },
   {
@@ -55,13 +132,70 @@
       "entityName": "pet-clinic/clients",
       "entityType": "org.terracotta.management.entity.sample.client.CacheEntity"
     },
-    "empty": false,
     "statistics": {
-      "Cluster:HitCount": 0,
-      "Cluster:PutCount": 0,
-      "Cluster:MissCount": 0,
-      "Cluster:ClearCount": 0,
-      "ServerCache:Size": 0
+      "Cluster:HitCount": {
+        "samples": [
+          {
+            "sample": 0,
+            "timestamp": 0
+          }
+        ],
+        "type": "COUNTER"
+      },
+      "Cluster:PutCount": {
+        "samples": [
+          {
+            "sample": 0,
+            "timestamp": 0
+          }
+        ],
+        "type": "COUNTER"
+      },
+      "Cluster:MissCount": {
+        "samples": [
+          {
+            "sample": 0,
+            "timestamp": 0
+          }
+        ],
+        "type": "COUNTER"
+      },
+      "Cluster:ClearCount": {
+        "samples": [
+          {
+            "sample": 0,
+            "timestamp": 0
+          }
+        ],
+        "type": "COUNTER"
+      },
+      "Cluster:CacheEntryLength": {
+        "samples": [
+          {
+            "sample": {
+              "rowCount": 0,
+              "rowLabels": [],
+              "statisticCount": 2,
+              "statisticNames": [
+                "KeyLength",
+                "ValueLength"
+              ],
+              "statistics": {}
+            },
+            "timestamp": 0
+          }
+        ],
+        "type": "TABLE"
+      },
+      "ServerCache:Size": {
+        "samples": [
+          {
+            "sample": 0,
+            "timestamp": 0
+          }
+        ],
+        "type": "GAUGE"
+      }
     }
   }
 ]

--- a/management/testing/integration-tests/src/test/resources/topology-after-failover.json
+++ b/management/testing/integration-tests/src/test/resources/topology-after-failover.json
@@ -67,7 +67,7 @@
                     "descriptors": [
                       {
                         "name": "OffHeapResource:AllocatedMemory",
-                        "type": "SIZE"
+                        "type": "GAUGE"
                       }
                     ]
                   },
@@ -254,6 +254,10 @@
                     ],
                     "descriptors": [
                       {
+                        "name": "Cluster:CacheEntryLength",
+                        "type": "TABLE"
+                      },
+                      {
                         "name": "Cluster:ClearCount",
                         "type": "COUNTER"
                       },
@@ -271,7 +275,7 @@
                       },
                       {
                         "name": "ServerCache:Size",
-                        "type": "SIZE"
+                        "type": "GAUGE"
                       }
                     ]
                   }
@@ -416,6 +420,10 @@
                     ],
                     "descriptors": [
                       {
+                        "name": "Cluster:CacheEntryLength",
+                        "type": "TABLE"
+                      },
+                      {
                         "name": "Cluster:ClearCount",
                         "type": "COUNTER"
                       },
@@ -433,7 +441,7 @@
                       },
                       {
                         "name": "ServerCache:Size",
-                        "type": "SIZE"
+                        "type": "GAUGE"
                       }
                     ]
                   }
@@ -622,7 +630,7 @@
               },
               {
                 "name": "ClientCache:Size",
-                "type": "SIZE"
+                "type": "GAUGE"
               }
             ]
           },
@@ -817,7 +825,7 @@
               },
               {
                 "name": "ClientCache:Size",
-                "type": "SIZE"
+                "type": "GAUGE"
               }
             ]
           },

--- a/management/testing/integration-tests/src/test/resources/topology-before-reconfigure.json
+++ b/management/testing/integration-tests/src/test/resources/topology-before-reconfigure.json
@@ -74,7 +74,7 @@
                     "descriptors": [
                       {
                         "name": "OffHeapResource:AllocatedMemory",
-                        "type": "SIZE"
+                        "type": "GAUGE"
                       }
                     ]
                   },
@@ -254,6 +254,10 @@
                     ],
                     "descriptors": [
                       {
+                        "name": "Cluster:CacheEntryLength",
+                        "type": "TABLE"
+                      },
+                      {
                         "name": "Cluster:ClearCount",
                         "type": "COUNTER"
                       },
@@ -271,7 +275,7 @@
                       },
                       {
                         "name": "ServerCache:Size",
-                        "type": "SIZE"
+                        "type": "GAUGE"
                       }
                     ]
                   }
@@ -416,6 +420,10 @@
                     ],
                     "descriptors": [
                       {
+                        "name": "Cluster:CacheEntryLength",
+                        "type": "TABLE"
+                      },
+                      {
                         "name": "Cluster:ClearCount",
                         "type": "COUNTER"
                       },
@@ -433,7 +441,7 @@
                       },
                       {
                         "name": "ServerCache:Size",
-                        "type": "SIZE"
+                        "type": "GAUGE"
                       }
                     ]
                   }
@@ -622,7 +630,7 @@
               },
               {
                 "name": "ClientCache:Size",
-                "type": "SIZE"
+                "type": "GAUGE"
               }
             ]
           },
@@ -817,7 +825,7 @@
               },
               {
                 "name": "ClientCache:Size",
-                "type": "SIZE"
+                "type": "GAUGE"
               }
             ]
           },

--- a/management/testing/integration-tests/src/test/resources/topology-reconfigured.json
+++ b/management/testing/integration-tests/src/test/resources/topology-reconfigured.json
@@ -74,7 +74,7 @@
                     "descriptors": [
                       {
                         "name": "OffHeapResource:AllocatedMemory",
-                        "type": "SIZE"
+                        "type": "GAUGE"
                       }
                     ]
                   },
@@ -254,6 +254,10 @@
                     ],
                     "descriptors": [
                       {
+                        "name": "Cluster:CacheEntryLength",
+                        "type": "TABLE"
+                      },
+                      {
                         "name": "Cluster:ClearCount",
                         "type": "COUNTER"
                       },
@@ -271,7 +275,7 @@
                       },
                       {
                         "name": "ServerCache:Size",
-                        "type": "SIZE"
+                        "type": "GAUGE"
                       }
                     ]
                   }
@@ -416,6 +420,10 @@
                     ],
                     "descriptors": [
                       {
+                        "name": "Cluster:CacheEntryLength",
+                        "type": "TABLE"
+                      },
+                      {
                         "name": "Cluster:ClearCount",
                         "type": "COUNTER"
                       },
@@ -433,7 +441,7 @@
                       },
                       {
                         "name": "ServerCache:Size",
-                        "type": "SIZE"
+                        "type": "GAUGE"
                       }
                     ]
                   }
@@ -622,7 +630,7 @@
               },
               {
                 "name": "ClientCache:Size",
-                "type": "SIZE"
+                "type": "GAUGE"
               }
             ]
           },
@@ -817,7 +825,7 @@
               },
               {
                 "name": "ClientCache:Size",
-                "type": "SIZE"
+                "type": "GAUGE"
               }
             ]
           },

--- a/management/testing/integration-tests/src/test/resources/topology-renamed.json
+++ b/management/testing/integration-tests/src/test/resources/topology-renamed.json
@@ -74,7 +74,7 @@
                     "descriptors": [
                       {
                         "name": "OffHeapResource:AllocatedMemory",
-                        "type": "SIZE"
+                        "type": "GAUGE"
                       }
                     ]
                   },
@@ -176,7 +176,7 @@
                     "descriptors": [
                       {
                         "name": "OffHeapResource:AllocatedMemory",
-                        "type": "SIZE"
+                        "type": "GAUGE"
                       }
                     ]
                   },
@@ -356,6 +356,10 @@
                     ],
                     "descriptors": [
                       {
+                        "name": "Cluster:CacheEntryLength",
+                        "type": "TABLE"
+                      },
+                      {
                         "name": "Cluster:ClearCount",
                         "type": "COUNTER"
                       },
@@ -373,7 +377,7 @@
                       },
                       {
                         "name": "ServerCache:Size",
-                        "type": "SIZE"
+                        "type": "GAUGE"
                       }
                     ]
                   }
@@ -518,6 +522,10 @@
                     ],
                     "descriptors": [
                       {
+                        "name": "Cluster:CacheEntryLength",
+                        "type": "TABLE"
+                      },
+                      {
                         "name": "Cluster:ClearCount",
                         "type": "COUNTER"
                       },
@@ -535,7 +543,7 @@
                       },
                       {
                         "name": "ServerCache:Size",
-                        "type": "SIZE"
+                        "type": "GAUGE"
                       }
                     ]
                   }
@@ -751,7 +759,7 @@
               },
               {
                 "name": "ClientCache:Size",
-                "type": "SIZE"
+                "type": "GAUGE"
               }
             ]
           },
@@ -946,7 +954,7 @@
               },
               {
                 "name": "ClientCache:Size",
-                "type": "SIZE"
+                "type": "GAUGE"
               }
             ]
           },

--- a/management/testing/integration-tests/src/test/resources/topology.json
+++ b/management/testing/integration-tests/src/test/resources/topology.json
@@ -74,7 +74,7 @@
                     "descriptors": [
                       {
                         "name": "OffHeapResource:AllocatedMemory",
-                        "type": "SIZE"
+                        "type": "GAUGE"
                       }
                     ]
                   },
@@ -254,6 +254,10 @@
                     ],
                     "descriptors": [
                       {
+                        "name": "Cluster:CacheEntryLength",
+                        "type": "TABLE"
+                      },
+                      {
                         "name": "Cluster:ClearCount",
                         "type": "COUNTER"
                       },
@@ -271,7 +275,7 @@
                       },
                       {
                         "name": "ServerCache:Size",
-                        "type": "SIZE"
+                        "type": "GAUGE"
                       }
                     ]
                   }
@@ -416,6 +420,10 @@
                     ],
                     "descriptors": [
                       {
+                        "name": "Cluster:CacheEntryLength",
+                        "type": "TABLE"
+                      },
+                      {
                         "name": "Cluster:ClearCount",
                         "type": "COUNTER"
                       },
@@ -433,7 +441,7 @@
                       },
                       {
                         "name": "ServerCache:Size",
-                        "type": "SIZE"
+                        "type": "GAUGE"
                       }
                     ]
                   }
@@ -622,7 +630,7 @@
               },
               {
                 "name": "ClientCache:Size",
-                "type": "SIZE"
+                "type": "GAUGE"
               }
             ]
           },
@@ -817,7 +825,7 @@
               },
               {
                 "name": "ClientCache:Size",
-                "type": "SIZE"
+                "type": "GAUGE"
               }
             ]
           },

--- a/management/testing/sample-entity/src/main/java/org/terracotta/management/entity/sample/client/ClientCache.java
+++ b/management/testing/sample-entity/src/main/java/org/terracotta/management/entity/sample/client/ClientCache.java
@@ -19,6 +19,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terracotta.management.entity.sample.Cache;
 import org.terracotta.statistics.StatisticsManager;
+import org.terracotta.statistics.StatisticType;
 import org.terracotta.statistics.observer.OperationObserver;
 
 import java.io.Closeable;
@@ -69,6 +70,7 @@ public class ClientCache implements Cache, Closeable {
         "size",
         new HashSet<>(Arrays.asList("ClientCache", "cache")),
         properties,
+        StatisticType.GAUGE,
         this::size);
   }
 

--- a/management/testing/sample-entity/src/main/java/org/terracotta/management/entity/sample/client/management/Management.java
+++ b/management/testing/sample-entity/src/main/java/org/terracotta/management/entity/sample/client/management/Management.java
@@ -57,7 +57,7 @@ public class Management {
     // create a client-side management registry and add some providers for stats, calls and settings
     this.managementRegistry = new DefaultManagementRegistry(contextContainer);
     managementRegistry.addManagementProvider(new CacheSettingsManagementProvider(parentContext));
-    managementRegistry.addManagementProvider(new CacheStatisticsManagementProvider(parentContext));
+    managementRegistry.addManagementProvider(new CacheStatisticsManagementProvider(parentContext, System::currentTimeMillis));
     managementRegistry.addManagementProvider(new CacheCallManagementProvider(parentContext));
     managementRegistry.addManagementProvider(new CacheStatisticCollectorManagementProvider(parentContext));
 

--- a/management/testing/sample-entity/src/main/java/org/terracotta/management/entity/sample/server/ServerCache.java
+++ b/management/testing/sample-entity/src/main/java/org/terracotta/management/entity/sample/server/ServerCache.java
@@ -20,6 +20,7 @@ import org.slf4j.LoggerFactory;
 import org.terracotta.management.entity.sample.Cache;
 import org.terracotta.management.entity.sample.CacheOperationOutcomes;
 import org.terracotta.statistics.StatisticsManager;
+import org.terracotta.statistics.StatisticType;
 import org.terracotta.statistics.observer.OperationObserver;
 
 import java.util.Arrays;
@@ -61,6 +62,7 @@ public class ServerCache implements Cache {
         "size",
         new HashSet<>(Arrays.asList("ServerCache", "cluster")),
         properties,
+        StatisticType.GAUGE,
         this::size);
   }
 
@@ -164,7 +166,7 @@ public class ServerCache implements Cache {
     }
   }
 
-  Map<String, String> getData() {
+  public Map<String, String> getData() {
     return new HashMap<>(data);
   }
 

--- a/management/testing/sample-entity/src/test/java/org/terracotta/management/entity/sample/ClientCacheLocalManagementTest.java
+++ b/management/testing/sample-entity/src/test/java/org/terracotta/management/entity/sample/ClientCacheLocalManagementTest.java
@@ -31,7 +31,6 @@ import java.util.stream.Stream;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
@@ -123,32 +122,32 @@ public class ClientCacheLocalManagementTest extends AbstractTest {
     put(0, "pets", "pet1", "Cubitus");
 
     queryAllStatsUntil(1, "pets", stats -> stats
-        .getStatistic("Cache:HitCount")
-        .longValue() == 0L); // 0 hit
+        .<Long>getLatestSample("Cache:HitCount")
+        .get() == 0L); // 0 hit
 
     queryAllStatsUntil(1, "pets", stats -> stats
-        .getStatistic("Cache:HitCount")
-        .longValue() == 0L); // 0 miss
+        .<Long>getLatestSample("Cache:HitCount")
+        .get() == 0L); // 0 miss
 
     get(1, "pets", "pet1"); // hit
 
     queryAllStatsUntil(1, "pets", stats -> stats
-        .getStatistic("Cache:HitCount")
-        .longValue() == 1L); // 1 hit
+        .<Long>getLatestSample("Cache:HitCount")
+        .get() == 1L); // 1 hit
 
     get(1, "pets", "pet2"); // miss
 
     queryAllStatsUntil(1, "pets", stats -> stats
-        .getStatistic("Cache:MissCount")
-        .longValue() == 1L); // 1 miss
+        .<Long>getLatestSample("Cache:MissCount")
+        .get() == 1L); // 1 miss
 
     queryAllStatsUntil(1, "pets", stats -> stats
-        .getStatistic("ClientCache:Size")
-        .longValue() == 1L); // size 1 on heap of client 1
+        .<Integer>getLatestSample("ClientCache:Size")
+        .get() == 1); // size 1 on heap of client 1
 
     queryAllStatsUntil(0, "pets", stats -> stats
-        .getStatistic("ClientCache:Size")
-        .longValue() == 0L); // size 0 on heap of client 0
+        .<Integer>getLatestSample("ClientCache:Size")
+        .get() == 0); // size 0 on heap of client 0
   }
 
   private void queryAllStatsUntil(int node, String cacheName, Predicate<ContextualStatistics> test) {

--- a/management/testing/sample-entity/src/test/resources/client-descriptors.json
+++ b/management/testing/sample-entity/src/test/resources/client-descriptors.json
@@ -94,7 +94,7 @@
       },
       {
         "name": "ClientCache:Size",
-        "type": "SIZE"
+        "type": "GAUGE"
       }
     ],
     "capabilityContext": {

--- a/offheap-resource/src/main/java/org/terracotta/offheapresource/OffHeapResourcesProvider.java
+++ b/offheap-resource/src/main/java/org/terracotta/offheapresource/OffHeapResourcesProvider.java
@@ -28,6 +28,7 @@ import org.terracotta.offheapresource.management.OffHeapResourceBinding;
 import org.terracotta.offheapresource.management.OffHeapResourceSettingsManagementProvider;
 import org.terracotta.offheapresource.management.OffHeapResourceStatisticsManagementProvider;
 import org.terracotta.statistics.StatisticsManager;
+import org.terracotta.statistics.StatisticType;
 
 import java.math.BigInteger;
 import java.util.Arrays;
@@ -37,7 +38,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.Callable;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 /**
@@ -81,7 +81,8 @@ public class OffHeapResourcesProvider implements OffHeapResources, ManageableSer
           "allocatedMemory",
           new HashSet<>(Arrays.asList("OffHeapResource", "tier")),
           properties,
-          (Callable<Number>) () -> offHeapResource.capacity() - offHeapResource.available());
+          StatisticType.GAUGE,
+          () -> offHeapResource.capacity() - offHeapResource.available());
     }
     Long physicalMemory = PhysicalMemory.totalPhysicalMemory();
     if (physicalMemory != null && totalSize > physicalMemory) {

--- a/offheap-resource/src/main/java/org/terracotta/offheapresource/management/OffHeapResourceStatisticsManagementProvider.java
+++ b/offheap-resource/src/main/java/org/terracotta/offheapresource/management/OffHeapResourceStatisticsManagementProvider.java
@@ -23,11 +23,7 @@ import org.terracotta.management.registry.collect.StatisticRegistry;
 import org.terracotta.management.service.monitoring.registry.provider.AbstractExposedStatistics;
 import org.terracotta.management.service.monitoring.registry.provider.AbstractStatisticsManagementProvider;
 
-import java.util.HashSet;
-import java.util.Set;
-
-import static java.util.Arrays.asList;
-import static org.terracotta.context.extended.ValueStatisticDescriptor.descriptor;
+import static org.terracotta.statistics.registry.ValueStatisticDescriptor.descriptor;
 
 @Named("OffHeapResourceStatistics")
 @RequiredContext({@Named("consumerId"), @Named("type"), @Named("alias")})
@@ -47,10 +43,8 @@ public class OffHeapResourceStatisticsManagementProvider extends AbstractStatist
     OffHeapResourceBindingExposedStatistics(Context context, OffHeapResourceBinding binding, StatisticRegistry statisticRegistry) {
       super(context.with("type", "OffHeapResource"), binding, statisticRegistry);
 
-      getRegistry().registerSize("AllocatedMemory", descriptor("allocatedMemory", tags("tier", "OffHeapResource")));
+      getStatisticRegistry().registerStatistic("AllocatedMemory", descriptor("allocatedMemory", "tier", "OffHeapResource"));
     }
   }
-
-  private static Set<String> tags(String... tags) {return new HashSet<>(asList(tags));}
 
 }

--- a/offheap-resource/src/test/java/org/terracotta/offheapresource/OffHeapResourcesProviderTest.java
+++ b/offheap-resource/src/test/java/org/terracotta/offheapresource/OffHeapResourcesProviderTest.java
@@ -52,7 +52,7 @@ public class OffHeapResourcesProviderTest {
     assertThat(offHeapResource.available(), equalTo(2L * 1024 * 1024));
 
     assertThat(StatisticsManager.nodeFor(offHeapResource).getChildren().size(), equalTo(1));
-    ValueStatistic valueStatistic = (ValueStatistic) StatisticsManager.nodeFor(offHeapResource).getChildren().iterator().next().getContext().attributes().get("this");
+    ValueStatistic<Long> valueStatistic = (ValueStatistic<Long>) StatisticsManager.nodeFor(offHeapResource).getChildren().iterator().next().getContext().attributes().get("this");
     assertThat(valueStatistic.value(), equalTo(0L));
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
     <terracotta-configuration.version>10.4.0-pre9</terracotta-configuration.version>
     <passthrough-testing.version>1.4.0-pre9</passthrough-testing.version>
     <terracotta-core.version>5.4.0-pre15</terracotta-core.version>
-    <statistics.version>1.5.0</statistics.version>
+    <statistics.version>2.0.0</statistics.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <java.version>1.8</java.version>


### PR DESCRIPTION
__Set of 3 PRs:__

- statistics: https://github.com/Terracotta-OSS/statistics/pull/40
- platform: https://github.com/Terracotta-OSS/terracotta-platform/pull/421
- ehcache: https://github.com/ehcache/ehcache3/pull/2224

__Changes:__

- add support for a more versatile `Statistic` object which can be sampled and where the types can be: COUNTER, GAUGE, TABLE, etc.

- add support for TABLE statistics. This can be used for example in the case where we would like to report a `TopQueries` statistic with the content being for an entry per _query pattern_, and each entry could have several statistics (count, total execution time, etc)

- add support for sampled statistics in api that we need for latencies

__Fixes / Refactoring:__

- moved statistic type to a lower level (this is the registrant that know if it registers a gauge or a counter or a table)

- statistic value type (T) needs to be a serializable object because of passive -> active com. constraint and because we are using java serialization

- `SIZE` replaced by `GAUGE`, which is the right name to use in the monitoring lexicography

- Using `Supplier` instead of `Callable` for passthrough stats (change missing from previous migration to 1.8)

- Moved in statistics project `ZeroOperationStatistic` from ehcache
  
- Cleaned up unused classes, moved classes at right location (package)