### PR TITLE
Fixing Nomad entity client-server com

### DIFF
--- a/dynamic-config/entities/nomad-entity/common/src/main/java/org/terracotta/nomad/entity/common/NomadEntityMessage.java
+++ b/dynamic-config/entities/nomad-entity/common/src/main/java/org/terracotta/nomad/entity/common/NomadEntityMessage.java
@@ -20,6 +20,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import org.terracotta.entity.EntityMessage;
 import org.terracotta.nomad.messages.MutativeMessage;
 
+import static java.util.Objects.requireNonNull;
+
 /**
  * @author Mathieu Carbou
  */
@@ -29,10 +31,15 @@ public class NomadEntityMessage implements EntityMessage {
 
   @JsonCreator
   public NomadEntityMessage(@JsonProperty(value = "nomadMessage", required = true) MutativeMessage nomadMessage) {
-    this.nomadMessage = nomadMessage;
+    this.nomadMessage = requireNonNull(nomadMessage);
   }
 
   public MutativeMessage getNomadMessage() {
     return nomadMessage;
+  }
+
+  @Override
+  public String toString() {
+    return nomadMessage.toString();
   }
 }

--- a/dynamic-config/entities/nomad-entity/common/src/main/java/org/terracotta/nomad/entity/common/NomadEntityResponse.java
+++ b/dynamic-config/entities/nomad-entity/common/src/main/java/org/terracotta/nomad/entity/common/NomadEntityResponse.java
@@ -20,6 +20,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import org.terracotta.entity.EntityResponse;
 import org.terracotta.nomad.messages.AcceptRejectResponse;
 
+import static java.util.Objects.requireNonNull;
+
 /**
  * @author Mathieu Carbou
  */
@@ -29,10 +31,15 @@ public class NomadEntityResponse implements EntityResponse {
 
   @JsonCreator
   public NomadEntityResponse(@JsonProperty(value = "response", required = true) AcceptRejectResponse response) {
-    this.response = response;
+    this.response = requireNonNull(response);
   }
 
   public AcceptRejectResponse getResponse() {
     return response;
+  }
+
+  @Override
+  public String toString() {
+    return response.toString();
   }
 }

--- a/dynamic-config/entities/nomad-entity/server/src/main/java/org/terracotta/nomad/entity/server/NomadActiveServerEntity.java
+++ b/dynamic-config/entities/nomad-entity/server/src/main/java/org/terracotta/nomad/entity/server/NomadActiveServerEntity.java
@@ -15,8 +15,6 @@
  */
 package org.terracotta.nomad.entity.server;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.terracotta.entity.ActiveInvokeContext;
 import org.terracotta.entity.ActiveServerEntity;
 import org.terracotta.entity.ClientDescriptor;
@@ -24,13 +22,13 @@ import org.terracotta.entity.EntityUserException;
 import org.terracotta.entity.PassiveSynchronizationChannel;
 import org.terracotta.nomad.entity.common.NomadEntityMessage;
 import org.terracotta.nomad.entity.common.NomadEntityResponse;
+import org.terracotta.nomad.messages.AcceptRejectResponse;
+import org.terracotta.nomad.messages.MutativeMessage;
 import org.terracotta.nomad.server.NomadException;
 import org.terracotta.nomad.server.NomadServer;
 
 
 public class NomadActiveServerEntity<T> extends NomadCommonServerEntity<T> implements ActiveServerEntity<NomadEntityMessage, NomadEntityResponse> {
-  private static final Logger LOGGER = LoggerFactory.getLogger(NomadActiveServerEntity.class);
-
   public NomadActiveServerEntity(NomadServer<T> nomadServer) {
     super(nomadServer);
   }
@@ -59,10 +57,13 @@ public class NomadActiveServerEntity<T> extends NomadCommonServerEntity<T> imple
 
   @Override
   public NomadEntityResponse invokeActive(ActiveInvokeContext<NomadEntityResponse> context, NomadEntityMessage message) throws EntityUserException {
-    LOGGER.trace("invokeActive({})", message.getNomadMessage());
+    logger.trace("invokeActive({})", message);
     try {
-      return new NomadEntityResponse(processMessage(message.getNomadMessage()));
+      MutativeMessage nomadMessage = message.getNomadMessage();
+      AcceptRejectResponse response = processMessage(nomadMessage);
+      return new NomadEntityResponse(response);
     } catch (NomadException | RuntimeException e) {
+      logger.error("Failure happened while processing Nomad message: {}: {}", message, e.getMessage(), e);
       throw new EntityUserException(e.getMessage(), e);
     }
   }

--- a/dynamic-config/entities/nomad-entity/server/src/main/java/org/terracotta/nomad/entity/server/NomadCommonServerEntity.java
+++ b/dynamic-config/entities/nomad-entity/server/src/main/java/org/terracotta/nomad/entity/server/NomadCommonServerEntity.java
@@ -15,6 +15,8 @@
  */
 package org.terracotta.nomad.entity.server;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.terracotta.entity.CommonServerEntity;
 import org.terracotta.nomad.entity.common.NomadEntityMessage;
 import org.terracotta.nomad.entity.common.NomadEntityResponse;
@@ -28,6 +30,8 @@ import org.terracotta.nomad.server.NomadException;
 import org.terracotta.nomad.server.NomadServer;
 
 public class NomadCommonServerEntity<T> implements CommonServerEntity<NomadEntityMessage, NomadEntityResponse> {
+
+  protected final Logger logger = LoggerFactory.getLogger(getClass());
 
   private final NomadServer<T> nomadServer;
 
@@ -44,6 +48,7 @@ public class NomadCommonServerEntity<T> implements CommonServerEntity<NomadEntit
   }
 
   protected AcceptRejectResponse processMessage(MutativeMessage nomadMessage) throws NomadException {
+    logger.trace("Processing Nomad message: {}", nomadMessage);
     AcceptRejectResponse response;
     if (nomadMessage instanceof CommitMessage) {
       response = nomadServer.commit((CommitMessage) nomadMessage);
@@ -56,6 +61,7 @@ public class NomadCommonServerEntity<T> implements CommonServerEntity<NomadEntit
     } else {
       throw new IllegalArgumentException("Unsupported Nomad message: " + nomadMessage.getClass().getName());
     }
+    logger.trace("Result: {}", response);
     return response;
   }
 }

--- a/dynamic-config/entities/nomad-entity/server/src/main/java/org/terracotta/nomad/entity/server/NomadServerEntityService.java
+++ b/dynamic-config/entities/nomad-entity/server/src/main/java/org/terracotta/nomad/entity/server/NomadServerEntityService.java
@@ -25,7 +25,6 @@ import org.terracotta.entity.MessageCodecException;
 import org.terracotta.entity.ServiceException;
 import org.terracotta.entity.ServiceRegistry;
 import org.terracotta.entity.SyncMessageCodec;
-import org.terracotta.monitoring.PlatformService;
 import org.terracotta.nomad.entity.common.NomadEntityConstants;
 import org.terracotta.nomad.entity.common.NomadEntityMessage;
 import org.terracotta.nomad.entity.common.NomadEntityResponse;
@@ -53,8 +52,7 @@ public class NomadServerEntityService<T> implements EntityServerService<NomadEnt
     try {
       @SuppressWarnings("unchecked")
       NomadServer<T> nomadServer = registry.getService(new BasicServiceConfiguration<>(NomadServer.class));
-      PlatformService platformService = registry.getService(new BasicServiceConfiguration<>(PlatformService.class));
-      return new NomadPassiveServerEntity<>(nomadServer, platformService);
+      return new NomadPassiveServerEntity<>(nomadServer);
     } catch (ServiceException e) {
       throw new ConfigurationException("Could not retrieve service ", e);
     }


### PR DESCRIPTION
- client should also cache any exception that happened per stripe during the commit phase (not only the method return)
- server entity should log failures
- passive entity should not restart in case of failure because if the passive restarts when the active failed to commit and is still in PREPARE state, the passive won't be able to restart because the sync process will shutdown the passive.
- passive entity should ignore messages that could be received twice and lead to a DEAD or BAD state in Nomad for the subsequent call