### PR TITLE
Fixing validation in offheap and datadir change handlers

### DIFF
--- a/data-root-resource/pom.xml
+++ b/data-root-resource/pom.xml
@@ -101,6 +101,12 @@
       <artifactId>passthrough-server</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.terracotta.common</groupId>
+      <artifactId>common-test-utilities</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/data-root-resource/src/main/java/org/terracotta/config/data_roots/DataRootsDynamicConfigExtension.java
+++ b/data-root-resource/src/main/java/org/terracotta/config/data_roots/DataRootsDynamicConfigExtension.java
@@ -44,7 +44,7 @@ public class DataRootsDynamicConfigExtension implements DynamicConfigExtension {
     Map<String, Path> dataDirs = nodeContext.getNode().getDataDirs();
     DataDirectoriesConfigImpl dataDirectoriesConfig = new DataDirectoriesConfigImpl(parameterSubstitutor, pathResolver, nodeMetadataDir, dataDirs);
 
-    configChangeHandlerManager.set(Setting.DATA_DIRS, new DataDirectoryConfigChangeHandler(dataDirectoriesConfig));
+    configChangeHandlerManager.set(Setting.DATA_DIRS, new DataDirectoryConfigChangeHandler(dataDirectoriesConfig, parameterSubstitutor, pathResolver));
 
     registrar.registerExtendedConfiguration(dataDirectoriesConfig);
   }

--- a/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/startup/ConfigFileCommandLineProcessor.java
+++ b/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/startup/ConfigFileCommandLineProcessor.java
@@ -22,25 +22,25 @@ import org.terracotta.dynamic_config.api.model.Node;
 import org.terracotta.dynamic_config.api.model.NodeContext;
 import org.terracotta.dynamic_config.api.service.ClusterFactory;
 import org.terracotta.dynamic_config.api.service.IParameterSubstitutor;
-import org.terracotta.dynamic_config.server.configuration.service.ParameterSubstitutor;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
 public class ConfigFileCommandLineProcessor implements CommandLineProcessor {
   private static final Logger LOGGER = LoggerFactory.getLogger(ConfigFileCommandLineProcessor.class);
-  private static final IParameterSubstitutor PARAMETER_SUBSTITUTOR = new ParameterSubstitutor();
 
   private final Options options;
   private final ClusterFactory clusterCreator;
   private final CommandLineProcessor nextStarter;
   private final ConfigurationGeneratorVisitor configurationGeneratorVisitor;
+  private final IParameterSubstitutor parameterSubstitutor;
 
-  ConfigFileCommandLineProcessor(CommandLineProcessor nextStarter, Options options, ClusterFactory clusterCreator, ConfigurationGeneratorVisitor configurationGeneratorVisitor) {
+  ConfigFileCommandLineProcessor(CommandLineProcessor nextStarter, Options options, ClusterFactory clusterCreator, ConfigurationGeneratorVisitor configurationGeneratorVisitor, IParameterSubstitutor parameterSubstitutor) {
     this.options = options;
     this.clusterCreator = clusterCreator;
     this.nextStarter = nextStarter;
     this.configurationGeneratorVisitor = configurationGeneratorVisitor;
+    this.parameterSubstitutor = parameterSubstitutor;
   }
 
   @Override
@@ -51,7 +51,7 @@ public class ConfigFileCommandLineProcessor implements CommandLineProcessor {
       return;
     }
 
-    Path substitutedConfigFile = Paths.get(PARAMETER_SUBSTITUTOR.substitute(options.getConfigFile()));
+    Path substitutedConfigFile = Paths.get(parameterSubstitutor.substitute(options.getConfigFile()));
     LOGGER.info("Starting node from config file: {}", substitutedConfigFile);
     Cluster cluster = clusterCreator.create(substitutedConfigFile);
 

--- a/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/startup/MainCommandLineProcessor.java
+++ b/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/startup/MainCommandLineProcessor.java
@@ -38,7 +38,7 @@ public class MainCommandLineProcessor implements CommandLineProcessor {
   public void process() {
     // Each NodeStarter either handles the startup itself or hands over to the next NodeStarter, following the chain-of-responsibility pattern
     CommandLineProcessor third = new ConsoleCommandLineProcessor(options, clusterCreator, configurationGeneratorVisitor, parameterSubstitutor);
-    CommandLineProcessor second = new ConfigFileCommandLineProcessor(third, options, clusterCreator, configurationGeneratorVisitor);
+    CommandLineProcessor second = new ConfigFileCommandLineProcessor(third, options, clusterCreator, configurationGeneratorVisitor, parameterSubstitutor);
     CommandLineProcessor first = new ConfigRepoCommandLineProcessor(second, options, configurationGeneratorVisitor, parameterSubstitutor);
     first.process();
   }

--- a/dynamic-config/server/configuration-provider/src/test/java/org/terracotta/dynamic_config/server/configuration/startup/CommandLineProcessorChainTest.java
+++ b/dynamic-config/server/configuration-provider/src/test/java/org/terracotta/dynamic_config/server/configuration/startup/CommandLineProcessorChainTest.java
@@ -115,6 +115,7 @@ public class CommandLineProcessorChainTest {
     when(options.getNodeHostname()).thenReturn(HOST_NAME);
     when(options.getNodePort()).thenReturn(NODE_PORT);
     when(clusterCreator.create(Paths.get(CONFIG_FILE))).thenReturn(cluster);
+    when(parameterSubstitutor.substitute(CONFIG_FILE)).thenReturn(CONFIG_FILE);
     when(configurationGeneratorVisitor.getMatchingNodeFromConfigFile(HOST_NAME, NODE_PORT, CONFIG_FILE, cluster)).thenReturn(node1);
     cluster.setName(CLUSTER_NAME);
 
@@ -134,6 +135,7 @@ public class CommandLineProcessorChainTest {
     when(options.getNodeHostname()).thenReturn(HOST_NAME);
     when(options.getNodePort()).thenReturn(NODE_PORT);
     when(clusterCreator.create(Paths.get(CONFIG_FILE))).thenReturn(cluster);
+    when(parameterSubstitutor.substitute(CONFIG_FILE)).thenReturn(CONFIG_FILE);
     when(configurationGeneratorVisitor.getMatchingNodeFromConfigFile(HOST_NAME, NODE_PORT, CONFIG_FILE, cluster)).thenReturn(node1);
     cluster.setName(CLUSTER_NAME);
 
@@ -153,6 +155,7 @@ public class CommandLineProcessorChainTest {
     when(options.getNodeHostname()).thenReturn(HOST_NAME);
     when(options.getNodePort()).thenReturn(NODE_PORT);
     when(clusterCreator.create(Paths.get(CONFIG_FILE))).thenReturn(cluster);
+    when(parameterSubstitutor.substitute(CONFIG_FILE)).thenReturn(CONFIG_FILE);
     when(configurationGeneratorVisitor.getMatchingNodeFromConfigFile(HOST_NAME, NODE_PORT, CONFIG_FILE, cluster)).thenReturn(node1);
     cluster.addStripe(new Stripe(node2));
     cluster.setName(CLUSTER_NAME);
@@ -173,6 +176,7 @@ public class CommandLineProcessorChainTest {
     when(options.getNodeHostname()).thenReturn(HOST_NAME);
     when(options.getNodePort()).thenReturn(NODE_PORT);
     when(clusterCreator.create(Paths.get(CONFIG_FILE))).thenReturn(cluster);
+    when(parameterSubstitutor.substitute(CONFIG_FILE)).thenReturn(CONFIG_FILE);
     when(configurationGeneratorVisitor.getMatchingNodeFromConfigFile(HOST_NAME, NODE_PORT, CONFIG_FILE, cluster)).thenReturn(node1);
     cluster.getSingleStripe().get().attachNode(node2);
 

--- a/dynamic-config/testing/system-tests/pom.xml
+++ b/dynamic-config/testing/system-tests/pom.xml
@@ -160,7 +160,7 @@
         <groupId>org.terracotta</groupId>
         <artifactId>maven-forge-plugin</artifactId>
         <configuration>
-          <forkCount>1C</forkCount>
+          <forkCount>2</forkCount>
           <systemPropertyVariables>
             <angela.rootDir>${project.build.directory}/angela</angela.rootDir>
             <angela.skipUninstall>true</angela.skipUninstall>
@@ -183,7 +183,7 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
         <configuration>
-          <forkCount>1C</forkCount>
+          <forkCount>2</forkCount>
           <systemPropertyVariables>
             <angela.rootDir>${project.build.directory}/angela</angela.rootDir>
             <angela.skipUninstall>true</angela.skipUninstall>

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/AttachCommandWithVoter1x3IT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/AttachCommandWithVoter1x3IT.java
@@ -33,7 +33,6 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.terracotta.angela.client.support.hamcrest.AngelaMatchers.successful;
-import static org.terracotta.utilities.test.WaitForAssert.assertThatEventually;
 
 @ClusterDefinition(nodesPerStripe = 3)
 public class AttachCommandWithVoter1x3IT extends DynamicConfigIT {
@@ -86,8 +85,8 @@ public class AttachCommandWithVoter1x3IT extends DynamicConfigIT {
           getNode(1, passiveId).getHostPort(),
           getNode(1, 3).getHostPort()};
 
-      assertThatEventually(activeVoter::getExistingTopology, containsInAnyOrder(nodes));
-      assertThatEventually(() -> activeVoter.getHeartbeatFutures().size(), is(3));
+      waitUntil(activeVoter::getExistingTopology, containsInAnyOrder(nodes));
+      waitUntil(() -> activeVoter.getHeartbeatFutures().size(), is(3));
 
       // kill the old passive and detach it from cluster
       stopNode(1, passiveId);
@@ -97,8 +96,8 @@ public class AttachCommandWithVoter1x3IT extends DynamicConfigIT {
           getNode(1, activeId).getHostPort(),
           getNode(1, 3).getHostPort()};
 
-      assertThatEventually(activeVoter::getExistingTopology, containsInAnyOrder(nodes));
-      assertThatEventually(() -> activeVoter.getHeartbeatFutures().size(), is(2));
+      waitUntil(activeVoter::getExistingTopology, containsInAnyOrder(nodes));
+      waitUntil(() -> activeVoter.getHeartbeatFutures().size(), is(2));
 
       withTopologyService(1, activeId, topologyService -> assertTrue(topologyService.isActivated()));
       withTopologyService(1, 3, topologyService -> assertTrue(topologyService.isActivated()));
@@ -128,8 +127,8 @@ public class AttachCommandWithVoter1x3IT extends DynamicConfigIT {
           getNode(1, passiveId).getHostPort(),
           getNode(1, 3).getHostPort()};
 
-      assertThatEventually(activeVoter::getExistingTopology, containsInAnyOrder(nodes));
-      assertThatEventually(() -> activeVoter.getHeartbeatFutures().size(), is(3));
+      waitUntil(activeVoter::getExistingTopology, containsInAnyOrder(nodes));
+      waitUntil(() -> activeVoter.getHeartbeatFutures().size(), is(3));
     }
   }
 
@@ -153,8 +152,8 @@ public class AttachCommandWithVoter1x3IT extends DynamicConfigIT {
           getNode(1, passiveId).getHostPort(),
           getNode(1, 3).getHostPort()};
 
-      assertThatEventually(activeVoter::getExistingTopology, containsInAnyOrder(nodes));
-      assertThatEventually(() -> activeVoter.getHeartbeatFutures().size(), is(3));
+      waitUntil(activeVoter::getExistingTopology, containsInAnyOrder(nodes));
+      waitUntil(() -> activeVoter.getHeartbeatFutures().size(), is(3));
 
       withTopologyService(1, activeId, topologyService -> assertTrue(topologyService.isActivated()));
       withTopologyService(1, passiveId, topologyService -> assertTrue(topologyService.isActivated()));

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/DetachCommandWithVoter1x2IT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/DetachCommandWithVoter1x2IT.java
@@ -31,7 +31,6 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.terracotta.angela.client.support.hamcrest.AngelaMatchers.successful;
-import static org.terracotta.utilities.test.WaitForAssert.assertThatEventually;
 
 @ClusterDefinition(nodesPerStripe = 2, autoActivate = true)
 public class DetachCommandWithVoter1x2IT extends DynamicConfigIT {
@@ -61,8 +60,8 @@ public class DetachCommandWithVoter1x2IT extends DynamicConfigIT {
 
       String[] nodes = new String[]{getNode(1, activeId).getHostPort()};
 
-      assertThatEventually(activeVoter::getExistingTopology, containsInAnyOrder(nodes));
-      assertThatEventually(() -> activeVoter.getHeartbeatFutures().size(), is(1));
+      waitUntil(activeVoter::getExistingTopology, containsInAnyOrder(nodes));
+      waitUntil(() -> activeVoter.getHeartbeatFutures().size(), is(1));
 
       withTopologyService(1, activeId, topologyService -> assertTrue(topologyService.isActivated()));
     }
@@ -83,17 +82,20 @@ public class DetachCommandWithVoter1x2IT extends DynamicConfigIT {
 
       String[] nodes = new String[]{getNode(1, activeId).getHostPort()};
 
-      assertThatEventually(activeVoter::getExistingTopology, containsInAnyOrder(nodes));
-      assertThatEventually(() -> activeVoter.getHeartbeatFutures().size(), is(1));
+      waitUntil(activeVoter::getExistingTopology, containsInAnyOrder(nodes));
+      waitUntil(() -> activeVoter.getHeartbeatFutures().size(), is(1));
 
       startNode(1, passiveId);
       waitForDiagnostic(1, passiveId);
 
       assertThat(configToolInvocation("attach", "-d", "localhost:" + getNodePort(1, activeId), "-s", "localhost:" + getNodePort(1, passiveId)), is(successful()));
 
-      nodes = new String[]{getNode(1, passiveId).getHostPort()};
-      assertThatEventually(activeVoter::getExistingTopology, containsInAnyOrder(nodes));
-      assertThatEventually(() -> activeVoter.getHeartbeatFutures().size(), is(2));
+      nodes = new String[]{
+          getNode(1, activeId).getHostPort(),
+          getNode(1, passiveId).getHostPort()
+      };
+      waitUntil(activeVoter::getExistingTopology, containsInAnyOrder(nodes));
+      waitUntil(() -> activeVoter.getHeartbeatFutures().size(), is(2));
 
       withTopologyService(1, activeId, topologyService -> assertTrue(topologyService.isActivated()));
       withTopologyService(1, passiveId, topologyService -> assertTrue(topologyService.isActivated()));

--- a/dynamic-config/testing/system-tests/src/test/resources/logback-ext.xml
+++ b/dynamic-config/testing/system-tests/src/test/resources/logback-ext.xml
@@ -21,4 +21,5 @@
   <!--  <logger name="org.terracotta.persistence.sanskrit" level="TRACE"/>-->
   <!--  <logger name="org.terracotta.nomad" level="TRACE"/>-->
   <!--  <logger name="org.terracotta.diagnostic" level="TRACE"/>-->
+  <!--<logger name="org.terracotta.config.data_roots.DataDirectoryConfigChangeHandler" level="TRACE"/>-->
 </included>

--- a/management/testing/integration-tests/pom.xml
+++ b/management/testing/integration-tests/pom.xml
@@ -175,7 +175,7 @@
         <groupId>org.terracotta</groupId>
         <artifactId>maven-forge-plugin</artifactId>
         <configuration>
-          <forkCount>1C</forkCount>
+          <forkCount>2</forkCount>
           <systemPropertyVariables>
             <kitInstallationPath>${project.build.directory}/platform-kit-${project.version}</kitInstallationPath>
           </systemPropertyVariables>
@@ -190,7 +190,7 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
         <configuration>
-          <forkCount>1C</forkCount>
+          <forkCount>2</forkCount>
           <systemPropertyVariables>
             <kitInstallationPath>${project.build.directory}/platform-kit-${project.version}</kitInstallationPath>
             <!--            <serverDebugPortStart>5005</serverDebugPortStart>-->

--- a/offheap-resource/src/main/java/org/terracotta/offheapresource/OffheapResourceConfigChangeHandler.java
+++ b/offheap-resource/src/main/java/org/terracotta/offheapresource/OffheapResourceConfigChangeHandler.java
@@ -50,11 +50,11 @@ public class OffheapResourceConfigChangeHandler implements ConfigChangeHandler {
       Measure<MemoryUnit> measure = Measure.parse(change.getValue(), MemoryUnit.class);
       String name = change.getKey();
       long newValue = measure.getQuantity(MemoryUnit.B);
-      OffHeapResource offHeapResource = offHeapResources.getOffHeapResource(OffHeapResourceIdentifier.identifier(name));
-      if (offHeapResource != null) {
-        if (newValue <= offHeapResource.capacity()) {
+      Measure<MemoryUnit> existing = baseConfig.getCluster().getOffheapResources().get(name);
+      if (existing != null) {
+        if (newValue <= existing.getQuantity(MemoryUnit.B)) {
           throw new InvalidConfigChangeException("New offheap-resource size: " + change.getValue() +
-              " should be larger than the old size: " + Measure.of(offHeapResource.capacity(), measure.getUnit()));
+              " should be larger than the old size: " + existing);
         }
       }
 


### PR DESCRIPTION
Validation inside config handlers must be done against the topology that is upcoming. 
This topology also gets updated by the previous validated change in case of a multi setting nomad change.