### PR TITLE
New kit with new core versions (plugins/api vs plugins/lib)

### DIFF
--- a/dynamic-config/server/configuration-provider/pom.xml
+++ b/dynamic-config/server/configuration-provider/pom.xml
@@ -29,12 +29,6 @@
   <artifactId>dynamic-config-configuration-provider</artifactId>
   <name>Dynamic Config :: Server :: Configuration Provider</name>
 
-  <properties>
-    <terracotta-configuration.version>10.7.0-pre2</terracotta-configuration.version>
-    <passthrough-testing.version>1.7.0-pre8</passthrough-testing.version>
-    <terracotta-core.version>5.7.0-pre18</terracotta-core.version>
-  </properties>
-
   <dependencies>
     <dependency>
       <groupId>org.terracotta.dynamic-config.server</groupId>

--- a/dynamic-config/testing/pom.xml
+++ b/dynamic-config/testing/pom.xml
@@ -34,7 +34,7 @@
   <modules>
     <module>support</module>
     <module>entity</module>
-<!--    <module>system-tests</module>-->
+    <module>system-tests</module>
   </modules>
 
 </project>

--- a/kit/pom.xml
+++ b/kit/pom.xml
@@ -1,0 +1,456 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright Terracotta, Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.terracotta</groupId>
+    <artifactId>platform-root</artifactId>
+    <version>5.7-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>platform-kit</artifactId>
+  <name>KIT :: Platform</name>
+  <packaging>jar</packaging>
+
+  <dependencies>
+
+    <!--
+      server/plugins/api
+    -->
+
+    <dependency>
+      <groupId>org.terracotta</groupId>
+      <artifactId>statistics</artifactId>
+      <version>${statistics.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.terracotta.management</groupId>
+      <artifactId>monitoring-service-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.terracotta.dynamic-config</groupId>
+      <artifactId>dynamic-config-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.terracotta.dynamic-config.server</groupId>
+      <artifactId>dynamic-config-server-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.terracotta.diagnostic</groupId>
+      <artifactId>diagnostic-service-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <!--
+      server/plugins/lib
+    -->
+
+    <dependency>
+      <groupId>org.terracotta</groupId>
+      <artifactId>data-root-resource</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.terracotta</groupId>
+      <artifactId>offheap-resource</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.terracotta</groupId>
+      <artifactId>lease-entity-server</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <!-- management -->
+    <dependency>
+      <groupId>org.terracotta.management</groupId>
+      <artifactId>monitoring-service</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.terracotta.management</groupId>
+      <artifactId>nms-agent-entity-server</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.terracotta.management</groupId>
+      <artifactId>nms-entity-server</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <!-- dynamic config -->
+    <dependency>
+      <groupId>org.terracotta.dynamic-config.server</groupId>
+      <artifactId>dynamic-config-configuration-provider</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.terracotta.dynamic-config.server</groupId>
+      <artifactId>dynamic-config-services</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.terracotta.dynamic-config.entities</groupId>
+      <artifactId>dynamic-config-management-entity-server</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.terracotta.dynamic-config.entities</groupId>
+      <artifactId>dynamic-config-topology-entity-server</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.terracotta.dynamic-config.entities</groupId>
+      <artifactId>dynamic-config-nomad-entity-server</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <!--
+      tools/config-tool/lib
+    -->
+
+    <dependency>
+      <groupId>org.terracotta.dynamic-config.cli</groupId>
+      <artifactId>dynamic-config-cli-config-tool</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <!--
+      tools/config-convertor/lib
+    -->
+
+    <dependency>
+      <groupId>org.terracotta.dynamic-config.cli</groupId>
+      <artifactId>dynamic-config-cli-config-convertor</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.terracotta.dynamic-config.cli</groupId>
+      <artifactId>config-convertor-oss</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <!--
+      KIT
+    -->
+
+    <dependency>
+      <groupId>org.terracotta.internal</groupId>
+      <artifactId>terracotta-kit</artifactId>
+      <version>${terracotta-core.version}</version>
+      <type>tar.gz</type>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>default-jar</id>
+            <phase>none</phase>
+          </execution>
+        </executions>
+      </plugin>
+      <!-- open the KIT -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>unpack-kit</id>
+            <phase>prepare-package</phase>
+            <goals>
+              <goal>unpack</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${project.build.directory}/terracotta-kit-${terracotta-core.version}</outputDirectory>
+              <artifactItems>
+                <artifactItem>
+                  <groupId>org.terracotta.internal</groupId>
+                  <artifactId>terracotta-kit</artifactId>
+                  <version>${terracotta-core.version}</version>
+                  <type>tar.gz</type>
+                </artifactItem>
+              </artifactItems>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <!-- generate plugins -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <configuration>
+          <shadedArtifactAttached>false</shadedArtifactAttached>
+          <createDependencyReducedPom>false</createDependencyReducedPom>
+          <createSourcesJar>false</createSourcesJar>
+          <transformers>
+            <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+          </transformers>
+          <artifactSet>
+            <excludes>
+              <exclude>org.terracotta:platform-kit</exclude>
+            </excludes>
+          </artifactSet>
+        </configuration>
+        <executions>
+          <!-- api -->
+          <execution>
+            <id>terracotta-api-management</id>
+            <phase>prepare-package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${project.build.directory}/packages/server/plugins/api</outputDirectory>
+              <finalName>terracotta-api-management-${project.version}</finalName>
+              <artifactSet>
+                <includes>
+                  <include>org.terracotta.management:monitoring-service-api</include>
+                  <include>org.terracotta.management:cluster-topology</include>
+                  <include>org.terracotta.management:management-model</include>
+                  <include>org.terracotta.management:management-registry</include>
+                  <include>org.terracotta.management:sequence-generator</include>
+                </includes>
+              </artifactSet>
+            </configuration>
+          </execution>
+          <execution>
+            <id>terracotta-api-diagnostic</id>
+            <phase>prepare-package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${project.build.directory}/packages/server/plugins/api</outputDirectory>
+              <finalName>terracotta-api-diagnostic-${project.version}</finalName>
+              <artifactSet>
+                <includes>
+                  <include>org.terracotta.diagnostic:diagnostic-service-api</include>
+                </includes>
+              </artifactSet>
+            </configuration>
+          </execution>
+          <execution>
+            <id>terracotta-api-dynamic-config</id>
+            <phase>prepare-package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${project.build.directory}/packages/server/plugins/api</outputDirectory>
+              <finalName>terracotta-api-dynamic-config-${project.version}</finalName>
+              <artifactSet>
+                <includes>
+                  <include>org.terracotta.dynamic-config:dynamic-config-api</include>
+                  <include>org.terracotta.dynamic-config.server:dynamic-config-server-api</include>
+                  <include>org.terracotta.common:common-inet-support</include>
+                  <include>org.terracotta.common:common-nomad</include>
+                  <include>org.terracotta.common:common-structures</include>
+                </includes>
+              </artifactSet>
+            </configuration>
+          </execution>
+          <!-- lib -->
+          <execution>
+            <id>terracotta-plugin-offheap</id>
+            <phase>prepare-package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${project.build.directory}/packages/server/plugins/lib</outputDirectory>
+              <finalName>terracotta-plugin-offheap-${project.version}</finalName>
+              <artifactSet>
+                <includes>
+                  <include>org.terracotta:offheap-resource</include>
+                </includes>
+              </artifactSet>
+            </configuration>
+          </execution>
+          <execution>
+            <id>terracotta-plugin-data-roots</id>
+            <phase>prepare-package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${project.build.directory}/packages/server/plugins/lib</outputDirectory>
+              <finalName>terracotta-plugin-data-roots-${project.version}</finalName>
+              <artifactSet>
+                <includes>
+                  <include>org.terracotta:data-root-resource</include>
+                </includes>
+              </artifactSet>
+            </configuration>
+          </execution>
+          <execution>
+            <id>terracotta-plugin-lease</id>
+            <phase>prepare-package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${project.build.directory}/packages/server/plugins/lib</outputDirectory>
+              <finalName>terracotta-plugin-lease-${project.version}</finalName>
+              <artifactSet>
+                <includes>
+                  <include>org.terracotta:lease-entity-server</include>
+                  <include>org.terracotta:lease-entity-common</include>
+                  <include>org.terracotta:lease-common</include>
+                  <include>org.terracotta:runnel</include>
+                </includes>
+              </artifactSet>
+            </configuration>
+          </execution>
+          <execution>
+            <id>terracotta-plugin-management</id>
+            <phase>prepare-package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${project.build.directory}/packages/server/plugins/lib</outputDirectory>
+              <finalName>terracotta-plugin-management-${project.version}</finalName>
+              <artifactSet>
+                <includes>
+                  <include>org.terracotta.management:monitoring-service</include>
+                  <include>org.terracotta.management:nms-agent-entity-common</include>
+                  <include>org.terracotta.management:nms-agent-entity-server</include>
+                  <include>org.terracotta.management:nms-entity-common</include>
+                  <include>org.terracotta.management:nms-entity-server</include>
+                  <include>org.terracotta.voltron.proxy:voltron-proxy-common</include>
+                  <include>org.terracotta.voltron.proxy:voltron-proxy-server</include>
+                </includes>
+              </artifactSet>
+            </configuration>
+          </execution>
+          <execution>
+            <id>terracotta-plugin-dynamic-config</id>
+            <phase>prepare-package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${project.build.directory}/packages/server/plugins/lib</outputDirectory>
+              <finalName>terracotta-plugin-dynamic-config-${project.version}</finalName>
+              <artifactSet>
+                <includes>
+                  <include>org.terracotta.dynamic-config.server:dynamic-config-configuration-provider</include>
+                  <include>org.terracotta.dynamic-config.server:dynamic-config-configuration-repository</include>
+                  <include>org.terracotta.dynamic-config.server:dynamic-config-services</include>
+                  <include>org.terracotta.dynamic-config.entities:dynamic-config-management-entity-server</include>
+                  <include>org.terracotta.dynamic-config.entities:dynamic-config-nomad-entity-common</include>
+                  <include>org.terracotta.dynamic-config.entities:dynamic-config-nomad-entity-server</include>
+                  <include>org.terracotta.dynamic-config.entities:dynamic-config-topology-entity-common</include>
+                  <include>org.terracotta.dynamic-config.entities:dynamic-config-topology-entity-server</include>
+                  <include>org.terracotta.diagnostic:diagnostic-service</include>
+                  <include>org.terracotta.diagnostic:diagnostic-common</include>
+                  <include>org.terracotta.common:common-json-support</include>
+                  <include>org.terracotta.common:common-sanskrit</include>
+                </includes>
+              </artifactSet>
+            </configuration>
+          </execution>
+          <execution>
+            <id>config-convertor</id>
+            <phase>prepare-package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${project.build.directory}/packages/tools/config-convertor/lib</outputDirectory>
+              <finalName>config-convertor-${project.version}</finalName>
+              <artifactSet>
+                <includes>
+                  <include>org.terracotta.dynamic-config.cli:dynamic-config-cli-config-convertor</include>
+                  <include>org.terracotta.dynamic-config.cli:dynamic-config-cli-support</include>
+                  <include>org.terracotta.internal:tc-config-parser</include>
+                  <include>org.terracotta:tcconfig-schema</include>
+                </includes>
+              </artifactSet>
+            </configuration>
+          </execution>
+
+          <execution>
+            <id>config-tool</id>
+            <phase>prepare-package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${project.build.directory}/packages/tools/config-tool/lib</outputDirectory>
+              <finalName>config-tool-${project.version}</finalName>
+              <artifactSet>
+                <includes>
+                  <include>org.terracotta.dynamic-config.cli:dynamic-config-cli-config-tool</include>
+                  <include>org.terracotta.dynamic-config.cli:dynamic-config-cli-support</include>
+                  <include>org.terracotta.dynamic-config:dynamic-config-api</include>
+                  <include>org.terracotta.dynamic-config.entities:dynamic-config-nomad-entity-common</include>
+                  <include>org.terracotta.dynamic-config.entities:dynamic-config-nomad-entity-client</include>
+                  <include>org.terracotta.diagnostic:diagnostic-client</include>
+                  <include>org.terracotta.diagnostic:diagnostic-common</include>
+                  <include>org.terracotta.common:common-inet-support</include>
+                  <include>org.terracotta.common:common-json-support</include>
+                  <include>org.terracotta.common:common-nomad</include>
+                  <include>org.terracotta.common:common-structures</include>
+                </includes>
+              </artifactSet>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+      <!-- apply the platform Kit layout -->
+      <plugin>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <configuration>
+          <appendAssemblyId>false</appendAssemblyId>
+          <tarLongFileMode>posix</tarLongFileMode>
+          <attach>true</attach>
+          <descriptors>
+            <descriptor>src/main/assembly/platform-kit.xml</descriptor>
+          </descriptors>
+        </configuration>
+        <executions>
+          <execution>
+            <id>platform-kit</id>
+            <phase>package</phase>
+            <goals>
+              <goal>single</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/kit/src/main/assembly/platform-kit.xml
+++ b/kit/src/main/assembly/platform-kit.xml
@@ -1,0 +1,131 @@
+<!--
+
+    Copyright Terracotta, Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd">
+
+  <id>platform-kit</id>
+
+  <formats>
+    <format>dir</format>
+    <format>zip</format>
+    <format>tar.gz</format>
+  </formats>
+
+  <fileSets>
+    <fileSet>
+      <outputDirectory>.</outputDirectory>
+      <directory>${project.build.directory}/terracotta-kit-${terracotta-core.version}/terracotta-${terracotta-core.version}</directory>
+      <excludes>
+        <exclude>server/conf/**</exclude>
+        <exclude>server/plugins/lib/default-configuration-*.jar</exclude>
+      </excludes>
+    </fileSet>
+    <fileSet>
+      <outputDirectory>.</outputDirectory>
+      <directory>${project.build.directory}/packages</directory>
+      <excludes>
+        <exclude>**/original-terracotta-*.jar</exclude>
+      </excludes>
+    </fileSet>
+    <fileSet>
+      <outputDirectory>.</outputDirectory>
+      <directory>src/main/kit</directory>
+      <fileMode>0644</fileMode>
+      <includes>
+        <include>**/*</include>
+      </includes>
+      <excludes>
+        <exclude>**/*.sh</exclude>
+        <exclude>**/*.bat</exclude>
+      </excludes>
+    </fileSet>
+    <fileSet>
+      <outputDirectory>.</outputDirectory>
+      <directory>src/main/kit</directory>
+      <fileMode>0755</fileMode>
+      <includes>
+        <include>**/*.sh</include>
+        <include>**/*.bat</include>
+      </includes>
+    </fileSet>
+  </fileSets>
+
+  <dependencySets>
+
+    <dependencySet>
+      <outputDirectory>server/plugins/api</outputDirectory>
+      <includes>
+        <include>com.fasterxml.jackson.core:jackson-annotations</include>
+        <include>org.terracotta:statistics</include>
+      </includes>
+    </dependencySet>
+
+    <dependencySet>
+      <outputDirectory>server/plugins/lib</outputDirectory>
+      <includes>
+        <include>net.bytebuddy:byte-buddy</include>
+        <include>io.github.classgraph:classgraph</include>
+        <include>com.fasterxml.jackson.core:jackson-core</include>
+        <include>com.fasterxml.jackson.core:jackson-databind</include>
+        <include>com.fasterxml.jackson.datatype:jackson-datatype-jdk8</include>
+        <include>com.fasterxml.jackson.datatype:jackson-datatype-jsr310</include>
+        <include>com.beust:jcommander</include>
+      </includes>
+    </dependencySet>
+
+    <dependencySet>
+      <outputDirectory>tools/common/lib</outputDirectory>
+      <includes>
+        <include>io.github.classgraph:classgraph</include>
+        <include>com.fasterxml.jackson.core:jackson-annotations</include>
+        <include>com.fasterxml.jackson.core:jackson-core</include>
+        <include>com.fasterxml.jackson.core:jackson-databind</include>
+        <include>com.fasterxml.jackson.datatype:jackson-datatype-jdk8</include>
+        <include>com.fasterxml.jackson.datatype:jackson-datatype-jsr310</include>
+        <include>com.beust:jcommander</include>
+        <include>ch.qos.logback:logback-classic</include>
+        <include>ch.qos.logback:logback-core</include>
+        <include>org.slf4j:slf4j-api</include>
+      </includes>
+    </dependencySet>
+
+    <dependencySet>
+      <outputDirectory>tools/config-convertor/lib</outputDirectory>
+      <includes>
+        <include>org.terracotta.dynamic-config.cli:config-convertor-oss</include>
+        <include>com.sun.xml.fastinfoset:FastInfoset</include>
+        <include>com.sun.istack:istack-commons-runtime</include>
+        <include>jakarta.activation:jakarta.activation-api</include>
+        <include>jakarta.xml.bind:jakarta.xml.bind-api</include>
+        <include>org.glassfish.jaxb:jaxb-runtime</include>
+        <include>org.jvnet.staxex:stax-ex</include>
+        <include>org.glassfish.jaxb:txw2</include>
+      </includes>
+    </dependencySet>
+
+    <dependencySet>
+      <outputDirectory>tools/config-tool/lib</outputDirectory>
+      <includes>
+        <include>org.terracotta.internal:client-runtime</include>
+      </includes>
+    </dependencySet>
+
+  </dependencySets>
+
+</assembly>

--- a/kit/src/main/kit/tools/config-convertor/bin/config-convertor.bat
+++ b/kit/src/main/kit/tools/config-convertor/bin/config-convertor.bat
@@ -1,0 +1,42 @@
+@REM
+@REM Copyright Terracotta, Inc.
+@REM
+@REM Licensed under the Apache License, Version 2.0 (the "License");
+@REM you may not use this file except in compliance with the License.
+@REM You may obtain a copy of the License at
+@REM
+@REM     http://www.apache.org/licenses/LICENSE-2.0
+@REM
+@REM Unless required by applicable law or agreed to in writing, software
+@REM distributed under the License is distributed on an "AS IS" BASIS,
+@REM WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+@REM See the License for the specific language governing permissions and
+@REM limitations under the License.
+@REM
+
+@echo off
+setlocal EnableExtensions EnableDelayedExpansion
+
+pushd "%~dp0.."
+set "CONFIG_CONVERTOR_TOOL_DIR=%CD%"
+popd
+
+if exist "!CONFIG_CONVERTOR_TOOL_DIR!\bin\setenv.bat" (
+  pushd "!CONFIG_CONVERTOR_TOOL_DIR!\bin" && (
+    call .\setenv.bat
+    popd
+  )
+)
+
+if not defined JAVA_HOME (
+  echo Environment variable JAVA_HOME needs to be set
+  exit /b 1
+)
+
+set "JAVA=%JAVA_HOME%\bin\java.exe"
+set java_opts=%JAVA_OPTS%
+set "CP=%CONFIG_CONVERTOR_TOOL_DIR%\lib\*;%CONFIG_CONVERTOR_TOOL_DIR%\..\..\server\lib\*;%CONFIG_CONVERTOR_TOOL_DIR%\..\..\server\plugins\api\*;%CONFIG_CONVERTOR_TOOL_DIR%\..\..\server\plugins\lib\*"
+"%JAVA%" %java_opts% -cp "%CP%" org.terracotta.dynamic_config.cli.config_convertor.ConfigConvertorTool %*
+
+exit /b %ERRORLEVEL%
+endlocal

--- a/kit/src/main/kit/tools/config-convertor/bin/config-convertor.sh
+++ b/kit/src/main/kit/tools/config-convertor/bin/config-convertor.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+#
+# Copyright Terracotta, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+CONFIG_CONVERTOR_TOOL_DIR=$(dirname "$(cd "$(dirname "$0")";pwd)")
+
+# this will only happen if using sag installer
+if [ -r "${CONFIG_CONVERTOR_TOOL_DIR}/bin/setenv.sh" ] ; then
+  . "${CONFIG_CONVERTOR_TOOL_DIR}/bin/setenv.sh"
+fi
+
+java_opts="$JAVA_OPTS"
+
+if [ ! -d "$JAVA_HOME" ]; then
+   echo "Environment variable JAVA_HOME needs to be set"
+   echo "    $JAVA_HOME"
+   exit 2
+fi
+
+JAVA="$JAVA_HOME/bin/java"
+cp="$CONFIG_CONVERTOR_TOOL_DIR/lib/*:$CONFIG_CONVERTOR_TOOL_DIR/../../server/lib/*:$CONFIG_CONVERTOR_TOOL_DIR/../../server/plugins/api/*:$CONFIG_CONVERTOR_TOOL_DIR/../../server/plugins/lib/*"
+"$JAVA" $java_opts -cp $cp org.terracotta.dynamic_config.cli.config_convertor.ConfigConvertorTool "$@"

--- a/kit/src/main/kit/tools/config-tool/bin/config-tool.bat
+++ b/kit/src/main/kit/tools/config-tool/bin/config-tool.bat
@@ -1,0 +1,43 @@
+@REM
+@REM Copyright Terracotta, Inc.
+@REM
+@REM Licensed under the Apache License, Version 2.0 (the "License");
+@REM you may not use this file except in compliance with the License.
+@REM You may obtain a copy of the License at
+@REM
+@REM     http://www.apache.org/licenses/LICENSE-2.0
+@REM
+@REM Unless required by applicable law or agreed to in writing, software
+@REM distributed under the License is distributed on an "AS IS" BASIS,
+@REM WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+@REM See the License for the specific language governing permissions and
+@REM limitations under the License.
+@REM
+
+@echo off
+setlocal EnableExtensions EnableDelayedExpansion
+
+pushd "%~dp0.."
+set "CONFIG_TOOL_DIR=%CD%"
+popd
+set "CP=%CONFIG_TOOL_DIR%\lib\*;%CONFIG_TOOL_DIR%\..\common\lib\*"
+
+if exist "!CONFIG_TOOL_DIR!\bin\setenv.bat" (
+  pushd "!CONFIG_TOOL_DIR!\bin" && (
+    call .\setenv.bat
+    popd
+  )
+)
+
+if not defined JAVA_HOME (
+  echo Environment variable JAVA_HOME needs to be set
+  exit /b 1
+)
+
+set "JAVA=%JAVA_HOME%\bin\java.exe"
+set java_opts=%JAVA_OPTS%
+
+"%JAVA%" %java_opts% -cp "%CP%" org.terracotta.dynamic_config.cli.config_tool.ConfigTool %*
+
+exit /b %ERRORLEVEL%
+endlocal

--- a/kit/src/main/kit/tools/config-tool/bin/config-tool.sh
+++ b/kit/src/main/kit/tools/config-tool/bin/config-tool.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 #
 # Copyright Terracotta, Inc.
 #
@@ -14,14 +15,21 @@
 # limitations under the License.
 #
 
-# See shared code location for steps and parameters:
-# https://dev.azure.com/TerracottaCI/_git/terracotta
+CONFIG_TOOL_DIR=$(dirname "$(cd "$(dirname "$0")";pwd)")
 
-resources:
-  repositories:
-    - repository: templates
-      type: git
-      name: terracotta/terracotta
+# this will only happen if using sag installer
+if [ -r "${CONFIG_TOOL_DIR}/bin/setenv.sh" ] ; then
+  . "${CONFIG_TOOL_DIR}/bin/setenv.sh"
+fi
 
-jobs:
-- template: build-templates/maven-common.yml@templates
+java_opts="$JAVA_OPTS"
+
+if [ ! -d "$JAVA_HOME" ]; then
+   echo "Environment variable JAVA_HOME needs to be set"
+   echo "    $JAVA_HOME"
+   exit 2
+fi
+
+JAVA="$JAVA_HOME/bin/java"
+
+"$JAVA" $java_opts -cp "$CONFIG_TOOL_DIR/lib/*:$CONFIG_TOOL_DIR/../common/lib/*" org.terracotta.dynamic_config.cli.config_tool.ConfigTool "$@"

--- a/management/testing/integration-tests/pom.xml
+++ b/management/testing/integration-tests/pom.xml
@@ -32,6 +32,21 @@
   <name>Terracotta Management :: Testing :: Integration Tests</name>
 
   <dependencies>
+    <!-- declare the kit so that maven knows it has to build it before -->
+    <dependency>
+      <groupId>org.terracotta</groupId>
+      <artifactId>platform-kit</artifactId>
+      <version>${project.version}</version>
+      <type>tar.gz</type>
+      <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
     <dependency>
       <groupId>org.terracotta.management</groupId>
       <artifactId>nms-agent-entity-client</artifactId>
@@ -102,24 +117,25 @@
               <goal>unpack</goal>
             </goals>
             <configuration>
+              <outputDirectory>${project.build.directory}</outputDirectory>
               <artifactItems>
                 <artifactItem>
-                  <groupId>org.terracotta.internal</groupId>
-                  <artifactId>terracotta-kit</artifactId>
-                  <version>${terracotta-core.version}</version>
+                  <groupId>org.terracotta</groupId>
+                  <artifactId>platform-kit</artifactId>
+                  <version>${project.version}</version>
                   <type>tar.gz</type>
                 </artifactItem>
               </artifactItems>
-              <outputDirectory>${project.build.directory}/voltronKit</outputDirectory>
             </configuration>
           </execution>
           <execution>
-            <id>unpack-sample-entity</id>
+            <id>copy-test-entity</id>
             <phase>prepare-package</phase>
             <goals>
               <goal>copy</goal>
             </goals>
             <configuration>
+              <outputDirectory>${project.build.directory}/platform-kit-${project.version}/server/plugins/lib</outputDirectory>
               <artifactItems>
                 <artifactItem>
                   <groupId>org.terracotta.management.testing</groupId>
@@ -127,86 +143,30 @@
                   <version>${project.version}</version>
                   <classifier>plugin</classifier>
                 </artifactItem>
-
-                <artifactItem>
-                  <groupId>org.terracotta.management</groupId>
-                  <artifactId>management-model</artifactId>
-                  <version>${project.version}</version>
-                </artifactItem>
-                <artifactItem>
-                  <groupId>org.terracotta.management</groupId>
-                  <artifactId>management-registry</artifactId>
-                  <version>${project.version}</version>
-                </artifactItem>
-                <artifactItem>
-                  <groupId>org.terracotta.management</groupId>
-                  <artifactId>sequence-generator</artifactId>
-                  <version>${project.version}</version>
-                </artifactItem>
-                <artifactItem>
-                  <groupId>org.terracotta.management</groupId>
-                  <artifactId>cluster-topology</artifactId>
-                  <version>${project.version}</version>
-                </artifactItem>
-
-                <artifactItem>
-                  <groupId>org.terracotta.management</groupId>
-                  <artifactId>nms-agent-entity-common</artifactId>
-                  <version>${project.version}</version>
-                </artifactItem>
-                <artifactItem>
-                  <groupId>org.terracotta.management</groupId>
-                  <artifactId>nms-agent-entity-server</artifactId>
-                  <version>${project.version}</version>
-                </artifactItem>
-                <artifactItem>
-                  <groupId>org.terracotta.management</groupId>
-                  <artifactId>nms-entity-common</artifactId>
-                  <version>${project.version}</version>
-                </artifactItem>
-                <artifactItem>
-                  <groupId>org.terracotta.management</groupId>
-                  <artifactId>nms-entity-server</artifactId>
-                  <version>${project.version}</version>
-                </artifactItem>
-                <artifactItem>
-                  <groupId>org.terracotta.management</groupId>
-                  <artifactId>monitoring-service</artifactId>
-                  <version>${project.version}</version>
-                </artifactItem>
-                <artifactItem>
-                  <groupId>org.terracotta.management</groupId>
-                  <artifactId>monitoring-service-api</artifactId>
-                  <version>${project.version}</version>
-                </artifactItem>
-                <artifactItem>
-                  <groupId>org.terracotta.voltron.proxy</groupId>
-                  <artifactId>voltron-proxy-common</artifactId>
-                  <version>${project.version}</version>
-                </artifactItem>
-                <artifactItem>
-                  <groupId>org.terracotta.voltron.proxy</groupId>
-                  <artifactId>voltron-proxy-server</artifactId>
-                  <version>${project.version}</version>
-                </artifactItem>
-
-                <artifactItem>
-                  <groupId>org.terracotta</groupId>
-                  <artifactId>statistics</artifactId>
-                  <version>${statistics.version}</version>
-                </artifactItem>
-                <artifactItem>
-                  <groupId>org.terracotta</groupId>
-                  <artifactId>offheap-resource</artifactId>
-                  <version>${project.version}</version>
-                </artifactItem>
-                <artifactItem>
-                  <groupId>org.terracotta.common</groupId>
-                  <artifactId>common-structures</artifactId>
-                  <version>${project.version}</version>
-                </artifactItem>
               </artifactItems>
-              <outputDirectory>${project.build.directory}/voltronKit/terracotta-${terracotta-core.version}/server/plugins/lib</outputDirectory>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <artifactId>maven-resources-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>copy-logging-config</id>
+            <phase>package</phase>
+            <goals>
+              <goal>copy-resources</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${project.build.directory}/platform-kit-${project.version}/server/lib</outputDirectory>
+              <resources>
+                <resource>
+                  <directory>${project.basedir}/src/test/resources</directory>
+                  <includes>
+                    <include>logback-ext.xml</include>
+                  </includes>
+                </resource>
+              </resources>
             </configuration>
           </execution>
         </executions>
@@ -217,7 +177,8 @@
         <version>2.19.1</version>
         <configuration>
           <systemPropertyVariables>
-            <kitInstallationPath>${project.build.directory}/voltronKit/terracotta-${terracotta-core.version}/</kitInstallationPath>
+            <kitInstallationPath>${project.build.directory}/platform-kit-${project.version}</kitInstallationPath>
+<!--            <serverDebugPortStart>5005</serverDebugPortStart>-->
           </systemPropertyVariables>
         </configuration>
         <executions>

--- a/management/testing/integration-tests/src/test/java/org/terracotta/management/integration/tests/AbstractHATest.java
+++ b/management/testing/integration-tests/src/test/java/org/terracotta/management/integration/tests/AbstractHATest.java
@@ -23,7 +23,7 @@ import org.terracotta.management.model.cluster.AbstractManageableNode;
 import org.terracotta.management.model.cluster.Server;
 import org.terracotta.testing.rules.Cluster;
 
-import java.io.File;
+import java.nio.file.Paths;
 
 import static org.terracotta.testing.rules.BasicExternalClusterBuilder.newCluster;
 
@@ -42,10 +42,11 @@ public abstract class AbstractHATest extends AbstractTest {
 
   @Rule
   public Cluster voltron = newCluster(2)
-      .in(new File("target/galvan"))
+      .in(Paths.get("target" ,"galvan"))
       .withServiceFragment(resourceConfig)
       .withSystemProperty("terracotta.management.assert", "true")
       .withTcProperty("terracotta.management.assert", "true")
+      .startupBuilder(DynamicConfigStartupBuilder::new)
       .build();
 
   @Rule
@@ -66,7 +67,7 @@ public abstract class AbstractHATest extends AbstractTest {
         .filter(server -> !server.isActive())
         .flatMap(Server::serverEntityStream)
         .filter(AbstractManageableNode::isManageable)
-        .count() != 3) {
+        .count() != 4) {
       Thread.sleep(1_000);
     }
   }

--- a/management/testing/integration-tests/src/test/java/org/terracotta/management/integration/tests/AbstractSingleTest.java
+++ b/management/testing/integration-tests/src/test/java/org/terracotta/management/integration/tests/AbstractSingleTest.java
@@ -20,7 +20,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.terracotta.testing.rules.Cluster;
 
-import java.io.File;
+import java.nio.file.Paths;
 
 import static org.terracotta.testing.rules.BasicExternalClusterBuilder.newCluster;
 
@@ -38,13 +38,13 @@ public abstract class AbstractSingleTest extends AbstractTest {
           "</config>\n";
 
   @Rule
-  public Cluster voltron =
-      newCluster()
-          .in(new File("target/galvan"))
-          .withSystemProperty("terracotta.management.assert", "true")
-          .withTcProperty("terracotta.management.assert", "true")
-          .withServiceFragment(resourceConfig)
-          .build();
+  public Cluster voltron = newCluster()
+      .in(Paths.get("target", "galvan"))
+      .withSystemProperty("terracotta.management.assert", "true")
+      .withTcProperty("terracotta.management.assert", "true")
+      .withServiceFragment(resourceConfig)
+      .startupBuilder(DynamicConfigStartupBuilder::new)
+      .build();
 
   @Before
   public void setUp() throws Exception {

--- a/management/testing/integration-tests/src/test/java/org/terracotta/management/integration/tests/DiagnosticIT.java
+++ b/management/testing/integration-tests/src/test/java/org/terracotta/management/integration/tests/DiagnosticIT.java
@@ -27,7 +27,6 @@ import java.util.Properties;
 
 import static org.hamcrest.core.StringContains.containsString;
 import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
 
 /**
  * @author Mathieu Carbou
@@ -42,7 +41,7 @@ public class DiagnosticIT extends AbstractSingleTest {
     put(0, "pets", "pet1", "Cubitus");
 
     Properties properties = new Properties();
-    properties.setProperty(ConnectionPropertyNames.CONNECTION_TIMEOUT, String.valueOf("5000"));
+    properties.setProperty(ConnectionPropertyNames.CONNECTION_TIMEOUT, "5000");
     properties.setProperty(ConnectionPropertyNames.CONNECTION_NAME, "diagnostic");
     properties.setProperty(PROP_REQUEST_TIMEOUT, "5000");
     properties.setProperty(PROP_REQUEST_TIMEOUTMESSAGE, "5000");
@@ -55,25 +54,25 @@ public class DiagnosticIT extends AbstractSingleTest {
       // once https://github.com/Terracotta-OSS/terracotta-core/issues/613 and https://github.com/Terracotta-OSS/terracotta-core/pull/601 will be fixed 
       // and once the state dump format will be improved.
       String dump = diagnostics.getClusterState();
-      
+
       // monitoring service provider
       assertThat(dump, containsString("cluster="));
 
       // ActiveNmsServerEntity / PassiveNmsServerEntity
       assertThat(dump, containsString("consumerId="));
       assertThat(dump, containsString("stripeName="));
-      
+
       // OffHeapResourcesProvider
       assertThat(dump, containsString("capacity="));
-      assertThat(dump, containsString("available="));
-      
+      assertThat(dump, containsString("availableAtTime="));
+
       // ActiveCacheServerEntity / ActiveCacheServerEntity
       assertThat(dump, containsString("cacheName="));
       assertThat(dump, containsString("cacheSize="));
-      
+
       // MapProvider
       assertThat(dump, containsString("caches="));
-      
+
       // Common on all active entities
       assertThat(dump, containsString("instance="));
       assertThat(dump, containsString("clientCount="));

--- a/management/testing/integration-tests/src/test/java/org/terracotta/management/integration/tests/NmsAgentServiceIT.java
+++ b/management/testing/integration-tests/src/test/java/org/terracotta/management/integration/tests/NmsAgentServiceIT.java
@@ -40,7 +40,7 @@ import org.terracotta.management.registry.DefaultManagementRegistry;
 import org.terracotta.management.registry.ManagementRegistry;
 import org.terracotta.testing.rules.Cluster;
 
-import java.io.File;
+import java.nio.file.Paths;
 import java.util.Properties;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -68,10 +68,11 @@ public class NmsAgentServiceIT {
 
   @Rule
   public Cluster voltron = newCluster()
-      .in(new File("target/galvan"))
+      .in(Paths.get("target", "galvan"))
       .withSystemProperty("terracotta.management.assert", "true")
       .withTcProperty("terracotta.management.assert", "true")
       .withServiceFragment(resourceConfig)
+      .startupBuilder(DynamicConfigStartupBuilder::new)
       .build();
 
   Connection managementConnection;

--- a/management/testing/integration-tests/src/test/java/org/terracotta/management/integration/tests/ServerCacheManagementIT.java
+++ b/management/testing/integration-tests/src/test/java/org/terracotta/management/integration/tests/ServerCacheManagementIT.java
@@ -69,7 +69,7 @@ public class ServerCacheManagementIT extends AbstractSingleTest {
         .flatMap(ServerEntity::getManagementRegistry)
         .get();
 
-    assertThat(registry.getCapabilities().size(), equalTo(3));
+    assertThat(registry.getCapabilities().size(), equalTo(5));
     assertThat(registry.getCapability("OffHeapResourceSettings"), is(notNullValue()));
     assertThat(registry.getCapability("OffHeapResourceStatistics"), is(notNullValue()));
     assertThat(registry.getCapability("StatisticCollectorCapability"), is(notNullValue()));

--- a/management/testing/integration-tests/src/test/java/org/terracotta/management/integration/tests/SimpleGalvanIT.java
+++ b/management/testing/integration-tests/src/test/java/org/terracotta/management/integration/tests/SimpleGalvanIT.java
@@ -25,8 +25,8 @@ import org.junit.rules.Timeout;
 import org.terracotta.management.entity.sample.client.CacheFactory;
 import org.terracotta.testing.rules.Cluster;
 
-import java.io.File;
 import java.net.URI;
+import java.nio.file.Paths;
 
 import static org.terracotta.testing.rules.BasicExternalClusterBuilder.newCluster;
 
@@ -42,13 +42,13 @@ public class SimpleGalvanIT {
           "</config>\n";
 
   @ClassRule
-  public static Cluster CLUSTER =
-      newCluster()
-          .in(new File("target/galvan"))
-          .withSystemProperty("terracotta.management.assert", "true")
-          .withTcProperty("terracotta.management.assert", "true")
-          .withServiceFragment(RESOURCE_CONFIG)
-          .build();
+  public static Cluster CLUSTER = newCluster()
+      .in(Paths.get("target", "galvan"))
+      .withSystemProperty("terracotta.management.assert", "true")
+      .withTcProperty("terracotta.management.assert", "true")
+      .withServiceFragment(RESOURCE_CONFIG)
+      .startupBuilder(DynamicConfigStartupBuilder::new)
+      .build();
 
   @BeforeClass
   public static void waitForActive() throws Exception {

--- a/management/testing/integration-tests/src/test/java/org/terracotta/management/integration/tests/UserErrorsIT.java
+++ b/management/testing/integration-tests/src/test/java/org/terracotta/management/integration/tests/UserErrorsIT.java
@@ -83,7 +83,7 @@ public class UserErrorsIT extends AbstractSingleTest {
       fail();
     } catch (ExecutionException e) {
       assertThat(e.getCause(), is(instanceOf(EntityUserException.class)));
-      assertThat(e.getCause().getMessage(), equalTo("Entity: org.terracotta.management.entity.nms.server.ActiveNmsServerEntity: exception in user code: java.lang.IllegalArgumentException: Server Entity {stripeId=SINGLE, serverId=testServer0, serverName=INEXISTING, entityId=pet-clinic/pets:org.terracotta.management.entity.sample.client.CacheEntity, entityName=pet-clinic/pets, entityType=org.terracotta.management.entity.sample.client.CacheEntity, consumerId=3, cacheName=pet-clinic/pets} is either not found or not manageable"));
+      assertThat(e.getCause().getMessage(), equalTo("Entity: org.terracotta.management.entity.nms.server.ActiveNmsServerEntity: exception in user code: java.lang.IllegalArgumentException: Server Entity {stripeId=SINGLE, serverId=testServer0, serverName=INEXISTING, entityId=pet-clinic/pets:org.terracotta.management.entity.sample.client.CacheEntity, entityName=pet-clinic/pets, entityType=org.terracotta.management.entity.sample.client.CacheEntity, consumerId=7, cacheName=pet-clinic/pets} is either not found or not manageable"));
     }
   }
 

--- a/management/testing/integration-tests/src/test/resources/notifications-after-reconfigure.json
+++ b/management/testing/integration-tests/src/test/resources/notifications-after-reconfigure.json
@@ -2,7 +2,7 @@
   {
     "attributes": {},
     "context": {
-      "consumerId": "3",
+      "consumerId": "7",
       "alias": "pet-clinic/pets",
       "type": "ServerCache",
       "stripeId": "SINGLE",
@@ -17,7 +17,7 @@
   {
     "attributes": {},
     "context": {
-      "consumerId": "3",
+      "consumerId": "7",
       "alias": "pet-clinic/clients",
       "type": "ServerCache",
       "stripeId": "SINGLE",
@@ -32,7 +32,7 @@
   {
     "attributes": {},
     "context": {
-      "consumerId": "3",
+      "consumerId": "7",
       "alias": "0@127.0.0.1:pet-clinic:<uuid>",
       "type": "ClientState",
       "stripeId": "SINGLE",
@@ -47,7 +47,7 @@
   {
     "attributes": {},
     "context": {
-      "consumerId": "3",
+      "consumerId": "7",
       "alias": "0@127.0.0.1:pet-clinic:<uuid>",
       "type": "ClientState",
       "stripeId": "SINGLE",
@@ -68,7 +68,7 @@
       "entityId": "pet-clinic/pets:org.terracotta.management.entity.sample.client.CacheEntity",
       "entityName": "pet-clinic/pets",
       "entityType": "org.terracotta.management.entity.sample.client.CacheEntity",
-      "consumerId": "3"
+      "consumerId": "7"
     },
     "type": "SERVER_ENTITY_RECONFIGURED"
   }

--- a/management/testing/integration-tests/src/test/resources/notifications.json
+++ b/management/testing/integration-tests/src/test/resources/notifications.json
@@ -23,7 +23,7 @@
       "entityId": "NmsAgent:org.terracotta.management.entity.nms.agent.client.NmsAgentEntity",
       "entityName": "NmsAgent",
       "entityType": "org.terracotta.management.entity.nms.agent.client.NmsAgentEntity",
-      "consumerId": "1"
+      "consumerId": "3"
     },
     "type": "SERVER_ENTITY_FETCHED"
   },
@@ -73,7 +73,7 @@
       "entityId": "NmsAgent:org.terracotta.management.entity.nms.agent.client.NmsAgentEntity",
       "entityName": "NmsAgent",
       "entityType": "org.terracotta.management.entity.nms.agent.client.NmsAgentEntity",
-      "consumerId": "1"
+      "consumerId": "3"
     },
     "type": "SERVER_ENTITY_FETCHED"
   },
@@ -108,7 +108,7 @@
       "entityId": "pet-clinic/pets:org.terracotta.management.entity.sample.client.CacheEntity",
       "entityName": "pet-clinic/pets",
       "entityType": "org.terracotta.management.entity.sample.client.CacheEntity",
-      "consumerId": "3"
+      "consumerId": "7"
     },
     "type": "SERVER_ENTITY_CREATED"
   },
@@ -121,14 +121,14 @@
       "entityId": "pet-clinic/pets:org.terracotta.management.entity.sample.client.CacheEntity",
       "entityName": "pet-clinic/pets",
       "entityType": "org.terracotta.management.entity.sample.client.CacheEntity",
-      "consumerId": "3"
+      "consumerId": "7"
     },
     "type": "ENTITY_REGISTRY_AVAILABLE"
   },
   {
     "attributes": {},
     "context": {
-      "consumerId": "3",
+      "consumerId": "7",
       "alias": "pet-clinic/pets",
       "type": "ServerCache",
       "stripeId": "SINGLE",
@@ -151,14 +151,14 @@
       "entityId": "pet-clinic/pets:org.terracotta.management.entity.sample.client.CacheEntity",
       "entityName": "pet-clinic/pets",
       "entityType": "org.terracotta.management.entity.sample.client.CacheEntity",
-      "consumerId": "3"
+      "consumerId": "7"
     },
     "type": "SERVER_ENTITY_FETCHED"
   },
   {
     "attributes": {},
     "context": {
-      "consumerId": "3",
+      "consumerId": "7",
       "alias": "0@127.0.0.1:pet-clinic:<uuid>",
       "type": "ClientState",
       "stripeId": "SINGLE",
@@ -190,14 +190,14 @@
       "entityId": "pet-clinic/pets:org.terracotta.management.entity.sample.client.CacheEntity",
       "entityName": "pet-clinic/pets",
       "entityType": "org.terracotta.management.entity.sample.client.CacheEntity",
-      "consumerId": "3"
+      "consumerId": "7"
     },
     "type": "SERVER_ENTITY_FETCHED"
   },
   {
     "attributes": {},
     "context": {
-      "consumerId": "3",
+      "consumerId": "7",
       "alias": "0@127.0.0.1:pet-clinic:<uuid>",
       "type": "ClientState",
       "stripeId": "SINGLE",
@@ -227,7 +227,7 @@
       "entityId": "pet-clinic/clients:org.terracotta.management.entity.sample.client.CacheEntity",
       "entityName": "pet-clinic/clients",
       "entityType": "org.terracotta.management.entity.sample.client.CacheEntity",
-      "consumerId": "4"
+      "consumerId": "8"
     },
     "type": "SERVER_ENTITY_CREATED"
   },
@@ -240,14 +240,14 @@
       "entityId": "pet-clinic/clients:org.terracotta.management.entity.sample.client.CacheEntity",
       "entityName": "pet-clinic/clients",
       "entityType": "org.terracotta.management.entity.sample.client.CacheEntity",
-      "consumerId": "4"
+      "consumerId": "8"
     },
     "type": "ENTITY_REGISTRY_AVAILABLE"
   },
   {
     "attributes": {},
     "context": {
-      "consumerId": "4",
+      "consumerId": "8",
       "alias": "pet-clinic/clients",
       "type": "ServerCache",
       "stripeId": "SINGLE",
@@ -270,14 +270,14 @@
       "entityId": "pet-clinic/clients:org.terracotta.management.entity.sample.client.CacheEntity",
       "entityName": "pet-clinic/clients",
       "entityType": "org.terracotta.management.entity.sample.client.CacheEntity",
-      "consumerId": "4"
+      "consumerId": "8"
     },
     "type": "SERVER_ENTITY_FETCHED"
   },
   {
     "attributes": {},
     "context": {
-      "consumerId": "4",
+      "consumerId": "8",
       "alias": "0@127.0.0.1:pet-clinic:<uuid>",
       "type": "ClientState",
       "stripeId": "SINGLE",
@@ -309,14 +309,14 @@
       "entityId": "pet-clinic/clients:org.terracotta.management.entity.sample.client.CacheEntity",
       "entityName": "pet-clinic/clients",
       "entityType": "org.terracotta.management.entity.sample.client.CacheEntity",
-      "consumerId": "4"
+      "consumerId": "8"
     },
     "type": "SERVER_ENTITY_FETCHED"
   },
   {
     "attributes": {},
     "context": {
-      "consumerId": "4",
+      "consumerId": "8",
       "alias": "0@127.0.0.1:pet-clinic:<uuid>",
       "type": "ClientState",
       "stripeId": "SINGLE",

--- a/management/testing/integration-tests/src/test/resources/passive.json
+++ b/management/testing/integration-tests/src/test/resources/passive.json
@@ -5,20 +5,56 @@
       "id": "NmsAgent:org.terracotta.management.entity.nms.agent.client.NmsAgentEntity",
       "type": "org.terracotta.management.entity.nms.agent.client.NmsAgentEntity",
       "name": "NmsAgent",
-      "consumerId": 1,
+      "consumerId": 3,
       "managementRegistry": null
     },
     {
       "id": "PassiveTopologyIT:org.terracotta.management.entity.nms.client.NmsEntity",
       "type": "org.terracotta.management.entity.nms.client.NmsEntity",
       "name": "PassiveTopologyIT",
-      "consumerId": 2,
+      "consumerId": 6,
       "managementRegistry": {
         "contextContainer": {
-          "consumerId": "2",
+          "consumerId": "6",
           "subContexts": []
         },
         "capabilities": [
+          {
+            "name": "DataRootSettings",
+            "context": [
+              {
+                "name": "consumerId",
+                "required": true
+              },
+              {
+                "name": "type",
+                "required": true
+              },
+              {
+                "name": "alias",
+                "required": true
+              }
+            ],
+            "descriptors": []
+          },
+          {
+            "name": "DataRootStatistics",
+            "context": [
+              {
+                "name": "consumerId",
+                "required": true
+              },
+              {
+                "name": "type",
+                "required": true
+              },
+              {
+                "name": "alias",
+                "required": true
+              }
+            ],
+            "descriptors": []
+          },
           {
             "name": "OffHeapResourceSettings",
             "context": [
@@ -37,7 +73,7 @@
             ],
             "descriptors": [
               {
-                "consumerId": "2",
+                "consumerId": "6",
                 "alias": "primary-server-resource",
                 "type": "OffHeapResource",
                 "capacity": 67108864,
@@ -111,13 +147,47 @@
       }
     },
     {
-      "id": "pet-clinic/clients:org.terracotta.management.entity.sample.client.CacheEntity",
-      "type": "org.terracotta.management.entity.sample.client.CacheEntity",
-      "name": "pet-clinic/clients",
+      "id": "SystemLeaseAcquirer:org.terracotta.lease.LeaseAcquirer",
+      "type": "org.terracotta.lease.LeaseAcquirer",
+      "name": "SystemLeaseAcquirer",
+      "consumerId": 1,
+      "managementRegistry": null
+    },
+    {
+      "id": "dynamic-config-management-entity:org.terracotta.dynamic_config.entity.management.server.ManagementEntityServerService",
+      "type": "org.terracotta.dynamic_config.entity.management.server.ManagementEntityServerService",
+      "name": "dynamic-config-management-entity",
       "consumerId": 4,
       "managementRegistry": {
         "contextContainer": {
           "consumerId": "4",
+          "subContexts": []
+        },
+        "capabilities": []
+      }
+    },
+    {
+      "id": "dynamic-config-topology-entity:org.terracotta.dynamic_config.entity.topology.client.DynamicTopologyEntity",
+      "type": "org.terracotta.dynamic_config.entity.topology.client.DynamicTopologyEntity",
+      "name": "dynamic-config-topology-entity",
+      "consumerId": 2,
+      "managementRegistry": null
+    },
+    {
+      "id": "nomad-entity:org.terracotta.nomad.entity.client.NomadEntity",
+      "type": "org.terracotta.nomad.entity.client.NomadEntity",
+      "name": "nomad-entity",
+      "consumerId": 5,
+      "managementRegistry": null
+    },
+    {
+      "id": "pet-clinic/clients:org.terracotta.management.entity.sample.client.CacheEntity",
+      "type": "org.terracotta.management.entity.sample.client.CacheEntity",
+      "name": "pet-clinic/clients",
+      "consumerId": 8,
+      "managementRegistry": {
+        "contextContainer": {
+          "consumerId": "8",
           "subContexts": []
         },
         "capabilities": [
@@ -188,7 +258,7 @@
             ],
             "descriptors": [
               {
-                "consumerId": "4",
+                "consumerId": "8",
                 "alias": "pet-clinic/clients",
                 "type": "ServerCache",
                 "size": 0
@@ -253,10 +323,10 @@
       "id": "pet-clinic/pets:org.terracotta.management.entity.sample.client.CacheEntity",
       "type": "org.terracotta.management.entity.sample.client.CacheEntity",
       "name": "pet-clinic/pets",
-      "consumerId": 3,
+      "consumerId": 7,
       "managementRegistry": {
         "contextContainer": {
-          "consumerId": "3",
+          "consumerId": "7",
           "subContexts": []
         },
         "capabilities": [
@@ -327,7 +397,7 @@
             ],
             "descriptors": [
               {
-                "consumerId": "3",
+                "consumerId": "7",
                 "alias": "pet-clinic/pets",
                 "type": "ServerCache",
                 "size": 0

--- a/management/testing/integration-tests/src/test/resources/server-descriptors.json
+++ b/management/testing/integration-tests/src/test/resources/server-descriptors.json
@@ -18,13 +18,13 @@
     },
     "descriptors": [
       {
-        "consumerId": "4",
+        "consumerId": "8",
         "alias": "0@127.0.0.1:pet-clinic:<uuid>",
         "type": "ClientState",
         "attached": true
       },
       {
-        "consumerId": "4",
+        "consumerId": "8",
         "alias": "0@127.0.0.1:pet-clinic:<uuid>",
         "type": "ClientState",
         "attached": true
@@ -102,7 +102,7 @@
     },
     "descriptors": [
       {
-        "consumerId": "4",
+        "consumerId": "8",
         "alias": "pet-clinic/clients",
         "type": "ServerCache",
         "size": 0

--- a/management/testing/integration-tests/src/test/resources/stats.json
+++ b/management/testing/integration-tests/src/test/resources/stats.json
@@ -2,10 +2,10 @@
   {
     "capability": "OffHeapResourceStatistics",
     "context": {
-      "consumerId": "2",
+      "consumerId": "6",
       "alias": "primary-server-resource",
       "type": "OffHeapResource",
-      "collectorId": "2",
+      "collectorId": "6",
       "stripeId": "SINGLE",
       "serverId": "testServer0",
       "serverName": "testServer0",
@@ -28,10 +28,10 @@
   {
     "capability": "ServerCacheStatistics",
     "context": {
-      "consumerId": "3",
+      "consumerId": "7",
       "alias": "pet-clinic/pets",
       "type": "ServerCache",
-      "collectorId": "2",
+      "collectorId": "6",
       "stripeId": "SINGLE",
       "serverId": "testServer0",
       "serverName": "testServer0",
@@ -122,10 +122,10 @@
   {
     "capability": "ServerCacheStatistics",
     "context": {
-      "consumerId": "4",
+      "consumerId": "8",
       "alias": "pet-clinic/clients",
       "type": "ServerCache",
-      "collectorId": "2",
+      "collectorId": "6",
       "stripeId": "SINGLE",
       "serverId": "testServer0",
       "serverName": "testServer0",

--- a/management/testing/integration-tests/src/test/resources/topology-after-failover.json
+++ b/management/testing/integration-tests/src/test/resources/topology-after-failover.json
@@ -11,13 +11,49 @@
               "id": "FailoverIT:org.terracotta.management.entity.nms.client.NmsEntity",
               "type": "org.terracotta.management.entity.nms.client.NmsEntity",
               "name": "FailoverIT",
-              "consumerId": 2,
+              "consumerId": 6,
               "managementRegistry": {
                 "contextContainer": {
-                  "consumerId": "2",
+                  "consumerId": "6",
                   "subContexts": []
                 },
                 "capabilities": [
+                  {
+                    "name": "DataRootSettings",
+                    "context": [
+                      {
+                        "name": "consumerId",
+                        "required": true
+                      },
+                      {
+                        "name": "type",
+                        "required": true
+                      },
+                      {
+                        "name": "alias",
+                        "required": true
+                      }
+                    ],
+                    "descriptors": []
+                  },
+                  {
+                    "name": "DataRootStatistics",
+                    "context": [
+                      {
+                        "name": "consumerId",
+                        "required": true
+                      },
+                      {
+                        "name": "type",
+                        "required": true
+                      },
+                      {
+                        "name": "alias",
+                        "required": true
+                      }
+                    ],
+                    "descriptors": []
+                  },
                   {
                     "name": "OffHeapResourceSettings",
                     "context": [
@@ -36,7 +72,7 @@
                     ],
                     "descriptors": [
                       {
-                        "consumerId": "2",
+                        "consumerId": "6",
                         "alias": "primary-server-resource",
                         "type": "OffHeapResource",
                         "capacity": 67108864,
@@ -113,17 +149,51 @@
               "id": "NmsAgent:org.terracotta.management.entity.nms.agent.client.NmsAgentEntity",
               "type": "org.terracotta.management.entity.nms.agent.client.NmsAgentEntity",
               "name": "NmsAgent",
+              "consumerId": 3,
+              "managementRegistry": null
+            },
+            {
+              "id": "SystemLeaseAcquirer:org.terracotta.lease.LeaseAcquirer",
+              "type": "org.terracotta.lease.LeaseAcquirer",
+              "name": "SystemLeaseAcquirer",
               "consumerId": 1,
+              "managementRegistry": null
+            },
+            {
+              "id": "dynamic-config-management-entity:org.terracotta.dynamic_config.entity.management.server.ManagementEntityServerService",
+              "type": "org.terracotta.dynamic_config.entity.management.server.ManagementEntityServerService",
+              "name": "dynamic-config-management-entity",
+              "consumerId": 4,
+              "managementRegistry": {
+                "contextContainer": {
+                  "consumerId": "4",
+                  "subContexts": []
+                },
+                "capabilities": []
+              }
+            },
+            {
+              "id": "dynamic-config-topology-entity:org.terracotta.dynamic_config.entity.topology.client.DynamicTopologyEntity",
+              "type": "org.terracotta.dynamic_config.entity.topology.client.DynamicTopologyEntity",
+              "name": "dynamic-config-topology-entity",
+              "consumerId": 2,
+              "managementRegistry": null
+            },
+            {
+              "id": "nomad-entity:org.terracotta.nomad.entity.client.NomadEntity",
+              "type": "org.terracotta.nomad.entity.client.NomadEntity",
+              "name": "nomad-entity",
+              "consumerId": 5,
               "managementRegistry": null
             },
             {
               "id": "pet-clinic/clients:org.terracotta.management.entity.sample.client.CacheEntity",
               "type": "org.terracotta.management.entity.sample.client.CacheEntity",
               "name": "pet-clinic/clients",
-              "consumerId": 4,
+              "consumerId": 8,
               "managementRegistry": {
                 "contextContainer": {
-                  "consumerId": "4",
+                  "consumerId": "8",
                   "subContexts": []
                 },
                 "capabilities": [
@@ -145,13 +215,13 @@
                     ],
                     "descriptors": [
                       {
-                        "consumerId": "4",
+                        "consumerId": "8",
                         "alias": "0@127.0.0.1:pet-clinic:<uuid>",
                         "type": "ClientState",
                         "attached": true
                       },
                       {
-                        "consumerId": "4",
+                        "consumerId": "8",
                         "alias": "0@127.0.0.1:pet-clinic:<uuid>",
                         "type": "ClientState",
                         "attached": true
@@ -225,7 +295,7 @@
                     ],
                     "descriptors": [
                       {
-                        "consumerId": "4",
+                        "consumerId": "8",
                         "alias": "pet-clinic/clients",
                         "type": "ServerCache",
                         "size": 1
@@ -290,10 +360,10 @@
               "id": "pet-clinic/pets:org.terracotta.management.entity.sample.client.CacheEntity",
               "type": "org.terracotta.management.entity.sample.client.CacheEntity",
               "name": "pet-clinic/pets",
-              "consumerId": 3,
+              "consumerId": 7,
               "managementRegistry": {
                 "contextContainer": {
-                  "consumerId": "3",
+                  "consumerId": "7",
                   "subContexts": []
                 },
                 "capabilities": [
@@ -315,13 +385,13 @@
                     ],
                     "descriptors": [
                       {
-                        "consumerId": "3",
+                        "consumerId": "7",
                         "alias": "0@127.0.0.1:pet-clinic:<uuid>",
                         "type": "ClientState",
                         "attached": true
                       },
                       {
-                        "consumerId": "3",
+                        "consumerId": "7",
                         "alias": "0@127.0.0.1:pet-clinic:<uuid>",
                         "type": "ClientState",
                         "attached": true
@@ -395,7 +465,7 @@
                     ],
                     "descriptors": [
                       {
-                        "consumerId": "3",
+                        "consumerId": "7",
                         "alias": "pet-clinic/pets",
                         "type": "ServerCache",
                         "size": 0
@@ -484,9 +554,9 @@
       "clientId": "0@127.0.0.1:FailoverIT:<uuid>",
       "hostName": "<hostname>",
       "tags": [],
-      "properties" : { 
-        "clientReportedAddress" : "<clientReportedAddress>",
-        "version" : "<version>"
+      "properties": {
+        "version": "<version>",
+        "clientReportedAddress": "<clientReportedAddress>"
       },
       "connections": [
         {
@@ -518,10 +588,10 @@
         "caches",
         "pet-clinic"
       ],
-      "properties" : {
-        "clientReportedAddress" : "<clientReportedAddress>",
-        "version" : "<version>"
-       },
+      "properties": {
+        "clientReportedAddress": "<clientReportedAddress>",
+        "version": "<version>"
+      },
       "connections": [
         {
           "id": "<uuid>:SINGLE:testServer0:127.0.0.1:0",
@@ -717,9 +787,9 @@
         "caches",
         "pet-clinic"
       ],
-      "properties" : { 
-        "clientReportedAddress" : "<clientReportedAddress>",
-        "version" : "<version>"
+      "properties": {
+        "clientReportedAddress": "<clientReportedAddress>",
+        "version": "<version>"
       },
       "connections": [
         {

--- a/management/testing/integration-tests/src/test/resources/topology-before-reconfigure.json
+++ b/management/testing/integration-tests/src/test/resources/topology-before-reconfigure.json
@@ -11,20 +11,56 @@
               "id": "NmsAgent:org.terracotta.management.entity.nms.agent.client.NmsAgentEntity",
               "type": "org.terracotta.management.entity.nms.agent.client.NmsAgentEntity",
               "name": "NmsAgent",
-              "consumerId": 1,
+              "consumerId": 3,
               "managementRegistry": null
             },
             {
               "id": "ReconfigureEntityIT:org.terracotta.management.entity.nms.client.NmsEntity",
               "type": "org.terracotta.management.entity.nms.client.NmsEntity",
               "name": "ReconfigureEntityIT",
-              "consumerId": 2,
+              "consumerId": 6,
               "managementRegistry": {
                 "contextContainer": {
-                  "consumerId": "2",
+                  "consumerId": "6",
                   "subContexts": []
                 },
                 "capabilities": [
+                  {
+                    "name": "DataRootSettings",
+                    "context": [
+                      {
+                        "name": "consumerId",
+                        "required": true
+                      },
+                      {
+                        "name": "type",
+                        "required": true
+                      },
+                      {
+                        "name": "alias",
+                        "required": true
+                      }
+                    ],
+                    "descriptors": []
+                  },
+                  {
+                    "name": "DataRootStatistics",
+                    "context": [
+                      {
+                        "name": "consumerId",
+                        "required": true
+                      },
+                      {
+                        "name": "type",
+                        "required": true
+                      },
+                      {
+                        "name": "alias",
+                        "required": true
+                      }
+                    ],
+                    "descriptors": []
+                  },
                   {
                     "name": "OffHeapResourceSettings",
                     "context": [
@@ -43,7 +79,7 @@
                     ],
                     "descriptors": [
                       {
-                        "consumerId": "2",
+                        "consumerId": "6",
                         "alias": "primary-server-resource",
                         "type": "OffHeapResource",
                         "capacity": 67108864,
@@ -117,13 +153,47 @@
               }
             },
             {
-              "id": "pet-clinic/clients:org.terracotta.management.entity.sample.client.CacheEntity",
-              "type": "org.terracotta.management.entity.sample.client.CacheEntity",
-              "name": "pet-clinic/clients",
+              "id": "SystemLeaseAcquirer:org.terracotta.lease.LeaseAcquirer",
+              "type": "org.terracotta.lease.LeaseAcquirer",
+              "name": "SystemLeaseAcquirer",
+              "consumerId": 1,
+              "managementRegistry": null
+            },
+            {
+              "id": "dynamic-config-management-entity:org.terracotta.dynamic_config.entity.management.server.ManagementEntityServerService",
+              "type": "org.terracotta.dynamic_config.entity.management.server.ManagementEntityServerService",
+              "name": "dynamic-config-management-entity",
               "consumerId": 4,
               "managementRegistry": {
                 "contextContainer": {
                   "consumerId": "4",
+                  "subContexts": []
+                },
+                "capabilities": []
+              }
+            },
+            {
+              "id": "dynamic-config-topology-entity:org.terracotta.dynamic_config.entity.topology.client.DynamicTopologyEntity",
+              "type": "org.terracotta.dynamic_config.entity.topology.client.DynamicTopologyEntity",
+              "name": "dynamic-config-topology-entity",
+              "consumerId": 2,
+              "managementRegistry": null
+            },
+            {
+              "id": "nomad-entity:org.terracotta.nomad.entity.client.NomadEntity",
+              "type": "org.terracotta.nomad.entity.client.NomadEntity",
+              "name": "nomad-entity",
+              "consumerId": 5,
+              "managementRegistry": null
+            },
+            {
+              "id": "pet-clinic/clients:org.terracotta.management.entity.sample.client.CacheEntity",
+              "type": "org.terracotta.management.entity.sample.client.CacheEntity",
+              "name": "pet-clinic/clients",
+              "consumerId": 8,
+              "managementRegistry": {
+                "contextContainer": {
+                  "consumerId": "8",
                   "subContexts": []
                 },
                 "capabilities": [
@@ -145,13 +215,13 @@
                     ],
                     "descriptors": [
                       {
-                        "consumerId": "4",
+                        "consumerId": "8",
                         "alias": "0@127.0.0.1:pet-clinic:<uuid>",
                         "type": "ClientState",
                         "attached": true
                       },
                       {
-                        "consumerId": "4",
+                        "consumerId": "8",
                         "alias": "0@127.0.0.1:pet-clinic:<uuid>",
                         "type": "ClientState",
                         "attached": true
@@ -225,7 +295,7 @@
                     ],
                     "descriptors": [
                       {
-                        "consumerId": "4",
+                        "consumerId": "8",
                         "alias": "pet-clinic/clients",
                         "type": "ServerCache",
                         "size": 0
@@ -290,10 +360,10 @@
               "id": "pet-clinic/pets:org.terracotta.management.entity.sample.client.CacheEntity",
               "type": "org.terracotta.management.entity.sample.client.CacheEntity",
               "name": "pet-clinic/pets",
-              "consumerId": 3,
+              "consumerId": 7,
               "managementRegistry": {
                 "contextContainer": {
-                  "consumerId": "3",
+                  "consumerId": "7",
                   "subContexts": []
                 },
                 "capabilities": [
@@ -315,13 +385,13 @@
                     ],
                     "descriptors": [
                       {
-                        "consumerId": "3",
+                        "consumerId": "7",
                         "alias": "0@127.0.0.1:pet-clinic:<uuid>",
                         "type": "ClientState",
                         "attached": true
                       },
                       {
-                        "consumerId": "3",
+                        "consumerId": "7",
                         "alias": "0@127.0.0.1:pet-clinic:<uuid>",
                         "type": "ClientState",
                         "attached": true
@@ -395,7 +465,7 @@
                     ],
                     "descriptors": [
                       {
-                        "consumerId": "3",
+                        "consumerId": "7",
                         "alias": "pet-clinic/pets",
                         "type": "ServerCache",
                         "size": 0
@@ -484,9 +554,9 @@
       "clientId": "0@127.0.0.1:ReconfigureEntityIT:<uuid>",
       "hostName": "<hostname>",
       "tags": [],
-      "properties" : { 
-        "clientReportedAddress" : "<clientReportedAddress>",
-        "version" : "<version>"
+      "properties": {
+        "version": "<version>",
+        "clientReportedAddress": "<clientReportedAddress>"
       },
       "connections": [
         {
@@ -518,9 +588,9 @@
         "caches",
         "pet-clinic"
       ],
-      "properties" : { 
-        "clientReportedAddress" : "<clientReportedAddress>",
-        "version" : "<version>"
+      "properties": {
+        "version": "<version>",
+        "clientReportedAddress": "<clientReportedAddress>"
       },
       "connections": [
         {
@@ -717,9 +787,9 @@
         "caches",
         "pet-clinic"
       ],
-      "properties" : { 
-        "clientReportedAddress" : "<clientReportedAddress>",
-        "version" : "<version>"
+      "properties": {
+        "version": "<version>",
+        "clientReportedAddress": "<clientReportedAddress>"
       },
       "connections": [
         {

--- a/management/testing/integration-tests/src/test/resources/topology-reconfigured.json
+++ b/management/testing/integration-tests/src/test/resources/topology-reconfigured.json
@@ -11,20 +11,56 @@
               "id": "NmsAgent:org.terracotta.management.entity.nms.agent.client.NmsAgentEntity",
               "type": "org.terracotta.management.entity.nms.agent.client.NmsAgentEntity",
               "name": "NmsAgent",
-              "consumerId": 1,
+              "consumerId": 3,
               "managementRegistry": null
             },
             {
               "id": "ReconfigureEntityIT:org.terracotta.management.entity.nms.client.NmsEntity",
               "type": "org.terracotta.management.entity.nms.client.NmsEntity",
               "name": "ReconfigureEntityIT",
-              "consumerId": 2,
+              "consumerId": 6,
               "managementRegistry": {
                 "contextContainer": {
-                  "consumerId": "2",
+                  "consumerId": "6",
                   "subContexts": []
                 },
                 "capabilities": [
+                  {
+                    "name": "DataRootSettings",
+                    "context": [
+                      {
+                        "name": "consumerId",
+                        "required": true
+                      },
+                      {
+                        "name": "type",
+                        "required": true
+                      },
+                      {
+                        "name": "alias",
+                        "required": true
+                      }
+                    ],
+                    "descriptors": []
+                  },
+                  {
+                    "name": "DataRootStatistics",
+                    "context": [
+                      {
+                        "name": "consumerId",
+                        "required": true
+                      },
+                      {
+                        "name": "type",
+                        "required": true
+                      },
+                      {
+                        "name": "alias",
+                        "required": true
+                      }
+                    ],
+                    "descriptors": []
+                  },
                   {
                     "name": "OffHeapResourceSettings",
                     "context": [
@@ -43,7 +79,7 @@
                     ],
                     "descriptors": [
                       {
-                        "consumerId": "2",
+                        "consumerId": "6",
                         "alias": "primary-server-resource",
                         "type": "OffHeapResource",
                         "capacity": 67108864,
@@ -117,13 +153,47 @@
               }
             },
             {
-              "id": "pet-clinic/clients:org.terracotta.management.entity.sample.client.CacheEntity",
-              "type": "org.terracotta.management.entity.sample.client.CacheEntity",
-              "name": "pet-clinic/clients",
+              "id": "SystemLeaseAcquirer:org.terracotta.lease.LeaseAcquirer",
+              "type": "org.terracotta.lease.LeaseAcquirer",
+              "name": "SystemLeaseAcquirer",
+              "consumerId": 1,
+              "managementRegistry": null
+            },
+            {
+              "id": "dynamic-config-management-entity:org.terracotta.dynamic_config.entity.management.server.ManagementEntityServerService",
+              "type": "org.terracotta.dynamic_config.entity.management.server.ManagementEntityServerService",
+              "name": "dynamic-config-management-entity",
               "consumerId": 4,
               "managementRegistry": {
                 "contextContainer": {
                   "consumerId": "4",
+                  "subContexts": []
+                },
+                "capabilities": []
+              }
+            },
+            {
+              "id": "dynamic-config-topology-entity:org.terracotta.dynamic_config.entity.topology.client.DynamicTopologyEntity",
+              "type": "org.terracotta.dynamic_config.entity.topology.client.DynamicTopologyEntity",
+              "name": "dynamic-config-topology-entity",
+              "consumerId": 2,
+              "managementRegistry": null
+            },
+            {
+              "id": "nomad-entity:org.terracotta.nomad.entity.client.NomadEntity",
+              "type": "org.terracotta.nomad.entity.client.NomadEntity",
+              "name": "nomad-entity",
+              "consumerId": 5,
+              "managementRegistry": null
+            },
+            {
+              "id": "pet-clinic/clients:org.terracotta.management.entity.sample.client.CacheEntity",
+              "type": "org.terracotta.management.entity.sample.client.CacheEntity",
+              "name": "pet-clinic/clients",
+              "consumerId": 8,
+              "managementRegistry": {
+                "contextContainer": {
+                  "consumerId": "8",
                   "subContexts": []
                 },
                 "capabilities": [
@@ -145,13 +215,13 @@
                     ],
                     "descriptors": [
                       {
-                        "consumerId": "4",
+                        "consumerId": "8",
                         "alias": "0@127.0.0.1:pet-clinic:<uuid>",
                         "type": "ClientState",
                         "attached": true
                       },
                       {
-                        "consumerId": "4",
+                        "consumerId": "8",
                         "alias": "0@127.0.0.1:pet-clinic:<uuid>",
                         "type": "ClientState",
                         "attached": true
@@ -225,7 +295,7 @@
                     ],
                     "descriptors": [
                       {
-                        "consumerId": "4",
+                        "consumerId": "8",
                         "alias": "pet-clinic/clients",
                         "type": "ServerCache",
                         "size": 0
@@ -290,10 +360,10 @@
               "id": "pet-clinic/pets:org.terracotta.management.entity.sample.client.CacheEntity",
               "type": "org.terracotta.management.entity.sample.client.CacheEntity",
               "name": "pet-clinic/pets",
-              "consumerId": 3,
+              "consumerId": 7,
               "managementRegistry": {
                 "contextContainer": {
-                  "consumerId": "3",
+                  "consumerId": "7",
                   "subContexts": []
                 },
                 "capabilities": [
@@ -315,13 +385,13 @@
                     ],
                     "descriptors": [
                       {
-                        "consumerId": "3",
+                        "consumerId": "7",
                         "alias": "0@127.0.0.1:pet-clinic:<uuid>",
                         "type": "ClientState",
                         "attached": true
                       },
                       {
-                        "consumerId": "3",
+                        "consumerId": "7",
                         "alias": "0@127.0.0.1:pet-clinic:<uuid>",
                         "type": "ClientState",
                         "attached": true
@@ -395,7 +465,7 @@
                     ],
                     "descriptors": [
                       {
-                        "consumerId": "3",
+                        "consumerId": "7",
                         "alias": "pet-clinic/clients",
                         "type": "ServerCache",
                         "size": 0
@@ -484,9 +554,9 @@
       "clientId": "0@127.0.0.1:ReconfigureEntityIT:<uuid>",
       "hostName": "<hostname>",
       "tags": [],
-      "properties" : { 
-        "clientReportedAddress" : "<clientReportedAddress>",
-        "version" : "<version>"
+      "properties": {
+        "version": "<version>",
+        "clientReportedAddress": "<clientReportedAddress>"
       },
       "connections": [
         {
@@ -518,9 +588,9 @@
         "caches",
         "pet-clinic"
       ],
-      "properties" : { 
-        "clientReportedAddress" : "<clientReportedAddress>",
-        "version" : "<version>"
+      "properties": {
+        "version": "<version>",
+        "clientReportedAddress": "<clientReportedAddress>"
       },
       "connections": [
         {
@@ -717,9 +787,9 @@
         "caches",
         "pet-clinic"
       ],
-      "properties" : { 
-        "clientReportedAddress" : "<clientReportedAddress>",
-        "version" : "<version>"
+      "properties": {
+        "version": "<version>",
+        "clientReportedAddress": "<clientReportedAddress>"
       },
       "connections": [
         {

--- a/management/testing/integration-tests/src/test/resources/topology-renamed.json
+++ b/management/testing/integration-tests/src/test/resources/topology-renamed.json
@@ -11,20 +11,56 @@
               "id": "NmsAgent:org.terracotta.management.entity.nms.agent.client.NmsAgentEntity",
               "type": "org.terracotta.management.entity.nms.agent.client.NmsAgentEntity",
               "name": "NmsAgent",
-              "consumerId": 1,
+              "consumerId": 3,
               "managementRegistry": null
             },
             {
               "id": "StripeNamedIT:org.terracotta.management.entity.nms.client.NmsEntity",
               "type": "org.terracotta.management.entity.nms.client.NmsEntity",
               "name": "StripeNamedIT",
-              "consumerId": 5,
+              "consumerId": 9,
               "managementRegistry": {
                 "contextContainer": {
-                  "consumerId": "5",
+                  "consumerId": "9",
                   "subContexts": []
                 },
                 "capabilities": [
+                  {
+                    "name": "DataRootSettings",
+                    "context": [
+                      {
+                        "name": "consumerId",
+                        "required": true
+                      },
+                      {
+                        "name": "type",
+                        "required": true
+                      },
+                      {
+                        "name": "alias",
+                        "required": true
+                      }
+                    ],
+                    "descriptors": []
+                  },
+                  {
+                    "name": "DataRootStatistics",
+                    "context": [
+                      {
+                        "name": "consumerId",
+                        "required": true
+                      },
+                      {
+                        "name": "type",
+                        "required": true
+                      },
+                      {
+                        "name": "alias",
+                        "required": true
+                      }
+                    ],
+                    "descriptors": []
+                  },
                   {
                     "name": "OffHeapResourceSettings",
                     "context": [
@@ -43,7 +79,7 @@
                     ],
                     "descriptors": [
                       {
-                        "consumerId": "5",
+                        "consumerId": "9",
                         "alias": "primary-server-resource",
                         "type": "OffHeapResource",
                         "capacity": 67108864,
@@ -120,13 +156,49 @@
               "id": "StripeNamedIT:org.terracotta.management.entity.nms.client.NmsEntity",
               "type": "org.terracotta.management.entity.nms.client.NmsEntity",
               "name": "StripeNamedIT",
-              "consumerId": 2,
+              "consumerId": 6,
               "managementRegistry": {
                 "contextContainer": {
-                  "consumerId": "2",
+                  "consumerId": "6",
                   "subContexts": []
                 },
                 "capabilities": [
+                  {
+                    "name": "DataRootSettings",
+                    "context": [
+                      {
+                        "name": "consumerId",
+                        "required": true
+                      },
+                      {
+                        "name": "type",
+                        "required": true
+                      },
+                      {
+                        "name": "alias",
+                        "required": true
+                      }
+                    ],
+                    "descriptors": []
+                  },
+                  {
+                    "name": "DataRootStatistics",
+                    "context": [
+                      {
+                        "name": "consumerId",
+                        "required": true
+                      },
+                      {
+                        "name": "type",
+                        "required": true
+                      },
+                      {
+                        "name": "alias",
+                        "required": true
+                      }
+                    ],
+                    "descriptors": []
+                  },
                   {
                     "name": "OffHeapResourceSettings",
                     "context": [
@@ -145,7 +217,7 @@
                     ],
                     "descriptors": [
                       {
-                        "consumerId": "2",
+                        "consumerId": "6",
                         "alias": "primary-server-resource",
                         "type": "OffHeapResource",
                         "capacity": 67108864,
@@ -219,13 +291,47 @@
               }
             },
             {
-              "id": "pet-clinic/clients:org.terracotta.management.entity.sample.client.CacheEntity",
-              "type": "org.terracotta.management.entity.sample.client.CacheEntity",
-              "name": "pet-clinic/clients",
+              "id": "SystemLeaseAcquirer:org.terracotta.lease.LeaseAcquirer",
+              "type": "org.terracotta.lease.LeaseAcquirer",
+              "name": "SystemLeaseAcquirer",
+              "consumerId": 1,
+              "managementRegistry": null
+            },
+            {
+              "id": "dynamic-config-management-entity:org.terracotta.dynamic_config.entity.management.server.ManagementEntityServerService",
+              "type": "org.terracotta.dynamic_config.entity.management.server.ManagementEntityServerService",
+              "name": "dynamic-config-management-entity",
               "consumerId": 4,
               "managementRegistry": {
                 "contextContainer": {
                   "consumerId": "4",
+                  "subContexts": []
+                },
+                "capabilities": []
+              }
+            },
+            {
+              "id": "dynamic-config-topology-entity:org.terracotta.dynamic_config.entity.topology.client.DynamicTopologyEntity",
+              "type": "org.terracotta.dynamic_config.entity.topology.client.DynamicTopologyEntity",
+              "name": "dynamic-config-topology-entity",
+              "consumerId": 2,
+              "managementRegistry": null
+            },
+            {
+              "id": "nomad-entity:org.terracotta.nomad.entity.client.NomadEntity",
+              "type": "org.terracotta.nomad.entity.client.NomadEntity",
+              "name": "nomad-entity",
+              "consumerId": 5,
+              "managementRegistry": null
+            },
+            {
+              "id": "pet-clinic/clients:org.terracotta.management.entity.sample.client.CacheEntity",
+              "type": "org.terracotta.management.entity.sample.client.CacheEntity",
+              "name": "pet-clinic/clients",
+              "consumerId": 8,
+              "managementRegistry": {
+                "contextContainer": {
+                  "consumerId": "8",
                   "subContexts": []
                 },
                 "capabilities": [
@@ -247,13 +353,13 @@
                     ],
                     "descriptors": [
                       {
-                        "consumerId": "4",
+                        "consumerId": "8",
                         "alias": "0@127.0.0.1:pet-clinic:<uuid>",
                         "type": "ClientState",
                         "attached": true
                       },
                       {
-                        "consumerId": "4",
+                        "consumerId": "8",
                         "alias": "0@127.0.0.1:pet-clinic:<uuid>",
                         "type": "ClientState",
                         "attached": true
@@ -327,7 +433,7 @@
                     ],
                     "descriptors": [
                       {
-                        "consumerId": "4",
+                        "consumerId": "8",
                         "alias": "pet-clinic/clients",
                         "type": "ServerCache",
                         "size": 0
@@ -392,10 +498,10 @@
               "id": "pet-clinic/pets:org.terracotta.management.entity.sample.client.CacheEntity",
               "type": "org.terracotta.management.entity.sample.client.CacheEntity",
               "name": "pet-clinic/pets",
-              "consumerId": 3,
+              "consumerId": 7,
               "managementRegistry": {
                 "contextContainer": {
-                  "consumerId": "3",
+                  "consumerId": "7",
                   "subContexts": []
                 },
                 "capabilities": [
@@ -417,13 +523,13 @@
                     ],
                     "descriptors": [
                       {
-                        "consumerId": "3",
+                        "consumerId": "7",
                         "alias": "0@127.0.0.1:pet-clinic:<uuid>",
                         "type": "ClientState",
                         "attached": true
                       },
                       {
-                        "consumerId": "3",
+                        "consumerId": "7",
                         "alias": "0@127.0.0.1:pet-clinic:<uuid>",
                         "type": "ClientState",
                         "attached": true
@@ -497,7 +603,7 @@
                     ],
                     "descriptors": [
                       {
-                        "consumerId": "3",
+                        "consumerId": "7",
                         "alias": "pet-clinic/pets",
                         "type": "ServerCache",
                         "size": 0
@@ -586,9 +692,9 @@
       "clientId": "0@127.0.0.1:StripeNamedIT:<uuid>",
       "hostName": "<hostname>",
       "tags": [],
-      "properties" : { 
-        "clientReportedAddress" : "<clientReportedAddress>",
-        "version" : "<version>"
+      "properties": {
+        "clientReportedAddress": "<clientReportedAddress>",
+        "version": "<version>"
       },
       "connections": [
         {
@@ -617,9 +723,9 @@
       "clientId": "0@127.0.0.1:StripeNamedIT:<uuid>",
       "hostName": "<hostname>",
       "tags": [],
-      "properties" : { 
-        "clientReportedAddress" : "<clientReportedAddress>",
-        "version" : "<version>"
+      "properties": {
+        "clientReportedAddress": "<clientReportedAddress>",
+        "version": "<version>"
       },
       "connections": [
         {
@@ -651,9 +757,9 @@
         "caches",
         "pet-clinic"
       ],
-      "properties" : { 
-        "clientReportedAddress" : "<clientReportedAddress>",
-        "version" : "<version>"
+      "properties": {
+        "clientReportedAddress": "<clientReportedAddress>",
+        "version": "<version>"
       },
       "connections": [
         {
@@ -850,9 +956,9 @@
         "caches",
         "pet-clinic"
       ],
-      "properties" : { 
-        "clientReportedAddress" : "<clientReportedAddress>",
-        "version" : "<version>"
+      "properties": {
+        "clientReportedAddress": "<clientReportedAddress>",
+        "version": "<version>"
       },
       "connections": [
         {

--- a/management/testing/integration-tests/src/test/resources/topology.json
+++ b/management/testing/integration-tests/src/test/resources/topology.json
@@ -11,6 +11,13 @@
               "id": "NmsAgent:org.terracotta.management.entity.nms.agent.client.NmsAgentEntity",
               "type": "org.terracotta.management.entity.nms.agent.client.NmsAgentEntity",
               "name": "NmsAgent",
+              "consumerId": 3,
+              "managementRegistry": null
+            },
+            {
+              "id": "SystemLeaseAcquirer:org.terracotta.lease.LeaseAcquirer",
+              "type": "org.terracotta.lease.LeaseAcquirer",
+              "name": "SystemLeaseAcquirer",
               "consumerId": 1,
               "managementRegistry": null
             },
@@ -18,13 +25,49 @@
               "id": "TopologyIT:org.terracotta.management.entity.nms.client.NmsEntity",
               "type": "org.terracotta.management.entity.nms.client.NmsEntity",
               "name": "TopologyIT",
-              "consumerId": 2,
+              "consumerId": 6,
               "managementRegistry": {
                 "contextContainer": {
-                  "consumerId": "2",
+                  "consumerId": "6",
                   "subContexts": []
                 },
                 "capabilities": [
+                  {
+                    "name": "DataRootSettings",
+                    "context": [
+                      {
+                        "name": "consumerId",
+                        "required": true
+                      },
+                      {
+                        "name": "type",
+                        "required": true
+                      },
+                      {
+                        "name": "alias",
+                        "required": true
+                      }
+                    ],
+                    "descriptors": []
+                  },
+                  {
+                    "name": "DataRootStatistics",
+                    "context": [
+                      {
+                        "name": "consumerId",
+                        "required": true
+                      },
+                      {
+                        "name": "type",
+                        "required": true
+                      },
+                      {
+                        "name": "alias",
+                        "required": true
+                      }
+                    ],
+                    "descriptors": []
+                  },
                   {
                     "name": "OffHeapResourceSettings",
                     "context": [
@@ -43,7 +86,7 @@
                     ],
                     "descriptors": [
                       {
-                        "consumerId": "2",
+                        "consumerId": "6",
                         "alias": "primary-server-resource",
                         "type": "OffHeapResource",
                         "capacity": 67108864,
@@ -117,13 +160,40 @@
               }
             },
             {
-              "id": "pet-clinic/clients:org.terracotta.management.entity.sample.client.CacheEntity",
-              "type": "org.terracotta.management.entity.sample.client.CacheEntity",
-              "name": "pet-clinic/clients",
+              "id": "dynamic-config-management-entity:org.terracotta.dynamic_config.entity.management.server.ManagementEntityServerService",
+              "type": "org.terracotta.dynamic_config.entity.management.server.ManagementEntityServerService",
+              "name": "dynamic-config-management-entity",
               "consumerId": 4,
               "managementRegistry": {
                 "contextContainer": {
                   "consumerId": "4",
+                  "subContexts": []
+                },
+                "capabilities": []
+              }
+            },
+            {
+              "id": "dynamic-config-topology-entity:org.terracotta.dynamic_config.entity.topology.client.DynamicTopologyEntity",
+              "type": "org.terracotta.dynamic_config.entity.topology.client.DynamicTopologyEntity",
+              "name": "dynamic-config-topology-entity",
+              "consumerId": 2,
+              "managementRegistry": null
+            },
+            {
+              "id": "nomad-entity:org.terracotta.nomad.entity.client.NomadEntity",
+              "type": "org.terracotta.nomad.entity.client.NomadEntity",
+              "name": "nomad-entity",
+              "consumerId": 5,
+              "managementRegistry": null
+            },
+            {
+              "id": "pet-clinic/clients:org.terracotta.management.entity.sample.client.CacheEntity",
+              "type": "org.terracotta.management.entity.sample.client.CacheEntity",
+              "name": "pet-clinic/clients",
+              "consumerId": 8,
+              "managementRegistry": {
+                "contextContainer": {
+                  "consumerId": "8",
                   "subContexts": []
                 },
                 "capabilities": [
@@ -145,13 +215,13 @@
                     ],
                     "descriptors": [
                       {
-                        "consumerId": "4",
+                        "consumerId": "8",
                         "alias": "0@127.0.0.1:pet-clinic:<uuid>",
                         "type": "ClientState",
                         "attached": true
                       },
                       {
-                        "consumerId": "4",
+                        "consumerId": "8",
                         "alias": "0@127.0.0.1:pet-clinic:<uuid>",
                         "type": "ClientState",
                         "attached": true
@@ -225,7 +295,7 @@
                     ],
                     "descriptors": [
                       {
-                        "consumerId": "4",
+                        "consumerId": "8",
                         "alias": "pet-clinic/clients",
                         "type": "ServerCache",
                         "size": 0
@@ -290,10 +360,10 @@
               "id": "pet-clinic/pets:org.terracotta.management.entity.sample.client.CacheEntity",
               "type": "org.terracotta.management.entity.sample.client.CacheEntity",
               "name": "pet-clinic/pets",
-              "consumerId": 3,
+              "consumerId": 7,
               "managementRegistry": {
                 "contextContainer": {
-                  "consumerId": "3",
+                  "consumerId": "7",
                   "subContexts": []
                 },
                 "capabilities": [
@@ -315,13 +385,13 @@
                     ],
                     "descriptors": [
                       {
-                        "consumerId": "3",
+                        "consumerId": "7",
                         "alias": "0@127.0.0.1:pet-clinic:<uuid>",
                         "type": "ClientState",
                         "attached": true
                       },
                       {
-                        "consumerId": "3",
+                        "consumerId": "7",
                         "alias": "0@127.0.0.1:pet-clinic:<uuid>",
                         "type": "ClientState",
                         "attached": true
@@ -395,7 +465,7 @@
                     ],
                     "descriptors": [
                       {
-                        "consumerId": "3",
+                        "consumerId": "7",
                         "alias": "pet-clinic/pets",
                         "type": "ServerCache",
                         "size": 0
@@ -484,9 +554,9 @@
       "clientId": "0@127.0.0.1:TopologyIT:<uuid>",
       "hostName": "<hostname>",
       "tags": [],
-      "properties" : { 
-        "clientReportedAddress" : "<clientReportedAddress>",
-        "version" : "<version>"
+      "properties": {
+        "version": "<version>",
+        "clientReportedAddress": "<clientReportedAddress>"
       },
       "connections": [
         {
@@ -518,9 +588,9 @@
         "caches",
         "pet-clinic"
       ],
-      "properties" : { 
-        "clientReportedAddress" : "<clientReportedAddress>",
-        "version" : "<version>"
+      "properties": {
+        "version": "<version>",
+        "clientReportedAddress": "<clientReportedAddress>"
       },
       "connections": [
         {
@@ -717,9 +787,9 @@
         "caches",
         "pet-clinic"
       ],
-      "properties" : { 
-        "clientReportedAddress" : "<clientReportedAddress>",
-        "version" : "<version>"
+      "properties": {
+        "version": "<version>",
+        "clientReportedAddress": "<clientReportedAddress>"
       },
       "connections": [
         {

--- a/pom.xml
+++ b/pom.xml
@@ -30,9 +30,9 @@
     <slf4j.version>1.7.25</slf4j.version>
     <logback.version>1.2.3</logback.version>
     <terracotta-apis.version>1.7.0-pre1</terracotta-apis.version>
-    <terracotta-configuration.version>10.7.0-pre1</terracotta-configuration.version>
-    <passthrough-testing.version>1.7.0-pre4</passthrough-testing.version>
-    <terracotta-core.version>5.7.0-pre8</terracotta-core.version>
+    <terracotta-configuration.version>10.7.0-pre2</terracotta-configuration.version>
+    <passthrough-testing.version>1.7.0-pre8</passthrough-testing.version>
+    <terracotta-core.version>5.7.0-pre18</terracotta-core.version>
     <tripwire.version>1.0.0-pre7</tripwire.version>
     <angela.version>3.0.14</angela.version>
     <statistics.version>2.1</statistics.version>
@@ -60,6 +60,7 @@
     <module>data-root-resource</module>
     <module>diagnostic</module>
     <module>dynamic-config</module>
+    <module>kit</module>
   </modules>
 
   <dependencyManagement>


### PR DESCRIPTION
__Progress:__

- [X] Upgraded core versions
- [X] Remove unnecessary `@CommonComponent`
- [X] Remove unnecessary `packaging-support` dependency
- [X] Split the dynamic config server in parts (config provider, config repository, conversion, services)
- [X] Provided a dist to package dynamic config server plugin
- [X] Fixed scopes of some modules in tc-platform
- [X] Packaging entities plus dependencies in their own jar, ;like its done for `default-configuration`
- [X] New platform kit
- [X] Refactoring to get rid of our main class and use only config provider only
- [X] Remove the XML file generation for the temporary startup when building a cluster
- [X] Reviewed creation:
    -  to only include terracotta classes and not external libs in shaded jars
    -  fixed scopes
    -  fixed configuration of jar plugin with OSGI bundle plugin
    - to generate Class-Path entries according to maven dependencies
- [X] Verified all generated jar content, maven inclusions + MANIFEST
- [X] Verifying KIT (exposing dependencies for default-configuration jar, etc)
- [X] Applying spotBugs over all project
- [X] Added `-Pslow` and `-Pfast` profiles, slow being the default (with spotBugs, license check, javadoc and sources)
- [X] config tool in the kit
- [x] Use the new Galvan version and new kit for the existing systems tests in project
- [x] PoC to remove XML config
- [x] Fix Galvan tests assertions (i.e. regarding entity count, et)
- [x] Resurrect dynamic config system tests and use the new KIT

```
# fast clean the project
./mvnw clean -T4C

# fast build of the project
./mvnw install -Pfast -DskipTests

# run all unit tests - no system tests
./mvnw test -DskipITs

# rebuild the kit and all modules depending on the kit
./mvnw clean install -DskipTests -Pfast -rf :platform-kit
```

Note: `-Pfast` means:
- No javadoc jar
- No source jar
- No spotBugs
- No license check
