### PR TITLE
Better Nomad exception handling in case of timeout

### DIFF
--- a/common/nomad/src/main/java/org/terracotta/nomad/client/NomadMessageSender.java
+++ b/common/nomad/src/main/java/org/terracotta/nomad/client/NomadMessageSender.java
@@ -314,6 +314,6 @@ public class NomadMessageSender<T> implements AllResultsReceiver<T> {
   }
 
   private static String stringify(Throwable e) {
-    return e == null ? "" : e.getMessage() == null ? "" : e.getMessage();
+    return e == null ? "" : e.getMessage() == null ? e.getClass().getName() : e.getMessage();
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
     <terracotta-apis.version>1.7.0-pre1</terracotta-apis.version>
     <terracotta-configuration.version>10.7.0-pre2</terracotta-configuration.version>
     <passthrough-testing.version>1.7.0-pre12</passthrough-testing.version>
-    <terracotta-core.version>5.7.0-pre24</terracotta-core.version>
+    <terracotta-core.version>5.7.0-pre25</terracotta-core.version>
     <tripwire.version>1.0.0-pre7</tripwire.version>
     <angela.version>3.0.18</angela.version>
     <statistics.version>2.1</statistics.version>


### PR DESCRIPTION
This is so that we can see the timeout exception when it is failing. Right now we see:
`(1) Commit failed for node localhost:16560`. Reason: which is bad.
After the fix we should see:` (1) Commit failed for node localhost:16560. Reason: java.util.concurrent.TimeoutException`