### PR TITLE
Workaround for Voltron that is sending some internal runtime exception

### DIFF
--- a/management/nms-agent-entity/nms-agent-entity-client/src/main/java/org/terracotta/management/entity/nms/agent/client/DefaultNmsAgentService.java
+++ b/management/nms-agent-entity/nms-agent-entity-client/src/main/java/org/terracotta/management/entity/nms/agent/client/DefaultNmsAgentService.java
@@ -322,7 +322,7 @@ public class DefaultNmsAgentService implements EndpointListener, MessageListener
       } catch (ExecutionException e) {
         flushEntity();
         onOperationError.accept(() -> runOperation(op), e.getCause());
-      } catch (TimeoutException e) {
+      } catch (TimeoutException | RuntimeException e) {
         flushEntity();
         onOperationError.accept(() -> runOperation(op), e);
       }


### PR DESCRIPTION
Clients can see when closing :

```
2018-03-14 17:56:47.575 ERROR   --- [CallExecutor]-0] o.e.m.c.D.managementCallExecutor        : ERR: org.terracotta.management.entity.nms.agent.client.NmsAgentEntity:NmsAgent - Connection closed under in-flight message
com.tc.object.LocalConnectionClosedException: org.terracotta.management.entity.nms.agent.client.NmsAgentEntity:NmsAgent - Connection closed under in-flight message
	at com.tc.object.ExceptionUtils.throwRuntimeExceptionWithLocalStack(ExceptionUtils.java:65)
	at com.tc.object.ExceptionUtils.addLocalStackTraceToEntityException(ExceptionUtils.java:34)
	at com.tc.object.InFlightMessage.getWithTimeout(InFlightMessage.java:189)
	at com.tc.object.EntityClientEndpointImpl$InvocationBuilderImpl$1.getWithTimeout(EntityClientEndpointImpl.java:220)
	at org.terracotta.voltron.proxy.client.VoltronProxyInvocationHandler$ProxiedInvokeFuture.get(VoltronProxyInvocationHandler.java:208)
	at org.terracotta.management.entity.nms.agent.client.DefaultNmsAgentService.runOperation(DefaultNmsAgentService.java:319)
	at org.terracotta.management.entity.nms.agent.client.DefaultNmsAgentService.answerManagementCall(DefaultNmsAgentService.java:305)
	at org.terracotta.management.entity.nms.agent.client.DefaultNmsAgentService.executeManagementCall(DefaultNmsAgentService.java:299)
	at org.terracotta.management.entity.nms.agent.client.DefaultNmsAgentService.lambda$onMessage$2(DefaultNmsAgentService.java:104)
	at org.ehcache.management.cluster.LoggingExecutor.lambda$execute$0(LoggingExecutor.java:36)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
Caused by: org.terracotta.exception.ConnectionClosedException: Connection closed under in-flight message
	at com.tc.object.ClientEntityManagerImpl.throwClosedExceptionOnMessage(ClientEntityManagerImpl.java:387)
	at com.tc.object.ClientEntityManagerImpl.shutdown(ClientEntityManagerImpl.java:368)
	at com.tc.object.handshakemanager.ClientHandshakeManagerImpl.shutdownCallbacks(ClientHandshakeManagerImpl.java:200)
	at com.tc.object.handshakemanager.ClientHandshakeManagerImpl.shutdown(ClientHandshakeManagerImpl.java:93)
	at com.tc.object.ClientShutdownManager.closeLocalWork(ClientShutdownManager.java:94)
	at com.tc.object.ClientShutdownManager.execute(ClientShutdownManager.java:75)
	at com.tc.object.DistributedObjectClient.shutdownClient(DistributedObjectClient.java:676)
	at com.tc.object.DistributedObjectClient.shutdown(DistributedObjectClient.java:698)
	at com.tc.object.DistributedObjectClient.access$1100(DistributedObjectClient.java:125)
	at com.tc.object.DistributedObjectClient$ShutdownAction.run(DistributedObjectClient.java:708)
	... 1 common frames omitted

```