### PR TITLE
Temporary activating windows builds and Java 11 builds by hard-coding JVM paths in profiles

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -38,17 +38,17 @@ jobs:
       timeoutInMinutes: 120
       vmImage: 'ubuntu-latest'
       options: '-B -Dazure_linux_java_11'
-#  - template: build-templates/maven-common.yml@templates
-#    parameters:
-#      jdkVersion: '1.8'
-#      jobName: 'windows_java_8'
-#      timeoutInMinutes: 120
-#      vmImage: 'windows-latest'
-#      options: '-B'
-#  - template: build-templates/maven-common.yml@templates
-#    parameters:
-#      jdkVersion: '1.8'
-#      jobName: 'windows_java_11'
-#      timeoutInMinutes: 120
-#      vmImage: 'windows-latest'
-#      options: '-B -Dazure_windows_java_11'
+  - template: build-templates/maven-common.yml@templates
+    parameters:
+      jdkVersion: '1.8'
+      jobName: 'windows_java_8'
+      timeoutInMinutes: 120
+      vmImage: 'windows-latest'
+      options: '-B'
+  - template: build-templates/maven-common.yml@templates
+    parameters:
+      jdkVersion: '1.8'
+      jobName: 'windows_java_11'
+      timeoutInMinutes: 120
+      vmImage: 'windows-latest'
+      options: '-B -Dazure_windows_java_11'

--- a/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/command/TopologyCommand.java
+++ b/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/command/TopologyCommand.java
@@ -167,8 +167,7 @@ public abstract class TopologyCommand extends RemoteCommand {
   protected final void validateLogOrFail(Supplier<Boolean> expectedCondition, String error) {
     if (!expectedCondition.get()) {
       if (force) {
-        logger.warn("Force option supplied, not failing on the following validation:");
-        logger.warn(error);
+        logger.warn("Following validation has been bypassed with -f:{} - {}", lineSeparator(), error);
       } else {
         throw new IllegalArgumentException(error);
       }

--- a/dynamic-config/testing/support/src/main/java/org/terracotta/dynamic_config/test_support/DynamicConfigIT.java
+++ b/dynamic-config/testing/support/src/main/java/org/terracotta/dynamic_config/test_support/DynamicConfigIT.java
@@ -114,7 +114,8 @@ public class DynamicConfigIT {
   protected FailoverPriority failoverPriority = FailoverPriority.availability();
 
   public DynamicConfigIT() {
-    this(Duration.ofSeconds(60));
+    // 60 sec is not enough for Azure windows builds
+    this(Duration.ofSeconds(90));
   }
 
   public DynamicConfigIT(Duration testTimeout) {

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/AttachCommand1x3IT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/AttachCommand1x3IT.java
@@ -37,7 +37,7 @@ import static org.terracotta.dynamic_config.test_support.util.AngelaMatchers.suc
 public class AttachCommand1x3IT extends DynamicConfigIT {
 
   public AttachCommand1x3IT() {
-    super(Duration.ofSeconds(120));
+    super(Duration.ofSeconds(180));
   }
 
   @Before

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/AttachInConsistency1x3IT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/AttachInConsistency1x3IT.java
@@ -39,7 +39,7 @@ public class AttachInConsistency1x3IT extends DynamicConfigIT {
   public final NodeOutputRule out = new NodeOutputRule();
 
   public AttachInConsistency1x3IT() {
-    super(Duration.ofSeconds(120));
+    super(Duration.ofSeconds(180));
     this.failoverPriority = FailoverPriority.consistency();
   }
 

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/ConfigSyncIT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/ConfigSyncIT.java
@@ -67,7 +67,7 @@ public class ConfigSyncIT extends DynamicConfigIT {
   private int passiveNodeId;
 
   public ConfigSyncIT() {
-    super(Duration.ofSeconds(120));
+    super(Duration.ofSeconds(180));
   }
 
   @Before

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/DetachCommand1x2IT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/DetachCommand1x2IT.java
@@ -148,7 +148,7 @@ public class DetachCommand1x2IT extends DynamicConfigIT {
 
     // Stripe is lost no active
     assertThat(
-        configToolInvocation("-e", "10s", "detach", "-f", "-d", "localhost:" + getNodePort(1, activeId),
+        configToolInvocation("-e", "40s", "detach", "-f", "-d", "localhost:" + getNodePort(1, activeId),
             "-s", "localhost:" + getNodePort(1, passiveId)),
         containsOutput("Commit failed for node localhost:" + getNodePort(1, activeId) + ". Reason: java.util.concurrent.TimeoutException"));
 
@@ -196,7 +196,7 @@ public class DetachCommand1x2IT extends DynamicConfigIT {
 
     //Both active and passive is down.
     assertThat(
-        configToolInvocation("-e", "10s", "-r", "5s", "-t", "5s", "detach", "-f", "-d", "localhost:" + getNodePort(1, activeId),
+        configToolInvocation("-e", "40s", "-r", "5s", "-t", "5s", "detach", "-f", "-d", "localhost:" + getNodePort(1, activeId),
             "-s", "localhost:" + getNodePort(1, passiveId)),
         containsOutput("Two-Phase commit failed"));
 

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/DiagnosticMode1x2IT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/DiagnosticMode1x2IT.java
@@ -39,7 +39,7 @@ import static org.terracotta.dynamic_config.test_support.util.AngelaMatchers.has
 public class DiagnosticMode1x2IT extends DynamicConfigIT {
 
   public DiagnosticMode1x2IT() {
-    super(Duration.ofSeconds(120));
+    super(Duration.ofSeconds(180));
   }
 
   @SuppressWarnings("OptionalGetWithoutIsPresent")

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/RepairCommand1x1IT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/RepairCommand1x1IT.java
@@ -42,7 +42,7 @@ import static org.terracotta.dynamic_config.test_support.util.AngelaMatchers.con
 public class RepairCommand1x1IT extends DynamicConfigIT {
 
   public RepairCommand1x1IT() {
-    super(Duration.ofSeconds(120));
+    super(Duration.ofSeconds(180));
   }
 
   @SuppressWarnings("OptionalGetWithoutIsPresent")

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/RepairCommand1x2IT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/RepairCommand1x2IT.java
@@ -98,7 +98,7 @@ public class RepairCommand1x2IT extends DynamicConfigIT {
 
     // detach command will kill the active, so the stripe will go down
     assertThat(
-        configToolInvocation("-e", "10s", "-r", "5s", "-t", "5s", "detach", "-f", "-d", "localhost:" + getNodePort(1, activeId),
+        configToolInvocation("-e", "40s", "-r", "5s", "-t", "5s", "detach", "-f", "-d", "localhost:" + getNodePort(1, activeId),
             "-s", "localhost:" + getNodePort(1, passiveId)),
         containsOutput("Two-Phase commit failed"));
 
@@ -147,7 +147,7 @@ public class RepairCommand1x2IT extends DynamicConfigIT {
     assertThat(configToolInvocation("set", "-s", "localhost:" + getNodePort(1, 1), "-c", propertySettingString), is(successful()));
 
     assertThat(
-        configToolInvocation("-e", "10s", "detach", "-f", "-d", "localhost:" + getNodePort(1, activeId),
+        configToolInvocation("-e", "40s", "detach", "-f", "-d", "localhost:" + getNodePort(1, activeId),
             "-s", "localhost:" + getNodePort(1, passiveId)),
         containsOutput("Commit failed for node localhost:" + getNodePort(1, activeId) + ". Reason: java.util.concurrent.TimeoutException"));
 
@@ -192,7 +192,7 @@ public class RepairCommand1x2IT extends DynamicConfigIT {
 
     //Both active and passive is down.
     assertThat(
-        configToolInvocation("-e", "10s", "-r", "5s", "-t", "5s", "detach", "-f", "-d", "localhost:" + getNodePort(1, activeId),
+        configToolInvocation("-e", "40s", "-r", "5s", "-t", "5s", "detach", "-f", "-d", "localhost:" + getNodePort(1, activeId),
             "-s", "localhost:" + getNodePort(1, passiveId)),
         containsOutput("Two-Phase commit failed"));
 

--- a/management/nms-agent-entity/nms-agent-entity-client/src/main/java/org/terracotta/management/entity/nms/agent/client/NmsAgentEntityFactory.java
+++ b/management/nms-agent-entity/nms-agent-entity-client/src/main/java/org/terracotta/management/entity/nms/agent/client/NmsAgentEntityFactory.java
@@ -21,6 +21,8 @@ import org.terracotta.exception.EntityNotFoundException;
 import org.terracotta.exception.EntityNotProvidedException;
 import org.terracotta.exception.EntityVersionMismatchException;
 
+import static java.util.Objects.requireNonNull;
+
 /**
  * @author Mathieu Carbou
  */
@@ -31,7 +33,7 @@ public class NmsAgentEntityFactory {
   private final Connection connection;
 
   public NmsAgentEntityFactory(Connection connection) {
-    this.connection = connection;
+    this.connection = requireNonNull(connection);
   }
 
   public NmsAgentEntity retrieve() {

--- a/management/testing/integration-tests/src/test/java/org/terracotta/management/integration/tests/AbstractTest.java
+++ b/management/testing/integration-tests/src/test/java/org/terracotta/management/integration/tests/AbstractTest.java
@@ -84,7 +84,7 @@ public abstract class AbstractTest {
   protected NmsService nmsService;
 
   @Rule
-  public Timeout timeout = Timeout.seconds(60);
+  public Timeout timeout = Timeout.seconds(120);
 
   protected final void commonSetUp(Cluster cluster) throws Exception {
     this.cluster = cluster;
@@ -183,7 +183,7 @@ public abstract class AbstractTest {
     // connects to server
     Properties properties = new Properties();
     properties.setProperty(ConnectionPropertyNames.CONNECTION_NAME, getClass().getSimpleName());
-    properties.setProperty(ConnectionPropertyNames.CONNECTION_TIMEOUT, "5000");
+    properties.setProperty(ConnectionPropertyNames.CONNECTION_TIMEOUT, "20000");
     this.managementConnection = ConnectionFactory.connect(uri, properties);
 
     // create a NMS Entity

--- a/management/testing/integration-tests/src/test/java/org/terracotta/management/integration/tests/SimpleGalvanIT.java
+++ b/management/testing/integration-tests/src/test/java/org/terracotta/management/integration/tests/SimpleGalvanIT.java
@@ -56,7 +56,7 @@ public class SimpleGalvanIT {
   }
 
   @Rule
-  public Timeout timeout = Timeout.seconds(30);
+  public Timeout timeout = Timeout.seconds(60);
 
   CacheFactory cacheFactory;
 

--- a/management/testing/integration-tests/src/test/resources/sate-dump-partial.txt
+++ b/management/testing/integration-tests/src/test/resources/sate-dump-partial.txt
@@ -1,4 +1,3 @@
-entityID=EntityID{className='org.terracotta.lease.LeaseAcquirer', entityName='SystemLeaseAcquirer'}
 entityID=EntityID{className='org.terracotta.dynamic_config.entity.topology.client.DynamicTopologyEntity', entityName='dynamic-config-topology-entity'}
 entityID=EntityID{className='org.terracotta.management.entity.nms.agent.client.NmsAgentEntity', entityName='NmsAgent'}
 entityID=EntityID{className='org.terracotta.dynamic_config.entity.management.server.ManagementEntityServerService', entityName='dynamic-config-management-entity'}

--- a/management/testing/sample-entity/src/main/java/org/terracotta/management/entity/sample/client/CacheFactory.java
+++ b/management/testing/sample-entity/src/main/java/org/terracotta/management/entity/sample/client/CacheFactory.java
@@ -67,7 +67,7 @@ public class CacheFactory implements Closeable {
     // connects to server
     Properties properties = new Properties();
     properties.setProperty(ConnectionPropertyNames.CONNECTION_NAME, path);
-    properties.setProperty(ConnectionPropertyNames.CONNECTION_TIMEOUT, "5000");
+    properties.setProperty(ConnectionPropertyNames.CONNECTION_TIMEOUT, "20000");
     if(uuid != null) {
       properties.setProperty(ConnectionPropertyNames.CONNECTION_UUID, uuid);
     }

--- a/management/testing/sample-entity/src/test/java/org/terracotta/management/entity/sample/AbstractTest.java
+++ b/management/testing/sample-entity/src/test/java/org/terracotta/management/entity/sample/AbstractTest.java
@@ -26,9 +26,9 @@ import org.junit.rules.Timeout;
 import org.terracotta.connection.Connection;
 import org.terracotta.connection.ConnectionFactory;
 import org.terracotta.connection.ConnectionPropertyNames;
+import org.terracotta.management.entity.nms.NmsConfig;
 import org.terracotta.management.entity.nms.agent.client.NmsAgentEntityClientService;
 import org.terracotta.management.entity.nms.agent.server.NmsAgentEntityServerService;
-import org.terracotta.management.entity.nms.NmsConfig;
 import org.terracotta.management.entity.nms.client.DefaultNmsService;
 import org.terracotta.management.entity.nms.client.NmsEntity;
 import org.terracotta.management.entity.nms.client.NmsEntityClientService;
@@ -74,7 +74,7 @@ public abstract class AbstractTest {
   protected NmsService nmsService;
 
   @Rule
-  public Timeout timeout = Timeout.seconds(60);
+  public Timeout timeout = Timeout.seconds(90);
 
   protected AbstractTest() {
     this(0);


### PR DESCRIPTION
- To be able to run Windows builds
- To be able to run Java 11  builds correctly in Galvan (needs JAVA_HOME to be set)
- fix the failing tests.

This is not the ideal solution. Ideally, we would need #642, but it is not working yet.

So this is a temporary replacement.