### PR TITLE
Issue:554 - Relax accessibility in ConfigParser objects for reuse

### DIFF
--- a/lease/entity-server/src/main/java/org/terracotta/lease/service/config/LeaseConfigurationParser.java
+++ b/lease/entity-server/src/main/java/org/terracotta/lease/service/config/LeaseConfigurationParser.java
@@ -97,7 +97,7 @@ public class LeaseConfigurationParser implements ServiceConfigParser {
     return new LeaseConfiguration(TimeUnit.MILLISECONDS.convert(leaseLength, timeUnit));
   }
 
-  private Function<Element, LeaseElement> parser() {
+  public Function<Element, LeaseElement> parser() {
     return (element -> {
       NodeList childElements = element.getElementsByTagNameNS(NAMESPACE_STRING, LEASE_LENGTH_ELEMENT_NAME);
 

--- a/offheap-resource/src/main/java/org/terracotta/offheapresource/OffHeapResourceConfigurationParser.java
+++ b/offheap-resource/src/main/java/org/terracotta/offheapresource/OffHeapResourceConfigurationParser.java
@@ -62,7 +62,7 @@ public class OffHeapResourceConfigurationParser implements ExtendedConfigParser 
     return new OffHeapConfigValidator(parser());
   }
 
-  private Function<Element, OffheapResourcesType> parser() {
+  public Function<Element, OffheapResourcesType> parser() {
     return (Element element) -> {
       OffheapResourcesType retValue;
       try {


### PR DESCRIPTION
Relax accessibility in ConfigParser objects for reuse; parser() method can be reused from different parts of project to convert xml element to jaxb POJO.