### PR TITLE
Removing unnecessary @CommonComponent

### DIFF
--- a/management/cluster-topology/pom.xml
+++ b/management/cluster-topology/pom.xml
@@ -37,12 +37,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.terracotta</groupId>
-      <artifactId>packaging-support</artifactId>
-      <scope>provided</scope>
-    </dependency>
-
-    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>

--- a/management/cluster-topology/src/main/java/org/terracotta/management/model/cluster/AbstractManageableNode.java
+++ b/management/cluster-topology/src/main/java/org/terracotta/management/model/cluster/AbstractManageableNode.java
@@ -15,7 +15,6 @@
  */
 package org.terracotta.management.model.cluster;
 
-import com.tc.classloader.CommonComponent;
 import org.terracotta.management.model.context.Contextual;
 
 import java.util.Optional;
@@ -25,7 +24,6 @@ import java.util.Optional;
  *
  * @author Mathieu Carbou
  */
-@CommonComponent
 public abstract class AbstractManageableNode<P extends Contextual> extends AbstractNode<P> {
 
   private static final long serialVersionUID = 1;

--- a/management/cluster-topology/src/main/java/org/terracotta/management/model/cluster/AbstractNode.java
+++ b/management/cluster-topology/src/main/java/org/terracotta/management/model/cluster/AbstractNode.java
@@ -15,7 +15,6 @@
  */
 package org.terracotta.management.model.cluster;
 
-import com.tc.classloader.CommonComponent;
 import org.terracotta.management.model.context.Context;
 import org.terracotta.management.model.context.Contextual;
 
@@ -29,7 +28,6 @@ import java.util.Objects;
 /**
  * @author Mathieu Carbou
  */
-@CommonComponent
 public abstract class AbstractNode<P extends Contextual> implements Node {
 
   private static final long serialVersionUID = 1;

--- a/management/cluster-topology/src/main/java/org/terracotta/management/model/cluster/Client.java
+++ b/management/cluster-topology/src/main/java/org/terracotta/management/model/cluster/Client.java
@@ -15,7 +15,6 @@
  */
 package org.terracotta.management.model.cluster;
 
-import com.tc.classloader.CommonComponent;
 import org.terracotta.management.model.context.Context;
 
 import java.util.Collection;
@@ -33,7 +32,6 @@ import java.util.stream.Stream;
 /**
  * @author Mathieu Carbou
  */
-@CommonComponent
 public final class Client extends AbstractManageableNode<Cluster> {
 
   private static final long serialVersionUID = 2;

--- a/management/cluster-topology/src/main/java/org/terracotta/management/model/cluster/Cluster.java
+++ b/management/cluster-topology/src/main/java/org/terracotta/management/model/cluster/Cluster.java
@@ -15,7 +15,6 @@
  */
 package org.terracotta.management.model.cluster;
 
-import com.tc.classloader.CommonComponent;
 import org.terracotta.management.model.context.Context;
 import org.terracotta.management.model.context.Contextual;
 
@@ -33,7 +32,6 @@ import java.util.stream.Stream;
 /**
  * @author Mathieu Carbou
  */
-@CommonComponent
 public final class Cluster implements Contextual {
 
   private static final long serialVersionUID = 2;

--- a/management/cluster-topology/src/main/java/org/terracotta/management/model/cluster/Connection.java
+++ b/management/cluster-topology/src/main/java/org/terracotta/management/model/cluster/Connection.java
@@ -15,8 +15,6 @@
  */
 package org.terracotta.management.model.cluster;
 
-import com.tc.classloader.CommonComponent;
-
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -26,7 +24,6 @@ import java.util.stream.Stream;
 /**
  * @author Mathieu Carbou
  */
-@CommonComponent
 public final class Connection extends AbstractNode<Client> {
 
   private static final long serialVersionUID = 3;

--- a/management/cluster-topology/src/main/java/org/terracotta/management/model/cluster/Endpoint.java
+++ b/management/cluster-topology/src/main/java/org/terracotta/management/model/cluster/Endpoint.java
@@ -15,8 +15,6 @@
  */
 package org.terracotta.management.model.cluster;
 
-import com.tc.classloader.CommonComponent;
-
 import java.io.Serializable;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -25,7 +23,6 @@ import java.util.Objects;
 /**
  * @author Mathieu Carbou
  */
-@CommonComponent
 public final class Endpoint implements Serializable {
 
   private static final long serialVersionUID = 1;

--- a/management/cluster-topology/src/main/java/org/terracotta/management/model/cluster/ManagementRegistry.java
+++ b/management/cluster-topology/src/main/java/org/terracotta/management/model/cluster/ManagementRegistry.java
@@ -15,7 +15,6 @@
  */
 package org.terracotta.management.model.cluster;
 
-import com.tc.classloader.CommonComponent;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.terracotta.management.model.capabilities.Capability;
 import org.terracotta.management.model.capabilities.context.CapabilityContext;
@@ -39,7 +38,6 @@ import java.util.stream.Collectors;
 /**
  * @author Mathieu Carbou
  */
-@CommonComponent
 @SuppressFBWarnings("SE_BAD_FIELD")
 public final class ManagementRegistry implements Serializable {
 

--- a/management/cluster-topology/src/main/java/org/terracotta/management/model/cluster/Node.java
+++ b/management/cluster-topology/src/main/java/org/terracotta/management/model/cluster/Node.java
@@ -15,7 +15,6 @@
  */
 package org.terracotta.management.model.cluster;
 
-import com.tc.classloader.CommonComponent;
 import org.terracotta.management.model.context.Contextual;
 
 import java.util.List;
@@ -23,7 +22,6 @@ import java.util.List;
 /**
  * @author Mathieu Carbou
  */
-@CommonComponent
 public interface Node extends Contextual {
   String getId();
 

--- a/management/cluster-topology/src/main/java/org/terracotta/management/model/cluster/Server.java
+++ b/management/cluster-topology/src/main/java/org/terracotta/management/model/cluster/Server.java
@@ -15,7 +15,6 @@
  */
 package org.terracotta.management.model.cluster;
 
-import com.tc.classloader.CommonComponent;
 import org.terracotta.management.model.context.Context;
 
 import java.time.Clock;
@@ -29,7 +28,6 @@ import java.util.stream.Stream;
 /**
  * @author Mathieu Carbou
  */
-@CommonComponent
 public final class Server extends AbstractNode<Stripe> {
 
   private static final long serialVersionUID = 2;

--- a/management/cluster-topology/src/main/java/org/terracotta/management/model/cluster/ServerEntity.java
+++ b/management/cluster-topology/src/main/java/org/terracotta/management/model/cluster/ServerEntity.java
@@ -15,7 +15,6 @@
  */
 package org.terracotta.management.model.cluster;
 
-import com.tc.classloader.CommonComponent;
 import org.terracotta.management.model.context.Context;
 
 import java.util.Map;
@@ -23,7 +22,6 @@ import java.util.Map;
 /**
  * @author Mathieu Carbou
  */
-@CommonComponent
 public final class ServerEntity extends AbstractManageableNode<Server> {
 
   private static final long serialVersionUID = 3;

--- a/management/cluster-topology/src/main/java/org/terracotta/management/model/cluster/ServerEntityIdentifier.java
+++ b/management/cluster-topology/src/main/java/org/terracotta/management/model/cluster/ServerEntityIdentifier.java
@@ -15,15 +15,12 @@
  */
 package org.terracotta.management.model.cluster;
 
-import com.tc.classloader.CommonComponent;
-
 import java.io.Serializable;
 import java.util.Objects;
 
 /**
  * @author Mathieu Carbou
  */
-@CommonComponent
 public class ServerEntityIdentifier implements Serializable {
 
   private static final long serialVersionUID = 1L;

--- a/management/cluster-topology/src/main/java/org/terracotta/management/model/cluster/Stripe.java
+++ b/management/cluster-topology/src/main/java/org/terracotta/management/model/cluster/Stripe.java
@@ -15,7 +15,6 @@
  */
 package org.terracotta.management.model.cluster;
 
-import com.tc.classloader.CommonComponent;
 import org.terracotta.management.model.context.Context;
 
 import java.util.Map;
@@ -27,7 +26,6 @@ import java.util.stream.Stream;
 /**
  * @author Mathieu Carbou
  */
-@CommonComponent
 public final class Stripe extends AbstractNode<Cluster> {
 
   private static final long serialVersionUID = 2;

--- a/management/management-model/pom.xml
+++ b/management/management-model/pom.xml
@@ -43,12 +43,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.terracotta</groupId>
-      <artifactId>packaging-support</artifactId>
-      <scope>provided</scope>
-    </dependency>
-
-    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>

--- a/management/management-model/src/main/java/org/terracotta/management/model/call/ContextualCall.java
+++ b/management/management-model/src/main/java/org/terracotta/management/model/call/ContextualCall.java
@@ -15,7 +15,6 @@
  */
 package org.terracotta.management.model.call;
 
-import com.tc.classloader.CommonComponent;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.terracotta.management.model.context.Context;
 import org.terracotta.management.model.context.Contextual;
@@ -26,7 +25,6 @@ import java.util.Objects;
 /**
  * @author Mathieu Carbou
  */
-@CommonComponent
 public class ContextualCall<T> implements Contextual {
 
   private static final long serialVersionUID = 1;

--- a/management/management-model/src/main/java/org/terracotta/management/model/call/ContextualReturn.java
+++ b/management/management-model/src/main/java/org/terracotta/management/model/call/ContextualReturn.java
@@ -15,7 +15,6 @@
  */
 package org.terracotta.management.model.call;
 
-import com.tc.classloader.CommonComponent;
 import org.terracotta.management.model.context.Context;
 import org.terracotta.management.model.context.Contextual;
 
@@ -33,7 +32,6 @@ import java.util.concurrent.ExecutionException;
  *
  * @author Mathieu Carbou
  */
-@CommonComponent
 public final class ContextualReturn<T> implements Contextual {
 
   private static final long serialVersionUID = 1;

--- a/management/management-model/src/main/java/org/terracotta/management/model/call/Parameter.java
+++ b/management/management-model/src/main/java/org/terracotta/management/model/call/Parameter.java
@@ -15,8 +15,6 @@
  */
 package org.terracotta.management.model.call;
 
-import com.tc.classloader.CommonComponent;
-
 import java.io.Serializable;
 import java.util.Objects;
 
@@ -25,7 +23,6 @@ import java.util.Objects;
  *
  * @author Mathieu Carbou
  */
-@CommonComponent
 public final class Parameter implements Serializable {
 
   private static final long serialVersionUID = 1;

--- a/management/management-model/src/main/java/org/terracotta/management/model/capabilities/Capability.java
+++ b/management/management-model/src/main/java/org/terracotta/management/model/capabilities/Capability.java
@@ -15,7 +15,6 @@
  */
 package org.terracotta.management.model.capabilities;
 
-import com.tc.classloader.CommonComponent;
 import org.terracotta.management.model.capabilities.context.CapabilityContext;
 import org.terracotta.management.model.capabilities.descriptors.Descriptor;
 
@@ -24,7 +23,6 @@ import java.util.Collection;
 /**
  * @author Ludovic Orban
  */
-@CommonComponent
 public interface Capability {
 
   String getName();

--- a/management/management-model/src/main/java/org/terracotta/management/model/capabilities/DefaultCapability.java
+++ b/management/management-model/src/main/java/org/terracotta/management/model/capabilities/DefaultCapability.java
@@ -15,7 +15,6 @@
  */
 package org.terracotta.management.model.capabilities;
 
-import com.tc.classloader.CommonComponent;
 import org.terracotta.management.model.capabilities.context.CapabilityContext;
 import org.terracotta.management.model.capabilities.descriptors.Descriptor;
 
@@ -29,7 +28,6 @@ import java.util.Objects;
  * @author Ludovic Orban
  * @author Mathieu Carbou
  */
-@CommonComponent
 public final class DefaultCapability implements Capability, Serializable {
 
   private static final long serialVersionUID = 1;

--- a/management/management-model/src/main/java/org/terracotta/management/model/capabilities/context/CapabilityContext.java
+++ b/management/management-model/src/main/java/org/terracotta/management/model/capabilities/context/CapabilityContext.java
@@ -15,8 +15,6 @@
  */
 package org.terracotta.management.model.capabilities.context;
 
-import com.tc.classloader.CommonComponent;
-
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -28,7 +26,6 @@ import java.util.Objects;
  * @author Ludovic Orban
  * @author Mathieu Carbou
  */
-@CommonComponent
 public final class CapabilityContext implements Serializable {
 
   private static final long serialVersionUID = 1;
@@ -91,7 +88,6 @@ public final class CapabilityContext implements Serializable {
     return attributes.hashCode();
   }
 
-  @CommonComponent
   public static final class Attribute implements Serializable {
 
     private static final long serialVersionUID = 1;

--- a/management/management-model/src/main/java/org/terracotta/management/model/capabilities/descriptors/CallDescriptor.java
+++ b/management/management-model/src/main/java/org/terracotta/management/model/capabilities/descriptors/CallDescriptor.java
@@ -15,8 +15,6 @@
  */
 package org.terracotta.management.model.capabilities.descriptors;
 
-import com.tc.classloader.CommonComponent;
-
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.List;
@@ -26,7 +24,6 @@ import java.util.Objects;
  * @author Ludovic Orban
  * @author Mathieu Carbou
  */
-@CommonComponent
 public final class CallDescriptor implements Descriptor, Serializable {
 
   private static final long serialVersionUID = 1;

--- a/management/management-model/src/main/java/org/terracotta/management/model/capabilities/descriptors/Descriptor.java
+++ b/management/management-model/src/main/java/org/terracotta/management/model/capabilities/descriptors/Descriptor.java
@@ -15,11 +15,8 @@
  */
 package org.terracotta.management.model.capabilities.descriptors;
 
-import com.tc.classloader.CommonComponent;
-
 /**
  * @author Ludovic Orban
  */
-@CommonComponent
 public interface Descriptor {
 }

--- a/management/management-model/src/main/java/org/terracotta/management/model/capabilities/descriptors/Settings.java
+++ b/management/management-model/src/main/java/org/terracotta/management/model/capabilities/descriptors/Settings.java
@@ -15,8 +15,6 @@
  */
 package org.terracotta.management.model.capabilities.descriptors;
 
-import com.tc.classloader.CommonComponent;
-
 import java.io.Serializable;
 import java.util.AbstractMap;
 import java.util.Collection;
@@ -27,7 +25,6 @@ import java.util.Set;
 /**
  * @author Mathieu Carbou
  */
-@CommonComponent
 public class Settings extends AbstractMap<String, Object> implements Descriptor, Serializable {
 
   private static final long serialVersionUID = 1;

--- a/management/management-model/src/main/java/org/terracotta/management/model/capabilities/descriptors/StatisticDescriptor.java
+++ b/management/management-model/src/main/java/org/terracotta/management/model/capabilities/descriptors/StatisticDescriptor.java
@@ -15,8 +15,6 @@
  */
 package org.terracotta.management.model.capabilities.descriptors;
 
-import com.tc.classloader.CommonComponent;
-
 import java.io.Serializable;
 import java.util.Objects;
 
@@ -24,7 +22,6 @@ import java.util.Objects;
  * @author Ludovic Orban
  * @author Mathieu Carbou
  */
-@CommonComponent
 public final class StatisticDescriptor implements Descriptor, Serializable {
 
   private static final long serialVersionUID = 2;

--- a/management/management-model/src/main/java/org/terracotta/management/model/cluster/ClientIdentifier.java
+++ b/management/management-model/src/main/java/org/terracotta/management/model/cluster/ClientIdentifier.java
@@ -15,8 +15,6 @@
  */
 package org.terracotta.management.model.cluster;
 
-import com.tc.classloader.CommonComponent;
-
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
 import java.io.Serializable;
@@ -40,7 +38,6 @@ import java.util.logging.Logger;
  *
  * @author Mathieu Carbou
  */
-@CommonComponent
 public final class ClientIdentifier implements Serializable {
 
   private static final long serialVersionUID = 1;

--- a/management/management-model/src/main/java/org/terracotta/management/model/context/Context.java
+++ b/management/management-model/src/main/java/org/terracotta/management/model/context/Context.java
@@ -15,8 +15,6 @@
  */
 package org.terracotta.management.model.context;
 
-import com.tc.classloader.CommonComponent;
-
 import java.io.Serializable;
 import java.util.AbstractMap;
 import java.util.Collections;
@@ -28,7 +26,6 @@ import java.util.Set;
  * @author Ludovic Orban
  * @author Mathieu Carbou
  */
-@CommonComponent
 public class Context extends AbstractMap<String, String> implements Serializable {
 
   private static final long serialVersionUID = 1;

--- a/management/management-model/src/main/java/org/terracotta/management/model/context/ContextContainer.java
+++ b/management/management-model/src/main/java/org/terracotta/management/model/context/ContextContainer.java
@@ -15,8 +15,6 @@
  */
 package org.terracotta.management.model.context;
 
-import com.tc.classloader.CommonComponent;
-
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.Collection;
@@ -27,7 +25,6 @@ import java.util.Objects;
  * @author Ludovic Orban
  * @author Mathieu Carbou
  */
-@CommonComponent
 public final class ContextContainer implements Serializable {
 
   private static final long serialVersionUID = 1;

--- a/management/management-model/src/main/java/org/terracotta/management/model/context/Contextual.java
+++ b/management/management-model/src/main/java/org/terracotta/management/model/context/Contextual.java
@@ -15,14 +15,11 @@
  */
 package org.terracotta.management.model.context;
 
-import com.tc.classloader.CommonComponent;
-
 import java.io.Serializable;
 
 /**
  * @author Mathieu Carbou
  */
-@CommonComponent
 public interface Contextual extends Serializable {
   Context getContext();
 

--- a/management/management-model/src/main/java/org/terracotta/management/model/message/DefaultManagementCallMessage.java
+++ b/management/management-model/src/main/java/org/terracotta/management/model/message/DefaultManagementCallMessage.java
@@ -15,7 +15,6 @@
  */
 package org.terracotta.management.model.message;
 
-import com.tc.classloader.CommonComponent;
 import org.terracotta.management.model.context.Contextual;
 import org.terracotta.management.sequence.Sequence;
 
@@ -25,7 +24,6 @@ import java.util.Objects;
 /**
  * @author Mathieu Carbou
  */
-@CommonComponent
 public class DefaultManagementCallMessage extends DefaultMessage implements ManagementCallMessage, Serializable {
 
   private static final long serialVersionUID = 2L;

--- a/management/management-model/src/main/java/org/terracotta/management/model/message/DefaultMessage.java
+++ b/management/management-model/src/main/java/org/terracotta/management/model/message/DefaultMessage.java
@@ -15,7 +15,6 @@
  */
 package org.terracotta.management.model.message;
 
-import com.tc.classloader.CommonComponent;
 import org.terracotta.management.model.context.Contextual;
 import org.terracotta.management.sequence.Sequence;
 
@@ -26,7 +25,6 @@ import java.util.List;
 /**
  * @author Mathieu Carbou
  */
-@CommonComponent
 public class DefaultMessage implements Message, Serializable {
 
   private static final long serialVersionUID = 1;

--- a/management/management-model/src/main/java/org/terracotta/management/model/message/ManagementCallMessage.java
+++ b/management/management-model/src/main/java/org/terracotta/management/model/message/ManagementCallMessage.java
@@ -15,12 +15,9 @@
  */
 package org.terracotta.management.model.message;
 
-import com.tc.classloader.CommonComponent;
-
 /**
  * @author Mathieu Carbou
  */
-@CommonComponent
 public interface ManagementCallMessage extends Message {
 
   String getManagementCallIdentifier();

--- a/management/management-model/src/main/java/org/terracotta/management/model/message/Message.java
+++ b/management/management-model/src/main/java/org/terracotta/management/model/message/Message.java
@@ -15,7 +15,6 @@
  */
 package org.terracotta.management.model.message;
 
-import com.tc.classloader.CommonComponent;
 import org.terracotta.management.model.context.Contextual;
 import org.terracotta.management.sequence.Sequence;
 
@@ -25,7 +24,6 @@ import java.util.List;
 /**
  * @author Mathieu Carbou
  */
-@CommonComponent
 public interface Message extends Serializable {
 
   <T extends Contextual> List<T> unwrap(Class<T> type);

--- a/management/management-model/src/main/java/org/terracotta/management/model/notification/ContextualNotification.java
+++ b/management/management-model/src/main/java/org/terracotta/management/model/notification/ContextualNotification.java
@@ -15,7 +15,6 @@
  */
 package org.terracotta.management.model.notification;
 
-import com.tc.classloader.CommonComponent;
 import org.terracotta.management.model.context.Context;
 import org.terracotta.management.model.context.Contextual;
 
@@ -27,7 +26,6 @@ import java.util.Objects;
 /**
  * @author Mathieu Carbou
  */
-@CommonComponent
 public final class ContextualNotification implements Contextual {
 
   private static final long serialVersionUID = 1;

--- a/management/management-model/src/main/java/org/terracotta/management/model/stats/ContextualStatistics.java
+++ b/management/management-model/src/main/java/org/terracotta/management/model/stats/ContextualStatistics.java
@@ -15,7 +15,6 @@
  */
 package org.terracotta.management.model.stats;
 
-import com.tc.classloader.CommonComponent;
 import org.terracotta.management.model.context.Context;
 import org.terracotta.management.model.context.Contextual;
 import org.terracotta.statistics.Sample;
@@ -34,7 +33,6 @@ import static java.util.stream.Collectors.toMap;
  *
  * @author Mathieu Carbou
  */
-@CommonComponent
 public final class ContextualStatistics implements Contextual {
 
   private static final long serialVersionUID = 1;

--- a/management/management-model/src/main/java/org/terracotta/management/model/stats/DelegatingSample.java
+++ b/management/management-model/src/main/java/org/terracotta/management/model/stats/DelegatingSample.java
@@ -15,12 +15,10 @@
  */
 package org.terracotta.management.model.stats;
 
-import com.tc.classloader.CommonComponent;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.io.Serializable;
 
-@CommonComponent
 public class DelegatingSample<T extends Serializable> implements Sample<T> {
 
   private static final long serialVersionUID = 1L;

--- a/management/management-model/src/main/java/org/terracotta/management/model/stats/DelegatingStatistic.java
+++ b/management/management-model/src/main/java/org/terracotta/management/model/stats/DelegatingStatistic.java
@@ -15,8 +15,6 @@
  */
 package org.terracotta.management.model.stats;
 
-import com.tc.classloader.CommonComponent;
-
 import java.io.Serializable;
 import java.util.List;
 import java.util.Optional;
@@ -24,7 +22,6 @@ import java.util.stream.Collectors;
 
 import static org.terracotta.management.model.stats.StatisticType.convert;
 
-@CommonComponent
 public class DelegatingStatistic<T extends Serializable> implements Statistic<T> {
   private static final long serialVersionUID = 1L;
 

--- a/management/management-model/src/main/java/org/terracotta/management/model/stats/Sample.java
+++ b/management/management-model/src/main/java/org/terracotta/management/model/stats/Sample.java
@@ -15,11 +15,8 @@
  */
 package org.terracotta.management.model.stats;
 
-import com.tc.classloader.CommonComponent;
-
 import java.io.Serializable;
 
-@CommonComponent
 public interface Sample<T extends Serializable> extends Serializable {
   T getSample();
 

--- a/management/management-model/src/main/java/org/terracotta/management/model/stats/Statistic.java
+++ b/management/management-model/src/main/java/org/terracotta/management/model/stats/Statistic.java
@@ -15,13 +15,10 @@
  */
 package org.terracotta.management.model.stats;
 
-import com.tc.classloader.CommonComponent;
-
 import java.io.Serializable;
 import java.util.List;
 import java.util.Optional;
 
-@CommonComponent
 public interface Statistic<T extends Serializable> extends Serializable {
   StatisticType getType();
 

--- a/management/management-model/src/main/java/org/terracotta/management/model/stats/StatisticRegistry.java
+++ b/management/management-model/src/main/java/org/terracotta/management/model/stats/StatisticRegistry.java
@@ -15,7 +15,6 @@
  */
 package org.terracotta.management.model.stats;
 
-import com.tc.classloader.CommonComponent;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.terracotta.management.model.capabilities.descriptors.StatisticDescriptor;
 import org.terracotta.statistics.StatisticType;
@@ -36,7 +35,6 @@ import static java.util.stream.Collectors.toMap;
 /***
  * @author Mathieu Carbou
  */
-@CommonComponent
 @SuppressFBWarnings("NM_SAME_SIMPLE_NAME_AS_SUPERCLASS")
 public class StatisticRegistry extends org.terracotta.statistics.registry.StatisticRegistry {
 

--- a/management/management-model/src/main/java/org/terracotta/management/model/stats/StatisticType.java
+++ b/management/management-model/src/main/java/org/terracotta/management/model/stats/StatisticType.java
@@ -15,12 +15,9 @@
  */
 package org.terracotta.management.model.stats;
 
-import com.tc.classloader.CommonComponent;
-
 /**
  * @author Mathieu Carbou
  */
-@CommonComponent
 public enum StatisticType {
 
   COUNTER,

--- a/management/management-registry/pom.xml
+++ b/management/management-registry/pom.xml
@@ -38,12 +38,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.terracotta</groupId>
-      <artifactId>packaging-support</artifactId>
-      <scope>provided</scope>
-    </dependency>
-
-    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>

--- a/management/management-registry/src/main/java/org/terracotta/management/registry/CallQuery.java
+++ b/management/management-registry/src/main/java/org/terracotta/management/registry/CallQuery.java
@@ -15,14 +15,12 @@
  */
 package org.terracotta.management.registry;
 
-import com.tc.classloader.CommonComponent;
 import org.terracotta.management.model.call.ContextualReturn;
 import org.terracotta.management.model.call.Parameter;
 
 /**
  * @author Mathieu Carbou
  */
-@CommonComponent
 public interface CallQuery<T> extends Query<ContextualReturn<T>> {
 
   Class<T> getReturnType();
@@ -31,7 +29,6 @@ public interface CallQuery<T> extends Query<ContextualReturn<T>> {
 
   Parameter[] getParameters();
 
-  @CommonComponent
   interface Builder<T> extends QueryBuilder<Builder<T>, CallQuery<T>> {
 
   }

--- a/management/management-registry/src/main/java/org/terracotta/management/registry/CapabilityManagement.java
+++ b/management/management-registry/src/main/java/org/terracotta/management/registry/CapabilityManagement.java
@@ -15,7 +15,6 @@
  */
 package org.terracotta.management.registry;
 
-import com.tc.classloader.CommonComponent;
 import org.terracotta.management.model.call.Parameter;
 
 import java.util.Collection;
@@ -23,7 +22,6 @@ import java.util.Collection;
 /**
  * @author Mathieu Carbou
  */
-@CommonComponent
 public interface CapabilityManagement {
 
   /**

--- a/management/management-registry/src/main/java/org/terracotta/management/registry/CapabilityManagementSupport.java
+++ b/management/management-registry/src/main/java/org/terracotta/management/registry/CapabilityManagementSupport.java
@@ -15,7 +15,6 @@
  */
 package org.terracotta.management.registry;
 
-import com.tc.classloader.CommonComponent;
 import org.terracotta.management.model.capabilities.Capability;
 
 import java.util.Collection;
@@ -23,7 +22,6 @@ import java.util.Collection;
 /**
  * @author Mathieu Carbou
  */
-@CommonComponent
 public interface CapabilityManagementSupport {
 
   /**

--- a/management/management-registry/src/main/java/org/terracotta/management/registry/CombiningCapabilityManagementSupport.java
+++ b/management/management-registry/src/main/java/org/terracotta/management/registry/CombiningCapabilityManagementSupport.java
@@ -15,7 +15,6 @@
  */
 package org.terracotta.management.registry;
 
-import com.tc.classloader.CommonComponent;
 import org.terracotta.management.model.capabilities.Capability;
 
 import java.util.ArrayList;
@@ -26,7 +25,6 @@ import java.util.Objects;
 /**
  * @author Mathieu Carbou
  */
-@CommonComponent
 public class CombiningCapabilityManagementSupport implements CapabilityManagementSupport {
 
   private final CapabilityManagementSupport[] capabilityManagementSupports;

--- a/management/management-registry/src/main/java/org/terracotta/management/registry/ManagementProvider.java
+++ b/management/management-registry/src/main/java/org/terracotta/management/registry/ManagementProvider.java
@@ -15,7 +15,6 @@
  */
 package org.terracotta.management.registry;
 
-import com.tc.classloader.CommonComponent;
 import org.terracotta.management.model.call.Parameter;
 import org.terracotta.management.model.capabilities.Capability;
 import org.terracotta.management.model.capabilities.context.CapabilityContext;
@@ -33,7 +32,6 @@ import java.util.concurrent.ExecutionException;
  *
  * @author Ludovic Orban
  */
-@CommonComponent
 public interface ManagementProvider<T> {
 
   /**

--- a/management/management-registry/src/main/java/org/terracotta/management/registry/Query.java
+++ b/management/management-registry/src/main/java/org/terracotta/management/registry/Query.java
@@ -15,7 +15,6 @@
  */
 package org.terracotta.management.registry;
 
-import com.tc.classloader.CommonComponent;
 import org.terracotta.management.model.context.Context;
 
 import java.util.Collection;
@@ -23,7 +22,6 @@ import java.util.Collection;
 /**
  * @author Mathieu Carbou
  */
-@CommonComponent
 public interface Query<T> {
 
   /**

--- a/management/management-registry/src/main/java/org/terracotta/management/registry/QueryBuilder.java
+++ b/management/management-registry/src/main/java/org/terracotta/management/registry/QueryBuilder.java
@@ -15,7 +15,6 @@
  */
 package org.terracotta.management.registry;
 
-import com.tc.classloader.CommonComponent;
 import org.terracotta.management.model.context.Context;
 
 import java.util.Collection;
@@ -23,7 +22,6 @@ import java.util.Collection;
 /**
  * @author Mathieu Carbou
  */
-@CommonComponent
 public interface QueryBuilder<B, T> {
 
   /**

--- a/management/management-registry/src/main/java/org/terracotta/management/registry/ResultSet.java
+++ b/management/management-registry/src/main/java/org/terracotta/management/registry/ResultSet.java
@@ -15,7 +15,6 @@
  */
 package org.terracotta.management.registry;
 
-import com.tc.classloader.CommonComponent;
 import org.terracotta.management.model.context.Context;
 
 import java.util.Map;
@@ -26,7 +25,6 @@ import java.util.NoSuchElementException;
  *
  * @author Mathieu Carbou
  */
-@CommonComponent
 public interface ResultSet<T> extends Iterable<T> {
 
   /**

--- a/management/management-registry/src/main/java/org/terracotta/management/registry/StatisticQuery.java
+++ b/management/management-registry/src/main/java/org/terracotta/management/registry/StatisticQuery.java
@@ -15,7 +15,6 @@
  */
 package org.terracotta.management.registry;
 
-import com.tc.classloader.CommonComponent;
 import org.terracotta.management.model.stats.ContextualStatistics;
 
 import java.util.Collection;
@@ -23,7 +22,6 @@ import java.util.Collection;
 /**
  * @author Mathieu Carbou
  */
-@CommonComponent
 public interface StatisticQuery extends Query<ContextualStatistics> {
 
   /**
@@ -38,7 +36,6 @@ public interface StatisticQuery extends Query<ContextualStatistics> {
    */
   long getSince();
 
-  @CommonComponent
   interface Builder extends QueryBuilder<Builder, StatisticQuery> {
 
     /**

--- a/management/management-registry/src/main/java/org/terracotta/management/registry/action/AbstractActionManagementProvider.java
+++ b/management/management-registry/src/main/java/org/terracotta/management/registry/action/AbstractActionManagementProvider.java
@@ -15,7 +15,6 @@
  */
 package org.terracotta.management.registry.action;
 
-import com.tc.classloader.CommonComponent;
 import org.terracotta.management.model.call.Parameter;
 import org.terracotta.management.model.capabilities.descriptors.CallDescriptor;
 import org.terracotta.management.model.capabilities.descriptors.Descriptor;
@@ -41,7 +40,6 @@ import java.util.concurrent.ExecutionException;
 /**
  * @author Mathieu Carbou
  */
-@CommonComponent
 public abstract class AbstractActionManagementProvider<T> extends AbstractManagementProvider<T> {
 
   private static final Map<String, Class<?>> PRIMITIVE_MAP = new HashMap<String, Class<?>>();

--- a/management/management-registry/src/main/java/org/terracotta/management/registry/action/Exposed.java
+++ b/management/management-registry/src/main/java/org/terracotta/management/registry/action/Exposed.java
@@ -15,8 +15,6 @@
  */
 package org.terracotta.management.registry.action;
 
-import com.tc.classloader.CommonComponent;
-
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -29,6 +27,5 @@ import java.lang.annotation.Target;
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)
-@CommonComponent
 public @interface Exposed {
 }

--- a/management/monitoring-service-api/src/main/java/org/terracotta/management/service/monitoring/AbstractManagementRegistryConfiguration.java
+++ b/management/monitoring-service-api/src/main/java/org/terracotta/management/service/monitoring/AbstractManagementRegistryConfiguration.java
@@ -15,7 +15,6 @@
  */
 package org.terracotta.management.service.monitoring;
 
-import com.tc.classloader.CommonComponent;
 import org.terracotta.entity.BasicServiceConfiguration;
 import org.terracotta.entity.ServiceConfiguration;
 import org.terracotta.entity.ServiceException;
@@ -27,7 +26,6 @@ import java.util.Objects;
 /**
  * @author Mathieu Carbou
  */
-@CommonComponent
 public abstract class AbstractManagementRegistryConfiguration implements ServiceConfiguration<EntityManagementRegistry> {
 
   protected final ServiceRegistry registry;

--- a/management/monitoring-service-api/src/main/java/org/terracotta/management/service/monitoring/ClientMonitoringService.java
+++ b/management/monitoring-service-api/src/main/java/org/terracotta/management/service/monitoring/ClientMonitoringService.java
@@ -15,7 +15,6 @@
  */
 package org.terracotta.management.service.monitoring;
 
-import com.tc.classloader.CommonComponent;
 import org.terracotta.entity.ClientDescriptor;
 import org.terracotta.entity.CommonServerEntity;
 import org.terracotta.management.model.call.ContextualReturn;
@@ -31,7 +30,6 @@ import java.io.Closeable;
  *
  * @author Mathieu Carbou
  */
-@CommonComponent
 public interface ClientMonitoringService extends Closeable {
 
   /**

--- a/management/monitoring-service-api/src/main/java/org/terracotta/management/service/monitoring/ClientMonitoringServiceConfiguration.java
+++ b/management/monitoring-service-api/src/main/java/org/terracotta/management/service/monitoring/ClientMonitoringServiceConfiguration.java
@@ -15,7 +15,6 @@
  */
 package org.terracotta.management.service.monitoring;
 
-import com.tc.classloader.CommonComponent;
 import org.terracotta.entity.BasicServiceConfiguration;
 import org.terracotta.entity.ClientCommunicator;
 import org.terracotta.entity.ServiceConfiguration;
@@ -27,7 +26,6 @@ import java.util.Objects;
 /**
  * @author Mathieu Carbou
  */
-@CommonComponent
 public class ClientMonitoringServiceConfiguration implements ServiceConfiguration<ClientMonitoringService> {
   
   private final ServiceRegistry registry;

--- a/management/monitoring-service-api/src/main/java/org/terracotta/management/service/monitoring/EntityManagementRegistry.java
+++ b/management/monitoring-service-api/src/main/java/org/terracotta/management/service/monitoring/EntityManagementRegistry.java
@@ -15,7 +15,6 @@
  */
 package org.terracotta.management.service.monitoring;
 
-import com.tc.classloader.CommonComponent;
 import org.terracotta.entity.CommonServerEntity;
 import org.terracotta.management.model.context.ContextContainer;
 import org.terracotta.management.registry.CapabilityManagementSupport;
@@ -34,7 +33,6 @@ import java.util.concurrent.CompletableFuture;
  *
  * @author Mathieu Carbou
  */
-@CommonComponent
 public interface EntityManagementRegistry extends CapabilityManagementSupport, Closeable {
 
   /**

--- a/management/monitoring-service-api/src/main/java/org/terracotta/management/service/monitoring/EntityManagementRegistryConfiguration.java
+++ b/management/monitoring-service-api/src/main/java/org/terracotta/management/service/monitoring/EntityManagementRegistryConfiguration.java
@@ -15,13 +15,11 @@
  */
 package org.terracotta.management.service.monitoring;
 
-import com.tc.classloader.CommonComponent;
 import org.terracotta.entity.ServiceRegistry;
 
 /**
  * @author Mathieu Carbou
  */
-@CommonComponent
 public class EntityManagementRegistryConfiguration extends AbstractManagementRegistryConfiguration {
   public EntityManagementRegistryConfiguration(ServiceRegistry registry, boolean activeEntity) {
     super(registry, activeEntity);

--- a/management/monitoring-service-api/src/main/java/org/terracotta/management/service/monitoring/EntityMonitoringService.java
+++ b/management/monitoring-service-api/src/main/java/org/terracotta/management/service/monitoring/EntityMonitoringService.java
@@ -15,7 +15,6 @@
  */
 package org.terracotta.management.service.monitoring;
 
-import com.tc.classloader.CommonComponent;
 import org.terracotta.entity.ClientDescriptor;
 import org.terracotta.management.model.call.ContextualReturn;
 import org.terracotta.management.model.capabilities.Capability;
@@ -31,7 +30,6 @@ import java.util.concurrent.CompletableFuture;
  *
  * @author Mathieu Carbou
  */
-@CommonComponent
 public interface EntityMonitoringService {
 
   /**

--- a/management/monitoring-service-api/src/main/java/org/terracotta/management/service/monitoring/ManageableServerComponent.java
+++ b/management/monitoring-service-api/src/main/java/org/terracotta/management/service/monitoring/ManageableServerComponent.java
@@ -15,12 +15,9 @@
  */
 package org.terracotta.management.service.monitoring;
 
-import com.tc.classloader.CommonComponent;
-
 /**
  * @author Mathieu Carbou
  */
-@CommonComponent
 public interface ManageableServerComponent {
 
   /**

--- a/management/monitoring-service-api/src/main/java/org/terracotta/management/service/monitoring/ManagementExecutor.java
+++ b/management/monitoring-service-api/src/main/java/org/terracotta/management/service/monitoring/ManagementExecutor.java
@@ -15,7 +15,6 @@
  */
 package org.terracotta.management.service.monitoring;
 
-import com.tc.classloader.CommonComponent;
 import org.terracotta.entity.ClientDescriptor;
 import org.terracotta.management.model.call.ContextualCall;
 import org.terracotta.management.model.call.ContextualReturn;
@@ -34,7 +33,6 @@ import org.terracotta.management.model.message.Message;
  *
  * @author Mathieu Carbou
  */
-@CommonComponent
 public interface ManagementExecutor {
   void executeManagementCallOnServer(String managementCallIdentifier, ContextualCall<?> call);
 

--- a/management/monitoring-service-api/src/main/java/org/terracotta/management/service/monitoring/ManagementService.java
+++ b/management/monitoring-service-api/src/main/java/org/terracotta/management/service/monitoring/ManagementService.java
@@ -15,7 +15,6 @@
  */
 package org.terracotta.management.service.monitoring;
 
-import com.tc.classloader.CommonComponent;
 import org.terracotta.entity.ClientDescriptor;
 import org.terracotta.entity.CommonServerEntity;
 import org.terracotta.management.model.call.Parameter;
@@ -29,7 +28,6 @@ import java.io.Closeable;
  *
  * @author Mathieu Carbou
  */
-@CommonComponent
 public interface ManagementService extends Closeable {
 
   void setManagementExecutor(ManagementExecutor managementExecutor);

--- a/management/monitoring-service-api/src/main/java/org/terracotta/management/service/monitoring/ManagementServiceConfiguration.java
+++ b/management/monitoring-service-api/src/main/java/org/terracotta/management/service/monitoring/ManagementServiceConfiguration.java
@@ -15,13 +15,11 @@
  */
 package org.terracotta.management.service.monitoring;
 
-import com.tc.classloader.CommonComponent;
 import org.terracotta.entity.ServiceConfiguration;
 
 /**
  * @author Mathieu Carbou
  */
-@CommonComponent
 public class ManagementServiceConfiguration implements ServiceConfiguration<ManagementService> {
 
   @Override

--- a/management/monitoring-service-api/src/main/java/org/terracotta/management/service/monitoring/ServerManagementRegistryConfiguration.java
+++ b/management/monitoring-service-api/src/main/java/org/terracotta/management/service/monitoring/ServerManagementRegistryConfiguration.java
@@ -15,7 +15,6 @@
  */
 package org.terracotta.management.service.monitoring;
 
-import com.tc.classloader.CommonComponent;
 import org.terracotta.entity.BasicServiceConfiguration;
 import org.terracotta.entity.ServiceRegistry;
 
@@ -24,7 +23,6 @@ import java.util.Collection;
 /**
  * @author Mathieu Carbou
  */
-@CommonComponent
 public class ServerManagementRegistryConfiguration extends AbstractManagementRegistryConfiguration {
 
   public ServerManagementRegistryConfiguration(ServiceRegistry registry, boolean active) {

--- a/management/monitoring-service-api/src/main/java/org/terracotta/management/service/monitoring/SharedEntityManagementRegistry.java
+++ b/management/monitoring-service-api/src/main/java/org/terracotta/management/service/monitoring/SharedEntityManagementRegistry.java
@@ -15,7 +15,6 @@
  */
 package org.terracotta.management.service.monitoring;
 
-import com.tc.classloader.CommonComponent;
 import org.terracotta.management.model.context.ContextContainer;
 import org.terracotta.management.registry.CapabilityManagementSupport;
 
@@ -28,7 +27,6 @@ import java.util.Collection;
  *
  * @author Mathieu Carbou
  */
-@CommonComponent
 public interface SharedEntityManagementRegistry extends CapabilityManagementSupport {
 
   Collection<ContextContainer> getContextContainers();

--- a/management/monitoring-service-api/src/main/java/org/terracotta/management/service/monitoring/registry/provider/AbstractEntityManagementProvider.java
+++ b/management/monitoring-service-api/src/main/java/org/terracotta/management/service/monitoring/registry/provider/AbstractEntityManagementProvider.java
@@ -15,7 +15,6 @@
  */
 package org.terracotta.management.service.monitoring.registry.provider;
 
-import com.tc.classloader.CommonComponent;
 import org.terracotta.management.model.context.Context;
 import org.terracotta.management.registry.AbstractManagementProvider;
 import org.terracotta.management.registry.ExposedObject;
@@ -30,7 +29,6 @@ import java.util.concurrent.ExecutionException;
 /**
  * @author Mathieu Carbou
  */
-@CommonComponent
 public abstract class AbstractEntityManagementProvider<T> extends AbstractManagementProvider<T> implements ManagementProvider<T>, MonitoringServiceAware {
 
   private EntityMonitoringService monitoringService;

--- a/management/monitoring-service-api/src/main/java/org/terracotta/management/service/monitoring/registry/provider/AbstractExposedStatistics.java
+++ b/management/monitoring-service-api/src/main/java/org/terracotta/management/service/monitoring/registry/provider/AbstractExposedStatistics.java
@@ -15,7 +15,6 @@
  */
 package org.terracotta.management.service.monitoring.registry.provider;
 
-import com.tc.classloader.CommonComponent;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.terracotta.management.model.capabilities.descriptors.StatisticDescriptor;
 import org.terracotta.management.model.context.Context;
@@ -28,7 +27,6 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.Optional;
 
-@CommonComponent
 @SuppressFBWarnings("EQ_DOESNT_OVERRIDE_EQUALS")
 public class AbstractExposedStatistics<T extends AliasBinding> extends AliasBindingManagementProvider.ExposedAliasBinding<T> implements Closeable {
 

--- a/management/monitoring-service-api/src/main/java/org/terracotta/management/service/monitoring/registry/provider/AbstractStatisticsManagementProvider.java
+++ b/management/monitoring-service-api/src/main/java/org/terracotta/management/service/monitoring/registry/provider/AbstractStatisticsManagementProvider.java
@@ -15,15 +15,14 @@
  */
 package org.terracotta.management.service.monitoring.registry.provider;
 
-import com.tc.classloader.CommonComponent;
 import org.terracotta.management.model.capabilities.descriptors.Descriptor;
 import org.terracotta.management.model.capabilities.descriptors.StatisticDescriptor;
 import org.terracotta.management.model.context.Context;
+import org.terracotta.management.model.stats.Statistic;
+import org.terracotta.management.model.stats.StatisticRegistry;
 import org.terracotta.management.registry.ExposedObject;
 import org.terracotta.management.registry.Named;
 import org.terracotta.management.registry.RequiredContext;
-import org.terracotta.management.model.stats.Statistic;
-import org.terracotta.management.model.stats.StatisticRegistry;
 
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -33,7 +32,6 @@ import java.util.List;
 import java.util.Map;
 
 @RequiredContext({@Named("consumerId")})
-@CommonComponent
 public abstract class AbstractStatisticsManagementProvider<T extends AliasBinding> extends AliasBindingManagementProvider<T> {
 
   public AbstractStatisticsManagementProvider(Class<? extends T> type) {

--- a/management/monitoring-service-api/src/main/java/org/terracotta/management/service/monitoring/registry/provider/AliasBinding.java
+++ b/management/monitoring-service-api/src/main/java/org/terracotta/management/service/monitoring/registry/provider/AliasBinding.java
@@ -15,11 +15,8 @@
  */
 package org.terracotta.management.service.monitoring.registry.provider;
 
-import com.tc.classloader.CommonComponent;
-
 import java.util.Objects;
 
-@CommonComponent
 public class AliasBinding {
 
   private final String alias;

--- a/management/monitoring-service-api/src/main/java/org/terracotta/management/service/monitoring/registry/provider/AliasBindingManagementProvider.java
+++ b/management/monitoring-service-api/src/main/java/org/terracotta/management/service/monitoring/registry/provider/AliasBindingManagementProvider.java
@@ -15,7 +15,6 @@
  */
 package org.terracotta.management.service.monitoring.registry.provider;
 
-import com.tc.classloader.CommonComponent;
 import org.terracotta.management.model.capabilities.descriptors.Descriptor;
 import org.terracotta.management.model.context.Context;
 import org.terracotta.management.registry.ExposedObject;
@@ -24,7 +23,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Objects;
 
-@CommonComponent
 public class AliasBindingManagementProvider<T extends AliasBinding> extends AbstractEntityManagementProvider<T> {
 
   public AliasBindingManagementProvider(Class<? extends T> type) {
@@ -43,7 +41,6 @@ public class AliasBindingManagementProvider<T extends AliasBinding> extends Abst
     return new ExposedAliasBinding<>(context, managedObject);
   }
 
-  @CommonComponent
   public static class ExposedAliasBinding<T extends AliasBinding> implements ExposedObject<T> {
 
     private final T binding;

--- a/management/monitoring-service-api/src/main/java/org/terracotta/management/service/monitoring/registry/provider/ClientBinding.java
+++ b/management/monitoring-service-api/src/main/java/org/terracotta/management/service/monitoring/registry/provider/ClientBinding.java
@@ -15,13 +15,11 @@
  */
 package org.terracotta.management.service.monitoring.registry.provider;
 
-import com.tc.classloader.CommonComponent;
 import org.terracotta.entity.ClientDescriptor;
 import org.terracotta.management.model.cluster.ClientIdentifier;
 
 import java.util.Objects;
 
-@CommonComponent
 public class ClientBinding {
 
   private final ClientDescriptor clientDescriptor;

--- a/management/monitoring-service-api/src/main/java/org/terracotta/management/service/monitoring/registry/provider/ClientBindingManagementProvider.java
+++ b/management/monitoring-service-api/src/main/java/org/terracotta/management/service/monitoring/registry/provider/ClientBindingManagementProvider.java
@@ -15,7 +15,6 @@
  */
 package org.terracotta.management.service.monitoring.registry.provider;
 
-import com.tc.classloader.CommonComponent;
 import org.terracotta.entity.ClientDescriptor;
 import org.terracotta.management.model.capabilities.descriptors.Descriptor;
 import org.terracotta.management.model.cluster.ClientIdentifier;
@@ -27,7 +26,6 @@ import java.util.Collections;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 
-@CommonComponent
 public class ClientBindingManagementProvider<T extends ClientBinding> extends AbstractEntityManagementProvider<T> {
 
   public ClientBindingManagementProvider(Class<? extends T> type) {
@@ -60,7 +58,6 @@ public class ClientBindingManagementProvider<T extends ClientBinding> extends Ab
     return new ExposedClientBinding<>(context, managedObject);
   }
 
-  @CommonComponent
   public static class ExposedClientBinding<T extends ClientBinding> implements ExposedObject<T> {
 
     private final T clientBinding;

--- a/management/monitoring-service-api/src/main/java/org/terracotta/management/service/monitoring/registry/provider/MonitoringServiceAware.java
+++ b/management/monitoring-service-api/src/main/java/org/terracotta/management/service/monitoring/registry/provider/MonitoringServiceAware.java
@@ -15,11 +15,9 @@
  */
 package org.terracotta.management.service.monitoring.registry.provider;
 
-import com.tc.classloader.CommonComponent;
 import org.terracotta.management.sequence.TimeSource;
 import org.terracotta.management.service.monitoring.EntityMonitoringService;
 
-@CommonComponent
 public interface MonitoringServiceAware {
   default void setMonitoringService(EntityMonitoringService monitoringService) {}
 

--- a/management/monitoring-service-api/src/main/java/org/terracotta/management/service/monitoring/registry/provider/StatisticCollectorManagementProvider.java
+++ b/management/monitoring-service-api/src/main/java/org/terracotta/management/service/monitoring/registry/provider/StatisticCollectorManagementProvider.java
@@ -15,14 +15,12 @@
  */
 package org.terracotta.management.service.monitoring.registry.provider;
 
-import com.tc.classloader.CommonComponent;
 import org.terracotta.management.model.context.Context;
 import org.terracotta.management.registry.Named;
 import org.terracotta.management.registry.RequiredContext;
 import org.terracotta.management.registry.collect.StatisticCollectorProvider;
 
 @RequiredContext({@Named("consumerId")})
-@CommonComponent
 public class StatisticCollectorManagementProvider extends StatisticCollectorProvider {
   public StatisticCollectorManagementProvider(Context context) {
     super(context);

--- a/management/monitoring-service/src/test/java/org/terracotta/management/service/monitoring/ManagementExecutorAdapter.java
+++ b/management/monitoring-service/src/test/java/org/terracotta/management/service/monitoring/ManagementExecutorAdapter.java
@@ -15,7 +15,6 @@
  */
 package org.terracotta.management.service.monitoring;
 
-import com.tc.classloader.CommonComponent;
 import org.terracotta.entity.ClientDescriptor;
 import org.terracotta.management.model.call.ContextualCall;
 import org.terracotta.management.model.message.Message;
@@ -23,7 +22,6 @@ import org.terracotta.management.model.message.Message;
 /**
  * @author Mathieu Carbou
  */
-@CommonComponent
 public class ManagementExecutorAdapter implements ManagementExecutor {
   @Override
   public void executeManagementCallOnServer(String managementCallIdentifier, ContextualCall<?> call) {

--- a/management/nms-agent-entity/nms-agent-entity-client/pom.xml
+++ b/management/nms-agent-entity/nms-agent-entity-client/pom.xml
@@ -57,11 +57,6 @@
       <artifactId>entity-client-api</artifactId>
       <scope>provided</scope>
     </dependency>
-    <dependency>
-      <groupId>org.terracotta</groupId>
-      <artifactId>packaging-support</artifactId>
-      <scope>provided</scope>
-    </dependency>
   </dependencies>
 
 </project>

--- a/management/sequence-generator/pom.xml
+++ b/management/sequence-generator/pom.xml
@@ -59,12 +59,6 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.terracotta</groupId>
-      <artifactId>packaging-support</artifactId>
-      <scope>provided</scope>
-    </dependency>
-
-    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>

--- a/management/sequence-generator/src/main/java/org/terracotta/management/sequence/Sequence.java
+++ b/management/sequence-generator/src/main/java/org/terracotta/management/sequence/Sequence.java
@@ -15,8 +15,6 @@
  */
 package org.terracotta.management.sequence;
 
-import com.tc.classloader.CommonComponent;
-
 import java.io.Serializable;
 
 /**
@@ -24,7 +22,6 @@ import java.io.Serializable;
  *
  * @author Mathieu Carbou
  */
-@CommonComponent
 public interface Sequence extends Comparable<Sequence>, Serializable {
 
   long getTimestamp();

--- a/management/testing/sample-entity/src/main/java/org/terracotta/management/entity/sample/server/MapConfiguration.java
+++ b/management/testing/sample-entity/src/main/java/org/terracotta/management/entity/sample/server/MapConfiguration.java
@@ -15,7 +15,6 @@
  */
 package org.terracotta.management.entity.sample.server;
 
-import com.tc.classloader.CommonComponent;
 import org.terracotta.entity.ServiceConfiguration;
 
 import java.util.Map;
@@ -23,7 +22,6 @@ import java.util.Map;
 /**
  * @author Mathieu Carbou
  */
-@CommonComponent
 @SuppressWarnings("rawtypes")
 public class MapConfiguration implements ServiceConfiguration<Map> {
 

--- a/management/testing/sample-entity/src/main/java/org/terracotta/management/entity/sample/server/MapRelease.java
+++ b/management/testing/sample-entity/src/main/java/org/terracotta/management/entity/sample/server/MapRelease.java
@@ -15,7 +15,6 @@
  */
 package org.terracotta.management.entity.sample.server;
 
-import com.tc.classloader.CommonComponent;
 import org.terracotta.entity.ServiceConfiguration;
 
 import java.util.Map;
@@ -23,7 +22,6 @@ import java.util.Map;
 /**
  * @author Mathieu Carbou
  */
-@CommonComponent
 @SuppressWarnings("rawtypes")
 public class MapRelease implements ServiceConfiguration<Map> {
   @Override


### PR DESCRIPTION
With the new kit structure, classes in plugins/api should not have any annotation.

Only classes in plugins/lib can have, if they are shared across services / entities.