### PR TITLE
Maven: fixing kit creation profiles, changed -Pfast to -Dfast

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,31 +24,25 @@ resources:
       name: terracotta/terracotta
 
 jobs:
-  - template: build-templates/maven-common.yml@templates
-    parameters:
-      jdkVersion: '1.8'
-      jobName: 'linux_java_8'
-      timeoutInMinutes: 120
-      vmImage: 'ubuntu-latest'
-      options: '-B'
-  - template: build-templates/maven-common.yml@templates
-    parameters:
-      jdkVersion: '1.8'
-      jobName: 'linux_java_11'
-      timeoutInMinutes: 120
-      vmImage: 'ubuntu-latest'
-      options: '-B -Dazure_linux_java_11'
-  - template: build-templates/maven-common.yml@templates
-    parameters:
-      jdkVersion: '1.8'
-      jobName: 'windows_java_8'
-      timeoutInMinutes: 120
-      vmImage: 'windows-latest'
-      options: '-B'
-  - template: build-templates/maven-common.yml@templates
-    parameters:
-      jdkVersion: '1.8'
-      jobName: 'windows_java_11'
-      timeoutInMinutes: 120
-      vmImage: 'windows-latest'
-      options: '-B -Dazure_windows_java_11'
+- template: build-templates/maven-common.yml@templates
+  parameters:
+    jobName: 'Linux_Java_8'
+    timeoutInMinutes: 120
+- template: build-templates/maven-common.yml@templates
+  parameters:
+    jobName: 'Linux_Java_11'
+    timeoutInMinutes: 120
+    options: '-B -Djava.test.version=1.11'
+- template: build-templates/maven-common.yml@templates
+  parameters:
+    jobName: 'Windows_Java_8'
+    timeoutInMinutes: 180
+    vmImage: 'windows-latest'
+- template: build-templates/maven-common.yml@templates
+  parameters:
+    jobName: 'Windows_Java_11'
+    timeoutInMinutes: 180
+    vmImage: 'windows-latest'
+    options: '-B -Djava.test.version=1.11'
+
+

--- a/dynamic-config/testing/system-tests/pom.xml
+++ b/dynamic-config/testing/system-tests/pom.xml
@@ -157,18 +157,10 @@
             <angela.distribution>${project.version}</angela.distribution>
             <angela.kitInstallationDir>${project.build.directory}/platform-kit-${project.version}</angela.kitInstallationDir>
             <angela.java.vendor/> <!--empty to allow any vendor-->
-            <angela.java.version>${toolchain.provider.version}</angela.java.version>
+            <angela.java.version>${java.test.version}</angela.java.version>
             <!--<angela.java.opts>-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005</angela.java.opts>-->
           </systemPropertyVariables>
         </configuration>
-        <executions>
-          <execution>
-            <goals>
-              <goal>integration-test</goal>
-              <goal>verify</goal>
-            </goals>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>

--- a/kit/pom.xml
+++ b/kit/pom.xml
@@ -219,23 +219,15 @@
           </execution>
         </executions>
       </plugin>
-
-    </plugins>
-  </build>
-
-  <profiles>
-
-    <profile>
-      <!-- builds a kit with all libraries exploded -->
-      <id>kit-v1</id>
-      <activation>
-        <activeByDefault>true</activeByDefault>
-      </activation>
-      <build>
-        <plugins>
-          <!-- apply the platform Kit layout -->
-          <plugin>
-            <artifactId>maven-assembly-plugin</artifactId>
+      <plugin>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>platform-kit</id>
+            <phase>package</phase>
+            <goals>
+              <goal>single</goal>
+            </goals>
             <configuration>
               <appendAssemblyId>false</appendAssemblyId>
               <tarLongFileMode>posix</tarLongFileMode>
@@ -244,20 +236,13 @@
                 <descriptor>src/main/assembly/platform-kit-v1.xml</descriptor>
               </descriptors>
             </configuration>
-            <executions>
-              <execution>
-                <id>platform-kit</id>
-                <phase>package</phase>
-                <goals>
-                  <goal>single</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 
+  <profiles>
     <profile>
       <!-- builds a nice kit -->
       <id>kit-v2</id>
@@ -680,14 +665,6 @@
           <!-- apply the platform Kit layout -->
           <plugin>
             <artifactId>maven-assembly-plugin</artifactId>
-            <configuration>
-              <appendAssemblyId>false</appendAssemblyId>
-              <tarLongFileMode>posix</tarLongFileMode>
-              <attach>true</attach>
-              <descriptors>
-                <descriptor>src/main/assembly/platform-kit-v2.xml</descriptor>
-              </descriptors>
-            </configuration>
             <executions>
               <execution>
                 <id>platform-kit</id>
@@ -695,6 +672,14 @@
                 <goals>
                   <goal>single</goal>
                 </goals>
+                <configuration>
+                  <appendAssemblyId>false</appendAssemblyId>
+                  <tarLongFileMode>posix</tarLongFileMode>
+                  <attach>true</attach>
+                  <descriptors>
+                    <descriptor>src/main/assembly/platform-kit-v2.xml</descriptor>
+                  </descriptors>
+                </configuration>
               </execution>
             </executions>
           </plugin>

--- a/management/testing/integration-tests/pom.xml
+++ b/management/testing/integration-tests/pom.xml
@@ -176,14 +176,6 @@
 <!--            <serverDebugPortStart>5005</serverDebugPortStart>-->
           </systemPropertyVariables>
         </configuration>
-        <executions>
-          <execution>
-            <goals>
-              <goal>integration-test</goal>
-              <goal>verify</goal>
-            </goals>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>

--- a/pom.xml
+++ b/pom.xml
@@ -39,8 +39,8 @@
     <jackson.version>2.10.1</jackson.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <java.version>1.8</java.version>
-    <toolchain.provider.version>1.8</toolchain.provider.version>
+    <java.build.version>1.8</java.build.version>
+    <java.test.version>${java.build.version}</java.test.version>
   </properties>
 
   <modules>
@@ -262,8 +262,8 @@
           <artifactId>maven-compiler-plugin</artifactId>
           <version>3.8.1</version>
           <configuration>
-            <source>${java.version}</source>
-            <target>${java.version}</target>
+            <source>${java.build.version}</source>
+            <target>${java.build.version}</target>
             <compilerArgs>
               <arg>-Xlint:all</arg>
               <arg>-Werror</arg>
@@ -277,6 +277,14 @@
           <configuration>
             <trimStackTrace>false</trimStackTrace>
           </configuration>
+          <executions>
+            <execution>
+              <goals>
+                <goal>integration-test</goal>
+                <goal>verify</goal>
+              </goals>
+            </execution>
+          </executions>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -304,7 +312,7 @@
           <configuration>
             <toolchains>
               <jdk>
-                <version>${toolchain.provider.version}</version>
+                <version>${java.build.version}</version>
               </jdk>
             </toolchains>
           </configuration>
@@ -446,15 +454,17 @@
   </build>
 
   <profiles>
-    <!-- fast profile for local use which will disable the default activated profiles and speed up the build -->
-    <profile>
-      <id>fast</id>
-    </profile>
-    <!-- default profile including toolchain, javadoc, findbugs, license check, enforcer, etc -->
+    <!--
+      default profile including toolchain, javadoc, findbugs, license check, enforcer, etc
+      Use any Maven command with -Dfast to speed up the build - used daily for just compilation and packaging
+    -->
     <profile>
       <id>slow</id>
       <activation>
-        <activeByDefault>true</activeByDefault>
+        <property>
+          <name>fast</name>
+          <value>!true</value>
+        </property>
       </activation>
       <build>
         <plugins>
@@ -484,7 +494,7 @@
                       <uniqueVersions>true</uniqueVersions>
                     </dependencyConvergence>
                     <requireJavaVersion>
-                      <version>[${java.version},)</version>
+                      <version>[${java.build.version},)</version>
                     </requireJavaVersion>
                     <requireMavenVersion>
                       <version>[${maven.version},)</version>
@@ -540,28 +550,25 @@
         </plugins>
       </build>
     </profile>
-    <!-- profile handling support for java versions >=9  -->
+    <!-- profile handling support for java versions >=9 -->
     <profile>
-      <id>azure_linux_java_11</id>
+      <id>java_11</id>
       <activation>
         <property>
-          <name>azure_linux_java_11</name>
+          <name>java.test.version</name>
+          <value>1.11</value>
         </property>
       </activation>
-      <properties>
-        <toolchain.provider.version>1.11</toolchain.provider.version>
-      </properties>
       <build>
         <plugins>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-failsafe-plugin</artifactId>
             <configuration>
-              <trimStackTrace>false</trimStackTrace>
               <argLine>--illegal-access=permit</argLine>
-              <jvm>/usr/lib/jvm/zulu-11-azure-amd64/bin/java</jvm>
+              <jvm>${java}</jvm>
               <environmentVariables>
-                <JAVA_HOME>/usr/lib/jvm/zulu-11-azure-amd64</JAVA_HOME>
+                <JAVA_HOME>${jvm}</JAVA_HOME>
               </environmentVariables>
             </configuration>
           </plugin>
@@ -571,9 +578,9 @@
             <configuration>
               <trimStackTrace>false</trimStackTrace>
               <argLine>--illegal-access=permit</argLine>
-              <jvm>/usr/lib/jvm/zulu-11-azure-amd64/bin/java</jvm>
+              <jvm>${java}</jvm>
               <environmentVariables>
-                <JAVA_HOME>/usr/lib/jvm/zulu-11-azure-amd64</JAVA_HOME>
+                <JAVA_HOME>${jvm}</JAVA_HOME>
               </environmentVariables>
             </configuration>
           </plugin>
@@ -581,43 +588,52 @@
       </build>
     </profile>
     <profile>
+      <id>local_java_11</id>
+      <activation>
+        <property>
+          <name>java.test.version</name>
+          <value>1.11</value>
+        </property>
+        <file>
+          <exists>/Users/matc/.jenv/versions/11.0/bin/java</exists>
+        </file>
+      </activation>
+      <properties>
+        <jvm>/Users/matc/.jenv/versions/11.0</jvm>
+        <java>/Users/matc/.jenv/versions/11.0/bin/java</java>
+      </properties>
+    </profile>
+    <profile>
+      <id>azure_linux_java_11</id>
+      <activation>
+        <property>
+          <name>java.test.version</name>
+          <value>1.11</value>
+        </property>
+        <file>
+          <exists>/usr/lib/jvm/zulu-11-azure-amd64/bin/java</exists>
+        </file>
+      </activation>
+      <properties>
+        <jvm>/usr/lib/jvm/zulu-11-azure-amd64</jvm>
+        <java>/usr/lib/jvm/zulu-11-azure-amd64/bin/java</java>
+      </properties>
+    </profile>
+    <profile>
       <id>azure_windows_java_11</id>
       <activation>
         <property>
-          <name>azure_windows_java_11</name>
+          <name>java.test.version</name>
+          <value>1.11</value>
         </property>
+        <file>
+          <exists>C:\program files\java\zulu-11-azure-jdk_11.33.15-11.0.4-win_x64\bin\java.exe</exists>
+        </file>
       </activation>
       <properties>
-        <toolchain.provider.version>1.11</toolchain.provider.version>
+        <jvm>C:\program files\java\zulu-11-azure-jdk_11.33.15-11.0.4-win_x64</jvm>
+        <java>C:\program files\java\zulu-11-azure-jdk_11.33.15-11.0.4-win_x64\bin\java.exe</java>
       </properties>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-failsafe-plugin</artifactId>
-            <configuration>
-              <trimStackTrace>false</trimStackTrace>
-              <argLine>--illegal-access=permit</argLine>
-              <jvm>C:\program files\java\zulu-11-azure-jdk_11.33.15-11.0.4-win_x64\bin\java.exe</jvm>
-              <environmentVariables>
-                <JAVA_HOME>C:\program files\java\zulu-11-azure-jdk_11.33.15-11.0.4-win_x64</JAVA_HOME>
-              </environmentVariables>
-            </configuration>
-          </plugin>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-surefire-plugin</artifactId>
-            <configuration>
-              <trimStackTrace>false</trimStackTrace>
-              <argLine>--illegal-access=permit</argLine>
-              <jvm>C:\program files\java\zulu-11-azure-jdk_11.33.15-11.0.4-win_x64\bin\java.exe</jvm>
-              <environmentVariables>
-                <JAVA_HOME>C:\program files\java\zulu-11-azure-jdk_11.33.15-11.0.4-win_x64</JAVA_HOME>
-              </environmentVariables>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
     </profile>
   </profiles>
 

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,6 @@
 
   <properties>
     <maven.version>3.2.5</maven.version>
-    <maven-forge-plugin.version>1.2.16</maven-forge-plugin.version>
     <slf4j.version>1.7.25</slf4j.version>
     <logback.version>1.2.3</logback.version>
     <terracotta-apis.version>1.7.0-pre1</terracotta-apis.version>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
   <packaging>pom</packaging>
 
   <properties>
-    <maven.version>3.2.5</maven.version>
+    <maven.version>3.6.3</maven.version>
     <slf4j.version>1.7.25</slf4j.version>
     <logback.version>1.2.3</logback.version>
     <terracotta-apis.version>1.7.0-pre1</terracotta-apis.version>


### PR DESCRIPTION
Changes:

__KIT__

Moved the default kit creation task in the main plugins section, outside of a profile. This is so that the kit-v2 profile overrides it and so that it is compatible with -Dfast. `kit-v2` was not compatible with `fast` before.

- `./mvnw clean install -DskipTests -Dfast` => builds normal kit
- `./mvnw clean install -DskipTests -Dfast -Pkit-v2` => builds a beautiful kit :P

__FAST BUILD__

use `-Dfast` instead of `-Pfast`

__JAVA 11 TESTING__

You can run a normal test with java 8 like that:

`./mvnw verify -f management/testing/integration-tests/pom.xml -Dit.test=DiagnosticIT`

If you want to run it with java 11:

`./mvnw verify -f management/testing/integration-tests/pom.xml -Dit.test=DiagnosticIT -Djava.test.version=1.11`

Note: you will first need to update this profile section in the parent pom to put your own paths:

```
    <profile>
      <id>local_java_11</id>
      <activation>
        <property>
          <name>java.test.version</name>
          <value>1.11</value>
        </property>
        <file>
          <exists>/Users/matc/.jenv/versions/11.0/bin/java</exists>
        </file>
      </activation>
      <properties>
        <jvm>/Users/matc/.jenv/versions/11.0</jvm>
        <java>/Users/matc/.jenv/versions/11.0/bin/java</java>
      </properties>
    </profile>
```

(this workaround is temporary until we have the forge plugin)