### PR TITLE
Several fixes

### DIFF
--- a/common/nomad/src/main/java/org/terracotta/nomad/server/NomadServerImpl.java
+++ b/common/nomad/src/main/java/org/terracotta/nomad/server/NomadServerImpl.java
@@ -133,10 +133,7 @@ public class NomadServerImpl<T> implements UpgradableNomadServer<T> {
 
   @Override
   public void setChangeApplicator(ChangeApplicator<T> changeApplicator) {
-    if (changeApplicator == null) {
-      throw new NullPointerException("Can not set NULL changeApplicator");
-    }
-    if (this.changeApplicator != null) {
+    if (this.changeApplicator != null && changeApplicator != null) {
       throw new IllegalArgumentException("Variable changeApplicator is already set");
     }
     this.changeApplicator = changeApplicator;

--- a/common/nomad/src/test/java/org/terracotta/nomad/server/NomadServerTest.java
+++ b/common/nomad/src/test/java/org/terracotta/nomad/server/NomadServerTest.java
@@ -707,7 +707,7 @@ public class NomadServerTest {
   }
 
   @SuppressWarnings("unchecked")
-  @Test(expected = NullPointerException.class)
+  @Test
   public void testSetNullChangeApplicator() throws Exception {
     NomadServerState<String> serverState = mock(NomadServerState.class);
     when(serverState.isInitialized()).thenReturn(true);

--- a/dynamic-config/api/src/main/java/org/terracotta/dynamic_config/api/service/DynamicConfigService.java
+++ b/dynamic-config/api/src/main/java/org/terracotta/dynamic_config/api/service/DynamicConfigService.java
@@ -53,4 +53,14 @@ public interface DynamicConfigService {
    * @param licenseContent license file content
    */
   void upgradeLicense(String licenseContent);
+
+  /**
+   * Reset and restart an activated node.
+   * <p>
+   * This method will backup and reset the configurations and Nomad append log,
+   * and will restart the node as if it was alone in its own cluster.
+   * <p>
+   * The node will restart in diagnostic mode.
+   */
+  void resetAndRestart();
 }

--- a/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/command/AttachCommand.java
+++ b/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/command/AttachCommand.java
@@ -15,13 +15,17 @@
  */
 package org.terracotta.dynamic_config.cli.config_tool.command;
 
+import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
+import org.terracotta.common.struct.Measure;
+import org.terracotta.common.struct.TimeUnit;
 import org.terracotta.dynamic_config.api.model.Cluster;
 import org.terracotta.dynamic_config.api.model.Node;
 import org.terracotta.dynamic_config.api.model.Stripe;
 import org.terracotta.dynamic_config.api.model.nomad.NodeAdditionNomadChange;
 import org.terracotta.dynamic_config.api.model.nomad.NodeNomadChange;
 import org.terracotta.dynamic_config.cli.command.Usage;
+import org.terracotta.dynamic_config.cli.converter.TimeUnitConverter;
 import org.terracotta.inet.InetSocketAddressUtils;
 
 import java.net.InetSocketAddress;
@@ -41,6 +45,12 @@ import static org.terracotta.dynamic_config.cli.config_tool.converter.OperationT
 @Parameters(commandNames = "attach", commandDescription = "Attach a node to a stripe, or a stripe to a cluster")
 @Usage("attach [-t node|stripe] -d <hostname[:port]> -s <hostname[:port]> [-f] [-W <restart-wait-time>] [-D <restart-delay>]")
 public class AttachCommand extends TopologyCommand {
+
+  @Parameter(names = {"-W"}, description = "Maximum time to wait for the nodes to restart. Default: 60s", converter = TimeUnitConverter.class)
+  protected Measure<TimeUnit> restartWaitTime = Measure.of(60, TimeUnit.SECONDS);
+
+  @Parameter(names = {"-D"}, description = "Restart delay. Default: 2s", converter = TimeUnitConverter.class)
+  protected Measure<TimeUnit> restartDelay = Measure.of(2, TimeUnit.SECONDS);
 
   // list of new nodes to add with their backup topology
   private final Map<InetSocketAddress, Cluster> newNodes = new LinkedHashMap<>();

--- a/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/command/AttachCommand.java
+++ b/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/command/AttachCommand.java
@@ -27,9 +27,11 @@ import org.terracotta.inet.InetSocketAddressUtils;
 import java.net.InetSocketAddress;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.stream.Stream;
 
 import static java.lang.System.lineSeparator;
-import static java.util.Collections.singletonList;
 import static org.terracotta.dynamic_config.cli.config_tool.converter.OperationType.NODE;
 import static org.terracotta.dynamic_config.cli.config_tool.converter.OperationType.STRIPE;
 
@@ -39,6 +41,9 @@ import static org.terracotta.dynamic_config.cli.config_tool.converter.OperationT
 @Parameters(commandNames = "attach", commandDescription = "Attach a node to a stripe, or a stripe to a cluster")
 @Usage("attach [-t node|stripe] -d <hostname[:port]> -s <hostname[:port]> [-f] [-W <restart-wait-time>] [-D <restart-delay>]")
 public class AttachCommand extends TopologyCommand {
+
+  // list of new nodes to add with their backup topology
+  private final Map<InetSocketAddress, Cluster> newNodes = new LinkedHashMap<>();
 
   @Override
   public void validate() {
@@ -129,26 +134,26 @@ public class AttachCommand extends TopologyCommand {
 
   @Override
   protected void onNomadChangeReady(NodeNomadChange nomadChange) {
-    setUpcomingCluster(Collections.singletonList(source), nomadChange.getCluster());
+    (operationType == NODE ? Stream.of(source) : sourceCluster.getStripe(source).get().getNodeAddresses().stream()).forEach(addr -> newNodes.put(addr, getUpcomingCluster(addr)));
+    setUpcomingCluster(newNodes.keySet(), nomadChange.getCluster());
   }
 
   @Override
   protected void onNomadChangeSuccess(NodeNomadChange nomadChange) {
     Cluster result = nomadChange.getCluster();
-
-    Collection<InetSocketAddress> newNodes = operationType == NODE ?
-        singletonList(source) :
-        sourceCluster.getStripe(source).get().getNodeAddresses();
-
-    activate(newNodes, result, null, restartDelay, restartWaitTime);
+    activate(newNodes.keySet(), result, null, restartDelay, restartWaitTime);
   }
 
   @Override
   protected void onNomadChangeFailure(NodeNomadChange nomadChange, RuntimeException error) {
     logger.error("An error occurred during the attach transaction." + lineSeparator() +
-        "The node information might still be added to the destination cluster: you will need to run the diagnostic / export command to make sure the configuration change is OK." + lineSeparator() +
-        "To prevent any error, the nodes to attach won't be activated and restarted"
+        "The node information may still be added to the destination cluster: you will need to run the diagnostic / export command to check the state of the transaction." + lineSeparator() +
+        "The nodes to attach won't be activated and restarted, and their topology will be rolled back to their initial value."
     );
+    newNodes.forEach((addr, cluster) -> {
+      logger.info("Rollback topology of node: {} to: {}", addr, cluster);
+      setUpcomingCluster(Collections.singletonList(addr), cluster);
+    });
     throw error;
   }
 }

--- a/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/command/DetachCommand.java
+++ b/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/command/DetachCommand.java
@@ -27,6 +27,7 @@ import java.net.InetSocketAddress;
 import java.time.Duration;
 import java.util.Collection;
 
+import static java.lang.System.lineSeparator;
 import static java.util.Collections.singletonList;
 import static org.terracotta.dynamic_config.cli.config_tool.converter.OperationType.NODE;
 
@@ -109,9 +110,9 @@ public class DetachCommand extends TopologyCommand {
 
   @Override
   protected void onNomadChangeFailure(NodeNomadChange nomadChange, RuntimeException error) {
-    logger.warn("An error occurred during the detach transaction. The node to detach will still be restarted, but you will need to run the diagnostic command to make sure the configuration change is OK.");
-    // even if there has been a failure during the Nomad 2PC process, we still restart the node so that is gets detached by the sync process
-    onNomadChangeSuccess(nomadChange);
+    logger.error("An error occurred during the detach transaction." + lineSeparator() +
+        "The node to detach will not be restarted." + lineSeparator() +
+        "You you will need to run the diagnostic command to check the configuration state and restart the node to detach manually.");
     throw error;
   }
 }

--- a/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/command/RemoteCommand.java
+++ b/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/command/RemoteCommand.java
@@ -319,9 +319,16 @@ public abstract class RemoteCommand extends Command {
   }
 
   protected final boolean isActivated(InetSocketAddress expectedOnlineNode) {
-    logger.trace("getRuntimeCluster({})", expectedOnlineNode);
+    logger.trace("isActivated({})", expectedOnlineNode);
     try (DiagnosticService diagnosticService = diagnosticServiceProvider.fetchDiagnosticService(expectedOnlineNode)) {
       return diagnosticService.getProxy(TopologyService.class).isActivated();
+    }
+  }
+
+  protected final void resetAndRestart(InetSocketAddress expectedOnlineNode) {
+    logger.trace("resetAndRestart({})", expectedOnlineNode);
+    try (DiagnosticService diagnosticService = diagnosticServiceProvider.fetchDiagnosticService(expectedOnlineNode)) {
+      diagnosticService.getProxy(DynamicConfigService.class).resetAndRestart();
     }
   }
 

--- a/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/command/TopologyCommand.java
+++ b/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/command/TopologyCommand.java
@@ -16,15 +16,12 @@
 package org.terracotta.dynamic_config.cli.config_tool.command;
 
 import com.beust.jcommander.Parameter;
-import org.terracotta.common.struct.Measure;
-import org.terracotta.common.struct.TimeUnit;
 import org.terracotta.diagnostic.model.LogicalServerState;
 import org.terracotta.dynamic_config.api.model.Cluster;
 import org.terracotta.dynamic_config.api.model.nomad.NodeNomadChange;
 import org.terracotta.dynamic_config.api.service.ClusterValidator;
 import org.terracotta.dynamic_config.cli.config_tool.converter.OperationType;
 import org.terracotta.dynamic_config.cli.converter.InetSocketAddressConverter;
-import org.terracotta.dynamic_config.cli.converter.TimeUnitConverter;
 import org.terracotta.inet.InetSocketAddressUtils;
 import org.terracotta.json.Json;
 
@@ -51,12 +48,6 @@ public abstract class TopologyCommand extends RemoteCommand {
 
   @Parameter(names = {"-f"}, description = "Force the operation")
   protected boolean force;
-
-  @Parameter(names = {"-W"}, description = "Maximum time to wait for the nodes to restart. Default: 60s", converter = TimeUnitConverter.class)
-  protected Measure<TimeUnit> restartWaitTime = Measure.of(60, TimeUnit.SECONDS);
-
-  @Parameter(names = {"-D"}, description = "Restart delay. Default: 2s", converter = TimeUnitConverter.class)
-  protected Measure<TimeUnit> restartDelay = Measure.of(2, TimeUnit.SECONDS);
 
   protected Map<InetSocketAddress, LogicalServerState> destinationOnlineNodes;
   protected boolean destinationClusterActivated;

--- a/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/service/DynamicConfigServiceImpl.java
+++ b/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/service/DynamicConfigServiceImpl.java
@@ -296,6 +296,23 @@ public class DynamicConfigServiceImpl implements TopologyService, DynamicConfigS
   }
 
   @Override
+  public void resetAndRestart() {
+    if (!isActivated()) {
+      throw new IllegalStateException("Node is not activated");
+    }
+    LOGGER.info("Resetting and restarting...");
+
+    try {
+      nomadServerManager.getNomadServer().reset();
+      clusterActivated = false;
+      nomadServerManager.downgradeForRead();
+      restart(Duration.ofSeconds(5));
+    } catch (NomadException e) {
+      throw new IllegalStateException("Unable to reset Nomad system: " + e.getMessage(), e);
+    }
+  }
+
+  @Override
   public synchronized void upgradeLicense(String licenseContent) {
     this.installLicense(licenseContent);
   }

--- a/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/service/NomadServerManager.java
+++ b/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/service/NomadServerManager.java
@@ -127,6 +127,10 @@ public class NomadServerManager {
     LOGGER.info("Bootstrapped nomad system with root: {}", parameterSubstitutor.substitute(repositoryPath.toString()));
   }
 
+  public void downgradeForRead() {
+    nomadServer.setChangeApplicator(null);
+  }
+
   /**
    * Makes Nomad server capable of write operations.
    *
@@ -137,6 +141,9 @@ public class NomadServerManager {
     requireNonNull(nodeName);
     if (stripeId < 1) {
       throw new IllegalArgumentException("Stripe ID should be greater than or equal to 1");
+    }
+    if (nomadServer.getChangeApplicator() != null) {
+      throw new IllegalStateException("Nomad is already upgraded");
     }
 
     DefaultRoutingNomadChangeProcessor router = new DefaultRoutingNomadChangeProcessor();

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
     <terracotta-apis.version>1.7.0-pre1</terracotta-apis.version>
     <terracotta-configuration.version>10.7.0-pre2</terracotta-configuration.version>
     <passthrough-testing.version>1.7.0-pre8</passthrough-testing.version>
-    <terracotta-core.version>5.7.0-pre19</terracotta-core.version>
+    <terracotta-core.version>5.7.0-pre21</terracotta-core.version>
     <tripwire.version>1.0.0-pre7</tripwire.version>
     <angela.version>3.0.17</angela.version>
     <statistics.version>2.1</statistics.version>


### PR DESCRIPTION
- Rollback the nodes to attach to their initial topology
- Do not restart the node to detach if prepare is failing because no action is done
- Detached nodes are reseted and restart back in diagnostic mode with an empty topology