### PR TITLE
A/P fixes and tasks

### DIFF
--- a/data-root-resource/src/main/java/org/terracotta/config/data_roots/DataDirectoriesConfigImpl.java
+++ b/data-root-resource/src/main/java/org/terracotta/config/data_roots/DataDirectoriesConfigImpl.java
@@ -21,7 +21,6 @@ import org.terracotta.config.data_roots.management.DataRootBinding;
 import org.terracotta.config.data_roots.management.DataRootSettingsManagementProvider;
 import org.terracotta.config.data_roots.management.DataRootStatisticsManagementProvider;
 import org.terracotta.data.config.DataRootMapping;
-import org.terracotta.dynamic_config.api.model.NodeContext;
 import org.terracotta.dynamic_config.api.service.IParameterSubstitutor;
 import org.terracotta.dynamic_config.server.api.PathResolver;
 import org.terracotta.entity.PlatformConfiguration;
@@ -58,20 +57,20 @@ public class DataDirectoriesConfigImpl implements DataDirectoriesConfig, Managea
   private final IParameterSubstitutor parameterSubstitutor;
   private final PathResolver pathResolver;
 
-  public DataDirectoriesConfigImpl(IParameterSubstitutor parameterSubstitutor, PathResolver pathResolver, NodeContext nodeContext) {
+  public DataDirectoriesConfigImpl(IParameterSubstitutor parameterSubstitutor, PathResolver pathResolver, Path metadataDir, Map<String, Path> userDataDirectories) {
     this.parameterSubstitutor = parameterSubstitutor;
     this.pathResolver = pathResolver;
 
     // add platform metadata dir first
-    if (nodeContext.getNode().getNodeMetadataDir() != null) {
-      addDataDirectory("platform", nodeContext.getNode().getNodeMetadataDir().toString());
+    if (metadataDir != null) {
+      addDataDirectory("platform", metadataDir.toString());
       this.platformRootIdentifier = "platform";
     } else {
       this.platformRootIdentifier = null;
     }
 
     // then add user ones
-    nodeContext.getNode().getDataDirs().forEach((name, path) -> addDataDirectory(name, path.toString()));
+    userDataDirectories.forEach((name, path) -> addDataDirectory(name, path.toString()));
   }
 
   public DataDirectoriesConfigImpl(IParameterSubstitutor parameterSubstitutor, PathResolver pathResolver, org.terracotta.data.config.DataDirectories dataDirectories) {

--- a/data-root-resource/src/main/java/org/terracotta/config/data_roots/DataRootConfigParser.java
+++ b/data-root-resource/src/main/java/org/terracotta/config/data_roots/DataRootConfigParser.java
@@ -18,7 +18,10 @@ package org.terracotta.config.data_roots;
 import org.terracotta.config.service.ConfigValidator;
 import org.terracotta.config.service.ExtendedConfigParser;
 import org.terracotta.config.util.DefaultSubstitutor;
+import org.terracotta.config.util.ParameterSubstitutor;
 import org.terracotta.data.config.DataDirectories;
+import org.terracotta.dynamic_config.api.service.IParameterSubstitutor;
+import org.terracotta.dynamic_config.server.api.PathResolver;
 import org.w3c.dom.Element;
 
 import javax.xml.bind.JAXBContext;
@@ -29,6 +32,9 @@ import javax.xml.transform.stream.StreamSource;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URL;
+import java.nio.file.InvalidPathException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.function.Function;
 
 /**
@@ -53,7 +59,10 @@ public class DataRootConfigParser implements ExtendedConfigParser {
   public DataDirectoriesConfigImpl parse(Element element, String source) {
     DataDirectories dataDirectories = parser().apply(element);
     DefaultSubstitutor.applyDefaults(dataDirectories);
-    return new DataDirectoriesConfigImpl(source, dataDirectories);
+
+    PathResolver pathResolver = getPathResolver(source);
+
+    return new DataDirectoriesConfigImpl(ParameterSubstitutor::substitute, pathResolver, dataDirectories);
   }
 
   public Function<Element, DataDirectories> parser() {
@@ -73,5 +82,22 @@ public class DataRootConfigParser implements ExtendedConfigParser {
 
   public ConfigValidator getConfigValidator() {
     return new DataRootValidator(parser());
+  }
+
+  static PathResolver getPathResolver(String source) {
+    Path tempRootPath = Paths.get(".").toAbsolutePath();
+    if (source != null) {
+      try {
+        Path sourcePath = Paths.get(source);
+        if (sourcePath.isAbsolute()) {
+          tempRootPath = sourcePath;
+        }
+      } catch (InvalidPathException e) {
+        // Ignore, we keep the root as . then
+      }
+    }
+
+    final IParameterSubstitutor substitutor = ParameterSubstitutor::substitute;
+    return new PathResolver(tempRootPath, substitutor::substitute);
   }
 }

--- a/data-root-resource/src/main/java/org/terracotta/config/data_roots/DataRootsDynamicConfigExtension.java
+++ b/data-root-resource/src/main/java/org/terracotta/config/data_roots/DataRootsDynamicConfigExtension.java
@@ -24,6 +24,9 @@ import org.terracotta.dynamic_config.server.api.DynamicConfigExtension;
 import org.terracotta.dynamic_config.server.api.PathResolver;
 import org.terracotta.entity.PlatformConfiguration;
 
+import java.nio.file.Path;
+import java.util.Map;
+
 /**
  * @author Mathieu Carbou
  */
@@ -37,7 +40,9 @@ public class DataRootsDynamicConfigExtension implements DynamicConfigExtension {
 
     NodeContext nodeContext = topologyService.getRuntimeNodeContext();
 
-    DataDirectoriesConfigImpl dataDirectoriesConfig = new DataDirectoriesConfigImpl(parameterSubstitutor, pathResolver, nodeContext);
+    Path nodeMetadataDir = nodeContext.getNode().getNodeMetadataDir();
+    Map<String, Path> dataDirs = nodeContext.getNode().getDataDirs();
+    DataDirectoriesConfigImpl dataDirectoriesConfig = new DataDirectoriesConfigImpl(parameterSubstitutor, pathResolver, nodeMetadataDir, dataDirs);
 
     configChangeHandlerManager.add(Setting.DATA_DIRS, new DataDirectoryConfigChangeHandler(dataDirectoriesConfig));
 

--- a/data-root-resource/src/test/java/org/terracotta/config/data_roots/DataDirectoriesConfigImplTest.java
+++ b/data-root-resource/src/test/java/org/terracotta/config/data_roots/DataDirectoriesConfigImplTest.java
@@ -199,13 +199,13 @@ public class DataDirectoriesConfigImplTest {
 
   @Test
   public void testPlatformRootNotSpecified() throws Exception {
-    DataDirectoriesConfigImpl dataRootConfig = configureDataRoot(new String[] { "data" }, new String[1]);
+    DataDirectoriesConfigImpl dataRootConfig = configureDataRoot(new String[]{"data"}, new String[1]);
     assertThat(dataRootConfig.getPlatformRootIdentifier(), is(Optional.empty()));
   }
 
   @Test
   public void testPlatformRootSpecified() throws Exception {
-    DataDirectoriesConfigImpl dataRootConfig = configureDataRoot(new String[] { "data" }, new String[1], null, 0);
+    DataDirectoriesConfigImpl dataRootConfig = configureDataRoot(new String[]{"data"}, new String[1], null, 0);
     assertThat(dataRootConfig.getPlatformRootIdentifier().orElse("busted"), is("data"));
   }
 
@@ -252,7 +252,7 @@ public class DataDirectoriesConfigImplTest {
       dataDirectories.getDirectory().add(dataRootMapping);
     }
 
-    return new DataDirectoriesConfigImpl(source, dataDirectories);
+    return new DataDirectoriesConfigImpl(ParameterSubstitutor::substitute, DataRootConfigParser.getPathResolver(source), dataDirectories);
   }
 
   private DataDirectoriesConfigImpl configureDataRoot(DataRootMapping[] dataRootMappings) throws IOException {
@@ -264,6 +264,6 @@ public class DataDirectoriesConfigImplTest {
       dataDirectories.getDirectory().add(dataRootMappings[i]);
     }
 
-    return new DataDirectoriesConfigImpl(null, dataDirectories);
+    return new DataDirectoriesConfigImpl(ParameterSubstitutor::substitute, DataRootConfigParser.getPathResolver(null), dataDirectories);
   }
 }

--- a/data-root-resource/src/test/java/org/terracotta/config/data_roots/PassthroughIntegrationTest.java
+++ b/data-root-resource/src/test/java/org/terracotta/config/data_roots/PassthroughIntegrationTest.java
@@ -20,6 +20,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.terracotta.config.util.ParameterSubstitutor;
 import org.terracotta.data.config.DataDirectories;
 import org.terracotta.data.config.DataRootMapping;
 import org.terracotta.entity.PlatformConfiguration;
@@ -56,7 +57,7 @@ public class PassthroughIntegrationTest {
     DATA_ROOT_PATH = folder.newFolder().getAbsolutePath();
 
     this.passthroughServer = new PassthroughServer();
-    this.passthroughServer.registerExtendedConfiguration(new DataDirectoriesConfigImpl(null, getConfiguration()));
+    this.passthroughServer.registerExtendedConfiguration(new DataDirectoriesConfigImpl(ParameterSubstitutor::substitute, DataRootConfigParser.getPathResolver(null), getConfiguration()));
     this.passthroughServer.registerServiceProvider(new TestServiceProvider(), null);
     this.passthroughServer.registerAsynchronousServerCrasher(p -> {});
     this.passthroughServer.start(true, false);

--- a/diagnostic/client/src/main/java/org/terracotta/diagnostic/client/DiagnosticService.java
+++ b/diagnostic/client/src/main/java/org/terracotta/diagnostic/client/DiagnosticService.java
@@ -21,7 +21,6 @@ import java.io.Closeable;
 
 import static org.terracotta.diagnostic.common.DiagnosticConstants.MBEAN_CONSISTENCY_MANAGER;
 import static org.terracotta.diagnostic.common.DiagnosticConstants.MBEAN_L2_DUMPER;
-import static org.terracotta.diagnostic.common.DiagnosticConstants.MBEAN_LOGICAL_SERVER_STATE;
 import static org.terracotta.diagnostic.common.DiagnosticConstants.MBEAN_SERVER;
 import static org.terracotta.diagnostic.common.DiagnosticConstants.MBEAN_SHUTDOWN;
 
@@ -51,9 +50,7 @@ public interface DiagnosticService extends DiagnosticMBeanSupport, Closeable {
 
   // LogicalServerState
 
-  default LogicalServerState getLogicalServerState() throws DiagnosticOperationTimeoutException, DiagnosticConnectionException {
-    return LogicalServerState.parse(invoke(MBEAN_LOGICAL_SERVER_STATE, "getLogicalServerState"));
-  }
+  LogicalServerState getLogicalServerState() throws DiagnosticOperationTimeoutException, DiagnosticConnectionException;
 
   // ConsistencyManager
 

--- a/diagnostic/client/src/main/java/org/terracotta/diagnostic/client/DiagnosticServiceImpl.java
+++ b/diagnostic/client/src/main/java/org/terracotta/diagnostic/client/DiagnosticServiceImpl.java
@@ -24,6 +24,7 @@ import org.terracotta.diagnostic.common.DiagnosticCodec;
 import org.terracotta.diagnostic.common.DiagnosticRequest;
 import org.terracotta.diagnostic.common.DiagnosticResponse;
 import org.terracotta.diagnostic.common.EmptyParameterDiagnosticCodec;
+import org.terracotta.diagnostic.model.LogicalServerState;
 
 import java.lang.reflect.Proxy;
 import java.util.function.Supplier;
@@ -31,6 +32,7 @@ import java.util.function.Supplier;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 import static org.terracotta.diagnostic.common.DiagnosticConstants.MBEAN_DIAGNOSTIC_REQUEST_HANDLER;
+import static org.terracotta.diagnostic.common.DiagnosticConstants.MBEAN_LOGICAL_SERVER_STATE;
 import static org.terracotta.diagnostic.common.DiagnosticConstants.MESSAGE_INVALID_JMX;
 import static org.terracotta.diagnostic.common.DiagnosticConstants.MESSAGE_NOT_PERMITTED;
 import static org.terracotta.diagnostic.common.DiagnosticConstants.MESSAGE_NULL_RETURN;
@@ -134,6 +136,34 @@ class DiagnosticServiceImpl implements DiagnosticService {
   @Override
   public String invokeWithArg(String name, String cmd, String arg) throws DiagnosticOperationTimeoutException, DiagnosticOperationExecutionException, DiagnosticConnectionException {
     return execute(() -> delegate.invokeWithArg(name, cmd, arg));
+  }
+
+  // LogicalServerState
+
+  @Override
+  public LogicalServerState getLogicalServerState() throws DiagnosticOperationTimeoutException, DiagnosticConnectionException {
+    try {
+      return LogicalServerState.parse(invoke(MBEAN_LOGICAL_SERVER_STATE, "getLogicalServerState"));
+    } catch (DiagnosticOperationUnsupportedException | DiagnosticOperationExecutionException ignored) {
+      // maybe we connect to an old version, 10.2 for example, that does not have this MBean. In this case, let's try the original Server state Mbean.
+      // Other possibility: the MBean has been unregistered...
+    }
+
+    String state = LogicalServerState.UNKNOWN.name();
+    try {
+      state = getState();
+    } catch (DiagnosticOperationUnsupportedException | DiagnosticOperationExecutionException ignored) {
+      // should never occur for getState()
+    }
+
+    boolean blocked = false;
+    try {
+      blocked = isBlocked();
+    } catch (DiagnosticOperationUnsupportedException | DiagnosticOperationExecutionException e2) {
+      // in case ConsistencyManager is not there
+    }
+
+    return LogicalServerState.from(state, isReconnectWindow(), blocked);
   }
 
   // DiagnosticsHandler

--- a/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/ConfigTool.java
+++ b/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/ConfigTool.java
@@ -60,11 +60,10 @@ public class ConfigTool {
     } catch (Exception e) {
       String message = e.getMessage();
       if (message != null && !message.isEmpty()) {
-        String errorMessage = String.format("%sError:%s%s%s", lineSeparator(), lineSeparator(), message, lineSeparator());
         if (LOGGER.isDebugEnabled()) {
           LOGGER.error("{}Error:", lineSeparator(), e); // do not output e.getMassage() because it duplicates the output
         } else {
-          LOGGER.error(errorMessage);
+          LOGGER.error("{}Error:{}{}{}", lineSeparator(), lineSeparator(), message, lineSeparator());
         }
       } else {
         LOGGER.error("{}Internal error:", lineSeparator(), e);

--- a/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/command/AttachCommand.java
+++ b/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/command/AttachCommand.java
@@ -55,9 +55,15 @@ public class AttachCommand extends TopologyCommand {
   // list of new nodes to add with their backup topology
   private final Map<InetSocketAddress, Cluster> newNodes = new LinkedHashMap<>();
 
+  private Cluster sourceCluster;
+
   @Override
   public void validate() {
     super.validate();
+
+    validateAddress(source);
+
+    sourceCluster = getUpcomingCluster(source);
 
     Collection<InetSocketAddress> destinationPeers = destinationCluster.getNodeAddresses();
     if (InetSocketAddressUtils.contains(destinationPeers, source)) {

--- a/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/command/RemoteCommand.java
+++ b/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/command/RemoteCommand.java
@@ -109,7 +109,7 @@ public abstract class RemoteCommand extends Command {
    * Ensure that the input address is really an address that can be used to connect to a node of a cluster
    */
   protected final void validateAddress(InetSocketAddress expectedOnlineNode) {
-    logger.trace("ensureAddressWithinCluster({})", expectedOnlineNode);
+    logger.info("Validating node address: {} (this can take time if the node is not reachable)", expectedOnlineNode);
     getRuntimeCluster(expectedOnlineNode).getNode(expectedOnlineNode)
         .orElseGet(() -> getUpcomingCluster(expectedOnlineNode).getNode(expectedOnlineNode)
             .orElseThrow(() -> new IllegalArgumentException("Targeted cluster does not contain any node with this address: " + expectedOnlineNode + ". Is it a mistake ? Are you connecting to the wrong cluster ? If not, please use the configured node hostname and port to connect.")));
@@ -123,7 +123,7 @@ public abstract class RemoteCommand extends Command {
   }
 
   protected final boolean hasIncompleteChange(InetSocketAddress expectedOnlineNode) {
-    logger.trace("hasPreparedConfigurationChange({})", expectedOnlineNode);
+    logger.trace("hasIncompleteChange({})", expectedOnlineNode);
     try (DiagnosticService diagnosticService = diagnosticServiceProvider.fetchDiagnosticService(expectedOnlineNode)) {
       return diagnosticService.getProxy(TopologyService.class).hasIncompleteChange();
     }

--- a/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/command/RemoteCommand.java
+++ b/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/command/RemoteCommand.java
@@ -56,6 +56,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.function.BiPredicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -265,9 +266,13 @@ public abstract class RemoteCommand extends Command {
   }
 
   protected final LinkedHashMap<InetSocketAddress, LogicalServerState> filterOnlineNodes(Map<InetSocketAddress, LogicalServerState> nodes) {
+    return filter(nodes, (addr, state) -> !state.isUnknown() && !state.isUnreacheable());
+  }
+
+  protected final LinkedHashMap<InetSocketAddress, LogicalServerState> filter(Map<InetSocketAddress, LogicalServerState> nodes, BiPredicate<InetSocketAddress, LogicalServerState> predicate) {
     return nodes.entrySet()
         .stream()
-        .filter(e -> !e.getValue().isUnknown() && !e.getValue().isUnreacheable())
+        .filter(e -> predicate.test(e.getKey(), e.getValue()))
         .collect(toMap(
             Map.Entry::getKey,
             Map.Entry::getValue,

--- a/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/command/RepairCommand.java
+++ b/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/command/RepairCommand.java
@@ -25,6 +25,8 @@ import org.terracotta.dynamic_config.cli.converter.InetSocketAddressConverter;
 import org.terracotta.nomad.client.results.ConsistencyAnalyzer;
 
 import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Map;
 
 import static java.util.Objects.requireNonNull;
@@ -44,24 +46,33 @@ public class RepairCommand extends RemoteCommand {
   @Parameter(names = {"-f"}, description = "State to force for the last prepared configuration: commit or rollback", converter = ChangeState.StateConverter.class)
   ChangeState forcedChangeState;
 
-  private Map<InetSocketAddress, LogicalServerState> allNodes;
-
   @Override
   public void validate() {
     requireNonNull(node);
 
     validateAddress(node);
-
-    // this call can take some time and we can have some timeout
-    allNodes = findRuntimePeersStatus(node);
-
-    if (!areAllNodesActivated(filterOnlineNodes(allNodes).keySet())) {
-      throw new IllegalStateException("Cannot run repair command on a non activated cluster");
-    }
   }
 
   @Override
   public final void run() {
+    Map<InetSocketAddress, LogicalServerState> allNodes = findRuntimePeersStatus(node);
+    Map<InetSocketAddress, LogicalServerState> onlineNodes = filterOnlineNodes(allNodes);
+
+    if (onlineNodes.size() != allNodes.size()) {
+      Collection<InetSocketAddress> offlines = new ArrayList<>(allNodes.keySet());
+      offlines.removeAll(onlineNodes.keySet());
+      logger.warn("Some nodes are not reachable: {}", toString(offlines));
+    }
+
+    // the automatic repair command can only work on activated nodes
+    Map<InetSocketAddress, LogicalServerState> activatedNodes = filter(onlineNodes, (addr, state) -> isActivated(addr));
+
+    if (activatedNodes.size() != onlineNodes.size()) {
+      Collection<InetSocketAddress> unconfigured = new ArrayList<>(onlineNodes.keySet());
+      unconfigured.removeAll(activatedNodes.keySet());
+      logger.warn("Some online nodes are not activated: {}. Automatic repair will only work against activated nodes: {}", toString(unconfigured), toString(activatedNodes.keySet()));
+    }
+
     ConsistencyAnalyzer<NodeContext> consistencyAnalyzer = analyzeNomadConsistency(allNodes);
 
     switch (consistencyAnalyzer.getGlobalState()) {
@@ -96,7 +107,7 @@ public class RepairCommand extends RemoteCommand {
           logger.info("All nodes are online.");
         }
 
-        logger.info("Attempting an automatic repair of the configuration...");
+        logger.info("Attempting an automatic repair of the configuration on nodes: {}...", toString(activatedNodes.keySet()));
 
         if (forcedChangeState == null) {
           logger.info("Auto-detecting what needs to be done...");
@@ -104,7 +115,7 @@ public class RepairCommand extends RemoteCommand {
           logger.warn("Forcing a " + forcedChangeState.name().toLowerCase() + "...");
         }
 
-        runConfigurationRepair(allNodes, forcedChangeState == ChangeState.COMMIT ? COMMITTED : forcedChangeState == ChangeState.ROLLBACK ? ROLLED_BACK : null);
+        runConfigurationRepair(activatedNodes, forcedChangeState == ChangeState.COMMIT ? COMMITTED : forcedChangeState == ChangeState.ROLLBACK ? ROLLED_BACK : null);
         logger.info("Configuration is repaired.");
 
         break;

--- a/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/command/TopologyCommand.java
+++ b/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/command/TopologyCommand.java
@@ -52,7 +52,6 @@ public abstract class TopologyCommand extends RemoteCommand {
   protected Map<InetSocketAddress, LogicalServerState> destinationOnlineNodes;
   protected boolean destinationClusterActivated;
   protected Cluster destinationCluster;
-  protected Cluster sourceCluster;
 
   @Override
   public void validate() {
@@ -71,7 +70,6 @@ public abstract class TopologyCommand extends RemoteCommand {
 
     logger.debug("Validating the parameters");
     validateAddress(destination);
-    validateAddress(source);
 
     // prevent any topology change if a configuration change has been made through Nomad, requiring a restart, but nodes were not restarted yet
     validateLogOrFail(
@@ -95,8 +93,6 @@ public abstract class TopologyCommand extends RemoteCommand {
         throw new UnsupportedOperationException("Topology modifications of whole stripes on an activated cluster is not yet supported");
       }
     }
-
-    sourceCluster = getUpcomingCluster(source);
   }
 
   @Override

--- a/dynamic-config/cli/config-tool/src/test/java/org/terracotta/dynamic_config/cli/config_tool/command/DetachCommandTest.java
+++ b/dynamic-config/cli/config-tool/src/test/java/org/terracotta/dynamic_config/cli/config_tool/command/DetachCommandTest.java
@@ -70,10 +70,8 @@ public class DetachCommandTest extends TopologyCommandTest<DetachCommand> {
     super.setUp();
 
     when(topologyServiceMock("localhost", 9410).getUpcomingNodeContext()).thenReturn(new NodeContext(cluster, node0.getNodeAddress()));
-    when(topologyServiceMock("localhost", 9411).getUpcomingNodeContext()).thenReturn(new NodeContext(node1));
 
     when(topologyServiceMock("localhost", 9410).getRuntimeNodeContext()).thenReturn(new NodeContext(cluster, node0.getNodeAddress()));
-    when(topologyServiceMock("localhost", 9411).getRuntimeNodeContext()).thenReturn(new NodeContext(node1));
 
     when(topologyServiceMock("localhost", 9410).isActivated()).thenReturn(false);
     when(topologyServiceMock("localhost", 9411).isActivated()).thenReturn(false);

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/RepairCommandIT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/RepairCommandIT.java
@@ -69,7 +69,7 @@ public class RepairCommandIT extends DynamicConfigIT {
     assertThat(
         configToolInvocation("repair", "-s", "localhost:" + getNodePort()),
         allOf(
-            containsOutput("Attempting an automatic repair of the configuration..."),
+            containsOutput("Attempting an automatic repair of the configuration"),
             containsOutput("Configuration is repaired")));
 
     assertThat(getRuntimeCluster("localhost", getNodePort()).getSingleNode().get().getNodeLoggerOverrides(), hasEntry("org.terracotta.dynamic-config.simulate", DEBUG));
@@ -111,13 +111,13 @@ public class RepairCommandIT extends DynamicConfigIT {
         allOf(
             containsOutput("Reason: org.terracotta.nomad.server.NomadException: Error when applying setting change 'set node-logger-overrides.org.terracotta.dynamic-config.simulate=DEBUG (stripe ID: 1, node: node-1-1)': Simulate temporary commit failure"),
             containsOutput("Please run the 'diagnostic' command to diagnose the configuration state and try to run the 'repair' command."),
-            containsOutput("Attempting an automatic repair of the configuration..."),
+            containsOutput("Attempting an automatic repair of the configuration"),
             not(containsOutput("Configuration is repaired."))));
 
     assertThat(
         configToolInvocation("repair", "-s", "localhost:" + getNodePort()),
         allOf(
-            containsOutput("Attempting an automatic repair of the configuration..."),
+            containsOutput("Attempting an automatic repair of the configuration"),
             containsOutput("Configuration is repaired")));
 
     // ensure that the server has started with the last committed config

--- a/offheap-resource/src/main/java/org/terracotta/offheapresource/OffHeapDynamicConfigExtension.java
+++ b/offheap-resource/src/main/java/org/terracotta/offheapresource/OffHeapDynamicConfigExtension.java
@@ -33,7 +33,7 @@ public class OffHeapDynamicConfigExtension implements DynamicConfigExtension {
 
     NodeContext nodeContext = topologyService.getRuntimeNodeContext();
 
-    OffHeapResourcesProvider offHeapResourcesProvider = new OffHeapResourcesProvider(nodeContext);
+    OffHeapResourcesProvider offHeapResourcesProvider = new OffHeapResourcesProvider(nodeContext.getNode().getOffheapResources());
 
     configChangeHandlerManager.add(Setting.OFFHEAP_RESOURCES, new OffheapResourceConfigChangeHandler(topologyService, offHeapResourcesProvider));
 

--- a/offheap-resource/src/main/java/org/terracotta/offheapresource/OffHeapResourcesProvider.java
+++ b/offheap-resource/src/main/java/org/terracotta/offheapresource/OffHeapResourcesProvider.java
@@ -17,7 +17,7 @@ package org.terracotta.offheapresource;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.terracotta.dynamic_config.api.model.NodeContext;
+import org.terracotta.common.struct.Measure;
 import org.terracotta.entity.StateDumpCollector;
 import org.terracotta.entity.StateDumpable;
 import org.terracotta.management.service.monitoring.EntityManagementRegistry;
@@ -65,8 +65,8 @@ public class OffHeapResourcesProvider implements OffHeapResources, ManageableSer
     }
   }
 
-  public OffHeapResourcesProvider(NodeContext nodeContext) {
-    nodeContext.getNode().getOffheapResources().forEach((name, measure) -> {
+  public OffHeapResourcesProvider(Map<String, Measure<org.terracotta.common.struct.MemoryUnit>> resources) {
+    resources.forEach((name, measure) -> {
       long size = measure.getQuantity(org.terracotta.common.struct.MemoryUnit.B);
       addToResources(identifier(name), size);
     });


### PR DESCRIPTION
- Make repair command work in case some nodes are offline or not activated
- Removing an offline node

Note: removing an offline node works, but I have left the test ignored because the expected behavior would be that the detached node is able so start in diagnostic mode when detecting that it has been removed. It is not the case now it starts active...

@mobasherul @saurabhagas : you can stil merge, because the 2 commits are OK, we just need to determine what should be the right behavior to to a reset of the node. (for another commit).