### PR TITLE
Fixing Nomad entity client-server com. and passive sync process

### DIFF
--- a/dynamic-config/entities/nomad-entity/common/src/main/java/org/terracotta/nomad/entity/common/NomadEntityMessage.java
+++ b/dynamic-config/entities/nomad-entity/common/src/main/java/org/terracotta/nomad/entity/common/NomadEntityMessage.java
@@ -20,6 +20,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import org.terracotta.entity.EntityMessage;
 import org.terracotta.nomad.messages.MutativeMessage;
 
+import static java.util.Objects.requireNonNull;
+
 /**
  * @author Mathieu Carbou
  */
@@ -29,10 +31,15 @@ public class NomadEntityMessage implements EntityMessage {
 
   @JsonCreator
   public NomadEntityMessage(@JsonProperty(value = "nomadMessage", required = true) MutativeMessage nomadMessage) {
-    this.nomadMessage = nomadMessage;
+    this.nomadMessage = requireNonNull(nomadMessage);
   }
 
   public MutativeMessage getNomadMessage() {
     return nomadMessage;
+  }
+
+  @Override
+  public String toString() {
+    return nomadMessage.toString();
   }
 }

--- a/dynamic-config/entities/nomad-entity/common/src/main/java/org/terracotta/nomad/entity/common/NomadEntityResponse.java
+++ b/dynamic-config/entities/nomad-entity/common/src/main/java/org/terracotta/nomad/entity/common/NomadEntityResponse.java
@@ -20,6 +20,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import org.terracotta.entity.EntityResponse;
 import org.terracotta.nomad.messages.AcceptRejectResponse;
 
+import static java.util.Objects.requireNonNull;
+
 /**
  * @author Mathieu Carbou
  */
@@ -29,10 +31,15 @@ public class NomadEntityResponse implements EntityResponse {
 
   @JsonCreator
   public NomadEntityResponse(@JsonProperty(value = "response", required = true) AcceptRejectResponse response) {
-    this.response = response;
+    this.response = requireNonNull(response);
   }
 
   public AcceptRejectResponse getResponse() {
     return response;
+  }
+
+  @Override
+  public String toString() {
+    return response.toString();
   }
 }

--- a/dynamic-config/entities/nomad-entity/server/src/main/java/org/terracotta/nomad/entity/server/NomadActiveServerEntity.java
+++ b/dynamic-config/entities/nomad-entity/server/src/main/java/org/terracotta/nomad/entity/server/NomadActiveServerEntity.java
@@ -15,8 +15,6 @@
  */
 package org.terracotta.nomad.entity.server;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.terracotta.entity.ActiveInvokeContext;
 import org.terracotta.entity.ActiveServerEntity;
 import org.terracotta.entity.ClientDescriptor;
@@ -24,13 +22,13 @@ import org.terracotta.entity.EntityUserException;
 import org.terracotta.entity.PassiveSynchronizationChannel;
 import org.terracotta.nomad.entity.common.NomadEntityMessage;
 import org.terracotta.nomad.entity.common.NomadEntityResponse;
+import org.terracotta.nomad.messages.AcceptRejectResponse;
+import org.terracotta.nomad.messages.MutativeMessage;
 import org.terracotta.nomad.server.NomadException;
 import org.terracotta.nomad.server.NomadServer;
 
 
 public class NomadActiveServerEntity<T> extends NomadCommonServerEntity<T> implements ActiveServerEntity<NomadEntityMessage, NomadEntityResponse> {
-  private static final Logger LOGGER = LoggerFactory.getLogger(NomadActiveServerEntity.class);
-
   public NomadActiveServerEntity(NomadServer<T> nomadServer) {
     super(nomadServer);
   }
@@ -59,10 +57,13 @@ public class NomadActiveServerEntity<T> extends NomadCommonServerEntity<T> imple
 
   @Override
   public NomadEntityResponse invokeActive(ActiveInvokeContext<NomadEntityResponse> context, NomadEntityMessage message) throws EntityUserException {
-    LOGGER.trace("invokeActive({})", message.getNomadMessage());
+    logger.trace("invokeActive({})", message);
     try {
-      return new NomadEntityResponse(processMessage(message.getNomadMessage()));
+      MutativeMessage nomadMessage = message.getNomadMessage();
+      AcceptRejectResponse response = processMessage(nomadMessage);
+      return new NomadEntityResponse(response);
     } catch (NomadException | RuntimeException e) {
+      logger.error("Failure happened while processing Nomad message: {}: {}", message, e.getMessage(), e);
       throw new EntityUserException(e.getMessage(), e);
     }
   }

--- a/dynamic-config/entities/nomad-entity/server/src/main/java/org/terracotta/nomad/entity/server/NomadCommonServerEntity.java
+++ b/dynamic-config/entities/nomad-entity/server/src/main/java/org/terracotta/nomad/entity/server/NomadCommonServerEntity.java
@@ -15,6 +15,8 @@
  */
 package org.terracotta.nomad.entity.server;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.terracotta.entity.CommonServerEntity;
 import org.terracotta.nomad.entity.common.NomadEntityMessage;
 import org.terracotta.nomad.entity.common.NomadEntityResponse;
@@ -28,6 +30,8 @@ import org.terracotta.nomad.server.NomadException;
 import org.terracotta.nomad.server.NomadServer;
 
 public class NomadCommonServerEntity<T> implements CommonServerEntity<NomadEntityMessage, NomadEntityResponse> {
+
+  protected final Logger logger = LoggerFactory.getLogger(getClass());
 
   private final NomadServer<T> nomadServer;
 
@@ -44,6 +48,7 @@ public class NomadCommonServerEntity<T> implements CommonServerEntity<NomadEntit
   }
 
   protected AcceptRejectResponse processMessage(MutativeMessage nomadMessage) throws NomadException {
+    logger.trace("Processing Nomad message: {}", nomadMessage);
     AcceptRejectResponse response;
     if (nomadMessage instanceof CommitMessage) {
       response = nomadServer.commit((CommitMessage) nomadMessage);
@@ -56,6 +61,7 @@ public class NomadCommonServerEntity<T> implements CommonServerEntity<NomadEntit
     } else {
       throw new IllegalArgumentException("Unsupported Nomad message: " + nomadMessage.getClass().getName());
     }
+    logger.trace("Result: {}", response);
     return response;
   }
 }

--- a/dynamic-config/entities/nomad-entity/server/src/main/java/org/terracotta/nomad/entity/server/NomadPassiveServerEntity.java
+++ b/dynamic-config/entities/nomad-entity/server/src/main/java/org/terracotta/nomad/entity/server/NomadPassiveServerEntity.java
@@ -15,8 +15,6 @@
  */
 package org.terracotta.nomad.entity.server;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.terracotta.entity.EntityUserException;
 import org.terracotta.entity.InvokeContext;
 import org.terracotta.entity.PassiveServerEntity;
@@ -29,8 +27,6 @@ import org.terracotta.nomad.server.NomadException;
 import org.terracotta.nomad.server.NomadServer;
 
 public class NomadPassiveServerEntity<T> extends NomadCommonServerEntity<T> implements PassiveServerEntity<NomadEntityMessage, NomadEntityResponse> {
-  private static final Logger LOGGER = LoggerFactory.getLogger(NomadPassiveServerEntity.class);
-
   private final PlatformService platformService;
 
   public NomadPassiveServerEntity(NomadServer<T> nomadServer, PlatformService platformService) {
@@ -56,21 +52,33 @@ public class NomadPassiveServerEntity<T> extends NomadCommonServerEntity<T> impl
 
   @Override
   public void invokePassive(InvokeContext context, NomadEntityMessage message) throws EntityUserException {
-    LOGGER.trace("invokePassive({})", message.getNomadMessage());
+    logger.trace("invokePassive({})", message);
     try {
-      AcceptRejectResponse response = processMessage(message.getNomadMessage());
-      if (!response.isAccepted()) {
-        LOGGER.error("Node was unable to commit Nomad message: {}. Response: {}", message, response);
-        // Commit or rollback failed on passive: we restart it because we cannot do anything.
-        // Upon restart, the passive server will sync with the active server and repair itself if needed if the active server is committed or rolled back.
-        // The passive server will then restart with the wanted configuration without re-invoking the Nomad processors apply() methods of the commit phase.
-        // But if the commit failed on teh active server too and the active server is in prepared state,
-        // the passive server won't be able to repair itself and restart, it will be shutdown.
-        // The active server will need to be repaired with the CLI repair command first.
-        // This behavior is defined in DynamicConfigurationPassiveSync.
+      try {
+        AcceptRejectResponse response = processMessage(message.getNomadMessage());
+        if (!response.isAccepted()) {
+          // if message is not accepted, we just log (error) but we do not crash the passive:
+          switch (response.getRejectionReason()) {
+            case DEAD:
+              logger.warn("Node was unable to process Nomad message: {}. Response: {}. This can happen when the same message is received more than once and the first one was already processed.", message, response);
+              break;
+            case BAD:
+              logger.error("RESTARTING: Node was unable to process Nomad message: {}. Response: {}. This can happen when the Nomad system is not accepting changes or when the change does not exist.", message, response);
+              platformService.stopPlatformIfPassive(PlatformService.RestartMode.STOP_AND_RESTART);
+              break;
+            case UNACCEPTABLE:
+              logger.error("RESTARTING: Node was unable to process Nomad message: {}. Response: {}. This can happen when the Nomad system is not able to execute the requested change", message, response);
+              platformService.stopPlatformIfPassive(PlatformService.RestartMode.STOP_AND_RESTART);
+              break;
+          }
+        }
+      } catch (NomadException | RuntimeException e) {
+        logger.error("RESTARTING: Failure happened while processing Nomad message: {}: {}", message, e.getMessage(), e);
         platformService.stopPlatformIfPassive(PlatformService.RestartMode.STOP_AND_RESTART);
+        throw new EntityUserException(e.getMessage(), e);
       }
-    } catch (NomadException | RuntimeException | PlatformStopException e) {
+    } catch (PlatformStopException e) {
+      logger.error("Failed restarting node: {}", e.getMessage(), e);
       throw new EntityUserException(e.getMessage(), e);
     }
   }

--- a/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/service/DynamicConfigServiceImpl.java
+++ b/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/service/DynamicConfigServiceImpl.java
@@ -53,7 +53,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CopyOnWriteArrayList;
 
-import static java.lang.System.lineSeparator;
 import static java.util.Objects.requireNonNull;
 
 public class DynamicConfigServiceImpl implements TopologyService, DynamicConfigService, DynamicConfigEventService, DynamicConfigListener {
@@ -93,14 +92,6 @@ public class DynamicConfigServiceImpl implements TopologyService, DynamicConfigS
 
     clusterActivated = true;
     LOGGER.info("Node activation successful");
-
-    if (nomadServerManager.getNomadServer().hasIncompleteChange()) {
-      LOGGER.error(lineSeparator() + lineSeparator()
-          + "==============================================================================================================================================" + lineSeparator()
-          + "The configuration of this node has not been committed or rolled back. Please run the 'diagnostic' command to diagnose the configuration state." + lineSeparator()
-          + "==============================================================================================================================================" + lineSeparator()
-      );
-    }
   }
 
   // do not move this method up in the interface otherwise any client could access the license content through diagnostic port

--- a/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/sync/DynamicConfigurationPassiveSync.java
+++ b/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/sync/DynamicConfigurationPassiveSync.java
@@ -270,7 +270,8 @@ public class DynamicConfigurationPassiveSync {
 
     switch (nomadChangeInfo.getChangeRequestState()) {
       case PREPARED:
-        throw new IllegalStateException("Active has some PREPARED configuration changes that are not yet committed.");
+        prepare(nomadChangeInfo, mutativeMessageCount);
+        return Require.CAN_CONTINUE;
       case COMMITTED:
         prepare(nomadChangeInfo, mutativeMessageCount);
         commit(nomadChangeInfo, mutativeMessageCount + 1);

--- a/dynamic-config/testing/system-tests/pom.xml
+++ b/dynamic-config/testing/system-tests/pom.xml
@@ -133,6 +133,7 @@
             </goals>
             <configuration>
               <outputDirectory>${project.build.directory}/platform-kit-${project.version}/server/lib</outputDirectory>
+              <overwrite>true</overwrite>
               <resources>
                 <resource>
                   <directory>${project.basedir}/src/test/resources</directory>

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/ConfigSyncIT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/ConfigSyncIT.java
@@ -114,7 +114,7 @@ public class ConfigSyncIT extends DynamicConfigIT {
   }
 
   @Test
-  public void testPassiveZapsWhenActiveHasSomeUnCommittedChanges() throws Exception {
+  public void testPassiveSyncWhenActiveHasSomeUnCommittedChanges() throws Exception {
     stopNode(1, passiveNodeId);
     assertThat(tsa.getStopped().size(), is(1));
 
@@ -132,17 +132,13 @@ public class ConfigSyncIT extends DynamicConfigIT {
     tsa.start(getNode(1, activeNodeId));
     assertThat(tsa.getActives().size(), is(1));
 
-    err.clearLog();
-    try {
-      tsa.start(getNode(1, passiveNodeId));
-      fail();
-    } catch (Exception e) {
-      waitUntil(err::getLog, containsString("Active has some PREPARED configuration changes that are not yet committed."));
-    }
+    out.clearLog(1, passiveNodeId);
+    tsa.start(getNode(1, passiveNodeId));
+    waitUntil(out.getLog(1, passiveNodeId), containsLog("Moved to State[ PASSIVE-STANDBY ]"));
 
     //TODO TDB-4842: The stop is needed to prevent IOException on Windows
     tsa.stopAll();
-    assertContentsBeforeOrAfterSync(4, 3);
+    assertContentsBeforeOrAfterSync(4, 4);
   }
 
   @Test

--- a/dynamic-config/testing/system-tests/src/test/resources/logback-ext.xml
+++ b/dynamic-config/testing/system-tests/src/test/resources/logback-ext.xml
@@ -18,14 +18,15 @@
 -->
 <included>
   <!-- hide most of server logs-->
+  <logger name="org.terracotta" level="WARN"/>
   <logger name="com.terracottatech" level="WARN"/>
   <logger name="com.tc" level="WARN"/>
   <logger name="org.terracotta.lease" level="WARN"/>
   <!-- except some -->
   <logger name="com.tc.server.TCServerMain" level="INFO"/>
-  <!-- project logging -->
-<!--  <logger name="org.terracotta.dynamic_config" level="TRACE"/>-->
-<!--  <logger name="org.terracotta.persistence.sanskrit" level="TRACE"/>-->
-<!--  <logger name="org.terracotta.nomad" level="TRACE"/>-->
-<!--  <logger name="org.terracotta.diagnostic" level="TRACE"/>-->
+  <logger name="com.tc.objectserver.impl.DistributedObjectServer" level="INFO"/>
+  <!--  <logger name="org.terracotta.dynamic_config" level="TRACE"/>-->
+  <!--  <logger name="org.terracotta.persistence.sanskrit" level="TRACE"/>-->
+  <!--  <logger name="org.terracotta.nomad" level="TRACE"/>-->
+  <!--  <logger name="org.terracotta.diagnostic" level="TRACE"/>-->
 </included>


### PR DESCRIPTION
- Client should also cache any exception that happened per stripe during the commit phase (not only the method return)
- Nomad Server entities should log failures
- Passive Nomad entity should not restart in case of duplicate message sent (DEAD message)
- Passive Nomad entity should restart and try to sync again in case of Nomad prepare/commit/rollback failure
- Sync process should not fail if active ends with PREPARE: this change should be also synced to passive nodes
- Warning log should be displayed after sync in case the server starts with a prepared change