### PR TITLE
Several fixes and improvements

### DIFF
--- a/client-message-tracker/pom.xml
+++ b/client-message-tracker/pom.xml
@@ -33,11 +33,13 @@
       <groupId>org.terracotta</groupId>
       <artifactId>entity-server-api</artifactId>
       <version>${terracotta-apis.version}</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.terracotta</groupId>
       <artifactId>packaging-support</artifactId>
       <version>${terracotta-apis.version}</version>
+      <scope>provided</scope>
     </dependency>
 
     <dependency>

--- a/common/nomad/src/main/java/org/terracotta/nomad/messages/AcceptRejectResponse.java
+++ b/common/nomad/src/main/java/org/terracotta/nomad/messages/AcceptRejectResponse.java
@@ -78,6 +78,6 @@ public class AcceptRejectResponse {
 
   @Override
   public String toString() {
-    return accepted ? "accepted" : (rejectionReason.name().toLowerCase() + (rejectionMessage == null ? "" : (" ( " + rejectionMessage + ")")));
+    return accepted ? "accepted" : (rejectionReason.name().toLowerCase() + (rejectionMessage == null ? "" : (" ( " + rejectionMessage + ")")) + " by " + lastMutationUser + " from " + lastMutationHost);
   }
 }

--- a/common/nomad/src/main/java/org/terracotta/nomad/server/NomadServerImpl.java
+++ b/common/nomad/src/main/java/org/terracotta/nomad/server/NomadServerImpl.java
@@ -143,6 +143,20 @@ public class NomadServerImpl<T> implements UpgradableNomadServer<T> {
   }
 
   @Override
+  public Optional<NomadChangeInfo> getNomadChangeInfo(UUID uuid) throws NomadException {
+    return Optional.ofNullable(state.getChangeRequest(uuid))
+        .map(changeRequest -> new NomadChangeInfo(
+            uuid,
+            changeRequest.getChange(),
+            changeRequest.getState(),
+            changeRequest.getVersion(),
+            changeRequest.getCreationHost(),
+            changeRequest.getCreationUser(),
+            changeRequest.getCreationTimestamp()
+        ));
+  }
+
+  @Override
   public List<NomadChangeInfo> getAllNomadChanges() throws NomadException {
     LinkedList<NomadChangeInfo> allNomadChanges = new LinkedList<>();
     UUID changeUuid = state.getLatestChangeUuid();

--- a/common/nomad/src/main/java/org/terracotta/nomad/server/SingleThreadedNomadServer.java
+++ b/common/nomad/src/main/java/org/terracotta/nomad/server/SingleThreadedNomadServer.java
@@ -138,6 +138,16 @@ public class SingleThreadedNomadServer<T> implements UpgradableNomadServer<T> {
   }
 
   @Override
+  public Optional<NomadChangeInfo> getNomadChangeInfo(UUID uuid) throws NomadException {
+    lock.lock();
+    try {
+      return underlying.getNomadChangeInfo(uuid);
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  @Override
   public List<NomadChangeInfo> getAllNomadChanges() throws NomadException {
     lock.lock();
     try {

--- a/common/nomad/src/main/java/org/terracotta/nomad/server/UpgradableNomadServer.java
+++ b/common/nomad/src/main/java/org/terracotta/nomad/server/UpgradableNomadServer.java
@@ -27,6 +27,8 @@ public interface UpgradableNomadServer<T> extends NomadServer<T> {
 
   ChangeApplicator<T> getChangeApplicator();
 
+  Optional<NomadChangeInfo> getNomadChangeInfo(UUID uuid) throws NomadException;
+
   List<NomadChangeInfo> getAllNomadChanges() throws NomadException;
 
   Optional<NomadChangeInfo> getNomadChange(UUID uuid) throws NomadException;

--- a/common/nomad/src/main/java/org/terracotta/nomad/server/UpgradableNomadServerAdapter.java
+++ b/common/nomad/src/main/java/org/terracotta/nomad/server/UpgradableNomadServerAdapter.java
@@ -48,6 +48,11 @@ public class UpgradableNomadServerAdapter<T> implements UpgradableNomadServer<T>
   }
 
   @Override
+  public Optional<NomadChangeInfo> getNomadChangeInfo(UUID uuid) throws NomadException {
+    return delegate.getNomadChangeInfo(uuid);
+  }
+
+  @Override
   public List<NomadChangeInfo> getAllNomadChanges() throws NomadException {return delegate.getAllNomadChanges();}
 
   @Override

--- a/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/ConfigTool.java
+++ b/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/ConfigTool.java
@@ -108,7 +108,11 @@ public class ConfigTool {
     // create services
     DiagnosticServiceProvider diagnosticServiceProvider = new DiagnosticServiceProvider("CONFIG-TOOL", connectionTimeout, requestTimeout, MAIN.getSecurityRootDirectory());
     MultiDiagnosticServiceProvider multiDiagnosticServiceProvider = new ConcurrentDiagnosticServiceProvider(diagnosticServiceProvider, connectionTimeout, concurrencySizing);
-    NomadEntityProvider nomadEntityProvider = new NomadEntityProvider("CONFIG-TOOL", connectionTimeout, new NomadEntity.Settings().setRequestTimeout(requestTimeout), MAIN.getSecurityRootDirectory());
+    NomadEntityProvider nomadEntityProvider = new NomadEntityProvider(
+        "CONFIG-TOOL",
+        connectionTimeout,
+        new NomadEntity.Settings().setRequestTimeout(null), // a null timeout is important here. We need to block the call and wait for any return. We cannot timeout otherwise we won't know the outcome of the 2PC Nomad transaction
+        MAIN.getSecurityRootDirectory());
     NomadManager<NodeContext> nomadManager = new NomadManager<>(new NomadEnvironment(), multiDiagnosticServiceProvider, nomadEntityProvider);
     RestartService restartService = new RestartService(diagnosticServiceProvider, concurrencySizing);
 

--- a/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/command/TopologyCommand.java
+++ b/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/command/TopologyCommand.java
@@ -126,10 +126,14 @@ public abstract class TopologyCommand extends RemoteCommand {
     logger.info("Sending the topology change");
 
     if (destinationClusterActivated) {
-      beforeNomadChange(result);
       NodeNomadChange nomadChange = buildNomadChange(result);
-      runPassiveChange(destinationCluster, destinationOnlineNodes, nomadChange);
-      afterNomadChange(result);
+      onNomadChangeReady(nomadChange);
+      try {
+        runPassiveChange(destinationCluster, destinationOnlineNodes, nomadChange);
+      } catch (RuntimeException e) {
+        onNomadChangeFailure(nomadChange, e);
+      }
+      onNomadChangeSuccess(nomadChange);
 
     } else {
       setUpcomingCluster(Collections.singletonList(source), result);
@@ -182,10 +186,14 @@ public abstract class TopologyCommand extends RemoteCommand {
     }
   }
 
-  protected void beforeNomadChange(Cluster result) {
+  protected void onNomadChangeReady(NodeNomadChange nomadChange) {
   }
 
-  protected void afterNomadChange(Cluster result) {
+  protected void onNomadChangeSuccess(NodeNomadChange nomadChange) {
+  }
+
+  protected void onNomadChangeFailure(NodeNomadChange nomadChange, RuntimeException error) {
+    throw error;
   }
 
   protected abstract Cluster updateTopology();

--- a/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/nomad/NomadManager.java
+++ b/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/nomad/NomadManager.java
@@ -207,6 +207,8 @@ public class NomadManager<T> {
         InetSocketAddress address = getAddress();
         int stripeId = destinationCluster.getStripeId(address).getAsInt();
         CompletableFuture<AcceptRejectResponse> result = cache.computeIfAbsent(stripeId, sid -> {
+          LOGGER.info("Committing passive change to stripe ID: {}... (this operation is blocking and can take time in case a failover happens)", stripeId);
+
           LOGGER.trace("Sending commit message: {} to stripe ID: {}", message, stripeId);
           CompletableFuture<AcceptRejectResponse> c = new CompletableFuture<>();
           try {

--- a/dynamic-config/entities/nomad-entity/client/src/main/java/org/terracotta/nomad/entity/client/NomadEntity.java
+++ b/dynamic-config/entities/nomad-entity/client/src/main/java/org/terracotta/nomad/entity/client/NomadEntity.java
@@ -38,7 +38,7 @@ public interface NomadEntity<T> extends Entity, NomadServer<T> {
   }
 
   @Override
-  default AcceptRejectResponse prepare(PrepareMessage message) throws NomadException {
+  default AcceptRejectResponse prepare(PrepareMessage message) {
     throw new UnsupportedOperationException();
   }
 
@@ -53,8 +53,8 @@ public interface NomadEntity<T> extends Entity, NomadServer<T> {
   }
 
   @Override
-  default AcceptRejectResponse takeover(TakeoverMessage message) throws NomadException {
-    return send(message);
+  default AcceptRejectResponse takeover(TakeoverMessage message) {
+    throw new UnsupportedOperationException();
   }
 
   AcceptRejectResponse send(MutativeMessage message) throws NomadException;

--- a/dynamic-config/entities/nomad-entity/server/src/main/java/org/terracotta/nomad/entity/server/NomadActiveServerEntity.java
+++ b/dynamic-config/entities/nomad-entity/server/src/main/java/org/terracotta/nomad/entity/server/NomadActiveServerEntity.java
@@ -25,11 +25,11 @@ import org.terracotta.nomad.entity.common.NomadEntityResponse;
 import org.terracotta.nomad.messages.AcceptRejectResponse;
 import org.terracotta.nomad.messages.MutativeMessage;
 import org.terracotta.nomad.server.NomadException;
-import org.terracotta.nomad.server.NomadServer;
+import org.terracotta.nomad.server.UpgradableNomadServer;
 
 
 public class NomadActiveServerEntity<T> extends NomadCommonServerEntity<T> implements ActiveServerEntity<NomadEntityMessage, NomadEntityResponse> {
-  public NomadActiveServerEntity(NomadServer<T> nomadServer) {
+  public NomadActiveServerEntity(UpgradableNomadServer<T> nomadServer) {
     super(nomadServer);
   }
 

--- a/dynamic-config/entities/nomad-entity/server/src/main/java/org/terracotta/nomad/entity/server/NomadPassiveServerEntity.java
+++ b/dynamic-config/entities/nomad-entity/server/src/main/java/org/terracotta/nomad/entity/server/NomadPassiveServerEntity.java
@@ -24,12 +24,12 @@ import org.terracotta.nomad.entity.common.NomadEntityMessage;
 import org.terracotta.nomad.entity.common.NomadEntityResponse;
 import org.terracotta.nomad.messages.AcceptRejectResponse;
 import org.terracotta.nomad.server.NomadException;
-import org.terracotta.nomad.server.NomadServer;
+import org.terracotta.nomad.server.UpgradableNomadServer;
 
 public class NomadPassiveServerEntity<T> extends NomadCommonServerEntity<T> implements PassiveServerEntity<NomadEntityMessage, NomadEntityResponse> {
   private final PlatformService platformService;
 
-  public NomadPassiveServerEntity(NomadServer<T> nomadServer, PlatformService platformService) {
+  public NomadPassiveServerEntity(UpgradableNomadServer<T> nomadServer, PlatformService platformService) {
     super(nomadServer);
     this.platformService = platformService;
   }

--- a/dynamic-config/entities/nomad-entity/server/src/main/java/org/terracotta/nomad/entity/server/NomadServerEntityService.java
+++ b/dynamic-config/entities/nomad-entity/server/src/main/java/org/terracotta/nomad/entity/server/NomadServerEntityService.java
@@ -30,7 +30,7 @@ import org.terracotta.nomad.entity.common.NomadEntityConstants;
 import org.terracotta.nomad.entity.common.NomadEntityMessage;
 import org.terracotta.nomad.entity.common.NomadEntityResponse;
 import org.terracotta.nomad.entity.common.NomadMessageCodec;
-import org.terracotta.nomad.server.NomadServer;
+import org.terracotta.nomad.server.UpgradableNomadServer;
 
 @PermanentEntity(type = NomadEntityConstants.ENTITY_TYPE, name = NomadEntityConstants.ENTITY_NAME)
 public class NomadServerEntityService<T> implements EntityServerService<NomadEntityMessage, NomadEntityResponse> {
@@ -41,7 +41,7 @@ public class NomadServerEntityService<T> implements EntityServerService<NomadEnt
   public NomadActiveServerEntity<T> createActiveEntity(ServiceRegistry registry, byte[] configuration) throws ConfigurationException {
     try {
       @SuppressWarnings("unchecked")
-      NomadServer<T> nomadServer = registry.getService(new BasicServiceConfiguration<>(NomadServer.class));
+      UpgradableNomadServer<T> nomadServer = registry.getService(new BasicServiceConfiguration<>(UpgradableNomadServer.class));
       return new NomadActiveServerEntity<>(nomadServer);
     } catch (ServiceException e) {
       throw new ConfigurationException("Could not retrieve service ", e);
@@ -52,7 +52,7 @@ public class NomadServerEntityService<T> implements EntityServerService<NomadEnt
   public NomadPassiveServerEntity<T> createPassiveEntity(ServiceRegistry registry, byte[] configuration) throws ConfigurationException {
     try {
       @SuppressWarnings("unchecked")
-      NomadServer<T> nomadServer = registry.getService(new BasicServiceConfiguration<>(NomadServer.class));
+      UpgradableNomadServer<T> nomadServer = registry.getService(new BasicServiceConfiguration<>(UpgradableNomadServer.class));
       PlatformService platformService = registry.getService(new BasicServiceConfiguration<>(PlatformService.class));
       return new NomadPassiveServerEntity<>(nomadServer, platformService);
     } catch (ServiceException e) {

--- a/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/service/DynamicConfigServiceImpl.java
+++ b/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/service/DynamicConfigServiceImpl.java
@@ -247,7 +247,7 @@ public class DynamicConfigServiceImpl implements TopologyService, DynamicConfigS
   @Override
   public synchronized void setUpcomingCluster(Cluster updatedCluster) {
     if (isActivated()) {
-      throw new IllegalStateException("Use Nomad instead to change teh topology of activated node: " + runtimeNodeContext.getNode().getNodeAddress());
+      throw new IllegalStateException("Use Nomad instead to change the topology of activated node: " + runtimeNodeContext.getNode().getNodeAddress());
     }
 
     requireNonNull(updatedCluster);

--- a/dynamic-config/testing/support/src/main/java/org/terracotta/dynamic_config/test_support/DynamicConfigIT.java
+++ b/dynamic-config/testing/support/src/main/java/org/terracotta/dynamic_config/test_support/DynamicConfigIT.java
@@ -91,23 +91,23 @@ import static org.terracotta.common.struct.Tuple2.tuple2;
 import static org.terracotta.dynamic_config.test_support.util.AngelaMatchers.successful;
 
 public class DynamicConfigIT {
-  private static final Logger LOGGER = LoggerFactory.getLogger(DynamicConfigIT.class);
+  private static Logger LOGGER = LoggerFactory.getLogger(DynamicConfigIT.class);
 
-  @Rule public final TmpDir tmpDir = new TmpDir();
-  @Rule public final PortLockingRule ports;
+  @Rule public TmpDir tmpDir = new TmpDir();
+  @Rule public PortLockingRule ports;
   @Rule public Timeout timeoutRule;
 
-  protected final long timeout;
+  protected long timeout;
 
   protected ClusterFactory clusterFactory;
   protected Tsa tsa;
 
-  private final int stripes;
-  private final boolean autoStart;
-  private final int nodesPerStripe;
-  private final boolean autoActivate;
-  private final Map<String, TerracottaServer> nodes = new ConcurrentHashMap<>();
-  private final ClusterDefinition clusterDef;
+  private int stripes;
+  private boolean autoStart;
+  private int nodesPerStripe;
+  private boolean autoActivate;
+  private Map<String, TerracottaServer> nodes = new ConcurrentHashMap<>();
+  private ClusterDefinition clusterDef;
 
   public DynamicConfigIT() {
     this(Duration.ofSeconds(60));
@@ -147,7 +147,7 @@ public class DynamicConfigIT {
     }
   }
 
-  protected final void startNodes() {
+  protected void startNodes() {
     for (int stripeId = 1; stripeId <= stripes; stripeId++) {
       for (int nodeId = 1; nodeId <= nodesPerStripe; nodeId++) {
         startNode(stripeId, nodeId);
@@ -159,19 +159,19 @@ public class DynamicConfigIT {
     startNode(getNode(stripeId, nodeId));
   }
 
-  protected final void startNode(int stripeId, int nodeId, String... cli) {
+  protected void startNode(int stripeId, int nodeId, String... cli) {
     startNode(getNode(stripeId, nodeId), cli);
   }
 
-  protected final void startNode(TerracottaServer node, String... cli) {
+  protected void startNode(TerracottaServer node, String... cli) {
     tsa.start(node, cli);
   }
 
-  protected final void stopNode(int stripeId, int nodeId) {
+  protected void stopNode(int stripeId, int nodeId) {
     tsa.stop(getNode(stripeId, nodeId));
   }
 
-  protected final TerracottaServer getNode(int stripeId, int nodeId) {
+  protected TerracottaServer getNode(int stripeId, int nodeId) {
     String key = combine(stripeId, nodeId);
     TerracottaServer server = nodes.get(key);
     if (server == null) {
@@ -180,7 +180,7 @@ public class DynamicConfigIT {
     return server;
   }
 
-  protected final int getNodePort(int stripeId, int nodeId) {
+  protected int getNodePort(int stripeId, int nodeId) {
     //1-1 => 0 and 1
     //1-2 => 2 and 3
     //1-3 => 4 and 5
@@ -190,39 +190,39 @@ public class DynamicConfigIT {
     return ports.getPorts()[2 * (nodeId - 1) + 2 * nodesPerStripe * (stripeId - 1)];
   }
 
-  protected final int getNodeGroupPort(int stripeId, int nodeId) {
+  protected int getNodeGroupPort(int stripeId, int nodeId) {
     return getNodePort(stripeId, nodeId) + 1;
   }
 
-  protected final OptionalInt findActive(int stripeId) {
+  protected OptionalInt findActive(int stripeId) {
     return IntStream.rangeClosed(1, nodesPerStripe)
         .filter(nodeId -> tsa.getState(getNode(stripeId, nodeId)) == STARTED_AS_ACTIVE)
         .findFirst();
   }
 
-  protected final int[] findPassives(int stripeId) {
+  protected int[] findPassives(int stripeId) {
     return IntStream.rangeClosed(1, nodesPerStripe)
         .filter(nodeId -> tsa.getState(getNode(stripeId, nodeId)) == STARTED_AS_PASSIVE)
         .toArray();
   }
 
-  protected final int getNodePort() {
+  protected int getNodePort() {
     return getNodePort(1, 1);
   }
 
-  protected final int getNodeGroupPort() {
+  protected int getNodeGroupPort() {
     return getNodePort(1, 1) + 1;
   }
 
-  protected final Path getBaseDir() {
+  protected Path getBaseDir() {
     return tmpDir.getRoot();
   }
 
-  protected final InetSocketAddress getNodeAddress() {
+  protected InetSocketAddress getNodeAddress() {
     return InetSocketAddress.createUnresolved("localhost", getNodePort());
   }
 
-  protected final Path copyConfigProperty(String configFile) {
+  protected Path copyConfigProperty(String configFile) {
     Path src;
     try {
       src = Paths.get(getClass().getResource(configFile).toURI());
@@ -268,27 +268,27 @@ public class DynamicConfigIT {
     return getClass().getResource("/license.xml");
   }
 
-  protected final Path getNodeRepositoryDir() {
+  protected Path getNodeRepositoryDir() {
     return getNodeRepositoryDir(1, 1);
   }
 
-  protected final Path getNodeRepositoryDir(int stripeId, int nodeId) {
+  protected Path getNodeRepositoryDir(int stripeId, int nodeId) {
     return getBaseDir().resolve("repository").resolve("stripe" + stripeId).resolve("node-" + nodeId);
   }
 
-  protected final void waitUntil(ConfigToolExecutionResult result, Matcher<? super ConfigToolExecutionResult> matcher) {
+  protected void waitUntil(ConfigToolExecutionResult result, Matcher<? super ConfigToolExecutionResult> matcher) {
     waitUntil(() -> result, matcher, timeout);
   }
 
-  protected final void waitUntil(NodeOutputRule.NodeLog result, Matcher<? super NodeOutputRule.NodeLog> matcher) {
+  protected void waitUntil(NodeOutputRule.NodeLog result, Matcher<? super NodeOutputRule.NodeLog> matcher) {
     waitUntil(() -> result, matcher, timeout);
   }
 
-  protected final <T> void waitUntil(Callable<T> callable, Matcher<? super T> matcher) {
+  protected <T> void waitUntil(Callable<T> callable, Matcher<? super T> matcher) {
     waitUntil(callable, matcher, timeout);
   }
 
-  protected final <T> void waitUntil(Callable<T> callable, Matcher<? super T> matcher, long timeout) {
+  protected <T> void waitUntil(Callable<T> callable, Matcher<? super T> matcher, long timeout) {
     Awaitility.await()
         // do not use iterative because it slows down the whole test suite considerably, especially in case of a failing process causing a timeout
         .pollInterval(Duration.ofMillis(500))
@@ -296,7 +296,7 @@ public class DynamicConfigIT {
         .until(callable, matcher);
   }
 
-  protected final Path generateNodeRepositoryDir(int stripeId, int nodeId, Consumer<ConfigRepositoryGenerator> fn) throws Exception {
+  protected Path generateNodeRepositoryDir(int stripeId, int nodeId, Consumer<ConfigRepositoryGenerator> fn) throws Exception {
     Path nodeRepositoryDir = getNodeRepositoryDir(stripeId, nodeId);
     Path repositoriesDir = getBaseDir().resolve("repositories");
     ConfigRepositoryGenerator clusterGenerator = new ConfigRepositoryGenerator(repositoriesDir, ports.getPorts());
@@ -307,7 +307,11 @@ public class DynamicConfigIT {
     return nodeRepositoryDir;
   }
 
-  protected final Cluster getUpcomingCluster(String host, int port) throws Exception {
+  protected Cluster getUpcomingCluster(int stripeId, int nodeId) throws Exception {
+    return getUpcomingCluster("localhost", getNodePort(stripeId, nodeId));
+  }
+
+  protected Cluster getUpcomingCluster(String host, int port) throws Exception {
     try (DiagnosticService diagnosticService = DiagnosticServiceFactory.fetch(
         InetSocketAddress.createUnresolved(host, port),
         getClass().getSimpleName(),
@@ -318,7 +322,11 @@ public class DynamicConfigIT {
     }
   }
 
-  protected final Cluster getRuntimeCluster(String host, int port) throws Exception {
+  protected Cluster getRuntimeCluster(int stripeId, int nodeId) throws Exception {
+    return getUpcomingCluster("localhost", getNodePort(stripeId, nodeId));
+  }
+
+  protected Cluster getRuntimeCluster(String host, int port) throws Exception {
     try (DiagnosticService diagnosticService = DiagnosticServiceFactory.fetch(
         InetSocketAddress.createUnresolved(host, port),
         getClass().getSimpleName(),
@@ -329,7 +337,11 @@ public class DynamicConfigIT {
     }
   }
 
-  protected final void withTopologyService(String host, int port, Consumer<TopologyService> consumer) throws Exception {
+  protected void withTopologyService(int stripeId, int nodeId, Consumer<TopologyService> consumer) throws Exception {
+    withTopologyService("localhost", getNodePort(stripeId, nodeId), consumer);
+  }
+
+  protected void withTopologyService(String host, int port, Consumer<TopologyService> consumer) throws Exception {
     try (DiagnosticService diagnosticService = DiagnosticServiceFactory.fetch(
         InetSocketAddress.createUnresolved(host, port),
         getClass().getSimpleName(),
@@ -340,11 +352,11 @@ public class DynamicConfigIT {
     }
   }
 
-  protected final ConfigToolExecutionResult activateCluster() {
+  protected ConfigToolExecutionResult activateCluster() {
     return activateCluster("tc-cluster");
   }
 
-  protected final ConfigToolExecutionResult activateCluster(String name) {
+  protected ConfigToolExecutionResult activateCluster(String name) {
     String licensePath = licensePath();
     ConfigToolExecutionResult result;
     if (licensePath == null) {
@@ -437,7 +449,7 @@ public class DynamicConfigIT {
     return distribution(version(DISTRIBUTION.getValue()), KIT, TERRACOTTA_OS);
   }
 
-  protected final ConfigToolExecutionResult configToolInvocation(String... cli) {
+  protected ConfigToolExecutionResult configToolInvocation(String... cli) {
     return tsa.configTool(getNode(1, 1)).executeCommand(cli);
   }
 

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/DiagnosticMode1x2IT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/DiagnosticMode1x2IT.java
@@ -18,13 +18,21 @@ package org.terracotta.dynamic_config.system_tests.activated;
 import org.junit.Rule;
 import org.junit.Test;
 import org.terracotta.angela.common.tcconfig.TerracottaServer;
+import org.terracotta.dynamic_config.api.model.Cluster;
 import org.terracotta.dynamic_config.test_support.ClusterDefinition;
 import org.terracotta.dynamic_config.test_support.DynamicConfigIT;
 import org.terracotta.dynamic_config.test_support.util.NodeOutputRule;
 
+import java.time.Duration;
+
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertThat;
 import static org.terracotta.dynamic_config.test_support.util.AngelaMatchers.containsLog;
+import static org.terracotta.dynamic_config.test_support.util.AngelaMatchers.containsOutput;
+import static org.terracotta.dynamic_config.test_support.util.AngelaMatchers.hasExitStatus;
 
 /**
  * @author Mathieu Carbou
@@ -33,6 +41,10 @@ import static org.terracotta.dynamic_config.test_support.util.AngelaMatchers.con
 public class DiagnosticMode1x2IT extends DynamicConfigIT {
 
   @Rule public final NodeOutputRule out = new NodeOutputRule();
+
+  public DiagnosticMode1x2IT() {
+    super(Duration.ofSeconds(120));
+  }
 
   @SuppressWarnings("OptionalGetWithoutIsPresent")
   @Test
@@ -55,5 +67,44 @@ public class DiagnosticMode1x2IT extends DynamicConfigIT {
 
     startNode(passive, "--diagnostic-mode", "--node-name", passive.getServerSymbolicName().getSymbolicName(), "-r", passive.getConfigRepo());
     waitUntil(out.getLog(1, passiveNodeId), containsLog("Started the server in diagnostic mode"));
+  }
+
+  @SuppressWarnings("OptionalGetWithoutIsPresent")
+  @Test
+  public void test_diagnostic_port_accessible_but_nomad_change_impossible() throws Exception {
+    int activeNodeId = findActive(1).getAsInt();
+    int passiveId = findPassives(1)[0];
+    TerracottaServer active = getNode(1, activeNodeId);
+    tsa.stop(active);
+    assertThat(tsa.getStopped().size(), is(1));
+
+    out.clearLog(1, 1);
+    startNode(active, "--diagnostic-mode", "-n", active.getServerSymbolicName().getSymbolicName(), "-r", active.getConfigRepo());
+    waitUntil(out.getLog(1, activeNodeId), containsLog("Started the server in diagnostic mode"));
+
+    // diag port available
+    Cluster cluster = getUpcomingCluster("localhost", getNodePort(1, activeNodeId));
+    assertThat(cluster.getStripeCount(), is(equalTo(1)));
+
+    // log command works, both when targeting node to repair and a normal node in the cluster
+    assertThat(configToolInvocation("log", "-s", "localhost:" + getNodePort(1, activeNodeId)), containsOutput("Activating cluster"));
+    assertThat(configToolInvocation("log", "-s", "localhost:" + getNodePort(1, passiveId)), containsOutput("Activating cluster"));
+
+    // diag command works, both when targeting node to repair and a normal node in the cluster
+    assertThat(configToolInvocation("diagnostic", "-s", "localhost:" + getNodePort(1, activeNodeId)),
+        containsOutput("Node started in diagnostic mode for initial configuration or repair: YES"));
+
+    assertThat(configToolInvocation("diagnostic", "-s", "localhost:" + getNodePort(1, passiveId)),
+        containsOutput("Node started in diagnostic mode for initial configuration or repair: YES"));
+
+    // unable to trigger a change on the cluster from the node in diagnostic mode
+    assertThat(
+        configToolInvocation("set", "-s", "localhost:" + getNodePort(1, activeNodeId), "-c", "stripe.1.node." + activeNodeId + ".tc-properties.something=value"),
+        allOf(not(hasExitStatus(0)), containsOutput("Detected a mix of activated and unconfigured nodes (or being repaired).")));
+
+    // unable to trigger a change on the cluster from any other node
+    assertThat(
+        configToolInvocation("set", "-s", "localhost:" + getNodePort(1, passiveId), "-c", "stripe.1.node.1.tc-properties.something=value"),
+        allOf(not(hasExitStatus(0)), containsOutput("Detected a mix of activated and unconfigured nodes (or being repaired).")));
   }
 }

--- a/kit/pom.xml
+++ b/kit/pom.xml
@@ -28,7 +28,7 @@
 
   <artifactId>platform-kit</artifactId>
   <name>KIT :: Platform</name>
-  <packaging>jar</packaging>
+  <packaging>pom</packaging>
 
   <dependencies>
 
@@ -79,6 +79,16 @@
     <dependency>
       <groupId>org.terracotta</groupId>
       <artifactId>lease-entity-server</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.terracotta</groupId>
+      <artifactId>client-message-tracker</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.terracotta</groupId>
+      <artifactId>platform-base</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
@@ -235,8 +245,7 @@
               <goal>shade</goal>
             </goals>
             <configuration>
-              <outputDirectory>${project.build.directory}/packages/server/plugins/api</outputDirectory>
-              <finalName>terracotta-api-management-${project.version}</finalName>
+              <outputFile>${project.build.directory}/packages/server/plugins/api/terracotta-api-management-${project.version}.jar</outputFile>
               <artifactSet>
                 <includes>
                   <include>org.terracotta.management:monitoring-service-api</include>
@@ -245,9 +254,6 @@
                   <include>org.terracotta.management:management-registry</include>
                   <include>org.terracotta.management:sequence-generator</include>
                 </includes>
-                <excludes>
-                  <exclude>org.terracotta:platform-kit</exclude>
-                </excludes>
               </artifactSet>
               <transformers>
                 <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
@@ -268,16 +274,12 @@
               <goal>shade</goal>
             </goals>
             <configuration>
-              <outputDirectory>${project.build.directory}/packages/server/plugins/api</outputDirectory>
-              <finalName>terracotta-api-diagnostic-${project.version}</finalName>
+              <outputFile>${project.build.directory}/packages/server/plugins/api/terracotta-api-diagnostic-${project.version}.jar</outputFile>
               <artifactSet>
                 <includes>
                   <include>org.terracotta.diagnostic:diagnostic-service-api</include>
                   <include>org.terracotta.diagnostic:diagnostic-model</include>
                 </includes>
-                <excludes>
-                  <exclude>org.terracotta:platform-kit</exclude>
-                </excludes>
               </artifactSet>
               <transformers>
                 <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
@@ -292,25 +294,45 @@
             </configuration>
           </execution>
           <execution>
+            <id>terracotta-api-common</id>
+            <phase>prepare-package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <outputFile>${project.build.directory}/packages/server/plugins/api/terracotta-api-common-${project.version}.jar</outputFile>
+              <artifactSet>
+                <includes>
+                  <include>org.terracotta.common:common-nomad</include>
+                  <include>org.terracotta.common:common-inet-support</include>
+                  <include>org.terracotta.common:common-structures</include>
+                </includes>
+              </artifactSet>
+              <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.DontIncludeResourceTransformer">
+                  <resource>META-INF/MANIFEST.MF</resource>
+                </transformer>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.IncludeResourceTransformer">
+                  <resource>META-INF/MANIFEST.MF</resource>
+                  <file>../common/nomad/target/classes/META-INF/MANIFEST.MF</file>
+                </transformer>
+              </transformers>
+            </configuration>
+          </execution>
+          <execution>
             <id>terracotta-api-dynamic-config</id>
             <phase>prepare-package</phase>
             <goals>
               <goal>shade</goal>
             </goals>
             <configuration>
-              <outputDirectory>${project.build.directory}/packages/server/plugins/api</outputDirectory>
-              <finalName>terracotta-api-dynamic-config-${project.version}</finalName>
+              <outputFile>${project.build.directory}/packages/server/plugins/api/terracotta-api-dynamic-config-${project.version}.jar</outputFile>
               <artifactSet>
                 <includes>
                   <include>org.terracotta.dynamic-config.server:dynamic-config-server-api</include>
                   <include>org.terracotta.dynamic-config:dynamic-config-api</include>
-                  <include>org.terracotta.common:common-inet-support</include>
-                  <include>org.terracotta.common:common-nomad</include>
-                  <include>org.terracotta.common:common-structures</include>
                 </includes>
-                <excludes>
-                  <exclude>org.terracotta:platform-kit</exclude>
-                </excludes>
               </artifactSet>
               <transformers>
                 <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
@@ -332,15 +354,11 @@
               <goal>shade</goal>
             </goals>
             <configuration>
-              <outputDirectory>${project.build.directory}/packages/server/plugins/lib</outputDirectory>
-              <finalName>terracotta-plugin-offheap-${project.version}</finalName>
+              <outputFile>${project.build.directory}/packages/server/plugins/lib/terracotta-plugin-offheap-${project.version}.jar</outputFile>
               <artifactSet>
                 <includes>
                   <include>org.terracotta:offheap-resource</include>
                 </includes>
-                <excludes>
-                  <exclude>org.terracotta:platform-kit</exclude>
-                </excludes>
               </artifactSet>
               <transformers>
                 <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
@@ -361,15 +379,11 @@
               <goal>shade</goal>
             </goals>
             <configuration>
-              <outputDirectory>${project.build.directory}/packages/server/plugins/lib</outputDirectory>
-              <finalName>terracotta-plugin-data-roots-${project.version}</finalName>
+              <outputFile>${project.build.directory}/packages/server/plugins/lib/terracotta-plugin-data-roots-${project.version}.jar</outputFile>
               <artifactSet>
                 <includes>
                   <include>org.terracotta:data-root-resource</include>
                 </includes>
-                <excludes>
-                  <exclude>org.terracotta:platform-kit</exclude>
-                </excludes>
               </artifactSet>
               <transformers>
                 <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
@@ -390,8 +404,7 @@
               <goal>shade</goal>
             </goals>
             <configuration>
-              <outputDirectory>${project.build.directory}/packages/server/plugins/lib</outputDirectory>
-              <finalName>terracotta-plugin-lease-${project.version}</finalName>
+              <outputFile>${project.build.directory}/packages/server/plugins/lib/terracotta-plugin-lease-${project.version}.jar</outputFile>
               <artifactSet>
                 <includes>
                   <include>org.terracotta:lease-entity-server</include>
@@ -399,9 +412,6 @@
                   <include>org.terracotta:lease-common</include>
                   <include>org.terracotta:runnel</include>
                 </includes>
-                <excludes>
-                  <exclude>org.terracotta:platform-kit</exclude>
-                </excludes>
               </artifactSet>
               <transformers>
                 <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
@@ -422,8 +432,7 @@
               <goal>shade</goal>
             </goals>
             <configuration>
-              <outputDirectory>${project.build.directory}/packages/server/plugins/lib</outputDirectory>
-              <finalName>terracotta-plugin-management-${project.version}</finalName>
+              <outputFile>${project.build.directory}/packages/server/plugins/lib/terracotta-plugin-management-${project.version}.jar</outputFile>
               <artifactSet>
                 <includes>
                   <include>org.terracotta.management:monitoring-service</include>
@@ -434,9 +443,6 @@
                   <include>org.terracotta.voltron.proxy:voltron-proxy-common</include>
                   <include>org.terracotta.voltron.proxy:voltron-proxy-server</include>
                 </includes>
-                <excludes>
-                  <exclude>org.terracotta:platform-kit</exclude>
-                </excludes>
               </artifactSet>
               <transformers>
                 <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
@@ -457,17 +463,13 @@
               <goal>shade</goal>
             </goals>
             <configuration>
-              <outputDirectory>${project.build.directory}/packages/server/plugins/lib</outputDirectory>
-              <finalName>terracotta-plugin-diagnostic-${project.version}</finalName>
+              <outputFile>${project.build.directory}/packages/server/plugins/lib/terracotta-plugin-diagnostic-${project.version}.jar</outputFile>
               <artifactSet>
                 <includes>
                   <include>org.terracotta.diagnostic:diagnostic-service</include>
                   <include>org.terracotta.diagnostic:diagnostic-common</include>
                   <include>org.terracotta.common:common-json-support</include>
                 </includes>
-                <excludes>
-                  <exclude>org.terracotta:platform-kit</exclude>
-                </excludes>
               </artifactSet>
               <transformers>
                 <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
@@ -488,8 +490,7 @@
               <goal>shade</goal>
             </goals>
             <configuration>
-              <outputDirectory>${project.build.directory}/packages/server/plugins/lib</outputDirectory>
-              <finalName>terracotta-plugin-dynamic-config-${project.version}</finalName>
+              <outputFile>${project.build.directory}/packages/server/plugins/lib/terracotta-plugin-dynamic-config-${project.version}.jar</outputFile>
               <artifactSet>
                 <includes>
                   <include>org.terracotta.dynamic-config.server:dynamic-config-configuration-provider</include>
@@ -503,9 +504,6 @@
                   <include>org.terracotta.common:common-json-support</include>
                   <include>org.terracotta.common:common-sanskrit</include>
                 </includes>
-                <excludes>
-                  <exclude>org.terracotta:platform-kit</exclude>
-                </excludes>
               </artifactSet>
               <transformers>
                 <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
@@ -520,14 +518,63 @@
             </configuration>
           </execution>
           <execution>
+            <id>terracotta-plugin-client-message-tracker</id>
+            <phase>prepare-package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <outputFile>${project.build.directory}/packages/server/plugins/lib/terracotta-plugin-client-message-tracker-${project.version}.jar</outputFile>
+              <artifactSet>
+                <includes>
+                  <include>org.terracotta:client-message-tracker</include>
+                </includes>
+              </artifactSet>
+              <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.DontIncludeResourceTransformer">
+                  <resource>META-INF/MANIFEST.MF</resource>
+                </transformer>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.IncludeResourceTransformer">
+                  <resource>META-INF/MANIFEST.MF</resource>
+                  <file>../client-message-tracker/target/classes/META-INF/MANIFEST.MF</file>
+                </transformer>
+              </transformers>
+            </configuration>
+          </execution>
+          <execution>
+            <id>terracotta-plugin-platform-base</id>
+            <phase>prepare-package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <outputFile>${project.build.directory}/packages/server/plugins/lib/terracotta-plugin-platform-base-${project.version}.jar</outputFile>
+              <artifactSet>
+                <includes>
+                  <include>org.terracotta:platform-base</include>
+                </includes>
+              </artifactSet>
+              <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.DontIncludeResourceTransformer">
+                  <resource>META-INF/MANIFEST.MF</resource>
+                </transformer>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.IncludeResourceTransformer">
+                  <resource>META-INF/MANIFEST.MF</resource>
+                  <file>../platform-base/target/classes/META-INF/MANIFEST.MF</file>
+                </transformer>
+              </transformers>
+            </configuration>
+          </execution>
+          <execution>
             <id>config-convertor</id>
             <phase>prepare-package</phase>
             <goals>
               <goal>shade</goal>
             </goals>
             <configuration>
-              <outputDirectory>${project.build.directory}/packages/tools/config-convertor/lib</outputDirectory>
-              <finalName>config-convertor-${project.version}</finalName>
+              <outputFile>${project.build.directory}/packages/tools/config-convertor/lib/config-convertor-${project.version}.jar</outputFile>
               <artifactSet>
                 <includes>
                   <include>org.terracotta.dynamic-config.cli:dynamic-config-cli-config-convertor</include>
@@ -535,9 +582,6 @@
                   <include>org.terracotta.internal:tc-config-parser</include>
                   <include>org.terracotta:tcconfig-schema</include>
                 </includes>
-                <excludes>
-                  <exclude>org.terracotta:platform-kit</exclude>
-                </excludes>
               </artifactSet>
               <transformers>
                 <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
@@ -558,8 +602,7 @@
               <goal>shade</goal>
             </goals>
             <configuration>
-              <outputDirectory>${project.build.directory}/packages/tools/config-tool/lib</outputDirectory>
-              <finalName>config-tool-${project.version}</finalName>
+              <outputFile>${project.build.directory}/packages/tools/config-tool/lib/config-tool-${project.version}.jar</outputFile>
               <artifactSet>
                 <includes>
                   <include>org.terracotta.dynamic-config.cli:dynamic-config-cli-config-tool</include>
@@ -575,9 +618,6 @@
                   <include>org.terracotta.common:common-nomad</include>
                   <include>org.terracotta.common:common-structures</include>
                 </includes>
-                <excludes>
-                  <exclude>org.terracotta:platform-kit</exclude>
-                </excludes>
               </artifactSet>
               <transformers>
                 <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>

--- a/management/cluster-topology/src/main/java/org/terracotta/management/model/cluster/Cluster.java
+++ b/management/cluster-topology/src/main/java/org/terracotta/management/model/cluster/Cluster.java
@@ -193,7 +193,7 @@ public final class Cluster implements Contextual {
 
   @Override
   public void setContext(Context context) {
-    // do nothing: we do not change teh context of a cluster object
+    // do nothing: we do not change the context of a cluster object
   }
 
   @Override

--- a/management/management-registry/src/main/java/org/terracotta/management/registry/QueryBuilder.java
+++ b/management/management-registry/src/main/java/org/terracotta/management/registry/QueryBuilder.java
@@ -34,7 +34,7 @@ public interface QueryBuilder<B, T> {
 
   /**
    * Adds some contexts to run this query against.
-   * The order is important and kept: if teh query is ran on several contexts, then the order of results will match the order of the contexts
+   * The order is important and kept: if the query is ran on several contexts, then the order of results will match the order of the contexts
    *
    * @param contexts The management registry contexts
    * @return this builder


### PR DESCRIPTION
-  Typos
- Moving common libs in common api in kit
- Nomad entity communication should not have any timeout. Command should wait until completion.
- Better logging to warn user that the operation can take time (i.e. i failover is happening)
- Added information about who and from in toString()
- Do not support takeover in Nomad entity
- Added UpgradableNomadServer#getNomadChangeInfo(UUID)
- Fixing Nomad Server Entity to be tolerant in case the same message is received more than once
- Improved attach/detach/activate commands:
    - Better logging
    - Refactored activation (same code for attach and activate commands)
    - activate command now support -r flag to allow the activation of a node only with a given topology, which can be used to activate and restart a node that wasn't added to a cluster with the attach command if the later has failed during commit phase
    - detach command is always restarting the node to detach regardless if the Nomad Change was successful or not
    - attach command is not activating and not restarting the node to attach in case of a Nomad Change failure, and displays a warning to the user

@mobasherul : this PR contains the changes we have discussed plus a fix for the kit packaging.

@mobasherul @saurabhagas : I added a flag on the activate command (`-R`) which allows to restrict the activation to the node only.

__Example:__

```java
  @Test
  public void testRestrictedActivation() throws Exception {
    String config = copyConfigProperty("/config-property-files/single-stripe_multi-node.properties").toString();

    // import the cluster config to node 1 and node 2
    assertThat(configToolInvocation("import", "-f", config), is(successful()));

    // restrict activation to only node 1
    assertThat(configToolInvocation("activate", "-R", "-n", "my-cluster", "-s", "localhost:" + getNodePort(1, 1)),
        allOf(is(successful()), containsOutput("No license installed"), containsOutput("came back up")));

    waitUntil(out.getLog(1, 1), containsLog("Moved to State[ ACTIVE-COORDINATOR ]"));

    withTopologyService(1, 1, topologyService -> assertTrue(topologyService.isActivated()));
    withTopologyService(1, 2, topologyService -> assertFalse(topologyService.isActivated()));

    // restrict activation to only node 2, which will become passive as node 1
    assertThat(configToolInvocation("activate", "-R", "-n", "my-cluster", "-s", "localhost:" + getNodePort(1, 2)),
        allOf(is(successful()), containsOutput("No license installed"), containsOutput("came back up")));

    waitUntil(out.getLog(1, 2), containsLog("Moved to State[ PASSIVE-STANDBY ]"));

    withTopologyService(1, 1, topologyService -> assertTrue(topologyService.isActivated()));
    withTopologyService(1, 2, topologyService -> assertTrue(topologyService.isActivated()));

    assertThat(getRuntimeCluster(1, 1), is(equalTo(getRuntimeCluster(1, 2))));
  }
```

So it is helpful in the use cases:

1. A user would want to activate the nodes but one by one on a single stripe
2. The attach command fails in the Nomad commit process (which can be repaired) so we have a destination cluster that contains the information about the added node, but sadly, the node that we want to add has not been activated or restarted. So we can in this case export the configuration of the cluster, and run the activate command on the passive node to add with `-R` so that the node will be activated with the same topology as the destination cluster and will become a passive.