### PR TITLE
Runnel: Perf improvement in sizing calculations.

### DIFF
--- a/management/management-registry/src/test/java/org/terracotta/management/registry/ManagementRegistryTest.java
+++ b/management/management-registry/src/test/java/org/terracotta/management/registry/ManagementRegistryTest.java
@@ -61,6 +61,7 @@ public class ManagementRegistryTest {
     mapper.addMixIn(CapabilityContext.class, CapabilityContextMixin.class);
 
     String actual = mapper.writeValueAsString(registry.getCapabilities());
+    actual = actual.replaceAll("\\r\\n", "\n");
     assertEquals(expectedJson, actual);
 
     ContextualReturn<?> cr = registry.withCapability("TheActionProvider")

--- a/runnel/src/main/java/org/terracotta/runnel/encoding/dataholders/AbstractDataHolder.java
+++ b/runnel/src/main/java/org/terracotta/runnel/encoding/dataholders/AbstractDataHolder.java
@@ -22,7 +22,6 @@ import org.terracotta.runnel.utils.WriteBuffer;
  * @author Ludovic Orban
  */
 public abstract class AbstractDataHolder implements DataHolder {
-
   private final int index;
 
   protected AbstractDataHolder(int index) {

--- a/runnel/src/main/java/org/terracotta/runnel/encoding/dataholders/ArrayDataHolder.java
+++ b/runnel/src/main/java/org/terracotta/runnel/encoding/dataholders/ArrayDataHolder.java
@@ -29,6 +29,7 @@ import java.util.List;
 public class ArrayDataHolder extends AbstractDataHolder {
 
   private final List<? extends DataHolder> values;
+  private int cacheSize = -1;
 
   public ArrayDataHolder(List<? extends DataHolder> values, int index) {
     super(index);
@@ -37,12 +38,15 @@ public class ArrayDataHolder extends AbstractDataHolder {
 
   @Override
   protected int valueSize() {
-    int size = 0;
-    for (DataHolder value : values) {
-      size += value.size(false);
+    if (cacheSize < 0) {
+      int size = 0;
+      for (DataHolder value : values) {
+        size += value.size(false);
+      }
+      size += VLQ.encodedSize(values.size()); // length field
+      cacheSize = size;
     }
-    size += VLQ.encodedSize(values.size()); // length field
-    return size;
+    return cacheSize;
   }
 
   @Override

--- a/runnel/src/main/java/org/terracotta/runnel/encoding/dataholders/DataHolder.java
+++ b/runnel/src/main/java/org/terracotta/runnel/encoding/dataholders/DataHolder.java
@@ -22,6 +22,12 @@ import org.terracotta.runnel.utils.WriteBuffer;
  */
 public interface DataHolder {
 
+  /**
+   * Return the byte size of this data holder. Note that this value is cached
+   * on first calculation. Memoized, even.
+   * @param withIndex
+   * @return byte size.
+   */
   int size(boolean withIndex);
 
   void encode(WriteBuffer writeBuffer, boolean withIndex);

--- a/runnel/src/main/java/org/terracotta/runnel/encoding/dataholders/StructDataHolder.java
+++ b/runnel/src/main/java/org/terracotta/runnel/encoding/dataholders/StructDataHolder.java
@@ -28,6 +28,7 @@ import java.util.List;
 public class StructDataHolder extends AbstractDataHolder {
 
   private final List<? extends DataHolder> values;
+  private int cacheSize = -1;
 
   public StructDataHolder(List<? extends DataHolder> values, int index) {
     super(index);
@@ -36,11 +37,14 @@ public class StructDataHolder extends AbstractDataHolder {
 
   @Override
   protected int valueSize() {
-    int size = 0;
-    for (DataHolder value : values) {
-      size += value.size(true);
+    if (cacheSize < 0) {
+      int size = 0;
+      for (DataHolder value : values) {
+        size += value.size(true);
+      }
+      cacheSize = size;
     }
-    return size;
+    return cacheSize;
   }
 
   @Override

--- a/runnel/src/test/java/org/terracotta/runnel/encoding/EncodingPerfTest.java
+++ b/runnel/src/test/java/org/terracotta/runnel/encoding/EncodingPerfTest.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.runnel.encoding;
+
+import org.junit.Ignore;
+import org.junit.Test;
+import org.terracotta.runnel.EnumMapping;
+import org.terracotta.runnel.EnumMappingBuilder;
+import org.terracotta.runnel.Struct;
+import org.terracotta.runnel.StructBuilder;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+
+public class EncodingPerfTest {
+
+  enum Typ {
+    BOOL,
+    CHAR,
+    INT,
+    LONG,
+    DOUBLE,
+    STRING,
+    BYTES;
+  }
+
+  @SuppressWarnings("rawtypes")
+  public static final EnumMapping<Typ> TYPE_ENUM_MAPPING = EnumMappingBuilder.newEnumMappingBuilder(Typ.class)
+                                                                             .mapping(Typ.BOOL,
+                                                                                      0)
+                                                                             .mapping(Typ.CHAR, 1)
+                                                                             .mapping(Typ.INT, 2)
+                                                                             .mapping(Typ.LONG, 3)
+                                                                             .mapping(Typ.DOUBLE, 4)
+                                                                             .mapping(Typ.STRING, 5)
+                                                                             .mapping(Typ.BYTES, 6)
+                                                                             .build();
+
+  public static final Struct KEY_STRUCT = StructBuilder.newStructBuilder().enm("keyType", 10, TYPE_ENUM_MAPPING).bool(
+    "bool",
+    20).chr("char", 30).int32("int", 40).int64("long", 50).fp64("double", 60).string("string", 70).build();
+
+  public static final Struct CELL_STRUCT = StructBuilder.newStructBuilder()
+                                                        .string("name", 10)
+                                                        .enm("type",
+                                                             20,
+                                                             TYPE_ENUM_MAPPING)
+                                                        .bool("bool", 30)
+                                                        .chr("char", 40)
+                                                        .int32("int", 50)
+                                                        .int64("long", 60)
+                                                        .fp64("double", 70)
+                                                        .string("string", 80)
+                                                        .byteBuffer("bytes", 90)
+                                                        .build();
+
+  private static final Struct RDS = StructBuilder.newStructBuilder()
+                                                 .int64("msn", 10)
+                                                 .struct("key", 20, KEY_STRUCT)
+                                                 .structs("cells", 30, CELL_STRUCT)
+                                                 .build();
+
+  static StructEncoder<Void> buildRecord(Random r, int seed, int minStrSize, int maxStrSize) {
+    return RDS.encoder()
+              .int64("msn", seed)
+              .struct("key")
+                 .string("string", "key" + seed)
+              .end()
+              .structs("cells")
+              .add()
+                 .string("name", "Cell1")
+                 .enm("type", Typ.STRING)
+                 .string("string", stringValue(r, minStrSize, maxStrSize))
+              .end()
+              .add()
+                 .string("name", "Cell2")
+                 .enm("type", Typ.INT)
+                 .int32("int", seed)
+              .end()
+              .add()
+                 .string("name", "Cell3")
+                 .enm("type", Typ.INT)
+                 .int32("int", 2 * seed)
+              .end()
+              .add()
+                 .string("name", "Cell4")
+                 .enm("type", Typ.STRING)
+                 .string("string", stringValue(r, minStrSize/4, maxStrSize/4))
+              .end()
+           .end();
+  }
+
+  private static String stringValue(Random r, int minsz, int maxsz) {
+    int sz = minsz + r.nextInt(maxsz - minsz);
+    char[] c = new char[sz];
+    for (int i = 0; i < c.length; i++) {
+      c[i] = (char) ('A' + r.nextInt(26));
+    }
+    return new String(c);
+  }
+
+  @Test
+  @Ignore
+  public void quickTest() {
+    Random r = new Random(0);
+    long totalBytes = 0;
+    long totalObjects = 0;
+    long totalMillis = 0;
+
+    for (int j = 0; j < 200; j++) {
+      ArrayList<StructEncoder<Void>> encoders = new ArrayList<>();
+      for (int i = 0; i < 5000; i++) {
+        StructEncoder<Void> ret = buildRecord(r, i, 2048, 8192);
+        encoders.add(ret);
+      }
+      long st = System.nanoTime();
+      for (StructEncoder<Void> enc : encoders) {
+        ByteBuffer b = enc.encode();
+        b.clear();
+        totalBytes += b.array().length;
+        totalObjects++;
+      }
+      long took = System.nanoTime() - st;
+      totalMillis = totalMillis + TimeUnit.MILLISECONDS.convert(took, TimeUnit.NANOSECONDS);
+      long objectRateSecs = (1000 * totalObjects) / totalMillis;
+      long byteRateSecs = (1000 * totalBytes) / totalMillis;
+      System.out.println(j + ". " + took + "ns " + objectRateSecs + " objs/sec " + byteRateSecs + " bytes/sec");
+      encoders.clear();
+    }
+    long objectRateSecs = (1000 * totalObjects) / totalMillis;
+    long byteRateSecs = (1000 * totalBytes) / totalMillis;
+    System.out.println(objectRateSecs + " objs/sec " + byteRateSecs + " bytes/sec");
+  }
+
+}

--- a/tc-config-generator/src/test/java/org/terracotta/config/generator/GenerateFromEnvironmentVariablesTest.java
+++ b/tc-config-generator/src/test/java/org/terracotta/config/generator/GenerateFromEnvironmentVariablesTest.java
@@ -24,7 +24,9 @@ import org.junit.rules.ExpectedException;
 
 import java.io.IOException;
 import java.io.StringWriter;
+import java.net.URL;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -138,7 +140,7 @@ public class GenerateFromEnvironmentVariablesTest {
     StringWriter output = new StringWriter();
     generateFromEnvironmentVariables.generateXmlFile(root, "template-tc-config.ftlh", output);
 
-    byte[] expectedEncoded = Files.readAllBytes(Paths.get(this.getClass().getResource("/tc-config-expected").getPath()));
+    byte[] expectedEncoded = Files.readAllBytes(Paths.get(this.getClass().getResource("/tc-config-expected").toURI()));
     String expected = new String(expectedEncoded, "UTF-8");
     String actual = output.toString();
     assertThat(actual, equalTo(expected));


### PR DESCRIPTION
When we encode, the first thing that happens is we ask what
the size of the encoded object will be, so we can create
the proper size buffer for output. This means a traversal
of the entire runnel struct, which can be quite nested.

But... then, as it traverses the structures, sub structures
do the same thing. So you get a tinyish NLogM  blow up
in counting sizes.

It's a small thing, but noticable.

By caching the valueSize() call in containing structures
(StructEncoder, ArrayEncoder) we only calculate the size once.

Additionally, I fixed 2 tests that were broken on Windows.