### PR TITLE
Making Angela use the lockingPortChooser mechanism

### DIFF
--- a/common/port-locking/src/main/java/org/terracotta/port_locking/LockingPortChooser.java
+++ b/common/port-locking/src/main/java/org/terracotta/port_locking/LockingPortChooser.java
@@ -24,7 +24,7 @@ public class LockingPortChooser {
     this.portLocker = portLocker;
   }
 
-  public MuxPortLock choosePorts(int portCount) {
+  public synchronized MuxPortLock choosePorts(int portCount) {
     while (true) {
       MuxPortLock muxPortLock = tryChoosePorts(portCount);
 

--- a/common/test-utilities/src/main/java/org/terracotta/testing/TmpDir.java
+++ b/common/test-utilities/src/main/java/org/terracotta/testing/TmpDir.java
@@ -57,6 +57,9 @@ public class TmpDir extends ExtendedTestRule {
 
   @Override
   protected void before(Description description) throws Throwable {
+    if (parent != null) {
+      Files.createDirectories(parent);
+    }
     delegate = TemporaryFolder.builder()
         .parentFolder(parent == null ? null : parent.toFile())
         .assureDeletion()

--- a/dynamic-config/testing/support/src/main/java/org/terracotta/dynamic_config/test_support/DynamicConfigIT.java
+++ b/dynamic-config/testing/support/src/main/java/org/terracotta/dynamic_config/test_support/DynamicConfigIT.java
@@ -101,7 +101,7 @@ public class DynamicConfigIT {
   }
 
   public DynamicConfigIT(Duration testTimeout) {
-    this(testTimeout, Paths.get(System.getProperty("user.dir"), "target"));
+    this(testTimeout, Paths.get(System.getProperty("user.dir"), "target", "test-data"));
   }
 
   public DynamicConfigIT(Duration testTimeout, Path parentTmpDir) {

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/AttachInConsistency1x2IT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/AttachInConsistency1x2IT.java
@@ -22,6 +22,8 @@ import org.terracotta.dynamic_config.test_support.ClusterDefinition;
 import org.terracotta.dynamic_config.test_support.DynamicConfigIT;
 import org.terracotta.dynamic_config.test_support.angela.NodeOutputRule;
 
+import java.time.Duration;
+
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
@@ -34,6 +36,10 @@ import static org.terracotta.dynamic_config.test_support.angela.AngelaMatchers.s
 public class AttachInConsistency1x2IT extends DynamicConfigIT {
   @Rule
   public final NodeOutputRule out = new NodeOutputRule();
+
+  public AttachInConsistency1x2IT() {
+    super(Duration.ofSeconds(180));
+  }
 
   @Override
   protected FailoverPriority getFailoverPriority() {

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
     <terracotta-core.version>5.7.0-pre25</terracotta-core.version>
     <tripwire.version>1.0.0-pre7</tripwire.version>
     <galvan.version>1.5.0-pre3</galvan.version>
-    <angela.version>3.0.19</angela.version>
+    <angela.version>3.0.20</angela.version>
     <statistics.version>2.1</statistics.version>
     <jackson.version>2.10.1</jackson.version>
   </properties>


### PR DESCRIPTION
**Rebased on #678**

**Depends on: https://github.com/Terracotta-OSS/angela/pull/42**

**Only look at last commit: https://github.com/Terracotta-OSS/terracotta-platform/pull/679/commits/bd7a3299ec101b27f4540a676baeb2793e2cc08a** (other commits are part of #678)

This PR updates the Angela Junit Rule so that it can provide ports by using the LockingPort mechanism that supports better running test in different forked JVM.