### PR TITLE
Using Terracotta Utilities : TemporaryFolder and WaitForAssert

### DIFF
--- a/common/test-utilities/pom.xml
+++ b/common/test-utilities/pom.xml
@@ -31,6 +31,10 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.terracotta</groupId>
+      <artifactId>terracotta-utilities-test-tools</artifactId>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
     </dependency>

--- a/common/test-utilities/src/main/java/org/terracotta/testing/TmpDir.java
+++ b/common/test-utilities/src/main/java/org/terracotta/testing/TmpDir.java
@@ -18,36 +18,21 @@ package org.terracotta.testing;
 import org.junit.rules.TestRule;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.terracotta.org.junit.rules.TemporaryFolder;
 
-import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.stream.Stream;
-
-import static java.util.Comparator.reverseOrder;
 
 /**
  * @author Mathieu Carbou
  */
 public class TmpDir implements TestRule {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(TmpDir.class);
-  private static final int MAX_RETRY_COUNT = 10;
-
   private final Path parent;
   private final boolean autoClean;
   private Path root;
 
-  public TmpDir(Path parent, boolean autoClean) {
-    this.parent = parent;
-    this.autoClean = autoClean;
-  }
-
   public TmpDir() {
-    this(Paths.get(System.getProperty("user.dir"), "target", "test-data").toAbsolutePath(), true);
+    this(null, true);
   }
 
   public TmpDir(Path parent) {
@@ -55,63 +40,38 @@ public class TmpDir implements TestRule {
   }
 
   public TmpDir(boolean autoClean) {
-    this(Paths.get(System.getProperty("user.dir"), "target", "test-data").toAbsolutePath(), autoClean);
+    this(null, autoClean);
+  }
+
+  public TmpDir(Path parent, boolean autoClean) {
+    this.parent = parent;
+    this.autoClean = autoClean;
   }
 
   @Override
   public Statement apply(Statement base, Description description) {
-    return new Statement() {
+    TemporaryFolder temporaryFolder = new TemporaryFolder(parent == null ? null : parent.toFile()) {
       @Override
-      public void evaluate() throws Throwable {
-        createRoot(description);
-        base.evaluate();
-        // not in a try catch: we do not clean if test failed
-        autoClean();
+      protected void after() {
+        if (autoClean) {
+          super.after();
+        }
       }
     };
+    return temporaryFolder.apply(new Statement() {
+      @Override
+      public void evaluate() throws Throwable {
+        if (description.getMethodName() == null) {
+          root = temporaryFolder.newFolder(description.getTestClass().getSimpleName()).toPath();
+        } else {
+          root = temporaryFolder.newFolder(description.getTestClass().getSimpleName(), description.getMethodName()).toPath();
+        }
+        base.evaluate();
+      }
+    }, description);
   }
 
   public Path getRoot() {
     return root;
-  }
-
-  protected void createRoot(Description description) throws IOException {
-    // generate a temporary working directory per test that does not depend on
-    // class name or test method names because the path can be greater than the
-    // limit allowed by Windows.
-    Files.createDirectories(parent);
-    root = Files.createTempDirectory(parent, System.currentTimeMillis() + "-");
-    Files.delete(root);
-    Files.createDirectory(root);
-    if (LOGGER.isInfoEnabled()) {
-      String cname = description.getTestClass().getSimpleName();
-      String mname = description.getMethodName();
-      if (mname == null) {
-        mname = "_static_"; // if the rule is set as being static
-      }
-      LOGGER.info("Temporary directory for test {}#{}: {}", cname, mname, root);
-    }
-  }
-
-  protected void autoClean() {
-    if (autoClean) {
-      for (int i = 0; i < MAX_RETRY_COUNT && Files.exists(root); i++) {
-        try (Stream<Path> stream = Files.walk(root)) {
-          stream.sorted(reverseOrder()).forEach(path -> {
-            try {
-              Files.delete(path);
-            } catch (IOException e) {
-              LOGGER.warn("Error deleting {}", path, e);
-            }
-          });
-        } catch (IOException e) {
-          // closing stream
-          throw new AssertionError(e);
-        }
-      }
-      if (Files.exists(root)) {
-        root.toFile().deleteOnExit();
-      }
-    }
   }
 }

--- a/dynamic-config/cli/config-convertor-oss/src/test/java/org/terracotta/dynamic_config/cli/config_convertor/ConfigConvertorToolTest.java
+++ b/dynamic-config/cli/config-convertor-oss/src/test/java/org/terracotta/dynamic_config/cli/config_convertor/ConfigConvertorToolTest.java
@@ -34,7 +34,7 @@ import static org.junit.Assert.assertTrue;
  */
 public class ConfigConvertorToolTest {
 
-  @Rule public TmpDir tmpDir = new TmpDir(Paths.get(System.getProperty("user.dir"), "target"));
+  @Rule public TmpDir tmpDir = new TmpDir(Paths.get(System.getProperty("user.dir"), "target"), false);
 
   @Test
   public void test_conversion_1() {

--- a/dynamic-config/cli/config-convertor-oss/src/test/java/org/terracotta/dynamic_config/cli/config_convertor/ConfigConvertorToolTest.java
+++ b/dynamic-config/cli/config-convertor-oss/src/test/java/org/terracotta/dynamic_config/cli/config_convertor/ConfigConvertorToolTest.java
@@ -22,6 +22,7 @@ import org.terracotta.testing.TmpDir;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
@@ -33,7 +34,7 @@ import static org.junit.Assert.assertTrue;
  */
 public class ConfigConvertorToolTest {
 
-  @Rule public TmpDir tmpDir = new TmpDir(false);
+  @Rule public TmpDir tmpDir = new TmpDir(Paths.get(System.getProperty("user.dir"), "target"));
 
   @Test
   public void test_conversion_1() {

--- a/dynamic-config/server/configuration-repository/src/test/java/org/terracotta/dynamic_config/server/configuration/nomad/persistence/FileConfigStorageTest.java
+++ b/dynamic-config/server/configuration-repository/src/test/java/org/terracotta/dynamic_config/server/configuration/nomad/persistence/FileConfigStorageTest.java
@@ -40,7 +40,7 @@ import static org.junit.Assert.assertTrue;
 public class FileConfigStorageTest {
 
   @Rule
-  public TmpDir temporaryFolder = new TmpDir(Paths.get(System.getProperty("user.dir"), "target"));
+  public TmpDir temporaryFolder = new TmpDir(Paths.get(System.getProperty("user.dir"), "target"), false);
 
   @Test
   public void saveAndRetrieve() throws Exception {

--- a/dynamic-config/server/configuration-repository/src/test/java/org/terracotta/dynamic_config/server/configuration/nomad/persistence/FileConfigStorageTest.java
+++ b/dynamic-config/server/configuration-repository/src/test/java/org/terracotta/dynamic_config/server/configuration/nomad/persistence/FileConfigStorageTest.java
@@ -40,7 +40,7 @@ import static org.junit.Assert.assertTrue;
 public class FileConfigStorageTest {
 
   @Rule
-  public TmpDir temporaryFolder = new TmpDir();
+  public TmpDir temporaryFolder = new TmpDir(Paths.get(System.getProperty("user.dir"), "target"));
 
   @Test
   public void saveAndRetrieve() throws Exception {

--- a/dynamic-config/testing/support/pom.xml
+++ b/dynamic-config/testing/support/pom.xml
@@ -59,10 +59,6 @@
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
     </dependency>
-    <dependency>
-      <groupId>org.awaitility</groupId>
-      <artifactId>awaitility</artifactId>
-    </dependency>
 
     <!-- provided libs because of EE/OSS diff -->
     <dependency>

--- a/dynamic-config/testing/support/src/main/java/org/terracotta/dynamic_config/test_support/DynamicConfigIT.java
+++ b/dynamic-config/testing/support/src/main/java/org/terracotta/dynamic_config/test_support/DynamicConfigIT.java
@@ -96,7 +96,7 @@ import static org.terracotta.utilities.test.WaitForAssert.assertThatEventually;
 public class DynamicConfigIT {
   private static Logger LOGGER = LoggerFactory.getLogger(DynamicConfigIT.class);
 
-  @Rule public TmpDir tmpDir = new TmpDir(Paths.get(System.getProperty("user.dir"), "target"));
+  @Rule public TmpDir tmpDir = new TmpDir(Paths.get(System.getProperty("user.dir"), "target"), false);
   @Rule public PortLockingRule ports;
   @Rule public Timeout timeoutRule;
 

--- a/dynamic-config/testing/support/src/main/java/org/terracotta/dynamic_config/test_support/DynamicConfigIT.java
+++ b/dynamic-config/testing/support/src/main/java/org/terracotta/dynamic_config/test_support/DynamicConfigIT.java
@@ -96,7 +96,7 @@ import static org.terracotta.dynamic_config.test_support.util.AngelaMatchers.suc
 public class DynamicConfigIT {
   private static Logger LOGGER = LoggerFactory.getLogger(DynamicConfigIT.class);
 
-  @Rule public TmpDir tmpDir = new TmpDir();
+  @Rule public TmpDir tmpDir = new TmpDir(Paths.get(System.getProperty("user.dir"), "target"));
   @Rule public PortLockingRule ports;
   @Rule public Timeout timeoutRule;
 

--- a/dynamic-config/testing/support/src/main/java/org/terracotta/dynamic_config/test_support/DynamicConfigIT.java
+++ b/dynamic-config/testing/support/src/main/java/org/terracotta/dynamic_config/test_support/DynamicConfigIT.java
@@ -15,7 +15,6 @@
  */
 package org.terracotta.dynamic_config.test_support;
 
-import org.awaitility.Awaitility;
 import org.hamcrest.Matcher;
 import org.junit.After;
 import org.junit.Before;
@@ -65,10 +64,10 @@ import java.time.Duration;
 import java.util.Map;
 import java.util.OptionalInt;
 import java.util.Properties;
-import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
@@ -92,6 +91,7 @@ import static org.terracotta.angela.common.topology.PackageType.KIT;
 import static org.terracotta.angela.common.topology.Version.version;
 import static org.terracotta.common.struct.Tuple2.tuple2;
 import static org.terracotta.dynamic_config.test_support.util.AngelaMatchers.successful;
+import static org.terracotta.utilities.test.WaitForAssert.assertThatEventually;
 
 public class DynamicConfigIT {
   private static Logger LOGGER = LoggerFactory.getLogger(DynamicConfigIT.class);
@@ -129,7 +129,8 @@ public class DynamicConfigIT {
   }
 
   @Before
-  public void before() {
+  // keep throws Exception to support extend the class
+  public void before() throws Exception {
     this.clusterFactory = new ClusterFactory(getClass().getSimpleName(), createConfigContext(clusterDef.stripes(), clusterDef.nodesPerStripe()));
     this.tsa = clusterFactory.tsa();
     if (autoStart) {
@@ -146,7 +147,8 @@ public class DynamicConfigIT {
   }
 
   @After
-  public void after() throws IOException {
+  // keep throws Exception to support extend the class
+  public void after() throws Exception {
     try {
       clusterFactory.close();
     } catch (IOException | RuntimeException e) {
@@ -284,47 +286,45 @@ public class DynamicConfigIT {
     return getBaseDir().resolve("repository").resolve("stripe" + stripeId).resolve("node-" + nodeId);
   }
 
-  protected void waitUntil(ConfigToolExecutionResult result, Matcher<? super ConfigToolExecutionResult> matcher) {
+  protected void waitUntil(ConfigToolExecutionResult result, Matcher<? super ConfigToolExecutionResult> matcher) throws TimeoutException {
     waitUntil(() -> result, matcher, timeout);
   }
 
-  protected void waitUntil(NodeOutputRule.NodeLog result, Matcher<? super NodeOutputRule.NodeLog> matcher) {
+  protected void waitUntil(NodeOutputRule.NodeLog result, Matcher<? super NodeOutputRule.NodeLog> matcher) throws TimeoutException {
     waitUntil(() -> result, matcher, timeout);
   }
 
-  protected <T> void waitUntil(Callable<T> callable, Matcher<? super T> matcher) {
+  protected <T> void waitUntil(Supplier<T> callable, Matcher<? super T> matcher) throws TimeoutException {
     waitUntil(callable, matcher, timeout);
   }
 
-  protected <T> void waitUntil(Callable<T> callable, Matcher<? super T> matcher, long timeout) {
-    Awaitility.await()
-        // do not use iterative because it slows down the whole test suite considerably, especially in case of a failing process causing a timeout
-        .pollInterval(Duration.ofMillis(500))
-        .atMost(timeout, TimeUnit.SECONDS)
-        .until(callable, matcher);
+  protected <T> void waitUntil(Supplier<T> callable, Matcher<? super T> matcher, long timeout) throws TimeoutException {
+    assertThatEventually(callable, matcher)
+        .threadDumpOnTimeout()
+        .within(Duration.ofSeconds(timeout));
   }
 
-  protected void waitForActive(int stripeId) {
+  protected void waitForActive(int stripeId) throws TimeoutException {
     waitUntil(() -> findActive(stripeId).isPresent(), is(true));
   }
 
-  protected void waitForActive(int stripeId, int nodeId) {
+  protected void waitForActive(int stripeId, int nodeId) throws TimeoutException {
     waitUntil(() -> tsa.getState(getNode(stripeId, nodeId)), is(equalTo(STARTED_AS_ACTIVE)));
   }
 
-  protected void waitForPassive(int stripeId, int nodeId) {
+  protected void waitForPassive(int stripeId, int nodeId) throws TimeoutException {
     waitUntil(() -> tsa.getState(getNode(stripeId, nodeId)), is(equalTo(STARTED_AS_PASSIVE)));
   }
 
-  protected void waitForDiagnostic(int stripeId, int nodeId) {
+  protected void waitForDiagnostic(int stripeId, int nodeId) throws TimeoutException {
     waitUntil(() -> tsa.getState(getNode(stripeId, nodeId)), is(equalTo(STARTED_IN_DIAGNOSTIC_MODE)));
   }
 
-  protected void waitForPassives(int stripeId) {
+  protected void waitForPassives(int stripeId) throws TimeoutException {
     waitUntil(() -> findPassives(stripeId).length, is(equalTo(nodesPerStripe - 1)));
   }
 
-  protected void waitForNPassives(int stripeId, int count) {
+  protected void waitForNPassives(int stripeId, int count) throws TimeoutException {
     waitUntil(() -> findPassives(stripeId).length, is(equalTo(count)));
   }
 
@@ -384,11 +384,11 @@ public class DynamicConfigIT {
     }
   }
 
-  protected ConfigToolExecutionResult activateCluster() {
+  protected ConfigToolExecutionResult activateCluster() throws TimeoutException {
     return activateCluster("tc-cluster");
   }
 
-  protected ConfigToolExecutionResult activateCluster(String name) {
+  protected ConfigToolExecutionResult activateCluster(String name) throws TimeoutException {
     String licensePath = licensePath();
     ConfigToolExecutionResult result;
     if (licensePath == null) {

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/AttachInConsistency1x4IT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/AttachInConsistency1x4IT.java
@@ -22,6 +22,7 @@ import org.terracotta.dynamic_config.test_support.ClusterDefinition;
 import org.terracotta.dynamic_config.test_support.DynamicConfigIT;
 
 import java.time.Duration;
+import java.util.concurrent.TimeoutException;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
@@ -146,7 +147,7 @@ public class AttachInConsistency1x4IT extends DynamicConfigIT {
         System.out.println("Restarting old active ID: " + activeId + "...");
         startNode(1, activeId, "-r", getNode(1, activeId).getConfigRepo());
         waitForPassive(1, activeId);
-      } catch (InterruptedException e) {
+      } catch (InterruptedException | TimeoutException e) {
         Thread.currentThread().interrupt();
       }
     });

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/ConfigSyncIT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/ConfigSyncIT.java
@@ -72,7 +72,7 @@ public class ConfigSyncIT extends DynamicConfigIT {
 
   @Before
   @Override
-  public void before() {
+  public void before() throws Exception {
     super.before();
     if (tsa.getActive() == getNode(1, 1)) {
       activeNodeId = 1;

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/DiagnosticMode1x2IT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/DiagnosticMode1x2IT.java
@@ -22,6 +22,7 @@ import org.terracotta.dynamic_config.test_support.ClusterDefinition;
 import org.terracotta.dynamic_config.test_support.DynamicConfigIT;
 
 import java.time.Duration;
+import java.util.concurrent.TimeoutException;
 
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.equalTo;
@@ -43,7 +44,7 @@ public class DiagnosticMode1x2IT extends DynamicConfigIT {
 
   @SuppressWarnings("OptionalGetWithoutIsPresent")
   @Test
-  public void test_restart_active_in_diagnostic_mode() {
+  public void test_restart_active_in_diagnostic_mode() throws TimeoutException {
     int activeNodeId = findActive(1).getAsInt();
     TerracottaServer active = getNode(1, activeNodeId);
     tsa.stop(active);
@@ -54,7 +55,7 @@ public class DiagnosticMode1x2IT extends DynamicConfigIT {
   }
 
   @Test
-  public void test_restart_passive_in_diagnostic_mode() {
+  public void test_restart_passive_in_diagnostic_mode() throws TimeoutException {
     int passiveNodeId = findPassives(1)[0];
     TerracottaServer passive = getNode(1, passiveNodeId);
     tsa.stop(passive);

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/RepairCommand1x2IT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/RepairCommand1x2IT.java
@@ -22,6 +22,7 @@ import org.terracotta.dynamic_config.test_support.DynamicConfigIT;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.time.Duration;
+import java.util.concurrent.TimeoutException;
 
 import static java.util.stream.Collectors.toList;
 import static org.hamcrest.Matchers.allOf;
@@ -225,7 +226,7 @@ public class RepairCommand1x2IT extends DynamicConfigIT {
   }
 
   @Test
-  public void test_reset_node() {
+  public void test_reset_node() throws TimeoutException {
     // reset diagnostic node
     startNode(1, 1);
     waitForDiagnostic(1, 1);
@@ -256,7 +257,7 @@ public class RepairCommand1x2IT extends DynamicConfigIT {
     waitForActive(1, 1);
   }
 
-  private void activate1x2Cluster() {
+  private void activate1x2Cluster() throws TimeoutException {
     assertThat(
         configToolInvocation("attach", "-d", "localhost:" + getNodePort(), "-s", "localhost:" + getNodePort(1, 2)),
         is(successful()));

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activation/ActivateCommand1x2IT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activation/ActivateCommand1x2IT.java
@@ -26,6 +26,7 @@ import org.terracotta.dynamic_config.test_support.DynamicConfigIT;
 import org.terracotta.dynamic_config.test_support.util.NodeOutputRule;
 
 import java.net.InetSocketAddress;
+import java.util.concurrent.TimeoutException;
 
 import static java.time.Duration.ofSeconds;
 import static org.hamcrest.Matchers.allOf;
@@ -43,14 +44,14 @@ public class ActivateCommand1x2IT extends DynamicConfigIT {
   @Rule public final NodeOutputRule out = new NodeOutputRule();
 
   @Test
-  public void testSingleNodeActivation() {
+  public void testSingleNodeActivation() throws TimeoutException {
     assertThat(activateCluster(),
         allOf(is(successful()), containsOutput("No license installed"), containsOutput("came back up")));
     waitForActive(1, 1);
   }
 
   @Test
-  public void testMultiNodeSingleStripeActivation() {
+  public void testMultiNodeSingleStripeActivation() throws TimeoutException {
     assertThat(
         configToolInvocation("attach", "-d", "localhost:" + getNodePort(), "-s", "localhost:" + getNodePort(1, 2)),
         is(successful()));
@@ -79,7 +80,7 @@ public class ActivateCommand1x2IT extends DynamicConfigIT {
   }
 
   @Test
-  public void testMultiNodeSingleStripeActivationWithConfigFile() {
+  public void testMultiNodeSingleStripeActivationWithConfigFile() throws TimeoutException {
     assertThat(
         configToolInvocation(
             "-r", timeout + "s",

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activation/Ipv6CliActivationIT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activation/Ipv6CliActivationIT.java
@@ -19,6 +19,8 @@ import org.junit.Test;
 import org.terracotta.dynamic_config.test_support.ClusterDefinition;
 import org.terracotta.dynamic_config.test_support.DynamicConfigIT;
 
+import java.util.concurrent.TimeoutException;
+
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.terracotta.dynamic_config.test_support.util.AngelaMatchers.successful;
@@ -45,7 +47,7 @@ public class Ipv6CliActivationIT extends DynamicConfigIT {
   }
 
   @Test
-  public void testSingleNodeStartupFromCliParamsAndActivateCommand() {
+  public void testSingleNodeStartupFromCliParamsAndActivateCommand() throws TimeoutException {
     waitForDiagnostic(1, 1);
 
     assertThat(configToolInvocation("activate", "-s", "[::1]:" + getNodePort(), "-n", "tc-cluster"), is(successful()));
@@ -54,7 +56,7 @@ public class Ipv6CliActivationIT extends DynamicConfigIT {
   }
 
   @Test
-  public void testMultiNodeStartupFromCliParamsAndActivateCommand() {
+  public void testMultiNodeStartupFromCliParamsAndActivateCommand() throws TimeoutException {
     waitForDiagnostic(1, 1);
     waitForDiagnostic(1, 2);
 

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/diagnostic/GetCommand1x2IT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/diagnostic/GetCommand1x2IT.java
@@ -31,7 +31,7 @@ import static org.terracotta.dynamic_config.test_support.util.AngelaMatchers.suc
 public class GetCommand1x2IT extends DynamicConfigIT {
   @Before
   @Override
-  public void before() {
+  public void before() throws Exception {
     super.before();
     assertThat(
         configToolInvocation("attach", "-d", "localhost:" + getNodePort(), "-s", "localhost:" + getNodePort(1, 2)),

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/diagnostic/Ipv6ConfigIT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/diagnostic/Ipv6ConfigIT.java
@@ -23,6 +23,7 @@ import org.terracotta.dynamic_config.test_support.util.ConfigRepositoryGenerator
 import org.terracotta.dynamic_config.test_support.util.NodeOutputRule;
 
 import java.nio.file.Path;
+import java.util.concurrent.TimeoutException;
 
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
@@ -35,7 +36,7 @@ public class Ipv6ConfigIT extends DynamicConfigIT {
   @Rule public final NodeOutputRule out = new NodeOutputRule();
 
   @Test
-  public void testStartupFromConfigFileAndExportCommand() {
+  public void testStartupFromConfigFileAndExportCommand() throws TimeoutException {
     Path configurationFile = copyConfigProperty("/config-property-files/single-stripe_multi-node_ipv6.properties");
     startNode(1, 1, "-f", configurationFile.toString(), "-s", "[::1]", "-p", String.valueOf(getNodePort()), "-r", "repository/stripe1/node-1-1");
     waitForDiagnostic(1, 1);

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/diagnostic/NodeStartupIT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/diagnostic/NodeStartupIT.java
@@ -30,6 +30,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.concurrent.TimeoutException;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
@@ -45,20 +46,20 @@ public class NodeStartupIT extends DynamicConfigIT {
   @Rule public final SystemErrRule err = new SystemErrRule().enableLog();
 
   @Test
-  public void testStartingWithNonExistentRepo() {
+  public void testStartingWithNonExistentRepo() throws TimeoutException {
     startSingleNode("-r", getNodeRepositoryDir().toString());
     waitForDiagnostic(1, 1);
   }
 
   @Test
-  public void testStartingWithSingleNodeConfigFile() {
+  public void testStartingWithSingleNodeConfigFile() throws TimeoutException {
     Path configurationFile = copyConfigProperty("/config-property-files/single-stripe.properties");
     startNode(1, 1, "--config-file", configurationFile.toString(), "--node-repository-dir", "repository/stripe1/node-1");
     waitForDiagnostic(1, 1);
   }
 
   @Test
-  public void testStartingWithSingleNodeConfigFileWithHostPort() {
+  public void testStartingWithSingleNodeConfigFileWithHostPort() throws TimeoutException {
     String port = String.valueOf(getNodePort());
     Path configurationFile = copyConfigProperty("/config-property-files/single-stripe.properties");
     startNode(1, 1, "-f", configurationFile.toString(), "-s", "localhost", "-p", port, "--node-repository-dir", "repository/stripe1/node-1");
@@ -75,7 +76,7 @@ public class NodeStartupIT extends DynamicConfigIT {
   }
 
   @Test
-  public void testFailedStartupConfigFile_nonExistentFile() {
+  public void testFailedStartupConfigFile_nonExistentFile() throws TimeoutException {
     Path configurationFile = Paths.get(".").resolve("blah");
     try {
       startNode(1, 1, "--config-file", configurationFile.toString(), "--node-repository-dir", "repository/stripe1/node-1");
@@ -86,7 +87,7 @@ public class NodeStartupIT extends DynamicConfigIT {
   }
 
   @Test
-  public void testFailedStartupConfigFile_invalidPort() {
+  public void testFailedStartupConfigFile_invalidPort() throws TimeoutException {
     String port = String.valueOf(getNodePort());
     Path configurationFile = copyConfigProperty("/config-property-files/single-stripe_invalid1.properties");
     try {
@@ -98,7 +99,7 @@ public class NodeStartupIT extends DynamicConfigIT {
   }
 
   @Test
-  public void testFailedStartupConfigFile_invalidSecurity() {
+  public void testFailedStartupConfigFile_invalidSecurity() throws TimeoutException {
     String port = String.valueOf(getNodePort());
     Path configurationFile = copyConfigProperty("/config-property-files/single-stripe_invalid2.properties");
     try {
@@ -110,7 +111,7 @@ public class NodeStartupIT extends DynamicConfigIT {
   }
 
   @Test
-  public void testFailedStartupConfigFile_invalidCliParams() {
+  public void testFailedStartupConfigFile_invalidCliParams() throws TimeoutException {
     Path configurationFile = copyConfigProperty("/config-property-files/single-stripe.properties");
     try {
       startSingleNode("--config-file", configurationFile.toString(), "--node-bind-address", "::1");
@@ -121,7 +122,7 @@ public class NodeStartupIT extends DynamicConfigIT {
   }
 
   @Test
-  public void testFailedStartupConfigFile_invalidCliParams_2() {
+  public void testFailedStartupConfigFile_invalidCliParams_2() throws TimeoutException {
     Path configurationFile = copyConfigProperty("/config-property-files/single-stripe.properties");
     try {
       startNode(1, 1, "-f", configurationFile.toString(), "-m", getNodeRepositoryDir().toString());
@@ -132,7 +133,7 @@ public class NodeStartupIT extends DynamicConfigIT {
   }
 
   @Test
-  public void testFailedStartupCliParams_invalidAuthc() {
+  public void testFailedStartupCliParams_invalidAuthc() throws TimeoutException {
     try {
       startSingleNode("--security-authc=blah", "-r", getNodeRepositoryDir().toString());
       fail();
@@ -142,7 +143,7 @@ public class NodeStartupIT extends DynamicConfigIT {
   }
 
   @Test
-  public void testFailedStartupCliParams_invalidHostname() {
+  public void testFailedStartupCliParams_invalidHostname() throws TimeoutException {
     try {
       startNode(1, 1, "--node-hostname=:::", "-r", getNodeRepositoryDir().toString());
       fail();
@@ -152,7 +153,7 @@ public class NodeStartupIT extends DynamicConfigIT {
   }
 
   @Test
-  public void testFailedStartupCliParams_invalidFailoverPriority() {
+  public void testFailedStartupCliParams_invalidFailoverPriority() throws TimeoutException {
     try {
       startSingleNode("--failover-priority=blah", "-r", getNodeRepositoryDir().toString());
       fail();
@@ -162,7 +163,7 @@ public class NodeStartupIT extends DynamicConfigIT {
   }
 
   @Test
-  public void testFailedStartupCliParams_invalidSecurity() {
+  public void testFailedStartupCliParams_invalidSecurity() throws TimeoutException {
     try {
       startSingleNode("--security-audit-log-dir", "audit-dir", "-r", getNodeRepositoryDir().toString());
       fail();
@@ -172,7 +173,7 @@ public class NodeStartupIT extends DynamicConfigIT {
   }
 
   @Test
-  public void testSuccessfulStartupCliParams() {
+  public void testSuccessfulStartupCliParams() throws TimeoutException {
     startSingleNode("-p", String.valueOf(getNodePort()), "-r", getNodeRepositoryDir().toString());
     waitForDiagnostic(1, 1);
   }
@@ -190,7 +191,7 @@ public class NodeStartupIT extends DynamicConfigIT {
   }
 
   @Test
-  public void testFailedStartupCliParamsWithConfigFileAndRepositoryDir() {
+  public void testFailedStartupCliParamsWithConfigFileAndRepositoryDir() throws TimeoutException {
     String port = String.valueOf(getNodePort());
     Path configurationFile = copyConfigProperty("/config-property-files/single-stripe.properties");
     try {

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/diagnostic/SetCommand1x2IT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/diagnostic/SetCommand1x2IT.java
@@ -34,7 +34,7 @@ public class SetCommand1x2IT extends DynamicConfigIT {
 
   @Before
   @Override
-  public void before() {
+  public void before() throws Exception {
     super.before();
     assertThat(configToolInvocation("attach", "-d", "localhost:" + getNodePort(), "-s", "localhost:" + getNodePort(1, 2)), is(successful()));
   }

--- a/pom.xml
+++ b/pom.xml
@@ -236,11 +236,6 @@
         <artifactId>system-rules</artifactId>
         <version>1.19.0</version>
       </dependency>
-      <dependency>
-        <groupId>org.awaitility</groupId>
-        <artifactId>awaitility</artifactId>
-        <version>4.0.2</version>
-      </dependency>
     </dependencies>
   </dependencyManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -92,6 +92,11 @@
         <version>${slf4j.version}</version>
       </dependency>
       <dependency>
+        <groupId>org.terracotta</groupId>
+        <artifactId>terracotta-utilities-test-tools</artifactId>
+        <version>0.0.2</version>
+      </dependency>
+      <dependency>
         <groupId>org.terracotta.internal</groupId>
         <artifactId>tc-config-parser</artifactId>
         <version>${terracotta-configuration.version}</version>


### PR DESCRIPTION
Copied Clifford and Chris to show them what use cases we have and why we cannot directly use the TemporaryFolder.

What is missing from `TemporaryFolder`:
- Path api support
- Being able to define the name of the temporary root directory (based on test name / method name)
- Being able to skip the final deletion

Also replaced Awaitility by WaitForAssert