### PR TITLE
[TDB-4843] Skip I/O when parsing data directories from XML

### DIFF
--- a/data-root-resource/src/main/java/org/terracotta/config/data_roots/DataRootConfigParser.java
+++ b/data-root-resource/src/main/java/org/terracotta/config/data_roots/DataRootConfigParser.java
@@ -62,7 +62,9 @@ public class DataRootConfigParser implements ExtendedConfigParser {
 
     PathResolver pathResolver = getPathResolver(source);
 
-    return new DataDirectoriesConfigImpl(ParameterSubstitutor::substitute, pathResolver, dataDirectories);
+    // true == skip any file IO when using this parser.
+    // this parser is only used by the migration tool now
+    return new DataDirectoriesConfigImpl(ParameterSubstitutor::substitute, pathResolver, dataDirectories, true);
   }
 
   public Function<Element, DataDirectories> parser() {

--- a/dynamic-config/testing/support/src/main/java/org/terracotta/dynamic_config/test_support/DynamicConfigIT.java
+++ b/dynamic-config/testing/support/src/main/java/org/terracotta/dynamic_config/test_support/DynamicConfigIT.java
@@ -94,7 +94,7 @@ import static org.terracotta.dynamic_config.test_support.util.AngelaMatchers.suc
 import static org.terracotta.utilities.test.WaitForAssert.assertThatEventually;
 
 public class DynamicConfigIT {
-  private static Logger LOGGER = LoggerFactory.getLogger(DynamicConfigIT.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(DynamicConfigIT.class);
 
   @Rule public TmpDir tmpDir = new TmpDir(Paths.get(System.getProperty("user.dir"), "target"), false);
   @Rule public PortLockingRule ports;


### PR DESCRIPTION
This is a bugfix to avoid having directories created in the working directory when the migration CLI is parsing the xml files to convert them in a config repo