### PR TITLE
#2203: Allow client management layer to recover after a reconnection.

### DIFF
--- a/management/nms-agent-entity/nms-agent-entity-client/src/main/java/org/terracotta/management/entity/nms/agent/client/DefaultNmsAgentService.java
+++ b/management/nms-agent-entity/nms-agent-entity-client/src/main/java/org/terracotta/management/entity/nms/agent/client/DefaultNmsAgentService.java
@@ -1,0 +1,348 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.management.entity.nms.agent.client;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.terracotta.connection.Connection;
+import org.terracotta.exception.ConnectionClosedException;
+import org.terracotta.exception.ConnectionShutdownException;
+import org.terracotta.management.entity.nms.agent.ReconnectData;
+import org.terracotta.management.entity.nms.agent.client.diag.DiagnosticProvider;
+import org.terracotta.management.entity.nms.agent.client.diag.DiagnosticUtility;
+import org.terracotta.management.model.call.ContextualCall;
+import org.terracotta.management.model.call.ContextualReturn;
+import org.terracotta.management.model.capabilities.Capability;
+import org.terracotta.management.model.context.Context;
+import org.terracotta.management.model.context.ContextContainer;
+import org.terracotta.management.model.message.ManagementCallMessage;
+import org.terracotta.management.model.message.Message;
+import org.terracotta.management.model.notification.ContextualNotification;
+import org.terracotta.management.model.stats.ContextualStatistics;
+import org.terracotta.management.registry.ManagementProvider;
+import org.terracotta.management.registry.ManagementProviderAdapter;
+import org.terracotta.management.registry.ManagementRegistry;
+import org.terracotta.voltron.proxy.MessageListener;
+import org.terracotta.voltron.proxy.client.EndpointListener;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Objects;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.function.BiConsumer;
+import java.util.function.Supplier;
+
+/**
+ * @author Mathieu Carbou
+ */
+public class DefaultNmsAgentService implements EndpointListener, MessageListener<Message>, NmsAgentService {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(DefaultNmsAgentService.class);
+  private static final String CAPABILITY_NAME = NmsAgentService.class.getSimpleName();
+
+  private final Supplier<NmsAgentEntity> entitySupplier;
+
+  private volatile boolean closed;
+  private volatile NmsAgentEntity entity;
+  private volatile ManagementRegistry registry;
+  private volatile String[] previouslyExposedTags;
+
+  private long timeoutMs = 5000;
+  private Executor managementCallExecutor = Runnable::run;
+  private ManagementProvider<?> diagnosticProvider = new DiagnosticProvider(DiagnosticUtility.class);
+  private BiConsumer<Operation, Throwable> onOperationError = (op, err) -> LOGGER.trace("Failed to call NmsAgent entity: {}", err.getMessage(), err);
+
+  private final ManagementProvider<?> managementProvider = new ManagementProviderAdapter<Object>(CAPABILITY_NAME, Object.class) {
+    @Override
+    public void register(Object managedObject) {
+      refreshManagementRegistry();
+    }
+
+    @Override
+    public void unregister(Object managedObject) {
+      refreshManagementRegistry();
+    }
+  };
+
+  public DefaultNmsAgentService(NmsAgentEntity entity) {
+    this(() -> entity);
+  }
+
+  public DefaultNmsAgentService(Connection connection) {
+    this(new NmsAgentEntityFactory(connection).retrieve());
+  }
+
+  public DefaultNmsAgentService(Supplier<NmsAgentEntity> entitySupplier) {
+    this.entitySupplier = entitySupplier;
+  }
+
+  // MessageListener
+
+  @Override
+  public void onMessage(Message message) {
+    LOGGER.trace("onMessage({})", message);
+    if (message.getType().equals("MANAGEMENT_CALL")) {
+      ContextualCall<?> contextualCall = message.unwrap(ContextualCall.class).get(0);
+      getManagementCallExecutor().execute(() -> executeManagementCall(((ManagementCallMessage) message).getManagementCallIdentifier(), contextualCall));
+    } else {
+      LOGGER.warn("Received unsupported message: " + message);
+    }
+  }
+
+  // EndpointListener
+
+  @Override
+  public Object onReconnect() {
+    if (isManagementRegistryBridged()) {
+      LOGGER.trace("onReconnect()");
+      ManagementRegistry registry = getRegistry();
+      Collection<? extends Capability> capabilities = registry == null ? Collections.<Capability>emptyList() : registry.getCapabilities();
+      Context context = registry == null ? Context.empty() : Context.create(registry.getContextContainer().getName(), registry.getContextContainer().getValue());
+      return new ReconnectData(
+          previouslyExposedTags,
+          registry == null ? null : registry.getContextContainer(),
+          registry == null ? null : capabilities.toArray(new Capability[capabilities.size()]),
+          new ContextualNotification(context, "CLIENT_RECONNECTED"));
+    } else {
+      return null;
+    }
+  }
+
+  @Override
+  public void onDisconnectUnexpectedly() {
+    LOGGER.trace("onDisconnectUnexpectedly()");
+    flushEntity();
+  }
+
+  // Closeable
+
+  @Override
+  public synchronized void close() {
+    if (!closed) {
+      LOGGER.trace("close()");
+      ManagementRegistry registry = getRegistry();
+      // disable bridging
+      if (registry != null) {
+        registry.removeManagementProvider(managementProvider);
+        this.registry = null;
+      }
+      flushEntity();
+      closed = true;
+    }
+  }
+
+  // NmsAgentService
+
+  @Override
+  public boolean isDisconnected() {
+    return entity == null;
+  }
+
+  @Override
+  public boolean isClosed() {
+    return closed;
+  }
+
+  /**
+   * Bridges a management registry with a NMS Agent Entity. All exposure in the registry will be propagated to the server and
+   * it will listen for management calls also.
+   */
+  public void setManagementRegistry(ManagementRegistry registry) {
+    LOGGER.trace("setManagementRegistry({})", registry.getContextContainer().getValue());
+    this.registry = registry;
+    {
+      boolean alreadybridged = registry.getManagementProvidersByCapability(CAPABILITY_NAME)
+          .stream()
+          .anyMatch(provider -> provider == managementProvider); // need to check by reference to be sure this is the same instance linked to this class
+      if (!alreadybridged) {
+        registry.addManagementProvider(managementProvider);
+      }
+    }
+    {
+      boolean alreadybridged = !registry.getManagementProvidersByCapability("DiagnosticCalls").isEmpty();
+      if (!alreadybridged) {
+        registry.addManagementProvider(diagnosticProvider);
+        registry.register(new DiagnosticUtility());
+      }
+    }
+  }
+
+  public ManagementRegistry getRegistry() {
+    return registry;
+  }
+
+  @Override
+  public boolean isManagementRegistryBridged() {
+    return registry != null;
+  }
+
+  public NmsAgentService setManagementCallExecutor(Executor managementCallExecutor) {
+    this.managementCallExecutor = Objects.requireNonNull(managementCallExecutor);
+    return this;
+  }
+
+  public Executor getManagementCallExecutor() {
+    return managementCallExecutor;
+  }
+
+  public NmsAgentService setOperationTimeout(long duration, TimeUnit unit) {
+    this.timeoutMs = TimeUnit.MILLISECONDS.convert(duration, unit);
+    return this;
+  }
+
+  public void setOnOperationError(BiConsumer<Operation, Throwable> onOperationError) {
+    this.onOperationError = onOperationError;
+  }
+
+  // features
+
+  @Override
+  public void setCapabilities(ContextContainer contextContainer, Collection<? extends Capability> capabilities) {
+    setCapabilities(contextContainer, capabilities.toArray(new Capability[capabilities.size()]));
+  }
+
+  @Override
+  public void setCapabilities(ContextContainer contextContainer, Capability... capabilities) {
+    LOGGER.trace("exposeManagementMetadata({})", contextContainer.getValue());
+    runOperation(() -> getEntity().exposeManagementMetadata(null, contextContainer, capabilities));
+  }
+
+  @Override
+  public void setTags(Collection<String> tags) {
+    setTags(tags.toArray(new String[tags.size()]));
+  }
+
+  @Override
+  public void setTags(String... tags) {
+    LOGGER.trace("setTags({})", Arrays.asList(tags));
+    runOperation(() -> getEntity().exposeTags(null, tags));
+    previouslyExposedTags = tags;
+  }
+
+  @Override
+  public void pushNotification(ContextualNotification notification) {
+    if (notification != null) {
+      LOGGER.trace("pushNotification({})", notification);
+      runOperation(() -> getEntity().pushNotification(null, notification));
+    }
+  }
+
+  @Override
+  public void pushStatistics(Collection<ContextualStatistics> statistics) {
+    pushStatistics(statistics.toArray(new ContextualStatistics[statistics.size()]));
+  }
+
+  @Override
+  public void pushStatistics(ContextualStatistics... statistics) {
+    if (statistics.length > 0) {
+      LOGGER.trace("pushStatistics({})", statistics.length);
+      runOperation(() -> getEntity().pushStatistics(null, statistics));
+    }
+  }
+
+  @Override
+  public void sendStates() {
+    LOGGER.trace("sendStates()");
+    refreshManagementRegistry();
+    if (previouslyExposedTags != null) {
+      setTags(previouslyExposedTags);
+    }
+  }
+
+  public void refreshManagementRegistry() {
+    // expose the registry each time a new object is registered in the management registry
+    if (isManagementRegistryBridged()) {
+      ManagementRegistry registry = getRegistry();
+      setCapabilities(registry.getContextContainer(), registry.getCapabilities());
+    }
+  }
+
+  protected void executeManagementCall(String managementCallIdentifier, ContextualCall<?> contextualCall) {
+    if (isManagementRegistryBridged()) {
+      ContextualReturn<?> aReturn = getRegistry().withCapability(contextualCall.getCapability())
+          .call(contextualCall.getMethodName(), contextualCall.getReturnType(), contextualCall.getParameters())
+          .on(contextualCall.getContext())
+          .build()
+          .execute()
+          .getSingleResult();
+      answerManagementCall(managementCallIdentifier, aReturn);
+    }
+  }
+
+  protected void answerManagementCall(String managementCallIdentifier, ContextualReturn<?> aReturn) {
+    LOGGER.trace("answerManagementCall({}, {})", managementCallIdentifier, aReturn);
+    runOperation(() -> getEntity().answerManagementCall(null, managementCallIdentifier, aReturn));
+  }
+
+  protected void runOperation(Supplier<Future<?>> op) {
+    if (!isClosed()) {
+      Future<?> future;
+      try {
+        future = op.get();
+      } catch (ConnectionClosedException | ConnectionShutdownException e) {
+        flushEntity();
+        onOperationError.accept(() -> runOperation(op), e);
+        return;
+      }
+      try {
+        future.get(timeoutMs, TimeUnit.MILLISECONDS);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+      } catch (ExecutionException e) {
+        flushEntity();
+        onOperationError.accept(() -> runOperation(op), e.getCause());
+      } catch (TimeoutException e) {
+        flushEntity();
+        onOperationError.accept(() -> runOperation(op), e);
+      }
+    }
+  }
+
+  protected NmsAgentEntity getEntity() {
+    if (isClosed()) {
+      throw new IllegalStateException("closed");
+    }
+    if (entity == null) {
+      LOGGER.trace("getEntity()");
+      entity = Objects.requireNonNull(entitySupplier.get());
+      entity.registerMessageListener(Message.class, this);
+      entity.setEndpointListener(this);
+
+      refreshManagementRegistry();
+      if (previouslyExposedTags != null) {
+        setTags(previouslyExposedTags);
+      }
+    }
+    return entity;
+  }
+
+  protected void flushEntity() {
+    if (entity != null) {
+      LOGGER.trace("flushEntity()");
+      entity = null;
+    }
+  }
+
+  public interface Operation {
+    void retry();
+  }
+
+}

--- a/management/nms-agent-entity/nms-agent-entity-client/src/main/java/org/terracotta/management/entity/nms/agent/client/NmsAgentService.java
+++ b/management/nms-agent-entity/nms-agent-entity-client/src/main/java/org/terracotta/management/entity/nms/agent/client/NmsAgentService.java
@@ -15,256 +15,43 @@
  */
 package org.terracotta.management.entity.nms.agent.client;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.terracotta.exception.ConnectionClosedException;
-import org.terracotta.management.entity.nms.agent.ReconnectData;
-import org.terracotta.management.entity.nms.agent.client.diag.DiagnosticProvider;
-import org.terracotta.management.entity.nms.agent.client.diag.DiagnosticUtility;
-import java.util.Objects;
-import org.terracotta.management.model.call.ContextualCall;
-import org.terracotta.management.model.call.ContextualReturn;
 import org.terracotta.management.model.capabilities.Capability;
-import org.terracotta.management.model.context.Context;
 import org.terracotta.management.model.context.ContextContainer;
-import org.terracotta.management.model.message.ManagementCallMessage;
-import org.terracotta.management.model.message.Message;
 import org.terracotta.management.model.notification.ContextualNotification;
 import org.terracotta.management.model.stats.ContextualStatistics;
-import org.terracotta.management.registry.ManagementProvider;
-import org.terracotta.management.registry.ManagementProviderAdapter;
-import org.terracotta.management.registry.ManagementRegistry;
-import org.terracotta.voltron.proxy.MessageListener;
-import org.terracotta.voltron.proxy.client.EndpointListener;
 
 import java.io.Closeable;
-import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Executor;
-import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
 /**
  * @author Mathieu Carbou
  */
-public class NmsAgentService implements Closeable {
+public interface NmsAgentService extends Closeable {
+  @Override
+  void close();
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(NmsAgentService.class);
+  boolean isDisconnected();
 
-  private final NmsAgentEntity entity;
+  boolean isClosed();
 
-  private volatile ManagementRegistry registry;
-  private volatile boolean bridging = false;
-  private volatile boolean disconnected = false;
-  private Capability[] previouslyExposedCapabilities;
-  private String[] previouslyExposedTags;
+  boolean isManagementRegistryBridged();
 
-  private long timeoutMs = 5000;
-  private Executor managementCallExecutor = new Executor() {
-    @Override
-    public void execute(Runnable command) {
-      command.run();
-    }
-  };
+  void setCapabilities(ContextContainer contextContainer, Collection<? extends Capability> capabilities);
 
-  private final ManagementProvider<?> managementProvider = new ManagementProviderAdapter<Object>(NmsAgentService.class.getSimpleName(), Object.class) {
-    @Override
-    public void register(Object managedObject) {
-      refresh(managedObject);
-    }
+  void setCapabilities(ContextContainer contextContainer, Capability... capabilities);
 
-    @Override
-    public void unregister(Object managedObject) {
-      refresh(managedObject);
-    }
+  void setTags(Collection<String> tags);
 
-    private void refresh(Object managedObject) {
-      // expose the registry each time a new object is registered in the management registry
-      if (bridging) {
-        try {
-          setCapabilities(registry.getContextContainer(), registry.getCapabilities());
-        } catch (InterruptedException e) {
-          LOGGER.warn("Failed to register managed object of type " + managedObject.getClass().getName() + ": " + e.getMessage(), e);
-          Thread.currentThread().interrupt();
-        } catch (ConnectionClosedException e) {
-          NmsAgentService.this.close();
-        } catch (Exception e) {
-          LOGGER.warn("Failed to register managed object of type " + managedObject.getClass().getName() + ": " + e.getMessage(), e);
-        }
-      }
-    }
-  };
-  private ManagementProvider<?> diagnosticProvider = new DiagnosticProvider(DiagnosticUtility.class);
+  void setTags(String... tags);
 
-  public NmsAgentService(final NmsAgentEntity entity) {
-    this.entity = Objects.requireNonNull(entity);
+  void pushNotification(ContextualNotification notification);
 
-    this.entity.registerMessageListener(Message.class, new MessageListener<Message>() {
-      @Override
-      public void onMessage(final Message message) {
-        LOGGER.trace("onMessage({})", message);
+  void pushStatistics(Collection<ContextualStatistics> statistics);
 
-        if (message.getType().equals("MANAGEMENT_CALL")) {
-          final ContextualCall<?> contextualCall = message.unwrap(ContextualCall.class).get(0);
-          managementCallExecutor.execute(new Runnable() {
-            @Override
-            public void run() {
-              try {
-                // check again because in another thread
-                if (bridging) {
-                  ContextualReturn<?> aReturn = registry.withCapability(contextualCall.getCapability())
-                      .call(contextualCall.getMethodName(), contextualCall.getReturnType(), contextualCall.getParameters())
-                      .on(contextualCall.getContext())
-                      .build()
-                      .execute()
-                      .getSingleResult();
-                  // check again in case the management call takes some time
-                  if (bridging) {
-                    LOGGER.trace("answerManagementCall({}, {})", message, contextualCall);
-                    try {
-                      get(entity.answerManagementCall(null, ((ManagementCallMessage) message).getManagementCallIdentifier(), aReturn));
-                    } catch (ConnectionClosedException e) {
-                      disconnected = true;
-                      throw e;
-                    }
-                  }
-                }
-              } catch (Exception err) {
-                if (LOGGER.isWarnEnabled()) {
-                  LOGGER.warn("Error on management call execution or result sending for " + contextualCall + ". Error: " + err.getMessage(), err);
-                }
-              }
-            }
-          });
-
-        } else {
-          LOGGER.warn("Received unsupported message: " + message);
-        }
-      }
-    });
-
-    this.entity.setEndpointListener(new EndpointListener() {
-      @Override
-      public Object onReconnect() {
-        if (bridging) {
-          LOGGER.trace("onReconnect()");
-          Collection<? extends Capability> capabilities = registry == null ? Collections.<Capability>emptyList() : registry.getCapabilities();
-          Context context = registry == null ? Context.empty() : Context.create(registry.getContextContainer().getName(), registry.getContextContainer().getValue());
-          return new ReconnectData(
-              previouslyExposedTags,
-              registry == null ? null : registry.getContextContainer(),
-              registry == null ? null : capabilities.toArray(new Capability[capabilities.size()]),
-              new ContextualNotification(context, "CLIENT_RECONNECTED"));
-        } else {
-          return null;
-        }
-      }
-
-      @Override
-      public void onDisconnectUnexpectedly() {
-        LOGGER.trace("onDisconnectUnexpectedly()");
-        close();
-      }
-    });
-  }
-
-  public void init() throws ExecutionException, InterruptedException, TimeoutException {
-    LOGGER.trace("init()");
-    // expose the registry when CM is first available
-    if (bridging) {
-      Collection<? extends Capability> capabilities = registry.getCapabilities();
-      setCapabilities(registry.getContextContainer(), capabilities.toArray(new Capability[capabilities.size()]));
-    }
-  }
+  void pushStatistics(ContextualStatistics... statistics);
 
   /**
-   * Bridges a management registry with a NMS Agent Entity. All exposure in the registry will be propagated to the server and
-   * it will listen for management calls also.
+   * Sends registry and tags to server
    */
-  public synchronized void setManagementRegistry(ManagementRegistry registry) {
-    if (!bridging) {
-      LOGGER.trace("setManagementRegistry({})", registry.getContextContainer().getValue());
-      this.registry = registry;
-      registry.addManagementProvider(diagnosticProvider);
-      // management provider must be added last
-      registry.addManagementProvider(managementProvider);
-      registry.register(new DiagnosticUtility());
-      bridging = true;
-    }
-  }
-
-  public boolean isDisconnected() {
-    return disconnected;
-  }
-
-  @Override
-  public synchronized void close() {
-    if (bridging) {
-      LOGGER.trace("close()");
-      registry.removeManagementProvider(managementProvider);
-      bridging = false;
-    }
-  }
-
-  // config ops
-
-  public NmsAgentService setManagementCallExecutor(Executor managementCallExecutor) {
-    this.managementCallExecutor = Objects.requireNonNull(managementCallExecutor);
-    return this;
-  }
-
-  public NmsAgentService setOperationTimeout(long duration, TimeUnit unit) {
-    this.timeoutMs = TimeUnit.MILLISECONDS.convert(duration, unit);
-    return this;
-  }
-
-  // features
-
-  public void setCapabilities(ContextContainer contextContainer, Collection<? extends Capability> capabilities) throws ExecutionException, InterruptedException, TimeoutException {
-    setCapabilities(contextContainer, capabilities.toArray(new Capability[capabilities.size()]));
-  }
-
-  public void setCapabilities(ContextContainer contextContainer, Capability... capabilities) throws ExecutionException, InterruptedException, TimeoutException {
-    if (!Arrays.deepEquals(previouslyExposedCapabilities, capabilities)) {
-      LOGGER.trace("exposeManagementMetadata({})", contextContainer.getValue());
-      get(entity.exposeManagementMetadata(null, contextContainer, capabilities));
-      previouslyExposedCapabilities = capabilities;
-    }
-  }
-
-  public void setTags(Collection<String> tags) throws ExecutionException, InterruptedException, TimeoutException {
-    setTags(tags.toArray(new String[tags.size()]));
-  }
-
-  public void setTags(String... tags) throws ExecutionException, InterruptedException, TimeoutException {
-    LOGGER.trace("setTags({})", Arrays.asList(tags));
-    get(entity.exposeTags(null, tags));
-    previouslyExposedTags = tags;
-  }
-
-  public void pushNotification(ContextualNotification notification) throws ExecutionException, InterruptedException, TimeoutException {
-    if (notification != null) {
-      LOGGER.trace("pushNotification({})", notification);
-      get(entity.pushNotification(null, notification));
-    }
-  }
-
-  public void pushStatistics(ContextualStatistics... statistics) throws ExecutionException, InterruptedException, TimeoutException {
-    if (statistics.length > 0) {
-      LOGGER.trace("pushStatistics({})", statistics.length);
-      get(entity.pushStatistics(null, statistics));
-    }
-  }
-
-  public void pushStatistics(Collection<ContextualStatistics> statistics) throws ExecutionException, InterruptedException, TimeoutException {
-    pushStatistics(statistics.toArray(new ContextualStatistics[statistics.size()]));
-  }
-
-  private <V> V get(Future<V> future) throws ExecutionException, TimeoutException, InterruptedException {
-    return future.get(timeoutMs, TimeUnit.MILLISECONDS);
-  }
-
+  void sendStates();
 }

--- a/management/testing/integration-tests/src/test/java/org/terracotta/management/integration/tests/NmsAgentServiceIT.java
+++ b/management/testing/integration-tests/src/test/java/org/terracotta/management/integration/tests/NmsAgentServiceIT.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.management.integration.tests;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+import org.terracotta.connection.Connection;
+import org.terracotta.connection.ConnectionException;
+import org.terracotta.connection.ConnectionFactory;
+import org.terracotta.exception.EntityConfigurationException;
+import org.terracotta.management.entity.nms.NmsConfig;
+import org.terracotta.management.entity.nms.agent.client.DefaultNmsAgentService;
+import org.terracotta.management.entity.nms.agent.client.NmsAgentEntityFactory;
+import org.terracotta.management.entity.nms.agent.client.NmsAgentService;
+import org.terracotta.management.entity.nms.client.DefaultNmsService;
+import org.terracotta.management.entity.nms.client.NmsEntity;
+import org.terracotta.management.entity.nms.client.NmsEntityFactory;
+import org.terracotta.management.entity.nms.client.NmsService;
+import org.terracotta.management.model.cluster.Client;
+import org.terracotta.management.model.context.Context;
+import org.terracotta.management.model.context.ContextContainer;
+import org.terracotta.management.model.message.Message;
+import org.terracotta.management.model.notification.ContextualNotification;
+import org.terracotta.management.registry.DefaultManagementRegistry;
+import org.terracotta.management.registry.ManagementRegistry;
+import org.terracotta.testing.rules.Cluster;
+
+import java.io.File;
+import java.util.Properties;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static org.terracotta.testing.rules.BasicExternalClusterBuilder.newCluster;
+
+/**
+ * @author Mathieu Carbou
+ */
+public class NmsAgentServiceIT {
+
+  private final String offheapResource = "primary-server-resource";
+  private final String resourceConfig =
+      "<config xmlns:ohr='http://www.terracotta.org/config/offheap-resource'>"
+          + "<ohr:offheap-resources>"
+          + "<ohr:resource name=\"" + offheapResource + "\" unit=\"MB\">64</ohr:resource>"
+          + "</ohr:offheap-resources>" +
+          "</config>\n";
+
+  @Rule
+  public Timeout timeout = Timeout.seconds(60);
+
+  @Rule
+  public Cluster voltron = newCluster().in(new File("target/galvan")).withServiceFragment(resourceConfig).build();
+
+  Connection managementConnection;
+  Connection clientConnection;
+  NmsService nmsService;
+  NmsAgentService nmsAgentService;
+  AtomicInteger opErrors = new AtomicInteger();
+  ManagementRegistry registry = new DefaultManagementRegistry(new ContextContainer("foo", "bar"));
+
+  @Before
+  public void setUp() throws Exception {
+    voltron.getClusterControl().waitForActive();
+    connectNmsService();
+    connectNmsAgentService();
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    managementConnection.close();
+    try {
+      clientConnection.close();
+    } catch (Exception ignored) {
+    }
+  }
+
+  @Test
+  public void can_set_tag_and_close_client() throws Exception {
+    nmsAgentService.setTags("tag");
+    assertThat(nmsService.readTopology().clientStream().anyMatch(client -> client.getTags().contains("tag")), is(true));
+
+    clientConnection.close();
+    assertThat(opErrors.get(), equalTo(0));
+    while (!Thread.currentThread().isInterrupted()) {
+      if (!nmsService.readTopology().clientStream().anyMatch(client -> client.getTags().contains("tag"))) {
+        return;
+      }
+    }
+    fail();
+  }
+
+  @Test
+  public void nmsAgentService_can_recycle_entity_and_recover_manually() throws Exception {
+    can_set_tag_and_close_client();
+
+    nmsAgentService.sendStates();
+    assertThat(opErrors.get(), equalTo(2));
+
+    clientConnection = ConnectionFactory.connect(voltron.getConnectionURI(), new Properties());
+    nmsAgentService.sendStates();
+    assertThat(opErrors.get(), equalTo(2));
+
+    while (!Thread.currentThread().isInterrupted()) {
+      if (nmsService.readTopology().clientStream().anyMatch(c -> c.getTags().contains("tag") && c.isManageable())) {
+        return;
+      }
+    }
+    fail();
+  }
+
+  @Test
+  public void nmsAgentService_can_recycle_entity_and_recover_states_automatically() throws Exception {
+    can_set_tag_and_close_client();
+
+    nmsAgentService.pushNotification(new ContextualNotification(Context.empty(), "MY_NOTIF_TYPE"));
+    assertThat(opErrors.get(), equalTo(1));
+
+    clientConnection = ConnectionFactory.connect(voltron.getConnectionURI(), new Properties());
+    nmsAgentService.pushNotification(new ContextualNotification(Context.empty(), "MY_NOTIF_TYPE"));
+    assertThat(opErrors.get(), equalTo(1));
+
+    while (!Thread.currentThread().isInterrupted()) {
+      if (nmsService.readTopology().clientStream().anyMatch(c -> c.getTags().contains("tag") && c.isManageable())) {
+        return;
+      }
+    }
+    fail();
+  }
+
+  @Test
+  public void nmsAgentService_can_retry_operation() throws Exception {
+    ((DefaultNmsAgentService) nmsAgentService).setOnOperationError((operation, throwable) -> {
+      opErrors.incrementAndGet();
+
+      // recycle the connection
+      try {
+        clientConnection = ConnectionFactory.connect(voltron.getConnectionURI(), new Properties());
+      } catch (ConnectionException e) {
+        throw new RuntimeException(e);
+      }
+
+      operation.retry();
+    });
+
+    can_set_tag_and_close_client();
+
+    nmsAgentService.pushNotification(new ContextualNotification(Context.empty(), "MY_NOTIF_TYPE"));
+    assertThat(opErrors.get(), equalTo(1));
+
+    while (!Thread.currentThread().isInterrupted()) {
+      if (nmsService.readTopology().clientStream().anyMatch(c -> c.getTags().contains("tag") && c.isManageable())) {
+        return;
+      }
+    }
+    fail();
+
+    while (!Thread.currentThread().isInterrupted()) {
+      Message message = nmsService.waitForMessage();
+      if (message.getType().equals("NOTIFICATION") && message.unwrap(ContextualNotification.class).get(0).getType().equals("MY_NOTIF_TYPE")) {
+        return;
+      }
+    }
+    fail();
+  }
+
+  private void connectNmsService() throws ConnectionException, EntityConfigurationException {
+    managementConnection = ConnectionFactory.connect(voltron.getConnectionURI(), new Properties());
+    NmsEntityFactory nmsEntityFactory = new NmsEntityFactory(managementConnection, getClass().getSimpleName());
+    NmsEntity nmsEntity = nmsEntityFactory.retrieveOrCreate(new NmsConfig());
+    nmsService = new DefaultNmsService(nmsEntity);
+  }
+
+  private void connectNmsAgentService() throws ConnectionException {
+    clientConnection = ConnectionFactory.connect(voltron.getConnectionURI(), new Properties());
+    DefaultNmsAgentService nmsAgentService = new DefaultNmsAgentService(() -> new NmsAgentEntityFactory(clientConnection).retrieve());
+    nmsAgentService.setOnOperationError((operation, throwable) -> opErrors.incrementAndGet());
+    nmsAgentService.setManagementRegistry(registry);
+    this.nmsAgentService = nmsAgentService;
+  }
+
+}

--- a/management/testing/sample-entity/src/main/java/org/terracotta/management/entity/sample/client/CacheFactory.java
+++ b/management/testing/sample-entity/src/main/java/org/terracotta/management/entity/sample/client/CacheFactory.java
@@ -35,8 +35,6 @@ import java.net.URI;
 import java.util.Properties;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeoutException;
 
 /**
  * @author Mathieu Carbou
@@ -61,11 +59,11 @@ public class CacheFactory implements Closeable {
     return management.getManagementRegistry();
   }
 
-  public void init() throws ConnectionException, ExecutionException, InterruptedException, TimeoutException {
+  public void init() throws ConnectionException {
     init(null);
   }
 
-  public void init(String uuid) throws ConnectionException, ExecutionException, InterruptedException, TimeoutException {
+  public void init(String uuid) throws ConnectionException {
     // connects to server
     Properties properties = new Properties();
     properties.setProperty(ConnectionPropertyNames.CONNECTION_NAME, path);


### PR DESCRIPTION
See: https://github.com/ehcache/ehcache3/issues/2203

# PLEASE LET @AbfrmBlr REVIEW & MERGE => he needs to test in Ehcache if the code is OK.

Changes:

- Introduced interface NmsAgentService for impl DefaultNmsAgentService.java
- DefaultNmsAgentService now request an NmsAgent entity lazily when it needs to send something to the server
- Supports a provider for NmsAgentEntity
- Supports a callback in case of connection error to be able to re-create the connection if needed
- Some other fixes.
- See: NmsAgentServiceIT