### PR TITLE
Several Fixes

### DIFF
--- a/data-root-resource/src/main/java/org/terracotta/config/data_roots/DataDirectoriesConfigImpl.java
+++ b/data-root-resource/src/main/java/org/terracotta/config/data_roots/DataDirectoriesConfigImpl.java
@@ -65,9 +65,18 @@ public class DataDirectoriesConfigImpl implements DataDirectoriesConfig, Managea
     this.parameterSubstitutor = parameterSubstitutor;
     this.pathResolver = pathResolver;
 
-    this.platform = compute(nodeContext.getNode().getNodeMetadataDir());
+    // add platform metadata dir first
+    if (nodeContext.getNode().getNodeMetadataDir() != null) {
+      addDataDirectory("platform", nodeContext.getNode().getNodeMetadataDir().toString());
+      this.platform = dataRootMap.get("platform");
+      this.platformRootIdentifier = "platform";
+    } else {
+      this.platform = null;
+      this.platformRootIdentifier = null;
+    }
+
+    // then add user ones
     nodeContext.getNode().getDataDirs().forEach((name, path) -> addDataDirectory(name, path.toString()));
-    this.platformRootIdentifier = platform == null ? null : "__platform__";
   }
 
   public DataDirectoriesConfigImpl(String source, org.terracotta.data.config.DataDirectories dataDirectories) {

--- a/dynamic-config/api/src/main/java/org/terracotta/dynamic_config/api/model/Setting.java
+++ b/dynamic-config/api/src/main/java/org/terracotta/dynamic_config/api/model/Setting.java
@@ -204,7 +204,7 @@ public enum Setting {
       NODE,
       extractor(Node::getNodeMetadataDir),
       setter((node, value) -> node.setNodeMetadataDir(Paths.get(value))),
-      of(GET, SET, CONFIG),
+      of(GET, SET, UNSET, CONFIG),
       of(ACTIVES_ONLINE, RESTART),
       emptyList(),
       emptyList(),

--- a/dynamic-config/api/src/test/java/org/terracotta/dynamic_config/api/model/ConfigurationTest.java
+++ b/dynamic-config/api/src/test/java/org/terracotta/dynamic_config/api/model/ConfigurationTest.java
@@ -301,7 +301,6 @@ public class ConfigurationTest {
           tuple2(NODE_GROUP_PORT, "9410"),
           tuple2(NODE_BIND_ADDRESS, "0.0.0.0"),
           tuple2(NODE_GROUP_BIND_ADDRESS, "0.0.0.0"),
-          tuple2(NODE_METADATA_DIR, "foo/bar"),
           tuple2(NODE_LOG_DIR, "foo/bar")
       ).forEach(tuple -> {
         allowInput(tuple.t1.toString(), tuple.t1, CLUSTER, null, null, null, null);
@@ -322,6 +321,7 @@ public class ConfigurationTest {
       // set allowed for all scopes
       Stream.of(
           tuple2(NODE_BACKUP_DIR, "foo/bar"),
+          tuple2(NODE_METADATA_DIR, "foo/bar"),
           tuple2(SECURITY_DIR, "foo/bar"),
           tuple2(SECURITY_AUDIT_LOG_DIR, "foo/bar")
       ).forEach(tuple -> {
@@ -578,7 +578,6 @@ public class ConfigurationTest {
         tuple2(NODE_GROUP_PORT, "9410"),
         tuple2(NODE_BIND_ADDRESS, "0.0.0.0"),
         tuple2(NODE_GROUP_BIND_ADDRESS, "0.0.0.0"),
-        tuple2(NODE_METADATA_DIR, "foo/bar"),
         tuple2(NODE_LOG_DIR, "foo/bar")
     ).forEach(tuple -> {
       allow(GET, tuple.t1.toString());
@@ -610,7 +609,8 @@ public class ConfigurationTest {
     Stream.of(
         tuple2(NODE_BACKUP_DIR, "foo/bar"),
         tuple2(SECURITY_DIR, "foo/bar"),
-        tuple2(SECURITY_AUDIT_LOG_DIR, "foo/bar")
+        tuple2(SECURITY_AUDIT_LOG_DIR, "foo/bar"),
+        tuple2(NODE_METADATA_DIR, "foo/bar")
     ).forEach(tuple -> {
       allow(GET, tuple.t1.toString());
       allow(UNSET, tuple.t1.toString());

--- a/dynamic-config/api/src/test/java/org/terracotta/dynamic_config/api/model/SettingValidatorTest.java
+++ b/dynamic-config/api/src/test/java/org/terracotta/dynamic_config/api/model/SettingValidatorTest.java
@@ -123,7 +123,7 @@ public class SettingValidatorTest {
 
   @Test
   public void test_paths() {
-    Stream.of(NODE_REPOSITORY_DIR, NODE_METADATA_DIR, NODE_LOG_DIR, LICENSE_FILE).forEach(setting -> {
+    Stream.of(NODE_REPOSITORY_DIR, NODE_LOG_DIR, LICENSE_FILE).forEach(setting -> {
       validateDefaults(setting);
       assertThat(
           () -> setting.validate("/\u0000/"),
@@ -134,7 +134,7 @@ public class SettingValidatorTest {
       setting.validate(".");
     });
 
-    Stream.of(NODE_BACKUP_DIR, SECURITY_DIR, SECURITY_AUDIT_LOG_DIR).forEach(setting -> {
+    Stream.of(NODE_BACKUP_DIR, NODE_METADATA_DIR, SECURITY_DIR, SECURITY_AUDIT_LOG_DIR).forEach(setting -> {
       validateDefaults(setting);
       assertThat(
           () -> setting.validate("/\u0000/"),

--- a/dynamic-config/cli/config-convertor-oss/src/main/java/org/terracotta/dynamic_config/xml/oss/OssTcConfigMapper.java
+++ b/dynamic-config/cli/config-convertor-oss/src/main/java/org/terracotta/dynamic_config/xml/oss/OssTcConfigMapper.java
@@ -69,7 +69,7 @@ public class OssTcConfigMapper extends AbstractTcConfigMapper implements TcConfi
               .setClientReconnectWindow(tcConfig.getServers().getClientReconnectWindow(), SECONDS)
               .setTcProperties(commonMapper.toProperties(tcConfig))
               // plugins
-              .setNodeMetadataDir(commonMapper.toNodeMetadataDir(xmlPlugins).map(Map.Entry::getValue).orElse(null))
+              .setNodeMetadataDir(null)
               .setDataDirs(commonMapper.toUserDataDirs(xmlPlugins))
               .setOffheapResources(commonMapper.toOffheapResources(xmlPlugins))
               .setNodeBackupDir(null)

--- a/dynamic-config/entities/topology-entity/client/src/main/java/org/terracotta/dynamic_config/entity/topology/client/DynamicTopologyEntity.java
+++ b/dynamic-config/entities/topology-entity/client/src/main/java/org/terracotta/dynamic_config/entity/topology/client/DynamicTopologyEntity.java
@@ -22,6 +22,7 @@ import org.terracotta.dynamic_config.api.model.License;
 import org.terracotta.dynamic_config.api.model.Node;
 
 import java.time.Duration;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeoutException;
 
 /**
@@ -69,6 +70,8 @@ public interface DynamicTopologyEntity extends Entity {
    * Can return null.
    */
   License getLicense() throws TimeoutException, InterruptedException;
+
+  Future<Void> releaseEntity();
 
   class Settings {
     private Duration requestTimeout = Duration.ofSeconds(20);

--- a/dynamic-config/entities/topology-entity/client/src/main/java/org/terracotta/dynamic_config/entity/topology/client/DynamicTopologyEntityFactory.java
+++ b/dynamic-config/entities/topology-entity/client/src/main/java/org/terracotta/dynamic_config/entity/topology/client/DynamicTopologyEntityFactory.java
@@ -36,6 +36,7 @@ import java.net.InetSocketAddress;
 import java.time.Duration;
 import java.util.List;
 import java.util.Properties;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeoutException;
 
 /**
@@ -118,6 +119,11 @@ public class DynamicTopologyEntityFactory {
       public boolean hasIncompleteChange() throws TimeoutException, InterruptedException {return entity.hasIncompleteChange();}
 
       public License getLicense() throws TimeoutException, InterruptedException {return entity.getLicense();}
+
+      @Override
+      public Future<Void> releaseEntity() {
+        return entity.releaseEntity();
+      }
 
       @Override
       public void close() {

--- a/dynamic-config/entities/topology-entity/client/src/main/java/org/terracotta/dynamic_config/entity/topology/client/DynamicTopologyEntityImpl.java
+++ b/dynamic-config/entities/topology-entity/client/src/main/java/org/terracotta/dynamic_config/entity/topology/client/DynamicTopologyEntityImpl.java
@@ -29,6 +29,7 @@ import org.terracotta.entity.MessageCodecException;
 import org.terracotta.exception.EntityException;
 
 import java.time.Duration;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
@@ -122,6 +123,11 @@ class DynamicTopologyEntityImpl implements DynamicTopologyEntity {
   @Override
   public License getLicense() throws TimeoutException, InterruptedException {
     return request(REQ_LICENSE, License.class);
+  }
+
+  @Override
+  public Future<Void> releaseEntity() {
+    return endpoint.release();
   }
 
   public <T> T request(DynamicTopologyEntityMessage.Type messageType, Class<T> type) throws TimeoutException, InterruptedException {

--- a/dynamic-config/server/services/src/main/java/org/terracotta/dynamic_config/server/service/DynamicConfigServiceProvider.java
+++ b/dynamic-config/server/services/src/main/java/org/terracotta/dynamic_config/server/service/DynamicConfigServiceProvider.java
@@ -52,7 +52,6 @@ import static org.terracotta.dynamic_config.api.model.Setting.NODE_GROUP_PORT;
 import static org.terracotta.dynamic_config.api.model.Setting.NODE_HOSTNAME;
 import static org.terracotta.dynamic_config.api.model.Setting.NODE_LOGGER_OVERRIDES;
 import static org.terracotta.dynamic_config.api.model.Setting.NODE_LOG_DIR;
-import static org.terracotta.dynamic_config.api.model.Setting.NODE_METADATA_DIR;
 import static org.terracotta.dynamic_config.api.model.Setting.NODE_NAME;
 import static org.terracotta.dynamic_config.api.model.Setting.NODE_PORT;
 import static org.terracotta.dynamic_config.api.model.Setting.NODE_PUBLIC_HOSTNAME;
@@ -120,7 +119,6 @@ public class DynamicConfigServiceProvider implements ServiceProvider {
           .fallback(accept()));
 
       // ensure to reject these changes
-      addToManager(configChangeHandlerManager, reject(), NODE_METADATA_DIR);
       addToManager(configChangeHandlerManager, reject(), NODE_NAME);
       addToManager(configChangeHandlerManager, reject(), NODE_HOSTNAME);
       addToManager(configChangeHandlerManager, reject(), NODE_PORT);

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/AttachCommand1x2IT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/AttachCommand1x2IT.java
@@ -46,7 +46,7 @@ public class AttachCommand1x2IT extends DynamicConfigIT {
 
     // start a second node
     startNode(1, 2);
-    waitUntil(out.getLog(1, 1), containsLog("Started the server in diagnostic mode"));
+    waitUntil(out.getLog(1, 2), containsLog("Started the server in diagnostic mode"));
     assertThat(getUpcomingCluster("localhost", getNodePort(1, 2)).getNodeCount(), is(equalTo(1)));
 
     // attach

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/AttachCommand1x3IT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/AttachCommand1x3IT.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.dynamic_config.system_tests.activated;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.terracotta.dynamic_config.test_support.ClusterDefinition;
+import org.terracotta.dynamic_config.test_support.DynamicConfigIT;
+import org.terracotta.dynamic_config.test_support.util.NodeOutputRule;
+
+import java.time.Duration;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.terracotta.dynamic_config.test_support.util.AngelaMatchers.containsLog;
+import static org.terracotta.dynamic_config.test_support.util.AngelaMatchers.successful;
+
+/**
+ * @author Mathieu Carbou
+ */
+@ClusterDefinition(nodesPerStripe = 3, autoStart = false)
+public class AttachCommand1x3IT extends DynamicConfigIT {
+
+  @Rule public final NodeOutputRule out = new NodeOutputRule();
+
+  public AttachCommand1x3IT() {
+    super(Duration.ofSeconds(120));
+  }
+
+  @Test
+  public void test_attach_to_activated_cluster_with_offline_node() throws Exception {
+    // activate a 1x2 cluster
+    startNode(1, 1);
+    startNode(1, 2);
+    waitUntil(out.getLog(1, 1), containsLog("Started the server in diagnostic mode"));
+    waitUntil(out.getLog(1, 2), containsLog("Started the server in diagnostic mode"));
+    assertThat(configToolInvocation("attach", "-d", "localhost:" + getNodePort(1, 1), "-s", "localhost:" + getNodePort(1, 2)), is(successful()));
+
+    // activation restarts the node, so either 1 or 2 will become active
+    activateCluster();
+    assertThat(getUpcomingCluster("localhost", getNodePort(1, 1)).getNodeCount(), is(equalTo(2)));
+    assertThat(getUpcomingCluster("localhost", getNodePort(1, 2)).getNodeCount(), is(equalTo(2)));
+
+    int activeId = findActive(1).getAsInt(); // either 1 or 2
+    int passiveId = findPassives(1)[0]; // either 1 or 2
+
+    stopNode(1, passiveId);
+
+    // start a third node
+    startNode(1, 3);
+    waitUntil(out.getLog(1, 3), containsLog("Started the server in diagnostic mode"));
+    assertThat(getUpcomingCluster("localhost", getNodePort(1, 3)).getNodeCount(), is(equalTo(1)));
+
+    // attach
+    assertThat(configToolInvocation("-v", "attach", "-d", "localhost:" + getNodePort(1, activeId), "-s", "localhost:" + getNodePort(1, 3)), is(successful()));
+    waitUntil(out.getLog(1, 3), containsLog("Moved to State[ PASSIVE-STANDBY ]"));
+
+    // verify that the active node topology has 3 nodes
+    assertThat(getUpcomingCluster("localhost", getNodePort(1, activeId)).getNodeCount(), is(equalTo(3)));
+    assertThat(getRuntimeCluster("localhost", getNodePort(1, activeId)).getNodeCount(), is(equalTo(3)));
+
+    // verify that the added node topology has 3 nodes
+    assertThat(getUpcomingCluster("localhost", getNodePort(1, 3)).getNodeCount(), is(equalTo(3)));
+    assertThat(getRuntimeCluster("localhost", getNodePort(1, 3)).getNodeCount(), is(equalTo(3)));
+
+    // then try to start the passive that was down
+    out.clearLog(1, passiveId);
+    startNode(1, passiveId);
+    waitUntil(out.getLog(1, passiveId), containsLog("Moved to State[ PASSIVE-STANDBY ]"));
+
+    // verify that the restarted passive topology has 3 nodes
+    assertThat(getUpcomingCluster("localhost", getNodePort(1, passiveId)).getNodeCount(), is(equalTo(3)));
+    assertThat(getRuntimeCluster("localhost", getNodePort(1, passiveId)).getNodeCount(), is(equalTo(3)));
+  }
+}


### PR DESCRIPTION
-  Added DynamicTopologyEntity#releaseEntity
-  Added test to attach a passive to a cluster with a node that is down
-  Platform data dir was missing from data dirs
- Node metadata-dir should be optional because nullable in OSS and defaulted in EE