### PR TITLE
Fix Ehcache#2289: Call addNode() on different paths

### DIFF
--- a/management/monitoring-service-api/src/main/java/org/terracotta/management/service/monitoring/EntityManagementRegistry.java
+++ b/management/monitoring-service-api/src/main/java/org/terracotta/management/service/monitoring/EntityManagementRegistry.java
@@ -108,8 +108,13 @@ public interface EntityManagementRegistry extends CapabilityManagementSupport, C
   /**
    * Must be called in ServerEntity.loadExisting() method to clear the previous
    * management registry created by the passive entity once the promotion to active
-   * is completed
+   * is completed, and initialize the monitoring service for this entity
    */
   void entityPromotionCompleted();
 
+  /**
+   * Must be called in ServerEntity.createNew() method to initialize the monitoring service
+   * for this entity
+   */
+  void entityCreated();
 }

--- a/management/monitoring-service/src/main/java/org/terracotta/management/service/monitoring/DefaultEntityManagementRegistry.java
+++ b/management/monitoring-service/src/main/java/org/terracotta/management/service/monitoring/DefaultEntityManagementRegistry.java
@@ -53,6 +53,7 @@ class DefaultEntityManagementRegistry implements EntityManagementRegistry, Topol
   private final ContextContainer contextContainer;
   private final List<ManagementProvider<?>> managementProviders = new CopyOnWriteArrayList<>();
   private final CompletableFuture<?> onEntityPromotionCompleted = new CompletableFuture<>();
+  private final CompletableFuture<?> onEntityCreated = new CompletableFuture<>();
   private final CompletableFuture<?> onClose = new CompletableFuture<>();
   private volatile boolean closed;
 
@@ -65,6 +66,10 @@ class DefaultEntityManagementRegistry implements EntityManagementRegistry, Topol
 
   void onEntityPromotionCompleted(Runnable r) {
     onEntityPromotionCompleted.thenRun(r);
+  }
+
+  void onEntityCreated(Runnable r) {
+    onEntityCreated.thenRun(r);
   }
 
   void onClose(Runnable r) {
@@ -210,6 +215,12 @@ class DefaultEntityManagementRegistry implements EntityManagementRegistry, Topol
   public void entityPromotionCompleted() {
     LOGGER.trace("[{}] entityPromotionCompleted() active={}", consumerId, monitoringService.isActiveEntityService());
     onEntityPromotionCompleted.complete(null);
+  }
+
+  @Override
+  public void entityCreated() {
+    LOGGER.trace("[{}] entityCreated() active={}", consumerId, monitoringService.isActiveEntityService());
+    onEntityCreated.complete(null);
   }
 
   @Override

--- a/management/monitoring-service/src/main/java/org/terracotta/management/service/monitoring/DefaultEntityMonitoringService.java
+++ b/management/monitoring-service/src/main/java/org/terracotta/management/service/monitoring/DefaultEntityMonitoringService.java
@@ -119,8 +119,16 @@ class DefaultEntityMonitoringService implements EntityMonitoringService {
     }
   }
 
+  public void init() {
+    LOGGER.trace("[{}] init()", getConsumerId());
+    monitoringProducer.addNode(new String[0], RELIABLE_CHANNEL_KEY, null);
+    Stream.of(REGISTRY, MANAGEMENT_ANSWER, NOTIFICATION)
+        .forEach(type -> monitoringProducer.addNode(new String[]{RELIABLE_CHANNEL_KEY}, type.name(), null));
+  }
+
   private void forwardToActiveServer(ManagementMessage.Type type, Serializable data) {
-    monitoringProducer.addNode(new String[0], RELIABLE_CHANNEL_KEY, new ManagementMessage(getServerName(), getConsumerId(), isActiveEntityService(), type, data));
+    LOGGER.trace("[{}] addNode(management/{}, {})", getConsumerId(), type, data);
+    monitoringProducer.addNode(new String[]{RELIABLE_CHANNEL_KEY}, type.name(), new ManagementMessage(getServerName(), getConsumerId(), isActiveEntityService(), type, data));
   }
 
 }

--- a/management/monitoring-service/src/main/java/org/terracotta/management/service/monitoring/IStripeMonitoringDataListenerAdapter.java
+++ b/management/monitoring-service/src/main/java/org/terracotta/management/service/monitoring/IStripeMonitoringDataListenerAdapter.java
@@ -53,11 +53,11 @@ final class IStripeMonitoringDataListenerAdapter implements IStripeMonitoring {
   @Override
   public boolean addNode(PlatformServer sender, String[] parents, String name, Serializable value) {
     LOGGER.trace("[{}] addNode({}, {})", consumerId, name, String.valueOf(value));
-    if (RELIABLE_CHANNEL_KEY.equals(name)) {
+    if (parents != null && parents.length == 1 && RELIABLE_CHANNEL_KEY.equals(parents[0])) {
       if (value instanceof ManagementMessage) {
         fire((ManagementMessage) value);
       } else if (value != null) {
-        Utils.warnOrAssert(LOGGER, "[0] addNode(from={}) IGNORED: wrong value type: {}", value.getClass().getSimpleName());
+        Utils.warnOrAssert(LOGGER, "[0] addNode(from={}) IGNORED: wrong value type: {}", name, value.getClass().getSimpleName());
       }
     }
     return false; // false to avoid replay of the cached data when a passive server becomes active

--- a/management/monitoring-service/src/main/java/org/terracotta/management/service/monitoring/ManagementMessage.java
+++ b/management/monitoring-service/src/main/java/org/terracotta/management/service/monitoring/ManagementMessage.java
@@ -64,6 +64,7 @@ public class ManagementMessage implements Serializable {
     final StringBuilder sb = new StringBuilder("ManagementMessage{");
     sb.append("type=").append(type);
     sb.append(", messageSource=").append(messageSource);
+    sb.append(", data=").append(data);
     sb.append('}');
     return sb.toString();
   }

--- a/management/monitoring-service/src/main/java/org/terracotta/management/service/monitoring/MonitoringServiceProvider.java
+++ b/management/monitoring-service/src/main/java/org/terracotta/management/service/monitoring/MonitoringServiceProvider.java
@@ -159,10 +159,14 @@ public class MonitoringServiceProvider implements ServiceProvider, Closeable {
 
         // create an active or passive monitoring service
         IMonitoringProducer monitoringProducer = managementRegistryConfiguration.getMonitoringProducer();
-        EntityMonitoringService entityMonitoringService = new DefaultEntityMonitoringService(consumerID, monitoringProducer, topologyService, activeEntity);
+        DefaultEntityMonitoringService entityMonitoringService = new DefaultEntityMonitoringService(consumerID, monitoringProducer, topologyService, activeEntity);
 
         // create a registry for the entity
         DefaultEntityManagementRegistry managementRegistry = new DefaultEntityManagementRegistry(consumerID, entityMonitoringService, timeSource);
+
+        // ensure voltron's monitoring tree is created or reseted on entity creation or failover
+        managementRegistry.onEntityCreated(entityMonitoringService::init);
+        managementRegistry.onEntityPromotionCompleted(entityMonitoringService::init);
 
         // make the registry listen for topology events
         topologyService.addTopologyEventListener(managementRegistry);

--- a/management/monitoring-service/src/test/java/org/terracotta/management/service/monitoring/VoltronMonitoringServiceTest.java
+++ b/management/monitoring-service/src/test/java/org/terracotta/management/service/monitoring/VoltronMonitoringServiceTest.java
@@ -371,7 +371,7 @@ public class VoltronMonitoringServiceTest {
     clientMonitoringService.pushStatistics(new FakeDesc("1-1"), new ContextualStatistics("capability", Context.empty().with("collectorId", "1"), Collections.emptyMap()));
 
     ManagementMessage notif = new ManagementMessage("server-2", 1, false, NOTIFICATION, new ContextualNotification(Context.empty(), "TYPE-2"));
-    activeDataListener.addNode(passive, new String[0], RELIABLE_CHANNEL_KEY, notif);
+    activeDataListener.addNode(passive, new String[]{RELIABLE_CHANNEL_KEY}, NOTIFICATION.name(), notif);
     ContextualStatistics[] data = {new ContextualStatistics("capability", Context.empty().with("collectorId", "1"), Collections.emptyMap())};
     activeDataListener.pushBestEffortsData(passive, UNRELIABLE_CHANNEL_KEY, new ManagementMessage("server-2", 1, false, STATISTICS, data));
 

--- a/management/nms-entity/nms-entity-server/src/main/java/org/terracotta/management/entity/nms/server/ActiveNmsServerEntity.java
+++ b/management/nms-entity/nms-entity-server/src/main/java/org/terracotta/management/entity/nms/server/ActiveNmsServerEntity.java
@@ -82,6 +82,7 @@ class ActiveNmsServerEntity extends ActiveProxiedServerEntity<Void, Void, NmsCal
   public void createNew() {
     super.createNew();
     LOGGER.trace("[{}] createNew()", consumerId);
+    entityManagementRegistry.entityCreated();
     entityManagementRegistry.refresh();
   }
 

--- a/management/nms-entity/nms-entity-server/src/main/java/org/terracotta/management/entity/nms/server/PassiveNmsServerEntity.java
+++ b/management/nms-entity/nms-entity-server/src/main/java/org/terracotta/management/entity/nms/server/PassiveNmsServerEntity.java
@@ -62,6 +62,7 @@ class PassiveNmsServerEntity extends PassiveProxiedServerEntity implements Nms, 
   public void createNew() {
     super.createNew();
     LOGGER.trace("[{}] createNew()", entityManagementRegistry.getMonitoringService().getConsumerId());
+    entityManagementRegistry.entityCreated();
     entityManagementRegistry.refresh();
   }
 

--- a/management/testing/sample-entity/src/main/java/org/terracotta/management/entity/sample/server/ActiveCacheServerEntity.java
+++ b/management/testing/sample-entity/src/main/java/org/terracotta/management/entity/sample/server/ActiveCacheServerEntity.java
@@ -93,7 +93,7 @@ class ActiveCacheServerEntity extends ActiveProxiedServerEntity<CacheSync, Void,
   public void createNew() {
     super.createNew();
     LOGGER.trace("[{}] createNew()", cache.getName());
-    management.init();
+    management.entityCreated();
     management.serverCacheCreated(cache);
   }
 
@@ -101,7 +101,7 @@ class ActiveCacheServerEntity extends ActiveProxiedServerEntity<CacheSync, Void,
   public void loadExisting() {
     super.loadExisting();
     LOGGER.trace("[{}] loadExisting()", cache.getName());
-    management.reload();
+    management.entityPromotionCompleted();
     management.serverCacheCreated(cache);
   }
 

--- a/management/testing/sample-entity/src/main/java/org/terracotta/management/entity/sample/server/PassiveCacheServerEntity.java
+++ b/management/testing/sample-entity/src/main/java/org/terracotta/management/entity/sample/server/PassiveCacheServerEntity.java
@@ -48,7 +48,7 @@ class PassiveCacheServerEntity extends PassiveProxiedServerEntity implements Cac
     super.createNew();
     
     LOGGER.trace("[{}] createNew()", cache.getName());
-    management.init();
+    management.entityCreated();
     management.serverCacheCreated(cache);
   }
 

--- a/management/testing/sample-entity/src/main/java/org/terracotta/management/entity/sample/server/management/Management.java
+++ b/management/testing/sample-entity/src/main/java/org/terracotta/management/entity/sample/server/management/Management.java
@@ -58,18 +58,19 @@ public class Management implements Closeable {
     managementRegistry.close();
   }
 
-  public void init() {
+  public void entityCreated() {
     if (managementRegistry != null) {
-      LOGGER.trace("[{}] init()", cacheName);
-      managementRegistry.refresh(); // send to voltron the registry at entity init
+      LOGGER.trace("[{}] entityCreated()", cacheName);
+      managementRegistry.entityCreated();
+      managementRegistry.refresh(); // send to voltron the registry at entity cretaion
     }
   }
 
-  public void reload() {
+  public void entityPromotionCompleted() {
     if (managementRegistry != null) {
-      LOGGER.trace("[{}] reload()", cacheName);
+      LOGGER.trace("[{}] entityPromotionCompleted()", cacheName);
       managementRegistry.entityPromotionCompleted();
-      init();
+      managementRegistry.refresh(); // send to voltron the registry at entity promotion
     }
   }
 


### PR DESCRIPTION
See also https://github.com/ehcache/ehcache3/issues/2289.

After discussing with @myronkscott, actually this is a misunderstanding about how the voltron tree is working especially during entity promotion.

So we have to use separate path for the different message types. 

- There is at most 1 registry per entity so using 1 path for this is OK
- There can be several management call answers per entity, so the new path will allow only at most one to remain after a failover, so other calls will time out
- Same for notifications. They will be lost except the last one

When no failover (normal usage), nothing is lost and all consecutive messages, even on the same path, are sent to the monitoring service.

__CHANGE__ All entities using management must now call call `registry.entityCreated()` in the `createNew()` method for active and passive.

@myronkscott : please correct me if I am wrong.