### PR TITLE
Change underlying tracker storage 

### DIFF
--- a/client-message-tracker/src/main/java/org/terracotta/client/message/tracker/Tracker.java
+++ b/client-message-tracker/src/main/java/org/terracotta/client/message/tracker/Tracker.java
@@ -26,7 +26,7 @@ import java.util.function.Predicate;
  *
  * @param <R> type of the value
  */
-public interface Tracker<R> extends StateDumpable {
+interface Tracker<R> extends StateDumpable {
 
   /**
    * A tracker policy that will track all messages

--- a/client-message-tracker/src/test/java/org/terracotta/client/message/tracker/TrackerImplTest.java
+++ b/client-message-tracker/src/test/java/org/terracotta/client/message/tracker/TrackerImplTest.java
@@ -82,19 +82,16 @@ public class TrackerImplTest {
     assertThat(tracker.getTrackedValue(1L), notNullValue());
     assertThat(tracker.getTrackedValue(2L), notNullValue());
     assertThat(tracker.getTrackedValue(3L), notNullValue());
-    assertThat(tracker.getLastReconciledId(), is(1L));
 
     tracker.reconcile(2L);
     assertThat(tracker.getTrackedValue(1L), nullValue());
     assertThat(tracker.getTrackedValue(2L), notNullValue());
     assertThat(tracker.getTrackedValue(3L), notNullValue());
-    assertThat(tracker.getLastReconciledId(), is(2L));
 
     tracker.reconcile(3L);
     assertThat(tracker.getTrackedValue(1L), nullValue());
     assertThat(tracker.getTrackedValue(2L), nullValue());
     assertThat(tracker.getTrackedValue(3L), notNullValue());
-    assertThat(tracker.getLastReconciledId(), is(3L));
   }
 
   @Test

--- a/lease/api/src/test/java/org/terracotta/lease/LeaseMaintenanceThreadTest.java
+++ b/lease/api/src/test/java/org/terracotta/lease/LeaseMaintenanceThreadTest.java
@@ -55,12 +55,12 @@ public class LeaseMaintenanceThreadTest {
     assertTrue(leaseMaintenanceThread.isDaemon());
     leaseMaintenanceThread.start();
 
-    verify(timeSource, timeout(2000L).times(1)).sleep(eq(2000L));
+    verify(timeSource, timeout(3000L).times(1)).sleep(eq(2000L));
     verify(leaseMaintainer, times(1)).refreshLease();
     
     timeSource.tickMillis(2000L);
 
-    verify(timeSource, timeout(2000L).atLeast(2)).sleep(eq(2000L));
+    verify(timeSource, timeout(4000L).atLeast(2)).sleep(eq(2000L));
     verify(leaseMaintainer, atLeast(2)).refreshLease();
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
     <terracotta-apis.version>1.6.1</terracotta-apis.version>
     <terracotta-configuration.version>10.6.2-pre1</terracotta-configuration.version>
     <passthrough-testing.version>1.6.1</passthrough-testing.version>
-    <terracotta-core.version>5.6.4-pre2</terracotta-core.version>
+    <terracotta-core.version>5.6.4-pre4</terracotta-core.version>
     <statistics.version>2.1</statistics.version>
     <jackson-databind.version>2.9.9</jackson-databind.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
to reduce the cost of bootstrap on failover reconnect.  Long lived clients that reconnect to a new server can be very expensive when streaming longs from zero to reconcile id.