### PR TITLE
Bumped to latest angela + addition of galvan-platform-support

### DIFF
--- a/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/nomad/NomadManager.java
+++ b/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/nomad/NomadManager.java
@@ -207,7 +207,7 @@ public class NomadManager<T> {
         InetSocketAddress address = getAddress();
         int stripeId = destinationCluster.getStripeId(address).getAsInt();
         CompletableFuture<AcceptRejectResponse> result = cache.computeIfAbsent(stripeId, sid -> {
-          LOGGER.info("Committing topology change to stripe ID: {}...", stripeId);
+          LOGGER.info("Committing topology change to stripe ID: {}", stripeId);
 
           LOGGER.trace("Sending commit message: {} to stripe ID: {}", message, stripeId);
           CompletableFuture<AcceptRejectResponse> c = new CompletableFuture<>();

--- a/galvan-platform-support/pom.xml
+++ b/galvan-platform-support/pom.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+
+    Copyright Terracotta, Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.terracotta</groupId>
+    <artifactId>platform-root</artifactId>
+    <version>5.7-SNAPSHOT</version>
+    <relativePath>..</relativePath>
+  </parent>
+
+  <artifactId>galvan-platform-support</artifactId>
+  <packaging>jar</packaging>
+
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.terracotta</groupId>
+      <artifactId>test-interfaces</artifactId>
+      <version>${galvan.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.terracotta</groupId>
+      <artifactId>galvan</artifactId>
+      <version>${galvan.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.terracotta.internal</groupId>
+      <artifactId>client-runtime</artifactId>
+      <version>${terracotta-core.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.terracotta.common</groupId>
+      <artifactId>common-port-locking</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/galvan-platform-support/src/main/java/org/terracotta/testing/api/BasicTestClusterConfiguration.java
+++ b/galvan-platform-support/src/main/java/org/terracotta/testing/api/BasicTestClusterConfiguration.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.testing.api;
+
+
+/**
+ * A test configuration for a single-stripe cluster.
+ */
+public class BasicTestClusterConfiguration implements ITestClusterConfiguration {
+  private final String name;
+  public final int serversInStripe;
+  
+  public BasicTestClusterConfiguration(String name, int serversInStripe) {
+    this.name = name;
+    this.serversInStripe = serversInStripe;
+  }
+
+  @Override
+  public String getName() {
+    return this.name;
+  }
+}

--- a/galvan-platform-support/src/main/java/org/terracotta/testing/config/ConfigRepoStartupBuilder.java
+++ b/galvan-platform-support/src/main/java/org/terracotta/testing/config/ConfigRepoStartupBuilder.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.testing.config;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import org.terracotta.ipceventbus.proc.AnyProcess;
+import org.terracotta.ipceventbus.proc.AnyProcessBuilder;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+
+public class ConfigRepoStartupBuilder extends StartupCommandBuilder {
+  private String[] builtCommand;
+
+  @Override
+  public String[] build() {
+    if (builtCommand == null) {
+      try {
+        installServer();
+        Path generatedRepositories = convertConfigFiles();
+        // moves the generated files onto the server folder, but only for this server we are building
+        Files.move(generatedRepositories.resolve("stripe-" + getStripeId()).resolve(getServerName()), getServerWorkingDir().resolve("repository"));
+        buildStartupCommand();
+      } catch (IOException e) {
+        throw new UncheckedIOException(e);
+      }
+    }
+    return builtCommand.clone();
+  }
+
+  private void buildStartupCommand() {
+    List<String> command = new ArrayList<>();
+    String scriptPath = getAbsolutePath(Paths.get("server", "bin", "start-tc-server"));
+    command.add(scriptPath);
+
+    if (isConsistentStartup()) {
+      command.add("-c");
+    }
+
+    command.add("-r");
+    command.add("repository");
+    builtCommand = command.toArray(new String[0]);
+  }
+
+  @SuppressFBWarnings("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE")
+  private Path convertConfigFiles() {
+    Path generatedRepositories = getServerWorkingDir().getParent().getParent().resolve("generated-repositories");
+
+    if (Files.exists(generatedRepositories)) {
+      // this builder is called fro each server, but the CLI will generate the repositories for all.
+      return generatedRepositories;
+    }
+
+    List<String> command = new ArrayList<>();
+    String scriptPath = getAbsolutePath(Paths.get("tools", "config-convertor", "bin", "config-convertor"));
+    command.add(scriptPath);
+
+    command.add("convert");
+
+    for (Path tcConfig : getTcConfigs()) {
+      command.add("-c");
+      command.add(tcConfig.toString());
+    }
+
+    command.add("-n");
+    command.add(getClusterName());
+
+    command.add("-d");
+    command.add(getServerWorkingDir().relativize(generatedRepositories).toString());
+
+    if (getLicensePath() != null) {
+      command.add("-l");
+      command.add(getLicensePath().toString());
+    }
+
+    command.add("-f"); //Do not fail for relative paths
+    executeCommand(command, getServerWorkingDir());
+    return generatedRepositories;
+  }
+
+  private void executeCommand(List<String> command, Path workingDir) {
+    AnyProcess process;
+    try {
+      AnyProcessBuilder<? extends AnyProcess> builder = AnyProcess.newBuilder()
+          .command(command.toArray(new String[0]))
+          .workingDir(workingDir.toFile())
+          .pipeStdout(System.out)
+          .pipeStderr(System.err);
+
+      if (getDebugPort() > 0) {
+        builder.env("JAVA_OPTS", "-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=" + getDebugPort());
+      }
+      process = builder.build();
+    } catch (Exception e) {
+      throw new IllegalStateException("Error launching command: " + String.join(" ", command), e);
+    }
+
+    int exitStatus;
+    try {
+      exitStatus = process.waitFor();
+    } catch (InterruptedException e) {
+      throw new IllegalStateException(e);
+    }
+
+    if (exitStatus != 0) {
+      throw new IllegalStateException("Process: '" + String.join(" ", command) + "' executed from '" + workingDir + "' exited with status: " + exitStatus);
+    }
+  }
+}

--- a/galvan-platform-support/src/main/java/org/terracotta/testing/config/StartupCommandBuilder.java
+++ b/galvan-platform-support/src/main/java/org/terracotta/testing/config/StartupCommandBuilder.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.testing.config;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
+import static org.terracotta.testing.demos.TestHelpers.isWindows;
+
+public abstract class StartupCommandBuilder {
+  private Path kitDir;
+  private Path serverWorkingDir;
+  private String logConfigExt;
+  private String serverName;
+  private boolean consistentStartup;
+  private Path[] tcConfigs;
+  private int debugPort = Integer.getInteger("serverDebugPortStart", 0);
+  private int port;
+  private int stripeId;
+  private String clusterName;
+  private Path licensePath;
+
+  public StartupCommandBuilder port(int port) {
+    this.port = port;
+    return this;
+  }
+
+  public StartupCommandBuilder serverWorkingDir(Path serverWorkingDir) {
+    this.serverWorkingDir = serverWorkingDir;
+    return this;
+  }
+
+  public StartupCommandBuilder serverName(String serverName) {
+    this.serverName = serverName;
+    return this;
+  }
+
+  public StartupCommandBuilder consistentStartup(boolean consistentStartup) {
+    this.consistentStartup = consistentStartup;
+    return this;
+  }
+
+  public StartupCommandBuilder kitDir(Path kitDir) {
+    this.kitDir = kitDir;
+    return this;
+  }
+
+  public StartupCommandBuilder logConfigExtension(String logConfigExt) {
+    this.logConfigExt = logConfigExt;
+    return this;
+  }
+
+  public StartupCommandBuilder tcConfigs(Path... tcConfigs) {
+    this.tcConfigs = tcConfigs;
+    return this;
+  }
+
+  public StartupCommandBuilder clusterName(String clusterName) {
+    this.clusterName = clusterName;
+    return this;
+  }
+
+  public StartupCommandBuilder license(Path licensePath) {
+    this.licensePath = licensePath;
+    return this;
+  }
+
+  public StartupCommandBuilder stripeName(String stripeName) {
+    this.stripeId = Integer.parseInt(stripeName.substring(6));
+    return this;
+  }
+
+  protected void installServer() throws IOException {
+    // Create a copy of the server for this installation.
+    Files.createDirectories(serverWorkingDir);
+
+    //Copy a custom logback configuration
+    Files.copy(this.getClass().getResourceAsStream("/tc-logback.xml"), serverWorkingDir.resolve("logback-test.xml"), REPLACE_EXISTING);
+
+    if (logConfigExt != null) {
+      InputStream logExt = this.getClass().getResourceAsStream("/" + logConfigExt);
+      if (logExt != null) {
+        Files.copy(logExt, serverWorkingDir.resolve("logback-ext-test.xml"), REPLACE_EXISTING);
+      }
+    }
+  }
+
+  /**
+   * Returns a normalized absolute path to the shell/bat script, and quotes the windows path to avoid issues with special path chars.
+   * @param scriptPath path to the script from the base kit
+   * @return string representation of processed path
+   */
+  protected String getAbsolutePath(Path scriptPath) {
+    Path basePath =  serverWorkingDir.resolve(kitDir).resolve(scriptPath).toAbsolutePath().normalize();
+    return isWindows() ? "\"" + basePath + ".bat\"" : basePath + ".sh";
+  }
+
+  public abstract String[] build();
+
+  public Path getKitDir() {
+    return kitDir;
+  }
+
+  public Path getServerWorkingDir() {
+    return serverWorkingDir;
+  }
+
+  public String getLogConfigExt() {
+    return logConfigExt;
+  }
+
+  public String getServerName() {
+    return serverName;
+  }
+
+  public boolean isConsistentStartup() {
+    return consistentStartup;
+  }
+
+  public Path[] getTcConfigs() {
+    return tcConfigs.clone();
+  }
+
+  public int getDebugPort() {
+    return debugPort;
+  }
+
+  public int getPort() {
+    return port;
+  }
+
+  public int getStripeId() {
+    return stripeId;
+  }
+
+  public String getClusterName() {
+    return clusterName;
+  }
+
+  public Path getLicensePath() {
+    return licensePath;
+  }
+}

--- a/galvan-platform-support/src/main/java/org/terracotta/testing/config/TcConfigBuilder.java
+++ b/galvan-platform-support/src/main/java/org/terracotta/testing/config/TcConfigBuilder.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.testing.config;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+public class TcConfigBuilder {
+  private final List<String> serverNames;
+  private final List<Integer> serverPorts;
+  private final List<Integer> serverGroupPorts;
+  private final String namespaceFragment;
+  private final String serviceFragment;
+  private final int clientReconnectWindow;
+  private final int voterCount;
+  private final Properties tcProperties = new Properties();
+
+  public TcConfigBuilder(List<String> serverNames, List<Integer> serverPorts, List<Integer> serverGroupPorts,
+                         Properties tcProperties, String namespaceFragment, String serviceFragment, int clientReconnectWindow, int voterCount) {
+    this.serverNames = serverNames;
+    this.serverPorts = serverPorts;
+    this.serverGroupPorts = serverGroupPorts;
+    this.tcProperties.putAll(tcProperties);
+    this.namespaceFragment = namespaceFragment;
+    this.serviceFragment = serviceFragment;
+    this.clientReconnectWindow = clientReconnectWindow;
+    this.voterCount = voterCount;
+  }
+
+  public String build() {
+    String namespaces = ((null != namespaceFragment) ? namespaceFragment : "");
+
+    String pre =
+        "<tc-config xmlns=\"http://www.terracotta.org/config\" " + namespaces + ">\n"
+            + "  <plugins>\n";
+    String services = ((null != this.serviceFragment) ? this.serviceFragment : "");
+    String postservices =
+        "  </plugins>\n" +
+            "  <tc-properties>\n";
+    StringBuilder properties = new StringBuilder();
+    for (Map.Entry<Object, Object> entry : tcProperties.entrySet()) {
+      properties.append("    <property name=\"").append(entry.getKey()).append("\" value=\"").append(entry.getValue()).append("\"/>\n");
+    }
+    String postProperties = "  </tc-properties>\n"
+        + "  <servers>\n";
+    StringBuilder servers = new StringBuilder();
+    for (int i = 0; i < serverNames.size(); i++) {
+      String serverName = serverNames.get(i);
+      Integer port = serverPorts.get(i);
+      Integer groupPort = serverGroupPorts.get(i);
+      String oneServer =
+          "    <server host=\"localhost\" name=\"" + serverName + "\">\n"
+              + "      <logs>logs</logs>\n"
+              + "      <tsa-port>" + port + "</tsa-port>\n"
+              + "      <tsa-group-port>" + groupPort + "</tsa-group-port>\n"
+              + "    </server>\n";
+      servers.append(oneServer);
+    }
+    String post =
+        "    <client-reconnect-window>" + clientReconnectWindow + "</client-reconnect-window>\n"
+            + "  </servers>\n"
+            + "  <failover-priority>\n"
+            + (voterCount == ConfigConstants.DEFAULT_VOTER_COUNT ?
+            "    <availability/>\n" :
+            "    <consistency>\n" +
+                "      <voter count=\"" + voterCount + "\"/>\n" +
+                "    </consistency>\n")
+            + "  </failover-priority>\n"
+            + "</tc-config>\n";
+    return pre + services + postservices + properties + postProperties + servers + post;
+  }
+}

--- a/galvan-platform-support/src/main/java/org/terracotta/testing/master/BasicHarnessEntry.java
+++ b/galvan-platform-support/src/main/java/org/terracotta/testing/master/BasicHarnessEntry.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.testing.master;
+
+import org.terracotta.port_locking.LockingPortChooser;
+import org.terracotta.port_locking.LockingPortChoosers;
+import org.terracotta.testing.api.BasicTestClusterConfiguration;
+import org.terracotta.testing.common.Assert;
+import org.terracotta.testing.config.BasicClientArgumentBuilder;
+import org.terracotta.testing.config.ClientsConfiguration;
+import org.terracotta.testing.config.ClusterInfo;
+import org.terracotta.testing.config.ConfigRepoStartupBuilder;
+import org.terracotta.testing.config.StartupCommandBuilder;
+import org.terracotta.testing.config.StripeConfiguration;
+import org.terracotta.testing.config.TcConfigBuilder;
+import org.terracotta.testing.logging.VerboseManager;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.terracotta.testing.config.ConfigConstants.DEFAULT_SERVER_HEAP_MB;
+
+/**
+ * The harness entry-point for the harness running {@link BasicTestClusterConfiguration} tests.
+ */
+public class BasicHarnessEntry extends AbstractHarnessEntry<BasicTestClusterConfiguration> {
+  private static final LockingPortChooser PORT_CHOOSER = LockingPortChoosers.getFileLockingPortChooser();
+
+  // Run the one configuration.
+  @Override
+  protected void runOneConfiguration(VerboseManager verboseManager, DebugOptions debugOptions, CommonHarnessOptions harnessOptions,
+                                     BasicTestClusterConfiguration runConfiguration) throws IOException, GalvanFailureException {
+    int stripeSize = runConfiguration.serversInStripe;
+    Assert.assertTrue(stripeSize > 0);
+
+    List<String> serverNames = new ArrayList<>();
+    List<Integer> serverPorts = new ArrayList<>();
+    List<Integer> serverGroupPorts = new ArrayList<>();
+    List<Integer> serverDebugPorts = new ArrayList<>();
+    int basePort = PORT_CHOOSER.choosePorts(stripeSize * 2).getPort();
+    int serverDebugPortStart = debugOptions.serverDebugPortStart;
+    for (int i = 0; i < stripeSize; i++) {
+      serverNames.add("testServer" + i);
+      serverPorts.add(basePort++);
+      serverGroupPorts.add(basePort++);
+      serverDebugPorts.add(serverDebugPortStart == 0 ? 0 : serverDebugPortStart++);
+    }
+
+    String stripeName = "stripe1";
+    Path stripeInstallationDir = harnessOptions.configTestDir.resolve(stripeName);
+    Files.createDirectory(stripeInstallationDir);
+
+    Path tcConfig = createTcConfig(serverNames, serverPorts, serverGroupPorts, stripeInstallationDir, harnessOptions);
+    VerboseManager stripeVerboseManager = verboseManager.createComponentManager("[" + stripeName + "]");
+
+    StripeConfiguration stripeConfig = new StripeConfiguration(serverDebugPorts, serverPorts, serverGroupPorts, serverNames,
+        stripeName, DEFAULT_SERVER_HEAP_MB, "logback-ext.xml", harnessOptions.serverProperties);
+    TestStateManager stateManager = new TestStateManager();
+    GalvanStateInterlock interlock = new GalvanStateInterlock(verboseManager.createComponentManager("[Interlock]").createHarnessLogger(), stateManager);
+    StripeInstaller stripeInstaller = new StripeInstaller(interlock, stateManager, stripeVerboseManager, stripeConfig);
+    // Configure and install each server in the stripe.
+    for (int i = 0; i < stripeSize; ++i) {
+      String serverName = stripeConfig.getServerNames().get(i);
+      Path serverWorkingDir = stripeInstallationDir.resolve(serverName);
+      Path tcConfigRelative = relativize(serverWorkingDir, tcConfig);
+      Path kitLocationRelative = relativize(serverWorkingDir, harnessOptions.kitOriginPath);
+      // Determine if we want a debug port.
+      int debugPort = stripeConfig.getServerDebugPorts().get(i);
+      StartupCommandBuilder builder = new ConfigRepoStartupBuilder()
+          .tcConfigs(tcConfigRelative)
+          .serverName(serverName)
+          .stripeName(stripeName)
+          .serverWorkingDir(serverWorkingDir)
+          .kitDir(kitLocationRelative)
+          .logConfigExtension("logback-ext.xml");
+      stripeInstaller.installNewServer(serverName, serverWorkingDir, debugPort, builder::build);
+    }
+    ReadyStripe oneStripe = ReadyStripe.configureAndStartStripe(interlock, verboseManager, stripeConfig, stripeInstaller);
+    // We just want to unwrap this, directly.
+    IMultiProcessControl processControl = oneStripe.getStripeControl();
+    String connectUri = oneStripe.getStripeUri();
+    ClusterInfo clusterInfo = oneStripe.getClusterInfo();
+    Assert.assertTrue(null != processControl);
+    Assert.assertTrue(null != connectUri);
+
+    // The cluster is now running so install and run the clients.
+    BasicClientArgumentBuilder argBuilder = new BasicClientArgumentBuilder(harnessOptions.testClassName, harnessOptions.errorClassName);
+    ClientsConfiguration clientsConfiguration = new ClientsConfiguration(harnessOptions.configTestDir, harnessOptions.clientClassPath,
+        harnessOptions.clientsToCreate, argBuilder, connectUri, 1, stripeSize, debugOptions.setupClientDebugPort,
+        debugOptions.destroyClientDebugPort, debugOptions.testClientDebugPortStart, harnessOptions.failOnLog, clusterInfo);
+    VerboseManager clientsVerboseManager = verboseManager.createComponentManager("[Clients]");
+
+    new ClientSubProcessManager(interlock, stateManager, clientsVerboseManager, clientsConfiguration, processControl).start();
+    // NOTE:  waitForFinish() throws GalvanFailureException on failure.
+    try {
+      stateManager.waitForFinish();
+    } finally {
+      // No matter what happened, shut down the test.
+      interlock.forceShutdown();
+    }
+  }
+
+  private Path relativize(Path root, Path other) {
+    return root.toAbsolutePath().relativize(other.toAbsolutePath());
+  }
+
+  private Path createTcConfig(List<String> serverNames, List<Integer> serverPorts, List<Integer> serverGroupPorts,
+                              Path stripeInstallationDir, CommonHarnessOptions harnessOpts) {
+    TcConfigBuilder configBuilder = new TcConfigBuilder(serverNames, serverPorts, serverGroupPorts, harnessOpts.tcProperties,
+        harnessOpts.namespaceFragment, harnessOpts.serviceFragment, harnessOpts.clientReconnectWindow, harnessOpts.voterCount);
+    String tcConfig = configBuilder.build();
+    try {
+      Path tcConfigPath = Files.createFile(stripeInstallationDir.resolve("tc-config.xml"));
+      Files.write(tcConfigPath, tcConfig.getBytes(UTF_8));
+      return tcConfigPath;
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+}

--- a/galvan-platform-support/src/main/java/org/terracotta/testing/master/BasicHarnessMain.java
+++ b/galvan-platform-support/src/main/java/org/terracotta/testing/master/BasicHarnessMain.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.testing.master;
+
+import org.terracotta.testing.api.BasicTestClusterConfiguration;
+import org.terracotta.testing.api.ITestMaster;
+import org.terracotta.testing.logging.VerboseManager;
+
+import java.io.IOException;
+
+/**
+ * The main class for tests running as a basic stand-alone test (running the harness directly, not part of JUnit).
+ * <p>
+ * While not typically used, it does persist as an example of how to run a single test on its own.
+ */
+public class BasicHarnessMain {
+  public static void main(String[] args) throws IOException {
+    // Parse required command-line args.
+    EnvironmentOptions environmentOptions = CommandLineSupport.parseEnvironmentOptions(args);
+    String parsedMasterClass = CommandLineSupport.parseTestMasterClass(args);
+
+    if (environmentOptions.isValid() && (null != parsedMasterClass)) {
+      // Determine if any debug options were given (these are all optional).
+      DebugOptions debugOptions = CommandLineSupport.parseDebugOptions(args);
+      VerboseManager verboseManager = CommandLineSupport.parseVerbose(args);
+      // Get the master given by the user.
+      ITestMaster<BasicTestClusterConfiguration> master = null;
+      try {
+        master = CommandLineSupport.loadMaster(parsedMasterClass);
+      } catch (Exception e) {
+        System.err.println("FATAL: ITestMaster \"" + parsedMasterClass + "\" could not be used: " + e.getLocalizedMessage());
+        e.printStackTrace();
+        System.exit(1);
+      }
+      try {
+        BasicHarnessEntry harness = new BasicHarnessEntry();
+        harness.runTestHarness(environmentOptions, master, debugOptions, verboseManager);
+        System.out.println("TEST RUN SUCCESSFUL!");
+      } catch (GalvanFailureException e) {
+        System.out.println("TEST FAILED! " + e.getLocalizedMessage());
+        e.printStackTrace();
+        System.exit(2);
+      }
+    } else {
+      System.err.println(CommandLineSupport.getUsageString());
+      System.exit(1);
+    }
+  }
+}

--- a/galvan-platform-support/src/main/java/org/terracotta/testing/rules/BasicExternalCluster.java
+++ b/galvan-platform-support/src/main/java/org/terracotta/testing/rules/BasicExternalCluster.java
@@ -1,0 +1,416 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.testing.rules;
+
+import com.tc.util.Assert;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+import org.terracotta.connection.Connection;
+import org.terracotta.connection.ConnectionException;
+import org.terracotta.connection.ConnectionFactory;
+import org.terracotta.passthrough.IClusterControl;
+import org.terracotta.port_locking.LockingPortChooser;
+import org.terracotta.port_locking.LockingPortChoosers;
+import org.terracotta.testing.config.ConfigFileStartupBuilder;
+import org.terracotta.testing.config.ConfigRepoStartupBuilder;
+import org.terracotta.testing.config.StartupCommandBuilder;
+import org.terracotta.testing.config.StripeConfiguration;
+import org.terracotta.testing.config.TcConfigBuilder;
+import org.terracotta.testing.logging.ContextualLogger;
+import org.terracotta.testing.logging.VerboseLogger;
+import org.terracotta.testing.logging.VerboseManager;
+import org.terracotta.testing.master.FileHelpers;
+import org.terracotta.testing.master.GalvanFailureException;
+import org.terracotta.testing.master.GalvanStateInterlock;
+import org.terracotta.testing.master.ReadyStripe;
+import org.terracotta.testing.master.StripeInstaller;
+import org.terracotta.testing.master.TestStateManager;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+import java.util.Set;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.terracotta.testing.config.ConfigConstants.DEFAULT_CLUSTER_NAME;
+
+class BasicExternalCluster extends Cluster {
+  private static final LockingPortChooser PORT_CHOOSER = LockingPortChoosers.getFileLockingPortChooser();
+
+  private final Path clusterDirectory;
+  private final int stripeSize;
+  private final Set<Path> serverJars;
+  private final String namespaceFragment;
+  private final String serviceFragment;
+  private final int clientReconnectWindow;
+  private final int voterCount;
+  private final boolean consistentStart;
+  private final Properties tcProperties = new Properties();
+  private final Properties systemProperties = new Properties();
+  private final String logConfigExt;
+  private final int serverHeapSize;
+  private final boolean activate;
+
+  private String displayName;
+  private ReadyStripe cluster;
+  private GalvanStateInterlock interlock;
+  private TestStateManager stateManager;
+  // Note that the clientThread is actually the main thread of the JUnit runner.
+  private final Thread clientThread;
+  // We keep a flag to describe whether or not we are currently trying to interrupt the clientThread during what is
+  // probably its join on shepherdingThread (as that can be ignored).
+  private volatile boolean isInterruptingClient;
+  private Thread shepherdingThread;
+  private boolean isSafe;
+
+  BasicExternalCluster(Path clusterDirectory, int stripeSize, Set<Path> serverJars, String namespaceFragment,
+                       String serviceFragment, int clientReconnectWindow, int voterCount, boolean consistentStart, Properties tcProperties,
+                       Properties systemProperties, String logConfigExt, int serverHeapSize, boolean activate) {
+    if (Files.exists(clusterDirectory)) {
+      if (Files.isRegularFile(clusterDirectory)) {
+        throw new IllegalArgumentException("Cluster directory is a file: " + clusterDirectory);
+      }
+    } else {
+      boolean didCreateDirectories = clusterDirectory.toFile().mkdirs();
+      if (!didCreateDirectories) {
+        throw new IllegalArgumentException("Cluster directory could not be created: " + clusterDirectory);
+      }
+    }
+
+    this.clusterDirectory = clusterDirectory;
+    this.stripeSize = stripeSize;
+    this.namespaceFragment = namespaceFragment;
+    this.serviceFragment = serviceFragment;
+    this.serverJars = serverJars;
+    this.clientReconnectWindow = clientReconnectWindow;
+    this.voterCount = voterCount;
+    this.consistentStart = consistentStart;
+    this.tcProperties.putAll(tcProperties);
+    this.systemProperties.putAll(systemProperties);
+    this.logConfigExt = logConfigExt;
+    this.serverHeapSize = serverHeapSize;
+    this.clientThread = Thread.currentThread();
+    this.activate = activate;
+  }
+
+  @Override
+  public Statement apply(Statement base, Description description) {
+    String methodName = description.getMethodName();
+    Class<?> testClass = description.getTestClass();
+    if (methodName == null) {
+      if (testClass == null) {
+        this.displayName = description.getDisplayName();
+      } else {
+        this.displayName = testClass.getSimpleName();
+      }
+    } else if (testClass == null) {
+      this.displayName = description.getDisplayName();
+    } else {
+      this.displayName = testClass.getSimpleName() + "-" + methodName;
+    }
+    return super.apply(base, description);
+  }
+
+  public void manualStart(String displayName) throws Throwable {
+    this.displayName = displayName;
+    internalStart();
+  }
+
+  @Override
+  protected void before() throws Throwable {
+    internalStart();
+  }
+
+  @SuppressFBWarnings("RV_RETURN_VALUE_IGNORED_BAD_PRACTICE")
+  private void internalStart() throws Throwable {
+    VerboseLogger harnessLogger = new VerboseLogger(System.out, null);
+    VerboseLogger fileHelpersLogger = new VerboseLogger(null, null);
+    VerboseLogger clientLogger = null;
+    VerboseLogger serverLogger = new VerboseLogger(System.out, System.err);
+    VerboseManager verboseManager = new VerboseManager("", harnessLogger, fileHelpersLogger, clientLogger, serverLogger);
+    VerboseManager displayVerboseManager = verboseManager.createComponentManager("[" + displayName + "]");
+
+    String kitInstallationPath = System.getProperty("kitInstallationPath");
+    harnessLogger.output("Using kitInstallationPath: \"" + kitInstallationPath + "\"");
+    Path kitDir = Paths.get(kitInstallationPath);
+    File testParentDir = File.createTempFile(displayName, "", clusterDirectory.toFile());
+    testParentDir.delete();
+    testParentDir.mkdir();
+    String debugPortString = System.getProperty("serverDebugPortStart");
+    int serverDebugStartPort = debugPortString != null ? Integer.parseInt(debugPortString) : 0;
+
+    stateManager = new TestStateManager();
+    interlock = new GalvanStateInterlock(verboseManager.createComponentManager("[Interlock]").createHarnessLogger(), stateManager);
+
+    List<String> serverNames = new ArrayList<>();
+    List<Integer> serverPorts = new ArrayList<>();
+    List<Integer> serverGroupPorts = new ArrayList<>();
+    List<Integer> serverDebugPorts = new ArrayList<>();
+    int basePort = PORT_CHOOSER.choosePorts(stripeSize * 2).getPort();
+    for (int i = 0; i < stripeSize; i++) {
+      serverNames.add("testServer" + i);
+      serverPorts.add(basePort++);
+      serverGroupPorts.add(basePort++);
+      serverDebugPorts.add(serverDebugStartPort == 0 ? 0 : serverDebugStartPort++);
+    }
+
+    String stripeName = "stripe1";
+    Path stripeInstallationDir = testParentDir.toPath().resolve(stripeName);
+    Files.createDirectory(stripeInstallationDir);
+
+    VerboseManager stripeVerboseManager = displayVerboseManager.createComponentManager("[" + stripeName + "]");
+
+    Path tcConfig = createTcConfig(serverNames, serverPorts, serverGroupPorts, stripeInstallationDir);
+    Path kitLocation = installKit(stripeVerboseManager, kitDir, serverJars, stripeInstallationDir);
+
+    StripeConfiguration stripeConfig = new StripeConfiguration(serverDebugPorts, serverPorts, serverGroupPorts, serverNames,
+        stripeName, serverHeapSize, logConfigExt, systemProperties);
+    StripeInstaller stripeInstaller = new StripeInstaller(interlock, stateManager, stripeVerboseManager, stripeConfig);
+    // Configure and install each server in the stripe.
+    for (int i = 0; i < stripeSize; ++i) {
+      String serverName = serverNames.get(i);
+      Path serverWorkingDir = stripeInstallationDir.resolve(serverName);
+      Path tcConfigRelative = relativize(serverWorkingDir, tcConfig);
+      Path kitLocationRelative = relativize(serverWorkingDir, kitLocation);
+      // Determine if we want a debug port.
+      int debugPort = stripeConfig.getServerDebugPorts().get(i);
+
+      StartupCommandBuilder baseStartupBuilder;
+      if (activate) {
+        baseStartupBuilder = new ConfigRepoStartupBuilder().clusterName(DEFAULT_CLUSTER_NAME);
+      } else {
+        baseStartupBuilder = new ConfigFileStartupBuilder().port(stripeConfig.getServerPorts().get(i));
+      }
+
+      StartupCommandBuilder builder = baseStartupBuilder
+          .tcConfigs(tcConfigRelative)
+          .stripeName(stripeName)
+          .serverName(serverName)
+          .serverWorkingDir(serverWorkingDir)
+          .kitDir(kitLocationRelative)
+          .logConfigExtension(logConfigExt)
+          .consistentStartup(consistentStart);
+      stripeInstaller.installNewServer(serverName, serverWorkingDir, debugPort, builder::build);
+    }
+
+    cluster = ReadyStripe.configureAndStartStripe(interlock, stripeVerboseManager, stripeConfig, stripeInstaller);
+    // Spin up an extra thread to call waitForFinish on the stateManager.
+    // This is required since galvan expects that the client is running in a different thread (different process, usually)
+    // than the framework, and the framework waits for the finish so that it can terminate the clients/servers if any of
+    // them trigger an unexpected failure.
+    // Without this, the client will hang in the case when the server crashes since nobody is running the logic to detect
+    // that.
+    Assert.assertTrue(null == this.shepherdingThread);
+    this.shepherdingThread = new Thread(() -> {
+      setSafeForRun(true);
+      boolean didPass;
+      try {
+        stateManager.waitForFinish();
+        didPass = true;
+      } catch (GalvanFailureException e) {
+        didPass = false;
+      }
+      // Whether we passed or failed, bring everything down.
+      try {
+        interlock.forceShutdown();
+      } catch (GalvanFailureException e) {
+        e.printStackTrace();
+        didPass = false;
+      }
+      setSafeForRun(false);
+      if (!didPass) {
+        // Typically, we want to interrupt the thread running as the "client" as it might be stuck in a connection
+        // attempt, etc.  When Galvan is run in the purely multi-process mode, this is typically where all
+        // sub-processes would be terminated.  Since we are running the client as another thread, in-process, the
+        // best we can do is interrupt it from a lower-level blocking call.
+        // NOTE:  the "client" is also the thread which created us and will join on our termination, before
+        // returning back to the user code so it is possible that this interruption could be experienced in its
+        // join() call (in which case, we can safely ignore it).
+        isInterruptingClient = true;
+        clientThread.interrupt();
+      }
+    });
+    this.shepherdingThread.setName("Shepherding Thread");
+    this.shepherdingThread.start();
+    waitForSafe();
+  }
+
+  private Path relativize(Path root, Path other) {
+    return root.toAbsolutePath().relativize(other.toAbsolutePath());
+  }
+
+  private Path createTcConfig(List<String> serverNames, List<Integer> serverPorts, List<Integer> serverGroupPorts,
+                              Path stripeInstallationDir) {
+    TcConfigBuilder configBuilder = new TcConfigBuilder(serverNames, serverPorts, serverGroupPorts, tcProperties,
+        namespaceFragment, serviceFragment, clientReconnectWindow, voterCount);
+    String tcConfig = configBuilder.build();
+    try {
+      Path tcConfigPath = Files.createFile(stripeInstallationDir.resolve("tc-config.xml"));
+      Files.write(tcConfigPath, tcConfig.getBytes(UTF_8));
+      return tcConfigPath;
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+
+  private Path installKit(VerboseManager logger, Path srcKit, Set<Path> extraJars, Path stripeInstall) throws IOException {
+    if (extraJars.isEmpty()) {
+      return srcKit;
+    } else {
+      ContextualLogger clogger = logger.createFileHelpersLogger();
+      Path stripeKit = FileHelpers.createTempCopyOfDirectory(clogger, stripeInstall, "installedKit", srcKit);
+      FileHelpers.copyJarsToServer(clogger, stripeKit, extraJars);
+      return stripeKit;
+    }
+  }
+
+  public void manualStop() {
+    internalStop();
+  }
+
+  @Override
+  protected void after() {
+    internalStop();
+  }
+
+  private void internalStop() {
+    stateManager.setTestDidPassIfNotFailed();
+    // NOTE:  The waitForFinish is called by the shepherding thread so we just join on it having done that.
+    try {
+      this.shepherdingThread.join();
+    } catch (InterruptedException ignorable) {
+      // Note that we both need to join on the shepherding thread (since we created it) but it also tries to interrupt
+      // us in the case where we are stuck somewhere else so this exception is possible.
+      // This confusion is part of the double-duty being done by the thread from the test harness:  running Galvan
+      // _and_ the test.  We split off the Galvan duty to the shepherding thread, so that the test thread can run the
+      // test, but we still need to re-join, at the end.
+      Assert.assertTrue(this.isInterruptingClient);
+      // Clear this flag.
+      this.isInterruptingClient = false;
+      try {
+        this.shepherdingThread.join();
+      } catch (InterruptedException unexpected) {
+        // Interrupts are unexpected at this point - fail.
+        Assert.fail(unexpected.getLocalizedMessage());
+      }
+    }
+    this.shepherdingThread = null;
+  }
+
+  @Override
+  public URI getConnectionURI() {
+    return URI.create(cluster.getStripeUri());
+  }
+
+  @Override
+  public String[] getClusterHostPorts() {
+    return cluster.getStripeUri().substring("terracotta://".length()).split(",");
+  }
+
+  @Override
+  public Connection newConnection() throws ConnectionException {
+    if (!checkSafe()) {
+      throw new ConnectionException(null);
+    }
+    return ConnectionFactory.connect(getConnectionURI(), new Properties());
+  }
+
+  @Override
+  public IClusterControl getClusterControl() {
+    return new IClusterControl() {
+      @Override
+      public void waitForActive() throws Exception {
+        cluster.getStripeControl().waitForActive();
+      }
+
+      @Override
+      public void waitForRunningPassivesInStandby() throws Exception {
+        cluster.getStripeControl().waitForRunningPassivesInStandby();
+      }
+
+      @Override
+      public void startOneServer() throws Exception {
+        cluster.getStripeControl().startOneServer();
+      }
+
+      @Override
+      public void startAllServers() throws Exception {
+        cluster.getStripeControl().startAllServers();
+      }
+
+      @Override
+      public void terminateActive() throws Exception {
+        cluster.getStripeControl().terminateActive();
+      }
+
+      @Override
+      public void terminateOnePassive() throws Exception {
+        cluster.getStripeControl().terminateOnePassive();
+      }
+
+      @Override
+      public void terminateAllServers() throws Exception {
+        cluster.getStripeControl().terminateAllServers();
+      }
+    };
+  }
+
+  private synchronized void setSafeForRun(boolean isSafe) {
+    // Note that this is called in 2 cases:
+    // 1) To state that the shepherding thread is running and we can proceed.
+    // 2) To state that there was a problem and we can't proceed.
+    this.isSafe = isSafe;
+    this.notifyAll();
+  }
+
+  private synchronized void waitForSafe() {
+    boolean interrupted = false;
+    while (!interrupted && !this.isSafe) {
+      try {
+        wait();
+      } catch (InterruptedException e) {
+        interrupted = true;
+      }
+    }
+    if (interrupted) {
+      Thread.currentThread().interrupt();
+    }
+  }
+
+  private synchronized boolean checkSafe() {
+    return this.isSafe;
+  }
+
+  public boolean checkForFailure() throws GalvanFailureException {
+    return stateManager.checkDidPass();
+  }
+
+  public void waitForFinish() throws GalvanFailureException {
+    stateManager.waitForFinish();
+  }
+
+  public void failTestOnServerCrash(boolean value) {
+    interlock.ignoreServerCrashes(value);
+  }
+}

--- a/galvan-platform-support/src/main/java/org/terracotta/testing/rules/BasicExternalClusterBuilder.java
+++ b/galvan-platform-support/src/main/java/org/terracotta/testing/rules/BasicExternalClusterBuilder.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.testing.rules;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.Properties;
+import java.util.Set;
+
+import static org.terracotta.testing.config.ConfigConstants.DEFAULT_CLIENT_RECONNECT_WINDOW;
+import static org.terracotta.testing.config.ConfigConstants.DEFAULT_SERVER_HEAP_MB;
+import static org.terracotta.testing.config.ConfigConstants.DEFAULT_VOTER_COUNT;
+
+public class BasicExternalClusterBuilder {
+  private final int stripeSize;
+
+  private Path clusterDirectory = Paths.get("target").resolve("galvan");
+  private Set<Path> serverJars = Collections.emptySet();
+  private String namespaceFragment = "";
+  private String serviceFragment = "";
+  private int clientReconnectWindowTime = DEFAULT_CLIENT_RECONNECT_WINDOW;
+  private int failoverPriorityVoterCount = DEFAULT_VOTER_COUNT;
+  private boolean consistentStart = false;
+  private Properties tcProperties = new Properties();
+  private Properties systemProperties = new Properties();
+  private String logConfigExt = "logback-ext.xml";
+  private int serverHeapSize = DEFAULT_SERVER_HEAP_MB;
+  private boolean activate = true;
+
+  private BasicExternalClusterBuilder(final int stripeSize) {
+    this.stripeSize = stripeSize;
+  }
+
+  public static BasicExternalClusterBuilder newCluster() {
+    return new BasicExternalClusterBuilder(1);
+  }
+
+  public static BasicExternalClusterBuilder newCluster(int stripeSize) {
+    if (stripeSize < 1) {
+      throw new IllegalArgumentException("Must be at least one server in the cluster");
+    }
+    return new BasicExternalClusterBuilder(stripeSize);
+  }
+
+  public BasicExternalClusterBuilder in(Path clusterDirectory) {
+    if (clusterDirectory == null) {
+      throw new NullPointerException("Cluster directory must be non-null");
+    }
+    this.clusterDirectory = clusterDirectory;
+    return this;
+  }
+
+  public BasicExternalClusterBuilder withServerJars(Set<Path> serverJars) {
+    if (serverJars == null) {
+      throw new NullPointerException("Server JARs list must be non-null");
+    }
+    this.serverJars = serverJars;
+    return this;
+  }
+
+  public BasicExternalClusterBuilder withNamespaceFragment(final String namespaceFragment) {
+    if (namespaceFragment == null) {
+      throw new NullPointerException("Namespace fragment must be non-null");
+    }
+    this.namespaceFragment = namespaceFragment;
+    return this;
+  }
+
+  public BasicExternalClusterBuilder withServiceFragment(final String serviceFragment) {
+    if (serviceFragment == null) {
+      throw new NullPointerException("Service fragment must be non-null");
+    }
+    this.serviceFragment = serviceFragment;
+    return this;
+  }
+
+  public BasicExternalClusterBuilder withClientReconnectWindowTime(final int clientReconnectWindowTime) {
+    this.clientReconnectWindowTime = clientReconnectWindowTime;
+    return this;
+  }
+
+  /**
+   * Zero or any positive value will tune the cluster for consistency and set the respective voter count as provided.
+   * A value of -1 will tune the cluster for availability. This is the default.
+   */
+  public BasicExternalClusterBuilder withFailoverPriorityVoterCount(final int failoverPriorityVoterCount) {
+    this.failoverPriorityVoterCount = failoverPriorityVoterCount;
+    return this;
+  }
+
+  public BasicExternalClusterBuilder withTcProperties(Properties tcProperties) {
+    this.tcProperties.putAll(tcProperties);
+    return this;
+  }
+
+  public BasicExternalClusterBuilder withTcProperty(String key, String value) {
+    this.tcProperties.put(key, value);
+    return this;
+  }
+
+  public BasicExternalClusterBuilder withSystemProperties(Properties props) {
+    this.systemProperties.putAll(props);
+    return this;
+  }
+
+  public BasicExternalClusterBuilder withSystemProperty(String key, String value) {
+    this.systemProperties.put(key, value);
+    return this;
+  }
+
+  public BasicExternalClusterBuilder withServerHeap(int heapSize) {
+    this.serverHeapSize = heapSize;
+    return this;
+  }
+
+  public BasicExternalClusterBuilder logConfigExtensionResourceName(String logConfigExt) {
+    this.logConfigExt = logConfigExt;
+    return this;
+  }
+
+  public BasicExternalClusterBuilder activateCluster(boolean activate) {
+    this.activate = activate;
+    return this;
+  }
+
+  public BasicExternalClusterBuilder withConsistentStartup(boolean consistent) {
+    this.consistentStart = consistent;
+    return this;
+  }
+
+  public Cluster build() {
+    return new BasicExternalCluster(clusterDirectory, stripeSize, serverJars, namespaceFragment, serviceFragment,
+        clientReconnectWindowTime, failoverPriorityVoterCount, consistentStart, tcProperties, systemProperties,
+        logConfigExt, serverHeapSize, activate);
+  }
+}

--- a/galvan-platform-support/src/main/java/org/terracotta/testing/rules/Cluster.java
+++ b/galvan-platform-support/src/main/java/org/terracotta/testing/rules/Cluster.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.testing.rules;
+
+import java.net.URI;
+import org.junit.rules.ExternalResource;
+import org.terracotta.connection.Connection;
+import org.terracotta.connection.ConnectionException;
+import org.terracotta.passthrough.IClusterControl;
+
+public abstract class Cluster extends ExternalResource {
+
+  public abstract URI getConnectionURI();
+
+  public abstract String[] getClusterHostPorts();
+
+  public abstract Connection newConnection() throws ConnectionException;
+
+  public abstract IClusterControl getClusterControl();
+}

--- a/galvan-platform-support/src/main/java/org/terracotta/testing/support/BasicHarnessRunner.java
+++ b/galvan-platform-support/src/main/java/org/terracotta/testing/support/BasicHarnessRunner.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.testing.support;
+
+import java.io.IOException;
+
+import org.terracotta.testing.api.ITestMaster;
+import org.terracotta.testing.api.BasicTestClusterConfiguration;
+import org.terracotta.testing.logging.VerboseManager;
+import org.terracotta.testing.master.BasicHarnessEntry;
+import org.terracotta.testing.master.DebugOptions;
+import org.terracotta.testing.master.EnvironmentOptions;
+import org.terracotta.testing.master.GalvanFailureException;
+
+
+/**
+ * The JUnit harness runner class for all {@link BasicHarnessTest} tests.
+ */
+public class BasicHarnessRunner extends AbstractHarnessRunner<BasicTestClusterConfiguration> {
+  public BasicHarnessRunner(Class<?> testClass) throws InstantiationException, IllegalAccessException {
+    super(testClass);
+  }
+
+  @Override
+  protected void runTest(EnvironmentOptions environmentOptions, ITestMaster<BasicTestClusterConfiguration> masterClass, DebugOptions debugOptions, VerboseManager verboseManager) throws IOException, GalvanFailureException {
+    BasicHarnessEntry harness = new BasicHarnessEntry();
+    harness.runTestHarness(environmentOptions, masterClass, debugOptions, verboseManager);
+  }
+}

--- a/galvan-platform-support/src/main/java/org/terracotta/testing/support/BasicHarnessTest.java
+++ b/galvan-platform-support/src/main/java/org/terracotta/testing/support/BasicHarnessTest.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.testing.support;
+
+import org.junit.runner.RunWith;
+import org.terracotta.testing.api.ITestMaster;
+import org.terracotta.testing.api.BasicTestClusterConfiguration;
+
+@RunWith(value = BasicHarnessRunner.class)
+public abstract class BasicHarnessTest extends AbstractHarnessTest<BasicTestClusterConfiguration> {
+  public abstract ITestMaster<BasicTestClusterConfiguration> getTestMaster();
+}

--- a/management/testing/integration-tests/pom.xml
+++ b/management/testing/integration-tests/pom.xml
@@ -81,9 +81,9 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.terracotta.internal</groupId>
-      <artifactId>galvan-support</artifactId>
-      <version>${terracotta-core.version}</version>
+      <groupId>org.terracotta</groupId>
+      <artifactId>galvan-platform-support</artifactId>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/management/testing/integration-tests/src/test/java/org/terracotta/management/integration/tests/AbstractHATest.java
+++ b/management/testing/integration-tests/src/test/java/org/terracotta/management/integration/tests/AbstractHATest.java
@@ -46,7 +46,6 @@ public abstract class AbstractHATest extends AbstractTest {
       .withServiceFragment(resourceConfig)
       .withSystemProperty("terracotta.management.assert", "true")
       .withTcProperty("terracotta.management.assert", "true")
-      .startupBuilder(DynamicConfigStartupBuilder::new)
       .build();
 
   @Rule

--- a/management/testing/integration-tests/src/test/java/org/terracotta/management/integration/tests/AbstractSingleTest.java
+++ b/management/testing/integration-tests/src/test/java/org/terracotta/management/integration/tests/AbstractSingleTest.java
@@ -43,7 +43,6 @@ public abstract class AbstractSingleTest extends AbstractTest {
       .withSystemProperty("terracotta.management.assert", "true")
       .withTcProperty("terracotta.management.assert", "true")
       .withServiceFragment(resourceConfig)
-      .startupBuilder(DynamicConfigStartupBuilder::new)
       .build();
 
   @Before

--- a/management/testing/integration-tests/src/test/java/org/terracotta/management/integration/tests/NmsAgentServiceIT.java
+++ b/management/testing/integration-tests/src/test/java/org/terracotta/management/integration/tests/NmsAgentServiceIT.java
@@ -69,7 +69,6 @@ public class NmsAgentServiceIT {
       .withSystemProperty("terracotta.management.assert", "true")
       .withTcProperty("terracotta.management.assert", "true")
       .withServiceFragment(resourceConfig)
-      .startupBuilder(DynamicConfigStartupBuilder::new)
       .build();
 
   Connection managementConnection;

--- a/management/testing/integration-tests/src/test/java/org/terracotta/management/integration/tests/SimpleGalvanIT.java
+++ b/management/testing/integration-tests/src/test/java/org/terracotta/management/integration/tests/SimpleGalvanIT.java
@@ -47,7 +47,6 @@ public class SimpleGalvanIT {
       .withSystemProperty("terracotta.management.assert", "true")
       .withTcProperty("terracotta.management.assert", "true")
       .withServiceFragment(RESOURCE_CONFIG)
-      .startupBuilder(DynamicConfigStartupBuilder::new)
       .build();
 
   @BeforeClass

--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,7 @@
     <passthrough-testing.version>1.7.0-pre12</passthrough-testing.version>
     <terracotta-core.version>5.7.0-pre25</terracotta-core.version>
     <tripwire.version>1.0.0-pre7</tripwire.version>
+    <galvan.version>1.5.0-pre3</galvan.version>
     <angela.version>3.0.19</angela.version>
     <statistics.version>2.1</statistics.version>
     <jackson.version>2.10.1</jackson.version>
@@ -61,6 +62,7 @@
     <module>data-root-resource</module>
     <module>diagnostic</module>
     <module>dynamic-config</module>
+    <module>galvan-platform-support</module>
     <module>kit</module>
   </modules>
 
@@ -165,6 +167,11 @@
         <groupId>org.terracotta</groupId>
         <artifactId>monitoring-support</artifactId>
         <version>${terracotta-apis.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.terracotta</groupId>
+        <artifactId>galvan</artifactId>
+        <version>${galvan.version}</version>
       </dependency>
       <dependency>
         <groupId>org.terracotta</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
     <passthrough-testing.version>1.7.0-pre12</passthrough-testing.version>
     <terracotta-core.version>5.7.0-pre25</terracotta-core.version>
     <tripwire.version>1.0.0-pre7</tripwire.version>
-    <angela.version>3.0.18</angela.version>
+    <angela.version>3.0.19</angela.version>
     <statistics.version>2.1</statistics.version>
     <jackson.version>2.10.1</jackson.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
1. Bumped to latest angela and use angela APIs to detect stopped servers
2. Added `galvan-platform-support` module to avoid class duplication and the need to supply a `StartupCommandBuilder` in downstream projects.