### PR TITLE
:racehorse: Improve performance of repeated calls to Defaults.readMacAddress

### DIFF
--- a/management/management-registry/src/test/java/org/terracotta/management/registry/ManagementRegistryTest.java
+++ b/management/management-registry/src/test/java/org/terracotta/management/registry/ManagementRegistryTest.java
@@ -61,7 +61,6 @@ public class ManagementRegistryTest {
     mapper.addMixIn(CapabilityContext.class, CapabilityContextMixin.class);
 
     String actual = mapper.writeValueAsString(registry.getCapabilities());
-    actual = actual.replaceAll("\\r\\n", "\n");
     assertEquals(expectedJson, actual);
 
     ContextualReturn<?> cr = registry.withCapability("TheActionProvider")


### PR DESCRIPTION
This commit stream changes how repeated calls to `org.terracotta.management.sequence.Defaults#readMacAddress` are handled.  Correction of a Windows test failure is also included.

Windows builds failures are also due to a shortcoming addressed by Terracotta-OSS/terracotta-core#1079.  Windows builds should be successful once a terracotta-core release containing corrections for that issue is adopted here.