### PR TITLE
Fixing PhysicalMemory logging and access

### DIFF
--- a/offheap-resource/src/test/java/org/terracotta/offheapresource/PhysicalMemoryTest.java
+++ b/offheap-resource/src/test/java/org/terracotta/offheapresource/PhysicalMemoryTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.terracotta.offheapresource;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * @author Mathieu Carbou
+ */
+public class PhysicalMemoryTest {
+  @Test
+  public void invocations_do_not_fail() {
+    assertNotNull(PhysicalMemory.totalPhysicalMemory());
+    assertNotNull(PhysicalMemory.freePhysicalMemory());
+    assertNotNull(PhysicalMemory.totalSwapSpace());
+    assertNotNull(PhysicalMemory.freeSwapSpace());
+    assertNotNull(PhysicalMemory.ourCommittedVirtualMemory());
+  }
+}


### PR DESCRIPTION
See the email thread sent to you guys.

Basically, the methods of this class are called a lot now, and it can happen that the methods are not accessible, or do a lot of things and lot of logging each time.

Example with:

```
openjdk version "1.8.0_242"
OpenJDK Runtime Environment (AdoptOpenJDK)(build 1.8.0_242-b08)
OpenJDK 64-Bit Server VM (AdoptOpenJDK)(build 25.242-b08, mixed mode)
```

We can have in TRACE mode more than 1300 lines of repeating exceptions like that:

```
2020-02-28 22:56:18,493 [main] TRACE org.terracotta.offheapresource.PhysicalMemory - Bean lookup failed on class java.lang.Object
java.lang.NoSuchMethodException: java.lang.Object.getTotalPhysicalMemorySize()
 at java.lang.Class.getMethod(Class.java:1786)
 at org.terracotta.offheapresource.PhysicalMemory.getAttribute(PhysicalMemory.java:57)
 at org.terracotta.offheapresource.PhysicalMemory.totalPhysicalMemory(PhysicalMemory.java:34)
 at org.terracotta.offheapresource.OffHeapResourcesProvider.warnIfOffheapExceedsPhysicalMemory(OffHeapResourcesProvider.java:206)
 at org.terracotta.offheapresource.OffHeapResourcesProvider.updateConfiguredOffheap(OffHeapResourcesProvider.java:197)
 at org.terracotta.offheapresource.OffHeapResourcesProvider.lambda$addToResources$3(OffHeapResourcesProvider.java:189)
 at java.util.concurrent.ConcurrentHashMap.computeIfAbsent(ConcurrentHashMap.java:1660)
 at org.terracotta.offheapresource.OffHeapResourcesProvider.addToResources(OffHeapResourcesProvider.java:152)
 at org.terracotta.offheapresource.OffHeapResourcesProvider.<init>(OffHeapResourcesProvider.java:63)
 at org.terracotta.offheapresource.OffHeapResourceConfigurationParser.parse(OffHeapResourceConfigurationParser.java:58)
 at org.terracotta.offheapresource.OffHeapResourceConfigurationParser.parse(OffHeapResourceConfigurationParser.java:41)
 at org.terracotta.config.TCConfigurationParser.parseStream(TCConfigurationParser.java:152)
 at org.terracotta.config.TCConfigurationParser.convert(TCConfigurationParser.java:245)
 at org.terracotta.config.TCConfigurationParser.parse(TCConfigurationParser.java:263)
 at org.terracotta.config.TCConfigurationParser.parse(TCConfigurationParser.java:259)
 at org.terracotta.dynamic_config.server.config_provider.DynamicConfigConfigurationProvider.createdTcConfiguration(DynamicConfigConfigurationProvider.java:182)
 at org.terracotta.dynamic_config.server.config_provider.DynamicConfigConfigurationProvider.initialize(DynamicConfigConfigurationProvider.java:98)
 at org.terracotta.dynamic_config.server.config_provider.SelectableConfigurationProvider.initialize(SelectableConfigurationProvider.java:26)
 at com.tc.server.TCServerMain.main(TCServerMain.java:65)
 at org.terracotta.dynamic_config.server.startup.StartupManager.startServer(StartupManager.java:181)
 at org.terracotta.dynamic_config.server.startup.StartupManager.startUsingConfigRepo(StartupManager.java:104)
 at org.terracotta.dynamic_config.server.startup.ConfigRepoStarter.startNode(ConfigRepoStarter.java:34)
 at org.terracotta.dynamic_config.server.startup.NodeProcessor.process(NodeProcessor.java:36)
 at org.terracotta.dynamic_config.server.startup.Options.process(Options.java:163)
 at org.terracotta.dynamic_config.server.TerracottaNode.main(TerracottaNode.java:20)
```

Also, with OpenJDK, the methods, even if being public and found, are not accessible if we do not use `method.setAccessible(true);`

So:
- I have reduced the logging
- I am finding the method another way and making it accessible (because on OpenJDK 8, it is not accessible)
- caching it so that the lookup is not done at each call
- and I do not log but throw in case of invocation error