### PR TITLE
Supports to compile with -Xlint:all -Werror in IDE

### DIFF
--- a/client-message-tracker/src/main/java/org/terracotta/client/message/tracker/OOOMessageHandlerImpl.java
+++ b/client-message-tracker/src/main/java/org/terracotta/client/message/tracker/OOOMessageHandlerImpl.java
@@ -47,9 +47,9 @@ public class OOOMessageHandlerImpl<M extends EntityMessage, R extends EntityResp
     this.clientMessageTrackers = new ArrayList<>(segments);
     for (int i = 0; i < segments; i++) {
       //Passing the TRACK_ALL tracker policy here to avoid the redundant trackability test in Tracker as the real policy is used in the invoke
-      clientMessageTrackers.add(new ClientTrackerImpl(TRACK_ALL));
+      clientMessageTrackers.add(new ClientTrackerImpl<>(TRACK_ALL));
     }
-    sharedMessageTracker = new ClientTrackerImpl(TRACK_ALL);
+    sharedMessageTracker = new ClientTrackerImpl<>(TRACK_ALL);
     this.callback = callback;
   }
 

--- a/client-message-tracker/src/main/java/org/terracotta/client/message/tracker/TrackerImpl.java
+++ b/client-message-tracker/src/main/java/org/terracotta/client/message/tracker/TrackerImpl.java
@@ -63,6 +63,7 @@ class TrackerImpl<R> implements Tracker<R> {
     trackedValues.headMap(id).clear();
   }
 
+  @SuppressWarnings({"unchecked", "rawtypes"})
   @Override
   public synchronized Map<Long, R> getTrackedValues() {
     return Collections.unmodifiableMap(new HashMap(trackedValues));

--- a/client-message-tracker/src/test/java/org/terracotta/client/message/tracker/OOOMessageHandlerImplTest.java
+++ b/client-message-tracker/src/test/java/org/terracotta/client/message/tracker/OOOMessageHandlerImplTest.java
@@ -195,6 +195,7 @@ public class OOOMessageHandlerImplTest {
     assertThat(trackedResponses2, is(trackedResponsesForSegment2));
   }
 
+  @SuppressWarnings("deprecation")
   @Test
   public void testLoadOnSyncWithOldServer() throws Exception {
     messageHandler = new OOOMessageHandlerImpl<>(m -> true, 2, m -> 0, () -> {});

--- a/client-message-tracker/src/test/java/org/terracotta/client/message/tracker/OOOMessageHandlerProviderTest.java
+++ b/client-message-tracker/src/test/java/org/terracotta/client/message/tracker/OOOMessageHandlerProviderTest.java
@@ -51,11 +51,11 @@ public class OOOMessageHandlerProviderTest {
     OOOMessageHandlerProvider provider =  new OOOMessageHandlerProvider();
     OOOMessageHandlerConfiguration<EntityMessage, EntityResponse> config =
       new OOOMessageHandlerConfiguration<>("foo", null, 1, m -> 0);
-    OOOMessageHandler messageHandler = provider.getService(1L, config);
+    OOOMessageHandler<EntityMessage, EntityResponse> messageHandler = provider.getService(1L, config);
 
     messageHandler.destroy();
 
-    OOOMessageHandler another = provider.getService(1L, config);
+    OOOMessageHandler<EntityMessage, EntityResponse> another = provider.getService(1L, config);
     assertNotSame(another, messageHandler);
   }
 

--- a/client-message-tracker/src/test/java/org/terracotta/client/message/tracker/demo/DemoActiveEntity.java
+++ b/client-message-tracker/src/test/java/org/terracotta/client/message/tracker/demo/DemoActiveEntity.java
@@ -32,7 +32,7 @@ import org.terracotta.entity.ServiceRegistry;
 
 import java.util.Map;
 
-public class DemoActiveEntity implements ActiveServerEntity {
+public class DemoActiveEntity implements ActiveServerEntity<EntityMessage, EntityResponse> {
 
   private final OOOMessageHandler<EntityMessage, EntityResponse> messageHandler;
 
@@ -58,7 +58,7 @@ public class DemoActiveEntity implements ActiveServerEntity {
   }
 
   @Override
-  public EntityResponse invokeActive(ActiveInvokeContext context, EntityMessage message) throws EntityUserException {
+  public EntityResponse invokeActive(ActiveInvokeContext<EntityResponse> context, EntityMessage message) throws EntityUserException {
     return messageHandler.invoke(context, message, this::processMessage);
   }
 
@@ -82,7 +82,7 @@ public class DemoActiveEntity implements ActiveServerEntity {
   }
 
   @Override
-  public void synchronizeKeyToPassive(PassiveSynchronizationChannel passiveSynchronizationChannel, int concurrencyKey) {
+  public void synchronizeKeyToPassive(PassiveSynchronizationChannel<EntityMessage> passiveSynchronizationChannel, int concurrencyKey) {
     // Sync entity data for the given concurrency key
     EntityMessage entityDataSyncMessage = null;
     passiveSynchronizationChannel.synchronizeToPassive(entityDataSyncMessage);

--- a/client-message-tracker/src/test/java/org/terracotta/client/message/tracker/demo/DemoPassiveEntity.java
+++ b/client-message-tracker/src/test/java/org/terracotta/client/message/tracker/demo/DemoPassiveEntity.java
@@ -27,7 +27,7 @@ import org.terracotta.entity.PassiveServerEntity;
 import org.terracotta.entity.ServiceException;
 import org.terracotta.entity.ServiceRegistry;
 
-public class DemoPassiveEntity implements PassiveServerEntity {
+public class DemoPassiveEntity implements PassiveServerEntity<EntityMessage, EntityResponse> {
 
   private final OOOMessageHandler<EntityMessage, EntityResponse> messageHandler;
 

--- a/concurrent-map-entity/client/src/main/java/org/terracotta/entity/map/ValueCodecFactory.java
+++ b/concurrent-map-entity/client/src/main/java/org/terracotta/entity/map/ValueCodecFactory.java
@@ -48,6 +48,7 @@ public class ValueCodecFactory {
       return input;
     }
 
+    @SuppressWarnings("unchecked")
     @Override
     public T decode(Object input) {
       return (T) input;
@@ -76,6 +77,7 @@ public class ValueCodecFactory {
       return new ValueWrapper(input.hashCode(), baos.toByteArray());
     }
 
+    @SuppressWarnings("unchecked")
     @Override
     public T decode(Object input) {
       if (input == null) {

--- a/concurrent-map-entity/common/src/main/java/org/terracotta/entity/map/common/PutAllOperation.java
+++ b/concurrent-map-entity/common/src/main/java/org/terracotta/entity/map/common/PutAllOperation.java
@@ -41,6 +41,7 @@ public class PutAllOperation implements MapOperation {
     PrimitiveCodec.writeTo(output, map);
   }
 
+  @SuppressWarnings("unchecked")
   static PutAllOperation readFrom(DataInput input) throws IOException {
     return new PutAllOperation((Map<Object, Object>) PrimitiveCodec.readFrom(input));
   }

--- a/concurrent-map-entity/integration-tests/src/test/java/ClusteredConcurrentMapPassthroughTest.java
+++ b/concurrent-map-entity/integration-tests/src/test/java/ClusteredConcurrentMapPassthroughTest.java
@@ -40,6 +40,7 @@ import static org.junit.Assert.assertThat;
 /**
  * ClusteredConcurrentMapPassthroughTest
  */
+@SuppressWarnings({"rawtypes", "unchecked"})
 public class ClusteredConcurrentMapPassthroughTest {
 
   private static final String MAP_NAME = "my-map";
@@ -145,6 +146,7 @@ public class ClusteredConcurrentMapPassthroughTest {
   }
 
   public static class Person implements Serializable  {
+    private static final long serialVersionUID = 1L;
     final String name;
     final int age;
 

--- a/healthchecker-entity/api/src/test/java/org/terracotta/healthchecker/HealthCheckerFactoryTest.java
+++ b/healthchecker-entity/api/src/test/java/org/terracotta/healthchecker/HealthCheckerFactoryTest.java
@@ -36,6 +36,7 @@ import org.terracotta.connection.entity.EntityRef;
 /**
  *
  */
+@SuppressWarnings({"unchecked", "rawtypes"})
 public class HealthCheckerFactoryTest {
   
   public HealthCheckerFactoryTest() {

--- a/healthchecker-entity/server-impl/src/main/java/org/terracotta/healthchecker/HealthCheckServerEntityService.java
+++ b/healthchecker-entity/server-impl/src/main/java/org/terracotta/healthchecker/HealthCheckServerEntityService.java
@@ -32,15 +32,15 @@ import org.terracotta.entity.SyncMessageCodec;
  */
 @PermanentEntity(type="org.terracotta.healthchecker.HealthCheck", names={"staticHealthChecker"}, version=1)
 public class HealthCheckServerEntityService implements EntityServerService<HealthCheckReq, HealthCheckRsp> {
-  
-  private static final ConcurrencyStrategy CONCURRENCY = new ConcurrencyStrategy() {
+
+  private static final ConcurrencyStrategy<HealthCheckReq> CONCURRENCY = new ConcurrencyStrategy<HealthCheckReq>() {
     @Override
-    public int concurrencyKey(EntityMessage message) {
+    public int concurrencyKey(HealthCheckReq message) {
       return ConcurrencyStrategy.UNIVERSAL_KEY;
     }
 
     @Override
-    public Set getKeysForSynchronization() {
+    public Set<Integer> getKeysForSynchronization() {
       return Collections.emptySet();
     }
 

--- a/lease/common/src/main/java/org/terracotta/lease/LeaseException.java
+++ b/lease/common/src/main/java/org/terracotta/lease/LeaseException.java
@@ -16,6 +16,8 @@
 package org.terracotta.lease;
 
 public class LeaseException extends Exception {
+  private static final long serialVersionUID = 1L;
+
   LeaseException(String message) {
     super(message);
   }

--- a/lease/entity-api/src/main/java/org/terracotta/lease/LeaseReconnectingException.java
+++ b/lease/entity-api/src/main/java/org/terracotta/lease/LeaseReconnectingException.java
@@ -19,6 +19,8 @@ package org.terracotta.lease;
  * Indicates that a reconnection is in progress and so lease requests will not be useful.
  */
 public class LeaseReconnectingException extends LeaseException {
+  private static final long serialVersionUID = 1L;
+
   LeaseReconnectingException(String message) {
     super(message);
   }

--- a/lease/entity-common/src/main/java/org/terracotta/lease/LeaseAcquirerCodec.java
+++ b/lease/entity-common/src/main/java/org/terracotta/lease/LeaseAcquirerCodec.java
@@ -29,6 +29,7 @@ import java.nio.ByteBuffer;
 /**
  * The codec responsible for converting back and forth between bytes and lease messages.
  */
+@SuppressWarnings({"unchecked", "rawtypes"})
 public class LeaseAcquirerCodec implements MessageCodec<LeaseMessage, LeaseResponse> {
   private static Struct messageStruct = createMessageStruct();
   private static Struct responseStruct = createResponseStruct();

--- a/lease/entity-server/src/main/java/org/terracotta/lease/ActiveLeaseAcquirer.java
+++ b/lease/entity-server/src/main/java/org/terracotta/lease/ActiveLeaseAcquirer.java
@@ -35,11 +35,11 @@ import java.util.concurrent.ConcurrentHashMap;
 public class ActiveLeaseAcquirer implements ActiveServerEntity<LeaseMessage, LeaseResponse> {
   private final LeaseService leaseService;
   private final ClientCommunicator clientCommunicator;
-  private final IEntityMessenger entityMessenger;
+  private final IEntityMessenger<LeaseMessage, LeaseResponse> entityMessenger;
   private final ConcurrentHashMap<ClientDescriptor, Long> connectionSequenceNumbers = new ConcurrentHashMap<>();
   private final ConcurrentHashMap<UUID, ClientDescriptor> clientDescriptors = new ConcurrentHashMap<>();
 
-  public ActiveLeaseAcquirer(LeaseService leaseService, ClientCommunicator clientCommunicator, IEntityMessenger entityMessenger) {
+  public ActiveLeaseAcquirer(LeaseService leaseService, ClientCommunicator clientCommunicator, IEntityMessenger<LeaseMessage, LeaseResponse> entityMessenger) {
     this.leaseService = leaseService;
     this.clientCommunicator = clientCommunicator;
     this.entityMessenger = entityMessenger;
@@ -56,7 +56,7 @@ public class ActiveLeaseAcquirer implements ActiveServerEntity<LeaseMessage, Lea
   }
 
   @Override
-  public LeaseResponse invokeActive(ActiveInvokeContext context, LeaseMessage leaseMessage) {
+  public LeaseResponse invokeActive(ActiveInvokeContext<LeaseResponse> context, LeaseMessage leaseMessage) {
     LeaseMessageType messageType = leaseMessage.getType();
     switch (messageType) {
       case LEASE_REQUEST:
@@ -68,7 +68,7 @@ public class ActiveLeaseAcquirer implements ActiveServerEntity<LeaseMessage, Lea
     }
   }
 
-  private LeaseResponse handleLeaseRequest(ActiveInvokeContext context, LeaseRequest leaseRequest) {
+  private LeaseResponse handleLeaseRequest(ActiveInvokeContext<LeaseResponse> context, LeaseRequest leaseRequest) {
     ClientDescriptor clientDescriptor = context.getClientDescriptor();
 
     if (!isLatestConnection(clientDescriptor, leaseRequest)) {
@@ -100,10 +100,10 @@ public class ActiveLeaseAcquirer implements ActiveServerEntity<LeaseMessage, Lea
     return messageConnectionSequenceNumber == latestConnectionSequenceNumber;
   }
 
-  
+
   @Override
   public ActiveServerEntity.ReconnectHandler startReconnect() {
-    return (ClientDescriptor clientDescriptor, byte[] bytes)->{
+    return (ClientDescriptor clientDescriptor, byte[] bytes) -> {
       LeaseReconnectData reconnectData = LeaseReconnectData.decode(bytes);
 
       long connectionSequenceNumber = reconnectData.getConnectionSequenceNumber();

--- a/lease/entity-server/src/main/java/org/terracotta/lease/LeaseAcquirerServerService.java
+++ b/lease/entity-server/src/main/java/org/terracotta/lease/LeaseAcquirerServerService.java
@@ -59,6 +59,7 @@ public class LeaseAcquirerServerService implements EntityServerService<LeaseMess
     return "org.terracotta.lease.LeaseAcquirer".equals(typeName);
   }
 
+  @SuppressWarnings("unchecked")
   @Override
   public ActiveServerEntity<LeaseMessage, LeaseResponse> createActiveEntity(ServiceRegistry serviceRegistry, byte[] bytes) throws ConfigurationException {
     ClientCommunicator clientCommunicator = getService(serviceRegistry, new BasicServiceConfiguration<>(ClientCommunicator.class));
@@ -67,7 +68,7 @@ public class LeaseAcquirerServerService implements EntityServerService<LeaseMess
     LeaseServiceConfiguration leaseServiceConfiguration = new LeaseServiceConfiguration(clientConnectionCloser);
     LeaseService leaseService = getService(serviceRegistry, leaseServiceConfiguration);
 
-    IEntityMessenger entityMessenger = getService(serviceRegistry, new BasicServiceConfiguration<>(IEntityMessenger.class));
+    IEntityMessenger<LeaseMessage, LeaseResponse> entityMessenger = getService(serviceRegistry, new BasicServiceConfiguration<>(IEntityMessenger.class));
 
     return new ActiveLeaseAcquirer(leaseService, clientCommunicator, entityMessenger);
   }

--- a/lease/entity-server/src/test/java/org/terracotta/lease/ActiveLeaseAcquirerTest.java
+++ b/lease/entity-server/src/test/java/org/terracotta/lease/ActiveLeaseAcquirerTest.java
@@ -39,6 +39,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 import org.terracotta.entity.ReconnectRejectedException;
 
+@SuppressWarnings({"rawtypes", "unchecked"})
 @RunWith(MockitoJUnitRunner.class)
 public class ActiveLeaseAcquirerTest {
   @Mock

--- a/lease/entity-server/src/test/java/org/terracotta/lease/LeaseAcquirerServerServiceTest.java
+++ b/lease/entity-server/src/test/java/org/terracotta/lease/LeaseAcquirerServerServiceTest.java
@@ -41,6 +41,7 @@ import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.verify;
 
+@SuppressWarnings("rawtypes")
 public class LeaseAcquirerServerServiceTest {
   @Test
   public void handlesEntityType() {
@@ -100,6 +101,7 @@ public class LeaseAcquirerServerServiceTest {
     return new ServiceTypeMatcher<T>(serviceType);
   }
 
+  @SuppressWarnings("rawtypes")
   private static class ServiceTypeMatcher<T> extends FeatureMatcher<ServiceConfiguration<T>, Class> {
     ServiceTypeMatcher(Class serviceType) {
       super(equalTo(serviceType), "serviceType", "serviceType");

--- a/lease/entity-server/src/test/java/org/terracotta/lease/service/config/LeaseConfigValidatorTest.java
+++ b/lease/entity-server/src/test/java/org/terracotta/lease/service/config/LeaseConfigValidatorTest.java
@@ -29,6 +29,7 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 
+@SuppressWarnings("unchecked")
 public class LeaseConfigValidatorTest {
 
   @Test

--- a/lease/entity-server/src/test/java/org/terracotta/lease/service/monitor/LeaseMonitorThreadTest.java
+++ b/lease/entity-server/src/test/java/org/terracotta/lease/service/monitor/LeaseMonitorThreadTest.java
@@ -18,13 +18,12 @@ package org.terracotta.lease.service.monitor;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Spy;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.terracotta.lease.TestTimeSource;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.times;

--- a/lease/entity-server/src/test/java/org/terracotta/lease/service/monitor/LeaseStateTest.java
+++ b/lease/entity-server/src/test/java/org/terracotta/lease/service/monitor/LeaseStateTest.java
@@ -19,7 +19,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.terracotta.entity.ClientDescriptor;
 import org.terracotta.lease.MockStateDumpCollector;
 import org.terracotta.lease.TestTimeSource;

--- a/lease/system-test/src/test/java/org/terracotta/lease/LeaseSystemTest.java
+++ b/lease/system-test/src/test/java/org/terracotta/lease/LeaseSystemTest.java
@@ -123,6 +123,7 @@ public class LeaseSystemTest {
     cluster.tearDown();
   }
 
+  @SuppressWarnings("unchecked")
   private static class LeaseDelayedConnection implements Connection {
     private final Connection delegate;
     private final Collection<LeaseDelayedEntityRef> entityRefs = Collections.synchronizedCollection(new ArrayList<>());

--- a/management/cluster-topology/src/main/java/org/terracotta/management/model/cluster/Client.java
+++ b/management/cluster-topology/src/main/java/org/terracotta/management/model/cluster/Client.java
@@ -255,6 +255,7 @@ public final class Client extends AbstractManageableNode<Cluster> {
   }
 
   @Override
+  @SuppressWarnings("rawtypes")
   public Map<String, Object> toMap() {
     Map<String, Object> map = super.toMap();
     map.put("pid", getPid());

--- a/management/cluster-topology/src/main/java/org/terracotta/management/model/cluster/Cluster.java
+++ b/management/cluster-topology/src/main/java/org/terracotta/management/model/cluster/Cluster.java
@@ -220,6 +220,7 @@ public final class Cluster implements Contextual {
     return toMap().toString();
   }
 
+  @SuppressWarnings("rawtypes")
   public Map<String, Object> toMap() {
     Map<String, Object> map = new LinkedHashMap<String, Object>();
     map.put("stripes", stripeStream().sorted(Comparator.comparing(AbstractNode::getId)).map(Stripe::toMap).collect(Collectors.toList()));

--- a/management/cluster-topology/src/test/java/org/terracotta/management/model/cluster/ClusterTest.java
+++ b/management/cluster-topology/src/test/java/org/terracotta/management/model/cluster/ClusterTest.java
@@ -213,6 +213,7 @@ public class ClusterTest extends AbstractTest {
   }
 
   @Test
+  @SuppressWarnings("rawtypes")
   public void test_toMap() throws Exception {
     String expectedJson = new String(Files.readAllBytes(new File("src/test/resources/cluster.json").toPath()), "UTF-8");
     Map actual = cluster1.toMap();

--- a/management/management-model/src/main/java/org/terracotta/management/model/cluster/ClientIdentifier.java
+++ b/management/management-model/src/main/java/org/terracotta/management/model/cluster/ClientIdentifier.java
@@ -241,11 +241,11 @@ public final class ClientIdentifier implements Serializable {
     try {
       InetAddress candidateAddress = null;
       // Iterate all NICs (network interface cards)...
-      for (Enumeration ifaces = NetworkInterface.getNetworkInterfaces(); ifaces.hasMoreElements(); ) {
-        NetworkInterface iface = (NetworkInterface) ifaces.nextElement();
+      for (Enumeration<NetworkInterface> ifaces = NetworkInterface.getNetworkInterfaces(); ifaces.hasMoreElements(); ) {
+        NetworkInterface iface = ifaces.nextElement();
         // Iterate all IP addresses assigned to each card...
-        for (Enumeration inetAddrs = iface.getInetAddresses(); inetAddrs.hasMoreElements(); ) {
-          InetAddress inetAddr = (InetAddress) inetAddrs.nextElement();
+        for (Enumeration<InetAddress> inetAddrs = iface.getInetAddresses(); inetAddrs.hasMoreElements(); ) {
+          InetAddress inetAddr = inetAddrs.nextElement();
           if (!inetAddr.isLoopbackAddress()) {
 
             if (inetAddr.isSiteLocalAddress()) {

--- a/management/management-model/src/main/java/org/terracotta/management/model/stats/StatisticRegistry.java
+++ b/management/management-model/src/main/java/org/terracotta/management/model/stats/StatisticRegistry.java
@@ -50,6 +50,7 @@ public class StatisticRegistry extends org.terracotta.statistics.registry.Statis
     return descriptors;
   }
 
+  @SuppressWarnings("rawtypes")
   public static Map<String, Statistic<? extends Serializable>> collect(StatisticRegistry registry, Collection<String> statisticNames, long since) {
     if (statisticNames == null || statisticNames.isEmpty()) {
       return registry.queryStatistics(since)

--- a/management/management-registry/src/main/java/org/terracotta/management/registry/AbstractManagementProvider.java
+++ b/management/management-registry/src/main/java/org/terracotta/management/registry/AbstractManagementProvider.java
@@ -129,7 +129,7 @@ public abstract class AbstractManagementProvider<T> implements ManagementProvide
     // LinkedHashSet to keep ordering because these objects end up in an immutable
     // topology so this is easier for testing to compare with json payloads
     Collection<Descriptor> capabilities = new LinkedHashSet<Descriptor>();
-    for (ExposedObject o : exposedObjects) {
+    for (ExposedObject<?> o : exposedObjects) {
       capabilities.addAll(((ExposedObject<T>) o).getDescriptors());
     }
     return capabilities;

--- a/management/management-registry/src/main/java/org/terracotta/management/registry/DefaultManagementRegistry.java
+++ b/management/management-registry/src/main/java/org/terracotta/management/registry/DefaultManagementRegistry.java
@@ -64,7 +64,7 @@ public class DefaultManagementRegistry implements ManagementRegistry, Closeable 
     managementProviders.remove(provider);
   }
 
-  @SuppressWarnings("unchecked")
+  @SuppressWarnings({"unchecked", "rawtypes"})
   @Override
   public void register(Object managedObject) {
     for (ManagementProvider managementProvider : managementProviders) {
@@ -74,7 +74,7 @@ public class DefaultManagementRegistry implements ManagementRegistry, Closeable 
     }
   }
 
-  @SuppressWarnings("unchecked")
+  @SuppressWarnings({"unchecked", "rawtypes"})
   @Override
   public void unregister(Object managedObject) {
     for (ManagementProvider managementProvider : managementProviders) {

--- a/management/management-registry/src/main/java/org/terracotta/management/registry/DefaultStatisticQuery.java
+++ b/management/management-registry/src/main/java/org/terracotta/management/registry/DefaultStatisticQuery.java
@@ -95,6 +95,7 @@ public class DefaultStatisticQuery implements StatisticQuery {
     return new DefaultResultSet<>(contextualStatistics);
   }
 
+  @SuppressWarnings("rawtypes")
   private static Map<String, Statistic<? extends Serializable>> getMap(Map<String, org.terracotta.management.model.stats.Statistic<? extends Serializable>> map) {
     return map.entrySet().stream().map(x -> new Map.Entry<String, Statistic<? extends Serializable>>() {
 
@@ -109,7 +110,7 @@ public class DefaultStatisticQuery implements StatisticQuery {
       }
 
       @Override
-      public Statistic<? extends Serializable> setValue(Statistic value) {
+      public Statistic<? extends Serializable> setValue(Statistic<? extends Serializable> value) {
         throw new UnsupportedOperationException();
       }
     }).collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));

--- a/management/management-registry/src/main/java/org/terracotta/management/registry/action/AbstractActionManagementProvider.java
+++ b/management/management-registry/src/main/java/org/terracotta/management/registry/action/AbstractActionManagementProvider.java
@@ -114,7 +114,7 @@ public abstract class AbstractActionManagementProvider<T> extends AbstractManage
   }
 
   private static Class<?>[] toClasses(ClassLoader classLoader, String[] classNames) {
-    Class<?>[] classes = new Class[classNames.length];
+    Class<?>[] classes = new Class<?>[classNames.length];
     for (int i = 0; i < classNames.length; i++) {
       String argClassName = classNames[i];
       classes[i] = PRIMITIVE_MAP.get(argClassName);

--- a/management/management-registry/src/test/java/org/terracotta/management/registry/DefaultCallQueryTest.java
+++ b/management/management-registry/src/test/java/org/terracotta/management/registry/DefaultCallQueryTest.java
@@ -41,7 +41,10 @@ public class DefaultCallQueryTest {
   public void execute_handles_unexpected_exceptions() throws Exception {
     final Context context = Context.create("key", "val");
     Parameter[] parameters = new Parameter[]{new Parameter("toto")};
-    Collection<Context> contexts = new ArrayList<Context>() {{
+    Collection<Context> contexts = new ArrayList<Context>() {
+      private static final long serialVersionUID = 1L;
+
+      {
       add(context);
     }};
 
@@ -57,9 +60,9 @@ public class DefaultCallQueryTest {
     when(capabilityManagementSupport.getManagementProvidersByCapability("myCapabilityName")).thenReturn(managementProviders);
 
     DefaultCallQuery<String> defaultCallQuery = new DefaultCallQuery<String>(capabilityManagementSupport, "myCapabilityName", "myMethodName", String.class, parameters, contexts);
-    ResultSet executeResults = defaultCallQuery.execute();
+    ResultSet<ContextualReturn<String>> executeResults = defaultCallQuery.execute();
 
-    ContextualReturn singleResult = (ContextualReturn) executeResults.getSingleResult();
+    ContextualReturn<String> singleResult = executeResults.getSingleResult();
     try {
       singleResult.getValue();
       fail();

--- a/management/monitoring-service/src/main/java/org/terracotta/management/service/monitoring/DefaultEntityManagementRegistry.java
+++ b/management/monitoring-service/src/main/java/org/terracotta/management/service/monitoring/DefaultEntityManagementRegistry.java
@@ -145,7 +145,7 @@ class DefaultEntityManagementRegistry implements EntityManagementRegistry, Topol
     return allProviders;
   }
 
-  @SuppressWarnings("unchecked")
+  @SuppressWarnings({"unchecked", "rawtypes"})
   @Override
   public CompletableFuture<Void> register(Object managedObject) {
     LOGGER.trace("[{}] register() active={}", consumerId, monitoringService.isActiveEntityService());
@@ -162,10 +162,10 @@ class DefaultEntityManagementRegistry implements EntityManagementRegistry, Topol
     }
     return futures.isEmpty() ?
         CompletableFuture.completedFuture(null) :
-        CompletableFuture.allOf(futures.toArray(new CompletableFuture<?>[futures.size()]));
+        CompletableFuture.allOf(futures.toArray(new CompletableFuture<?>[0]));
   }
 
-  @SuppressWarnings("unchecked")
+  @SuppressWarnings({"unchecked", "rawtypes"})
   @Override
   public void unregister(Object managedObject) {
     for (ManagementProvider managementProvider : managementProviders) {
@@ -184,7 +184,7 @@ class DefaultEntityManagementRegistry implements EntityManagementRegistry, Topol
     monitoringService.exposeManagementRegistry(getContextContainer(), capabilitiesArray);
   }
 
-  @SuppressWarnings("unchecked")
+  @SuppressWarnings({"unchecked", "rawtypes"})
   @Override
   public boolean pushServerEntityNotification(Object managedObjectSource, String type, Map<String, String> attrs) {
     LOGGER.trace("[{}] pushServerEntityNotification({})", consumerId, type);

--- a/management/monitoring-service/src/main/java/org/terracotta/management/service/monitoring/DefaultManagementService.java
+++ b/management/monitoring-service/src/main/java/org/terracotta/management/service/monitoring/DefaultManagementService.java
@@ -154,7 +154,7 @@ class DefaultManagementService implements ManagementService, TopologyEventListen
         ManagementCallMessage managementCallMessage = (ManagementCallMessage) message;
         String managementCallIdentifier = managementCallMessage.getManagementCallIdentifier();
         if (isTracked(managementCallIdentifier)) {
-          ContextualCall call = managementCallMessage.unwrap(ContextualCall.class).get(0);
+          ContextualCall<?> call = managementCallMessage.unwrap(ContextualCall.class).get(0);
           if (managementExecutor != null) {
             managementExecutor.executeManagementCallOnServer(managementCallIdentifier, call);
           }

--- a/management/monitoring-service/src/test/java/org/terracotta/management/service/monitoring/ManagementRegistryServiceTest.java
+++ b/management/monitoring-service/src/test/java/org/terracotta/management/service/monitoring/ManagementRegistryServiceTest.java
@@ -49,6 +49,7 @@ import static org.terracotta.monitoring.PlatformMonitoringConstants.STATE_NODE_N
  * @author Mathieu Carbou
  */
 @RunWith(JUnit4.class)
+@SuppressWarnings({"rawtypes", "unchecked"})
 public class ManagementRegistryServiceTest {
 
   MonitoringServiceProvider provider = new MonitoringServiceProvider();

--- a/management/nms-entity/nms-entity-client/src/main/java/org/terracotta/management/entity/nms/client/DefaultNmsService.java
+++ b/management/nms-entity/nms-entity-client/src/main/java/org/terracotta/management/entity/nms/client/DefaultNmsService.java
@@ -155,6 +155,7 @@ public class DefaultNmsService implements NmsService, Closeable {
     return messages;
   }
 
+  @SuppressWarnings("unchecked")
   @Override
   public <T> ManagementCall<T> call(Context context, String capabilityName, String methodName, Class<T> returnType, Parameter... parameters) throws InterruptedException, ExecutionException, TimeoutException {
     LOGGER.trace("call({}, {}, {})", context, capabilityName, methodName);

--- a/management/testing/integration-tests/src/test/java/org/terracotta/management/integration/tests/AbstractHATest.java
+++ b/management/testing/integration-tests/src/test/java/org/terracotta/management/integration/tests/AbstractHATest.java
@@ -52,6 +52,7 @@ public abstract class AbstractHATest extends AbstractTest {
   public TestName testName = new TestName();
 
   @Before
+  @SuppressWarnings("rawtypes")
   public void setUp() throws Exception {
     System.out.println(" => [" + testName.getMethodName() + "] " + getClass().getSimpleName() + ".setUp()");
     voltron.getClusterControl().waitForActive();

--- a/management/testing/integration-tests/src/test/java/org/terracotta/management/integration/tests/AbstractTest.java
+++ b/management/testing/integration-tests/src/test/java/org/terracotta/management/integration/tests/AbstractTest.java
@@ -251,6 +251,7 @@ public abstract class AbstractTest {
     triggerServerStatComputation(nmsService, getClass().getSimpleName(), interval, unit);
   }
 
+  @SuppressWarnings("rawtypes")
   protected void triggerServerStatComputation(NmsService nmsService, String entityName, long interval, TimeUnit unit) throws Exception {
     logger.info("triggerServerStatComputation({}, {}, {})", entityName, interval, unit);
     // trigger stats computation and wait for all stats to have been computed at least once
@@ -276,6 +277,7 @@ public abstract class AbstractTest {
     triggerClientStatComputation(1, TimeUnit.SECONDS);
   }
 
+  @SuppressWarnings("rawtypes")
   protected void triggerClientStatComputation(long interval, TimeUnit unit) throws Exception {
     logger.info("triggerClientStatComputation({}, {})", interval, unit);
     // trigger stats computation and wait for all stats to have been computed at least once

--- a/management/testing/sample-entity/src/main/java/org/terracotta/management/entity/sample/server/MapConfiguration.java
+++ b/management/testing/sample-entity/src/main/java/org/terracotta/management/entity/sample/server/MapConfiguration.java
@@ -24,6 +24,7 @@ import java.util.Map;
  * @author Mathieu Carbou
  */
 @CommonComponent
+@SuppressWarnings("rawtypes")
 public class MapConfiguration implements ServiceConfiguration<Map> {
 
   private final String name;

--- a/management/testing/sample-entity/src/main/java/org/terracotta/management/entity/sample/server/MapRelease.java
+++ b/management/testing/sample-entity/src/main/java/org/terracotta/management/entity/sample/server/MapRelease.java
@@ -24,6 +24,7 @@ import java.util.Map;
  * @author Mathieu Carbou
  */
 @CommonComponent
+@SuppressWarnings("rawtypes")
 public class MapRelease implements ServiceConfiguration<Map> {
   @Override
   public Class<Map> getServiceType() {

--- a/offheap-resource/src/main/java/org/terracotta/offheapresource/PhysicalMemory.java
+++ b/offheap-resource/src/main/java/org/terracotta/offheapresource/PhysicalMemory.java
@@ -50,6 +50,7 @@ class PhysicalMemory {
     return getAttribute("getCommittedVirtualMemorySize");
   }
 
+  @SuppressWarnings("unchecked")
   private static <T> T getAttribute(String name) {
     LOGGER.trace("Bean lookup for {}", name);
     for (Class<?> s = OS_BEAN.getClass(); s != null; s = s.getSuperclass()) {

--- a/offheap-resource/src/test/java/org/terracotta/offheapresource/OffHeapConfigValidatorTest.java
+++ b/offheap-resource/src/test/java/org/terracotta/offheapresource/OffHeapConfigValidatorTest.java
@@ -39,6 +39,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
+@SuppressWarnings("unchecked")
 public class OffHeapConfigValidatorTest {
   @Test
   public void testValidateWithMismatchedOffHeapResourceSize() {

--- a/offheap-resource/src/test/java/org/terracotta/offheapresource/OffHeapResourcesProviderTest.java
+++ b/offheap-resource/src/test/java/org/terracotta/offheapresource/OffHeapResourcesProviderTest.java
@@ -52,6 +52,7 @@ public class OffHeapResourcesProviderTest {
     configuration = mock(OffheapResourcesType.class);
   }
 
+  @SuppressWarnings("unchecked")
   @Test
   public void testObserverExposed() {
     when(resourceConfig.getName()).thenReturn("foo");

--- a/pom.xml
+++ b/pom.xml
@@ -138,7 +138,12 @@
       <dependency>
         <groupId>org.glassfish.jaxb</groupId>
         <artifactId>jaxb-runtime</artifactId>
-        <version>2.3.1</version>
+        <!--
+        Do not use 2.3.1
+        Jars are not correctly built (https://github.com/mojohaus/jaxb2-maven-plugin/issues/43)
+        We never saw that because we were not using -Xlint:all -Werror
+        -->
+        <version>2.3.2</version>
       </dependency>
       <dependency>
         <groupId>org.terracotta</groupId>
@@ -158,6 +163,10 @@
           <configuration>
             <source>${java.version}</source>
             <target>${java.version}</target>
+            <compilerArgs>
+              <arg>-Xlint:all</arg>
+              <arg>-Werror</arg>
+            </compilerArgs>
           </configuration>
         </plugin>
         <plugin>

--- a/runnel/src/main/java/org/terracotta/runnel/EnumMappingBuilder.java
+++ b/runnel/src/main/java/org/terracotta/runnel/EnumMappingBuilder.java
@@ -30,6 +30,7 @@ public class EnumMappingBuilder<E> {
   private final Map<Integer, E> integerToEnum = new HashMap<Integer, E>();
   private final Class<E> enumClass;
 
+  @SuppressWarnings({"unchecked", "rawtypes"})
   private EnumMappingBuilder(Class<E> enumClass) {
     this.enumClass = enumClass;
     if (Enum.class.isAssignableFrom(enumClass)) {
@@ -43,6 +44,7 @@ public class EnumMappingBuilder<E> {
     return new EnumMappingBuilder<E>(enumClass);
   }
 
+  @SuppressWarnings({"SuspiciousMethodCalls", "unchecked", "rawtypes"})
   public EnumMapping<E> build() {
     if (Enum.class.isAssignableFrom(enumClass)) {
       HashSet<Enum> unregisteredEnums = new HashSet<Enum>(EnumSet.allOf((Class)enumClass));

--- a/runnel/src/main/java/org/terracotta/runnel/StructBuilder.java
+++ b/runnel/src/main/java/org/terracotta/runnel/StructBuilder.java
@@ -65,9 +65,9 @@ public class StructBuilder {
     return this;
   }
 
-  public StructBuilder enm(String name, int index, EnumMapping enumMapping) {
+  public <T> StructBuilder enm(String name, int index, EnumMapping<T> enumMapping) {
     checkParams(name, index);
-    structField.addField(new EnumField(name, index, enumMapping));
+    structField.addField(new EnumField<>(name, index, enumMapping));
     return this;
   }
 

--- a/runnel/src/main/java/org/terracotta/runnel/decoding/StructDecoder.java
+++ b/runnel/src/main/java/org/terracotta/runnel/decoding/StructDecoder.java
@@ -65,6 +65,7 @@ public class StructDecoder<P> implements PrimitiveDecodingSupport {
     return fieldDecoder.decodeValue(name, Int32Field.class);
   }
 
+  @SuppressWarnings("unchecked")
   @Override
   public <E> Enm<E> enm(String name) {
     Enm<E> enm = (Enm<E>) fieldDecoder.decodeValue(name, (Class) EnumField.class);

--- a/runnel/src/main/java/org/terracotta/runnel/encoding/PrimitiveEncodingSupport.java
+++ b/runnel/src/main/java/org/terracotta/runnel/encoding/PrimitiveEncodingSupport.java
@@ -21,7 +21,7 @@ import java.nio.ByteBuffer;
  * Primitive types encoder interface.
  * @param <T> The actual encoder type.
  */
-public interface PrimitiveEncodingSupport<T extends PrimitiveEncodingSupport> {
+public interface PrimitiveEncodingSupport<T extends PrimitiveEncodingSupport<T>> {
 
   /**
    * Encode a boolean.

--- a/runnel/src/main/java/org/terracotta/runnel/encoding/StructEncoder.java
+++ b/runnel/src/main/java/org/terracotta/runnel/encoding/StructEncoder.java
@@ -79,6 +79,7 @@ public class StructEncoder<P> implements PrimitiveEncodingSupport<StructEncoder<
     return this;
   }
 
+  @SuppressWarnings("unchecked")
   @Override
   public <E> StructEncoder<P> enm(String name, E value) {
     EnumField<E> field = (EnumField<E>) fieldSearcher.findField(name, EnumField.class, null);

--- a/runnel/src/main/java/org/terracotta/runnel/metadata/FieldDecoder.java
+++ b/runnel/src/main/java/org/terracotta/runnel/metadata/FieldDecoder.java
@@ -55,12 +55,13 @@ public class FieldDecoder {
     return new StructDecoder<P>(field, readBuffer, parent);
   }
 
+  @SuppressWarnings("unchecked")
   public <T, P> ArrayDecoder<T, P> decodeValueArray(String name, Class<? extends ValueField<T>> clazz, P parent) {
     ArrayField field = nextField(name, ArrayField.class, clazz);
     if (field == null) {
       return null;
     }
-    return new ArrayDecoder<T, P>((ValueField<T>) field.subField(), readBuffer, parent);
+    return new ArrayDecoder<>((ValueField<T>) field.subField(), readBuffer, parent);
   }
 
   public <T> T decodeValue(String name, Class<? extends ValueField<T>> clazz) {
@@ -71,6 +72,7 @@ public class FieldDecoder {
     return field.decode(readBuffer);
   }
 
+  @SuppressWarnings("unchecked")
   private  <T extends Field, S extends Field> T nextField(String name, Class<T> fieldClazz, Class<S> subFieldClazz) {
     Field field = findFieldWithIndex(name, fieldClazz, subFieldClazz);
     if (readBuffer.limitReached()) {

--- a/runnel/src/main/java/org/terracotta/runnel/metadata/FieldSearcher.java
+++ b/runnel/src/main/java/org/terracotta/runnel/metadata/FieldSearcher.java
@@ -31,6 +31,7 @@ public class FieldSearcher {
   }
 
   public <T extends Field, S extends Field> T findField(String name, Class<T> fieldClazz, Class<S> subFieldClazz) {
+    @SuppressWarnings("unchecked")
     T field = (T) metadata.getFieldByName(name);
     if (field == null) {
       throw new IllegalArgumentException("No such field : " + name);

--- a/runnel/src/main/java/org/terracotta/runnel/utils/CorruptDataException.java
+++ b/runnel/src/main/java/org/terracotta/runnel/utils/CorruptDataException.java
@@ -19,6 +19,8 @@ package org.terracotta.runnel.utils;
  * @author Ludovic Orban
  */
 public class CorruptDataException extends RuntimeException {
+  private static final long serialVersionUID = 1L;
+
   public CorruptDataException(String msg) {
     super(msg);
   }

--- a/runnel/src/main/java/org/terracotta/runnel/utils/LimitReachedException.java
+++ b/runnel/src/main/java/org/terracotta/runnel/utils/LimitReachedException.java
@@ -19,4 +19,5 @@ package org.terracotta.runnel.utils;
  * @author Ludovic Orban
  */
 public class LimitReachedException extends RuntimeException {
+  private static final long serialVersionUID = 1L;
 }

--- a/runnel/src/test/java/org/terracotta/runnel/ByteBufferTest.java
+++ b/runnel/src/test/java/org/terracotta/runnel/ByteBufferTest.java
@@ -26,6 +26,7 @@ import static org.hamcrest.core.Is.is;
 /**
  * @author Ludovic Orban
  */
+@SuppressWarnings("rawtypes")
 public class ByteBufferTest {
 
   @Test

--- a/runnel/src/test/java/org/terracotta/runnel/EnumMappingBuilderTest.java
+++ b/runnel/src/test/java/org/terracotta/runnel/EnumMappingBuilderTest.java
@@ -26,6 +26,7 @@ import static org.junit.Assert.fail;
 /**
  * @author Ludovic Orban
  */
+@SuppressWarnings("rawtypes")
 public class EnumMappingBuilderTest {
 
   private enum TestEnum {

--- a/runnel/src/test/java/org/terracotta/runnel/PrimitiveArrayStructBuilderTest.java
+++ b/runnel/src/test/java/org/terracotta/runnel/PrimitiveArrayStructBuilderTest.java
@@ -30,6 +30,7 @@ import static org.hamcrest.core.Is.is;
 /**
  * @author Ludovic Orban
  */
+@SuppressWarnings("rawtypes")
 public class PrimitiveArrayStructBuilderTest {
 
   private final Struct struct = StructBuilder.newStructBuilder()

--- a/runnel/src/test/java/org/terracotta/runnel/PrimitiveStructBuilderTest.java
+++ b/runnel/src/test/java/org/terracotta/runnel/PrimitiveStructBuilderTest.java
@@ -30,6 +30,7 @@ import static org.junit.Assert.fail;
 /**
  * @author Ludovic Orban
  */
+@SuppressWarnings("rawtypes")
 public class PrimitiveStructBuilderTest {
 
   private final Struct struct = StructBuilder.newStructBuilder()

--- a/runnel/src/test/java/org/terracotta/runnel/StringTest.java
+++ b/runnel/src/test/java/org/terracotta/runnel/StringTest.java
@@ -30,6 +30,7 @@ import static org.junit.Assert.fail;
 /**
  * @author Ludovic Orban
  */
+@SuppressWarnings("rawtypes")
 public class StringTest {
 
   @Test

--- a/runnel/src/test/java/org/terracotta/runnel/StructArrayStructBuilderTest.java
+++ b/runnel/src/test/java/org/terracotta/runnel/StructArrayStructBuilderTest.java
@@ -38,6 +38,7 @@ import static org.junit.Assert.fail;
 /**
  * @author Ludovic Orban
  */
+@SuppressWarnings({"unchecked", "rawtypes"})
 public class StructArrayStructBuilderTest {
 
   enum Type {

--- a/runnel/src/test/java/org/terracotta/runnel/StructStructBuilderTest.java
+++ b/runnel/src/test/java/org/terracotta/runnel/StructStructBuilderTest.java
@@ -31,6 +31,7 @@ import static org.hamcrest.core.Is.is;
 /**
  * @author Ludovic Orban
  */
+@SuppressWarnings("rawtypes")
 public class StructStructBuilderTest {
 
   private final Struct mapEntry = StructBuilder.newStructBuilder()

--- a/runnel/src/test/java/org/terracotta/runnel/VersionCompatibilityTest.java
+++ b/runnel/src/test/java/org/terracotta/runnel/VersionCompatibilityTest.java
@@ -32,6 +32,7 @@ import static org.junit.Assert.fail;
 /**
  * @author Ludovic Orban
  */
+@SuppressWarnings({"rawtypes", "unchecked"})
 public class VersionCompatibilityTest {
 
   private enum TestEnum_v1 {

--- a/runnel/src/test/java/org/terracotta/runnel/docs/GettingStarted.java
+++ b/runnel/src/test/java/org/terracotta/runnel/docs/GettingStarted.java
@@ -25,6 +25,7 @@ import java.nio.ByteBuffer;
 /**
  * @author Ludovic Orban
  */
+@SuppressWarnings("rawtypes")
 public class GettingStarted {
 
   @Test

--- a/runnel/src/test/java/org/terracotta/runnel/encoding/dataholders/EnumMappingTest.java
+++ b/runnel/src/test/java/org/terracotta/runnel/encoding/dataholders/EnumMappingTest.java
@@ -29,6 +29,7 @@ import static org.hamcrest.core.Is.is;
 /**
  * @author Ludovic Orban
  */
+@SuppressWarnings("rawtypes")
 public class EnumMappingTest {
 
   private enum TestEnum {

--- a/tc-config-generator/src/main/java/org/terracotta/config/generator/GenerateFromEnvironmentVariables.java
+++ b/tc-config-generator/src/main/java/org/terracotta/config/generator/GenerateFromEnvironmentVariables.java
@@ -98,6 +98,7 @@ public class GenerateFromEnvironmentVariables {
     template.process(root, output);
   }
 
+  @SuppressWarnings({"rawtypes", "unchecked"})
   Map<String, Object> retrieveNamesWithPrefix(Map<String, String> envMap, String envVariablePrefix) {
     // make sure keys are sorted
     Map<String, String> sortedMap = new TreeMap(envMap);

--- a/tc-config-generator/src/test/java/org/terracotta/config/generator/GenerateFromEnvironmentVariablesTest.java
+++ b/tc-config-generator/src/test/java/org/terracotta/config/generator/GenerateFromEnvironmentVariablesTest.java
@@ -36,6 +36,7 @@ import java.util.TreeMap;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;
 
+@SuppressWarnings({"serial", "unchecked", "rawtypes"})
 public class GenerateFromEnvironmentVariablesTest {
 
   private static Configuration createTemplateConfiguration() throws IOException {

--- a/voltron-proxy/voltron-proxy-client/src/main/java/org/terracotta/voltron/proxy/client/ClientProxyFactory.java
+++ b/voltron-proxy/voltron-proxy-client/src/main/java/org/terracotta/voltron/proxy/client/ClientProxyFactory.java
@@ -51,11 +51,11 @@ public class ClientProxyFactory {
       throw new IllegalArgumentException("We only proxy interfaces!");
     }
 
-    final Class[] interfaces;
+    final Class<?>[] interfaces;
     if (messageTypes == null || messageTypes.length == 0) {
-      interfaces = new Class[]{clientType, Entity.class};
+      interfaces = new Class<?>[]{clientType, Entity.class};
     } else {
-      interfaces = new Class[]{clientType, Entity.class, ServerMessageAware.class};
+      interfaces = new Class<?>[]{clientType, Entity.class, ServerMessageAware.class};
     }
     return clientType.cast(Proxy.newProxyInstance(
         Entity.class.getClassLoader(),

--- a/voltron-proxy/voltron-proxy-client/src/test/java/org/terracotta/voltron/proxy/client/ClientProxyFactoryTest.java
+++ b/voltron-proxy/voltron-proxy-client/src/test/java/org/terracotta/voltron/proxy/client/ClientProxyFactoryTest.java
@@ -16,7 +16,7 @@
 package org.terracotta.voltron.proxy.client;
 
 import org.junit.Test;
-import org.mockito.Matchers;
+import org.mockito.ArgumentMatchers;
 import org.terracotta.connection.entity.Entity;
 import org.terracotta.entity.EntityClientEndpoint;
 import org.terracotta.entity.EntityMessage;
@@ -46,6 +46,7 @@ import static org.terracotta.voltron.proxy.ProxyEntityResponse.messageResponse;
 /**
  * @author Alex Snaps
  */
+@SuppressWarnings({"rawtypes", "unchecked"})
 public class ClientProxyFactoryTest {
 
   @Test
@@ -64,10 +65,10 @@ public class ClientProxyFactoryTest {
     final EntityClientEndpoint endpoint = mock(EntityClientEndpoint.class);
     final InvocationBuilder builder = mock(InvocationBuilder.class);
     when(endpoint.beginInvoke()).thenReturn(builder);
-    when(builder.message(Matchers.<EntityMessage>any())).thenReturn(builder);
+    when(builder.message(ArgumentMatchers.<EntityMessage>any())).thenReturn(builder);
     final InvokeFuture future = mock(InvokeFuture.class);
     when(builder.invoke()).thenReturn(future);
-    when(builder.withExecutor(Matchers.<Executor>any())).thenReturn(builder);
+    when(builder.withExecutor(ArgumentMatchers.<Executor>any())).thenReturn(builder);
     when(future.get()).thenReturn(messageResponse(Integer.class, 42));
 
     final PassThrough proxy = ClientProxyFactory.createProxy(PassThrough.class, PassThrough.class, endpoint, null, codec);
@@ -86,8 +87,8 @@ public class ClientProxyFactoryTest {
     final EntityClientEndpoint endpoint = mock(EntityClientEndpoint.class);
     final InvocationBuilder builder = mock(InvocationBuilder.class);
     when(endpoint.beginInvoke()).thenReturn(builder);
-    when(builder.message(Matchers.<EntityMessage>any())).thenReturn(builder);
-    when(builder.withExecutor(Matchers.<Executor>any())).thenReturn(builder);
+    when(builder.message(ArgumentMatchers.<EntityMessage>any())).thenReturn(builder);
+    when(builder.withExecutor(ArgumentMatchers.<Executor>any())).thenReturn(builder);
     final InvokeFuture future = mock(InvokeFuture.class);
     when(builder.invoke()).thenReturn(future);
     when(future.get()).thenReturn(messageResponse(Integer.class, 42));
@@ -111,8 +112,8 @@ public class ClientProxyFactoryTest {
     final EntityClientEndpoint endpoint = mock(EntityClientEndpoint.class);
     final InvocationBuilder builder = mock(InvocationBuilder.class);
     when(endpoint.beginInvoke()).thenReturn(builder);
-    when(builder.message(Matchers.<EntityMessage>any())).thenReturn(builder);
-    when(builder.withExecutor(Matchers.<Executor>any())).thenReturn(builder);
+    when(builder.message(ArgumentMatchers.<EntityMessage>any())).thenReturn(builder);
+    when(builder.withExecutor(ArgumentMatchers.<Executor>any())).thenReturn(builder);
     final InvokeFuture future = mock(InvokeFuture.class);
     when(builder.invoke()).thenReturn(future);
     when(future.get()).thenReturn(messageResponse(Integer.class, 42));

--- a/voltron-proxy/voltron-proxy-client/src/test/java/org/terracotta/voltron/proxy/client/VoltronProxyInvocationHandlerTest.java
+++ b/voltron-proxy/voltron-proxy-client/src/test/java/org/terracotta/voltron/proxy/client/VoltronProxyInvocationHandlerTest.java
@@ -42,8 +42,10 @@ import static org.terracotta.voltron.proxy.CommonProxyFactory.invert;
 /**
  * @author Alex Snaps
  */
+@SuppressWarnings("rawtypes")
 public class VoltronProxyInvocationHandlerTest {
 
+  @SuppressWarnings("unchecked")
   @Test
   public void testNullsClientIdAnnotatedParams() throws Throwable {
 

--- a/voltron-proxy/voltron-proxy-common/src/main/java/org/terracotta/voltron/proxy/ProxyMessageCodec.java
+++ b/voltron-proxy/voltron-proxy-common/src/main/java/org/terracotta/voltron/proxy/ProxyMessageCodec.java
@@ -38,7 +38,7 @@ public class ProxyMessageCodec implements MessageCodec<ProxyEntityMessage, Proxy
   private Codec codec = new SerializationCodec();
 
   public ProxyMessageCodec(Class<?> proxyType) {
-    this(proxyType, new Class[0], null, null);
+    this(proxyType, new Class<?>[0], null, null);
   }
 
   public ProxyMessageCodec(Class<?> proxyType, Class<?>[] eventTypes) {

--- a/voltron-proxy/voltron-proxy-common/src/test/java/org/terracotta/AvailableClass.java
+++ b/voltron-proxy/voltron-proxy-common/src/test/java/org/terracotta/AvailableClass.java
@@ -18,6 +18,7 @@ package org.terracotta;
 import java.io.Serializable;
 
 public class AvailableClass implements Serializable {
+  private static final long serialVersionUID = 1L;
 
   public String string;
 

--- a/voltron-proxy/voltron-proxy-common/src/test/java/org/terracotta/voltron/proxy/CommonProxyFactoryTest.java
+++ b/voltron-proxy/voltron-proxy-common/src/test/java/org/terracotta/voltron/proxy/CommonProxyFactoryTest.java
@@ -54,6 +54,7 @@ public class CommonProxyFactoryTest {
     }
   }
 
+  @SuppressWarnings("rawtypes")
   interface AsyncEntity<V> {
     @Async Future<String> test1();
     @Async Future<Collection<String>> test2();
@@ -69,6 +70,7 @@ public class CommonProxyFactoryTest {
     @Async Future test12();
   }
 
+  @SuppressWarnings("rawtypes")
   interface NonAsyncEntity<V> {
     Future<String> test1();
     Future<Collection<String>> test2();

--- a/voltron-proxy/voltron-proxy-common/src/test/java/org/terracotta/voltron/proxy/SerializationCodecTest.java
+++ b/voltron-proxy/voltron-proxy-common/src/test/java/org/terracotta/voltron/proxy/SerializationCodecTest.java
@@ -34,6 +34,7 @@ import static org.junit.Assert.fail;
 
 public class SerializationCodecTest {
 
+  @SuppressWarnings("unchecked")
   @Test
   public void testUnmatchedShadedSubstitution() {
     SerializationCodec codec = new SerializationCodec(Pattern.compile("blah"));

--- a/voltron-proxy/voltron-proxy-common/src/test/java/org/terracotta/voltron/proxy/shaded/org/terracotta/AvailableShadedClass.java
+++ b/voltron-proxy/voltron-proxy-common/src/test/java/org/terracotta/voltron/proxy/shaded/org/terracotta/AvailableShadedClass.java
@@ -18,6 +18,7 @@ package org.terracotta.voltron.proxy.shaded.org.terracotta;
 import java.io.Serializable;
 
 public class AvailableShadedClass implements Serializable {
+  private static final long serialVersionUID = 1L;
 
   public String string;
 

--- a/voltron-proxy/voltron-proxy-server/src/main/java/org/terracotta/voltron/proxy/server/ActiveProxiedServerEntity.java
+++ b/voltron-proxy/voltron-proxy-server/src/main/java/org/terracotta/voltron/proxy/server/ActiveProxiedServerEntity.java
@@ -40,7 +40,7 @@ public abstract class ActiveProxiedServerEntity<S, R, M extends Messenger> imple
   private Class<R> reconnectDataType;
 
   @Override
-  public ProxyEntityResponse invokeActive(ActiveInvokeContext context, ProxyEntityMessage message) throws EntityUserException {
+  public ProxyEntityResponse invokeActive(ActiveInvokeContext<ProxyEntityResponse> context, ProxyEntityMessage message) throws EntityUserException {
     switch (message.getType()) {
       case MESSAGE:
       case MESSENGER:

--- a/voltron-proxy/voltron-proxy-server/src/main/java/org/terracotta/voltron/proxy/server/ProxyInvoker.java
+++ b/voltron-proxy/voltron-proxy-server/src/main/java/org/terracotta/voltron/proxy/server/ProxyInvoker.java
@@ -38,7 +38,7 @@ import java.util.Set;
 class ProxyInvoker<T> implements MessageFiring {
 
   private final T target;
-  private final Set<ClientDescriptor> clients = Collections.synchronizedSet(new HashSet<ClientDescriptor>());
+  private final Set<ClientDescriptor> clients = Collections.synchronizedSet(new HashSet<>());
   private final ThreadLocal<InvocationContext> invocationContext = new ThreadLocal<>();
 
   private Set<Class<?>> messageTypes;
@@ -48,7 +48,7 @@ class ProxyInvoker<T> implements MessageFiring {
     this.target = target;
   }
 
-  ProxyEntityResponse invoke(ActiveInvokeContext context, final ProxyEntityMessage message) {
+  ProxyEntityResponse invoke(ActiveInvokeContext<ProxyEntityResponse> context, final ProxyEntityMessage message) {
     ClientDescriptor clientDescriptor = context.getClientDescriptor();
     try {
       invocationContext.set(new InvocationContext(clientDescriptor));
@@ -139,17 +139,14 @@ class ProxyInvoker<T> implements MessageFiring {
 
   ProxyInvoker<T> activateEvents(ClientCommunicator clientCommunicator, Class<?>[] messageTypes) {
     if (messageTypes == null) {
-      messageTypes = new Class[0];
+      messageTypes = new Class<?>[0];
     }
     this.messageTypes = new HashSet<>(Arrays.asList(messageTypes));
     if (target instanceof MessageFiringSupport) {
       ((MessageFiringSupport) target).setMessageFiring(this);
     }
 
-    for (Class eventType : messageTypes) {
-      this.messageTypes.add(eventType);
-
-    }
+    this.messageTypes.addAll(Arrays.asList(messageTypes));
     if (messageTypes.length != 0 && clientCommunicator == null) {
       throw new IllegalArgumentException("Messages cannot be sent using a null ClientCommunicator");
     } else {

--- a/voltron-proxy/voltron-proxy-server/src/main/java/org/terracotta/voltron/proxy/server/ProxyServerEntityService.java
+++ b/voltron-proxy/voltron-proxy-server/src/main/java/org/terracotta/voltron/proxy/server/ProxyServerEntityService.java
@@ -95,6 +95,7 @@ public abstract class ProxyServerEntityService<C, S, R, M extends Messenger> imp
     return syncMessageCodec;
   }
 
+  @SuppressWarnings("unchecked")
   @Override
   public final ActiveProxiedServerEntity<S, R, M> createActiveEntity(ServiceRegistry registry, byte[] configuration) throws ConfigurationException {
     C config = decodeConfig(configuration);
@@ -120,7 +121,7 @@ public abstract class ProxyServerEntityService<C, S, R, M extends Messenger> imp
 
     if (messengerType != null) {
       try {
-        IEntityMessenger<ProxyEntityMessage, ?> entityMessenger = Objects.requireNonNull(registry.getService(new BasicServiceConfiguration<>(IEntityMessenger.class)));
+        IEntityMessenger<ProxyEntityMessage, ?> entityMessenger = Objects.requireNonNull((IEntityMessenger<ProxyEntityMessage, ?>) registry.getService(new BasicServiceConfiguration<>(IEntityMessenger.class)));
         activeEntity.setMessenger(MessengerProxyFactory.createProxy(messengerType, entityMessenger));
       } catch (ServiceException e) {
         throw new ConfigurationException("Unable to retrieve IEntityMessenger: " + e.getMessage());

--- a/voltron-proxy/voltron-proxy-server/src/test/java/org/terracotta/voltron/proxy/server/EndToEndTest.java
+++ b/voltron-proxy/voltron-proxy-server/src/test/java/org/terracotta/voltron/proxy/server/EndToEndTest.java
@@ -65,8 +65,10 @@ import org.terracotta.entity.InvokeMonitor;
 /**
  * @author Alex Snaps
  */
+@SuppressWarnings({"rawtypes", "unchecked"})
 public class EndToEndTest {
 
+  @SuppressWarnings("rawtypes")
   @Test
   public void testBothEnds() throws ExecutionException, InterruptedException {
     final SerializationCodec codec = new SerializationCodec();
@@ -229,6 +231,7 @@ public class EndToEndTest {
     assertThat(proxy.much(12, 12), notNullValue());
   }
 
+  @SuppressWarnings({"unchecked", "rawtypes"})
   private static class RecordingInvocationBuilder implements InvocationBuilder<ProxyEntityMessage, ProxyEntityResponse> {
     private final MessageCodec<ProxyEntityMessage, ProxyEntityResponse> codec;
     private final ProxyInvoker<?> proxyInvoker;
@@ -276,6 +279,7 @@ public class EndToEndTest {
     }
 
     @Override
+    @Deprecated
     public InvocationBuilder<ProxyEntityMessage, ProxyEntityResponse> asDeferredResponse() {
       return this;
     }


### PR DESCRIPTION
@saurabhagas @chrisdennis @cschanck  : the reason I would like it merge is because the dynamic config code is clean relative to `-Xlint:all -Werror`. And the sad story is that the tc-platform code does not enforce and and the project has a lot of warnings....

I would like that we can at least continue working cleanly in dynamic config, so that implied being  able to easily spot the mistakes or warnings from our IDE at least.

Right now, there are too many, so if we introduce some more, it is hard to see.

I would like to enforce that with Maven if we all agree on that.