### PR TITLE
Galvan tests were not running with <forkCount>1C</forkCount>

### DIFF
--- a/management/testing/integration-tests/pom.xml
+++ b/management/testing/integration-tests/pom.xml
@@ -175,8 +175,8 @@
         <groupId>org.terracotta</groupId>
         <artifactId>maven-forge-plugin</artifactId>
         <configuration>
+          <forkCount>1C</forkCount>
           <systemPropertyVariables>
-            <forkCount>1C</forkCount>
             <kitInstallationPath>${project.build.directory}/platform-kit-${project.version}</kitInstallationPath>
           </systemPropertyVariables>
         </configuration>


### PR DESCRIPTION
`<forkCount>1C</forkCount>` was in the wrong xml section of the plugin 🙄 