### PR TITLE
Bump versions to latest core dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,10 +29,10 @@
     <maven-forge-plugin.version>1.2.16</maven-forge-plugin.version>
     <slf4j.version>1.7.25</slf4j.version>
     <logback.version>1.2.3</logback.version>
-    <terracotta-apis.version>1.6.0-pre3</terracotta-apis.version>
-    <terracotta-configuration.version>10.6.0-pre4</terracotta-configuration.version>
-    <passthrough-testing.version>1.6.0-pre3</passthrough-testing.version>
-    <terracotta-core.version>5.6.1-pre4</terracotta-core.version>
+    <terracotta-apis.version>1.6.1-pre1</terracotta-apis.version>
+    <terracotta-configuration.version>10.6.1-pre1</terracotta-configuration.version>
+    <passthrough-testing.version>1.6.1-pre1</passthrough-testing.version>
+    <terracotta-core.version>5.6.1-pre6</terracotta-core.version>
     <statistics.version>2.1</statistics.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>


### PR DESCRIPTION
Fixes a snapshotting deadlock on passive sync
adapt to new APIs where InvocationBuilder.asDeferredResponse() is deprecated
