### PR TITLE
[WIP] Concurrently run Galvan tests

### DIFF
--- a/dynamic-config/testing/support/src/main/java/org/terracotta/dynamic_config/test_support/DynamicConfigIT.java
+++ b/dynamic-config/testing/support/src/main/java/org/terracotta/dynamic_config/test_support/DynamicConfigIT.java
@@ -94,7 +94,7 @@ import static org.terracotta.dynamic_config.test_support.util.AngelaMatchers.suc
 import static org.terracotta.utilities.test.WaitForAssert.assertThatEventually;
 
 public class DynamicConfigIT {
-  private static Logger LOGGER = LoggerFactory.getLogger(DynamicConfigIT.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(DynamicConfigIT.class);
 
   @Rule public TmpDir tmpDir = new TmpDir(Paths.get(System.getProperty("user.dir"), "target"), false);
   @Rule public PortLockingRule ports;

--- a/management/testing/integration-tests/pom.xml
+++ b/management/testing/integration-tests/pom.xml
@@ -170,6 +170,7 @@
         <groupId>org.terracotta</groupId>
         <artifactId>maven-forge-plugin</artifactId>
         <configuration>
+          <forkCount>1C</forkCount>
           <systemPropertyVariables>
             <kitInstallationPath>${project.build.directory}/platform-kit-${project.version}</kitInstallationPath>
 <!--            <serverDebugPortStart>5005</serverDebugPortStart>-->


### PR DESCRIPTION
This PR runs the management IT tests with Galvan concurrently by spawning one JVM per core to run the tests. 

Azure has 2 cores, so there should be a little improvement in speed.

Locally, here are some tests result with `./mvnw verify -f management/testing/integration-tests/`:

**Test time reduces by 50%:**

Without concurrent tests (master):

```
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  03:51 min
[INFO] Finished at: 2020-04-16T11:35:31-04:00
[INFO] ------------------------------------------------------------------------
```

With concurrent tests (this PR):

```
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:55 min
[INFO] Finished at: 2020-04-16T11:25:56-04:00
[INFO] ------------------------------------------------------------------------
```