### PR TITLE
Adopt new api

### DIFF
--- a/client-message-tracker/src/main/java/org/terracotta/client/message/tracker/ClientTrackerImpl.java
+++ b/client-message-tracker/src/main/java/org/terracotta/client/message/tracker/ClientTrackerImpl.java
@@ -18,38 +18,77 @@ package org.terracotta.client.message.tracker;
 import org.terracotta.entity.StateDumpCollector;
 
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.function.Predicate;
+import java.util.stream.Stream;
+import org.terracotta.entity.ClientSourceId;
 
-public class ClientTrackerImpl<K, R> implements ClientTracker<K, R> {
+class ClientTrackerImpl<M, R> implements ClientTracker<M, R> {
 
   private final Predicate<?> trackerPolicy;
-  private final ConcurrentMap<K, Tracker<R>> objectTrackers = new ConcurrentHashMap<>();
+  private final ConcurrentMap<ClientSourceId, TrackerImpl<M, R>> objectTrackers = new ConcurrentHashMap<>();
 
   public ClientTrackerImpl(Predicate<?> trackerPolicy) {
     this.trackerPolicy = trackerPolicy;
   }
 
-  @Override
-  public Tracker<R> getTracker(K clientId) {
+  Stream<RecordedMessage<M, R>> getTrackedValues() {
+    Stream<RecordedMessage<M, R>> base = Stream.empty();
+    for (Entry<ClientSourceId, TrackerImpl<M, R>> t : objectTrackers.entrySet()) {
+      base = Stream.concat(base, t.getValue().getTrackedValues().stream().map(e->convert(t.getKey(), e)));
+    }
+    return base;
+  }
+
+  static <M, R> RecordedMessage<M, R> convert(ClientSourceId cid, TrackerImpl.RequestResponse<M, R> rr) {
+    return new RecordedMessage<M, R>() {
+      @Override
+      public long getSequenceId() {
+        return rr.getSequenceId();
+      }
+
+      @Override
+      public ClientSourceId getClientSourceId() {
+        return cid;
+      }
+
+      @Override
+      public long getTransactionId() {
+        return rr.getTransactionId();
+      }
+
+      @Override
+      public M getRequest() {
+        return rr.getRequest();
+      }
+
+      @Override
+      public R getResponse() {
+        return rr.getResponse();
+      }
+    };
+  }
+
+  TrackerImpl<M, R> getTracker(ClientSourceId clientId) {
     return objectTrackers.computeIfAbsent(clientId, d -> new TrackerImpl<>(trackerPolicy));
   }
 
   @Override
-  public void untrackClient(K clientId) {
+  public void untrackClient(ClientSourceId clientId) {
     objectTrackers.remove(clientId);
   }
 
   @Override
-  public Set<K> getTrackedClients() {
+  public Set<ClientSourceId> getTrackedClients() {
     return objectTrackers.keySet();
   }
 
   @Override
   public void addStateTo(StateDumpCollector stateDumper) {
-    for (Map.Entry<K, Tracker<R>> entry : objectTrackers.entrySet()) {
+    for (Map.Entry<ClientSourceId, TrackerImpl<M, R>> entry : objectTrackers.entrySet()) {
       entry.getValue().addStateTo(stateDumper.subStateDumpCollector(entry.getKey().toString()));
     }
   }

--- a/client-message-tracker/src/main/java/org/terracotta/client/message/tracker/OOOMessageHandler.java
+++ b/client-message-tracker/src/main/java/org/terracotta/client/message/tracker/OOOMessageHandler.java
@@ -61,14 +61,29 @@ public interface OOOMessageHandler<M extends EntityMessage, R extends EntityResp
   Stream<ClientSourceId> getTrackedClients();
 
   /**
-   * Get all message id - response mappings for the given {@code clientSourceId} in the given segment
-   *
+   * Get all message id - response mappings for the given {@code clientSourceId} in the given segment.
+   *  Deprecated for future use.  Use getRecordedMessagesForSegment instead
    * @param index the segment index
    * @param clientSourceId a client descriptor
    * @return a map with message id - response mappings
    */
+  @Deprecated
   Map<Long, R> getTrackedResponsesForSegment(int index, ClientSourceId clientSourceId);
 
+  /**
+   * Get a stream of tracked messages ordered by sequence id - Order is important so replay is
+   * sequenced correctly.
+   *
+   * @return a stream of ordered RecordedMessages
+   */
+  Stream<RecordedMessage<M, R>> getRecordedMessages();
+
+  /**
+   * load all the sequenced messages to the current message tracker
+   * 
+   * @param recorded - a stream of recorded messages
+   */
+  void loadRecordedMessages(Stream<RecordedMessage<M, R>> recorded);
   /**
    * Bulk load a set of message ids, response mappings for the given client descriptor  in the given segment.
    * To be used by a passive entity when the active syncs its message tracker data.
@@ -77,17 +92,9 @@ public interface OOOMessageHandler<M extends EntityMessage, R extends EntityResp
    * @param clientSourceId a client descriptor
    * @param trackedResponses a map of message id, response mappings
    */
+  @Deprecated
   void loadTrackedResponsesForSegment(int index, ClientSourceId clientSourceId, Map<Long, R> trackedResponses);
 
-  /**
-   * Bulk load a set of message ids, response mappings for the given client descriptor.
-   * To be used by a passive entity when the active syncs its message tracker data.
-   * The mappings loaded by this message will go to any of the segments but goes to a
-   * special tracker that is common between all segments.
-   *
-   * @param clientSourceId a client descriptor
-   * @param trackedResponses a map of message id, response mappings
-   */
   @Deprecated
   void loadOnSync(ClientSourceId clientSourceId, Map<Long, R> trackedResponses);
 

--- a/client-message-tracker/src/main/java/org/terracotta/client/message/tracker/OOOMessageHandlerImpl.java
+++ b/client-message-tracker/src/main/java/org/terracotta/client/message/tracker/OOOMessageHandlerImpl.java
@@ -25,21 +25,25 @@ import org.terracotta.entity.StateDumpCollector;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.BiFunction;
 import java.util.function.Predicate;
 import java.util.function.ToIntFunction;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.terracotta.client.message.tracker.Tracker.TRACK_ALL;
 
 public class OOOMessageHandlerImpl<M extends EntityMessage, R extends EntityResponse> implements OOOMessageHandler<M, R> {
 
-  private final List<ClientTracker<ClientSourceId, R>> clientMessageTrackers;
+  private final List<ClientTrackerImpl<M, R>> clientMessageTrackers;
   private final Predicate<M> trackerPolicy;
   private final ToIntFunction<M> segmentationStrategy;
   private final DestroyCallback callback;
 
-  private final ClientTracker<ClientSourceId, R> sharedMessageTracker;
+  private final ClientTrackerImpl<M, R> sharedMessageTracker;
+
+  AtomicLong trackid = new AtomicLong();
 
   public OOOMessageHandlerImpl(Predicate<M> trackerPolicy, int segments, ToIntFunction<M> segmentationStrategy, DestroyCallback callback) {
     this.trackerPolicy = trackerPolicy;
@@ -58,14 +62,16 @@ public class OOOMessageHandlerImpl<M extends EntityMessage, R extends EntityResp
     if (trackerPolicy.test(message) && context.isValidClientInformation()) {
       ClientSourceId clientId = context.getClientSource();
       int index = segmentationStrategy.applyAsInt(message);
-      Tracker<R> messageTracker = clientMessageTrackers.get(index).getTracker(clientId);
+      Tracker<M, R> messageTracker = clientMessageTrackers.get(index).getTracker(clientId);
       messageTracker.reconcile(context.getOldestTransactionId());
       R response = messageTracker.getTrackedValue(context.getCurrentTransactionId());
+//      Object request = messageTracker.getTrackedRequest(index);
 
       if (response == null && sharedMessageTracker.getTrackedClients().contains(clientId)) {
-        Tracker<R> sharedTracker = sharedMessageTracker.getTracker(clientId);
+        Tracker<M, R> sharedTracker = sharedMessageTracker.getTracker(clientId);
         sharedTracker.reconcile(context.getOldestTransactionId());
         response = sharedTracker.getTrackedValue(context.getCurrentTransactionId());
+//        request = sharedTracker.getTrackedRequest(index);
       }
 
       if (response != null) {
@@ -73,7 +79,7 @@ public class OOOMessageHandlerImpl<M extends EntityMessage, R extends EntityResp
       }
 
       response = invokeFunction.apply(context, message);
-      messageTracker.track(context.getCurrentTransactionId(), message, response);
+      messageTracker.track(trackid.incrementAndGet(), context.getCurrentTransactionId(), message, response);
       return response;
     } else {
       return invokeFunction.apply(context, message);
@@ -93,22 +99,53 @@ public class OOOMessageHandlerImpl<M extends EntityMessage, R extends EntityResp
         .distinct();
   }
 
-  @Override
-  public Map<Long, R> getTrackedResponsesForSegment(int index, ClientSourceId clientSourceId) {
-    return this.clientMessageTrackers.get(index).getTracker(clientSourceId).getTrackedValues();
+  public R getTrackedResponseForMessage(ClientSourceId source, M message) {
+    int index = segmentationStrategy.applyAsInt(message);
+    return this.clientMessageTrackers.get(index).getTracker(source).getTrackedValue(message);
   }
 
   @Override
-  public void loadTrackedResponsesForSegment(int index, ClientSourceId clientSourceId, Map<Long, R> trackedResponses) {
+  public Stream<RecordedMessage<M, R>> getRecordedMessages() {
+    Stream<RecordedMessage<M, R>> base = Stream.empty();
+    for (ClientTrackerImpl<M, R> ct : clientMessageTrackers) {
+      base = Stream.concat(base, ct.getTrackedValues());
+    }
+    return base.sorted((r1,r2)->(int)(r1.getSequenceId() - r2.getSequenceId()));
+  }
+
+  @Override
+  public void loadRecordedMessages(Stream<RecordedMessage<M, R>> recorded) {
+    recorded.forEach(rm->{
+      clientMessageTrackers.get(segmentationStrategy.applyAsInt(rm.getRequest()))
+              .getTracker(rm.getClientSourceId())
+              .track(rm.getSequenceId(), rm.getTransactionId(), rm.getRequest(), rm.getResponse());
+    });
+  }
+  
+  public R getTrackedResponse(ClientSourceId source, int index, long id) {
+    return this.clientMessageTrackers.get(index).getTracker(source).getTrackedValue(id);
+  }
+  /**
+   * for compatability with old tracker usage
+   */
+  @Override @Deprecated
+  public Map<Long, R> getTrackedResponsesForSegment(int index, ClientSourceId clientSourceId) {
+    return this.clientMessageTrackers.get(index)
+            .getTracker(clientSourceId).getTrackedValues()
+            .stream()
+            .collect(Collectors.toMap(rr->rr.getTransactionId(), rr->rr.getResponse()));
+  }
+
+  @Override @Deprecated
+  public void loadTrackedResponsesForSegment(int index, ClientSourceId clientSourceId,  Map<Long, R> trackedResponses) {
     this.clientMessageTrackers.get(index).getTracker(clientSourceId).loadOnSync(trackedResponses);
   }
 
-  @Deprecated
-  @Override
+  @Override @Deprecated
   public void loadOnSync(ClientSourceId clientSourceId, Map<Long, R> trackedResponses) {
     this.sharedMessageTracker.getTracker(clientSourceId).loadOnSync(trackedResponses);
   }
-
+  
   @Override
   public void destroy() {
     this.callback.destroy();

--- a/client-message-tracker/src/main/java/org/terracotta/client/message/tracker/RecordedMessage.java
+++ b/client-message-tracker/src/main/java/org/terracotta/client/message/tracker/RecordedMessage.java
@@ -15,28 +15,12 @@
  */
 package org.terracotta.client.message.tracker;
 
-import org.terracotta.entity.StateDumpable;
-
-import java.util.Set;
 import org.terracotta.entity.ClientSourceId;
 
-/**
- * Keeps track of the trackers for individual clients.
- */
-interface ClientTracker<M, R> extends StateDumpable {
-
-  /**
-   * Deregister a client from being tracked.
-   *
-   * @param clientId a client id
-   */
-  void untrackClient(ClientSourceId clientId);
-
-  /**
-   * Return ids of all the clients tracked by this tracker.
-   *
-   * @return set of tracked client sources
-   */
-  Set<ClientSourceId> getTrackedClients();
-
+public interface RecordedMessage<M, R> {
+  long getSequenceId();
+  ClientSourceId getClientSourceId();
+  long getTransactionId();
+  M getRequest();
+  R getResponse();
 }

--- a/client-message-tracker/src/main/java/org/terracotta/client/message/tracker/Tracker.java
+++ b/client-message-tracker/src/main/java/org/terracotta/client/message/tracker/Tracker.java
@@ -17,8 +17,8 @@ package org.terracotta.client.message.tracker;
 
 import org.terracotta.entity.StateDumpable;
 
-import java.util.Map;
 import java.util.function.Predicate;
+import java.util.stream.Stream;
 
 /**
  * Keeps track of an entity's objects with their ids and their corresponding values.
@@ -26,7 +26,7 @@ import java.util.function.Predicate;
  *
  * @param <R> type of the value
  */
-interface Tracker<R> extends StateDumpable {
+interface Tracker<M, R> extends StateDumpable {
 
   /**
    * A tracker policy that will track all messages
@@ -47,7 +47,7 @@ interface Tracker<R> extends StateDumpable {
    * @param object Incoming entity object
    * @param value Outgoing entity value
    */
-  void track(long id, Object object, R value);
+  void track(long track, long id, M object, R value);
 
   /**
    * Returns the tracked value associated with the given ID, null otherwise.
@@ -57,6 +57,15 @@ interface Tracker<R> extends StateDumpable {
    */
   R getTrackedValue(long id);
 
+  R getTrackedValue(M message);
+
+  /**
+   * 
+   * @param id Tracked entity ID
+   * @return Tracked entity request
+   */
+  M getTrackedRequest(long id);
+
   /**
    * Clears id-value mappings for all ids less than the provided id.
    *
@@ -65,17 +74,10 @@ interface Tracker<R> extends StateDumpable {
   void reconcile(long id);
 
   /**
-   * Get all id - value mappings.
-
-   * @return all tracked values
-   */
-  Map<Long, R> getTrackedValues();
-
-  /**
    * Bulk load a set of ids, value mappings.
    * To be used by a passive entity when the active syncs its message tracker data.
    *
    * @param trackedValues a map of id, value mappings
    */
-  void loadOnSync(Map<Long, R> trackedValues);
+  void loadOnSync(Stream<RecordedMessage<M, R>> trackedValues);
 }

--- a/client-message-tracker/src/test/java/org/terracotta/client/message/tracker/ClientTrackerImplTest.java
+++ b/client-message-tracker/src/test/java/org/terracotta/client/message/tracker/ClientTrackerImplTest.java
@@ -16,33 +16,67 @@
 package org.terracotta.client.message.tracker;
 
 import org.junit.Test;
-import org.terracotta.entity.ClientSourceId;
 
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertThat;
 import static org.hamcrest.Matchers.sameInstance;
-import static org.mockito.Mockito.mock;
+import org.terracotta.entity.ClientDescriptor;
+import org.terracotta.entity.ClientSourceId;
 
 public class ClientTrackerImplTest {
 
-  private ClientTrackerImpl<Long, Object> clientTracker = new ClientTrackerImpl<>(null);
+  private ClientTrackerImpl<Object, Object> clientTracker = new ClientTrackerImpl<>(null);
 
   @Test
   public void getMessageTracker() throws Exception {
-    Tracker<Object> messageTracker = this.clientTracker.getTracker(1L);
+    Tracker<Object, Object> messageTracker = this.clientTracker.getTracker(mockClientId(1L));
     assertThat(messageTracker, notNullValue());
-    assertThat(clientTracker.getTracker(1L), sameInstance(messageTracker));
+    assertThat(clientTracker.getTracker(mockClientId(1L)), sameInstance(messageTracker));
 
-    assertThat(clientTracker.getTracker(2L), not(sameInstance(messageTracker)));
+    assertThat(clientTracker.getTracker(mockClientId(2L)), not(sameInstance(messageTracker)));
   }
 
   @Test
   public void untrackClient() throws Exception {
-    Tracker<Object> messageTracker = this.clientTracker.getTracker(1L);
+    Tracker<Object, Object> messageTracker = this.clientTracker.getTracker(mockClientId(1L));
 
-    clientTracker.untrackClient(1L);
-    assertThat(clientTracker.getTracker(1L), not(sameInstance(messageTracker)));
+    clientTracker.untrackClient(mockClientId(1L));
+    assertThat(clientTracker.getTracker(mockClientId(1L)), not(sameInstance(messageTracker)));
   }
 
+  private ClientSourceId mockClientId(long id) {
+    return new ClientSourceId() {
+      @Override
+      public long toLong() {
+        return id;
+      }
+
+      @Override
+      public boolean matches(ClientDescriptor cd) {
+        return cd.getSourceId().toLong() == id;
+      }
+      
+      @Override
+      public int hashCode() {
+        int hash = 7;
+        hash = 67 * hash + (int)((id >> 32) & 0xffff) + (int)(id & 0xffff);
+        return hash;
+      }
+
+      @Override
+      public boolean equals(Object obj) {
+        if (this == obj) {
+          return true;
+        }
+        if (obj == null) {
+          return false;
+        }
+        if (getClass() != obj.getClass()) {
+          return false;
+        }
+        return ((ClientSourceId)obj).toLong() == id;
+      }
+    };
+  }
 }

--- a/client-message-tracker/src/test/java/org/terracotta/client/message/tracker/OOOMessageHandlerImplTest.java
+++ b/client-message-tracker/src/test/java/org/terracotta/client/message/tracker/OOOMessageHandlerImplTest.java
@@ -103,6 +103,7 @@ public class OOOMessageHandlerImplTest {
     assertThat(entityResponse2, sameInstance(entityResponse1));
   }
 
+  @SuppressWarnings("deprecation")
   @Test
   public void testSegmentation() throws Exception {
     EntityMessage message1 = mock(EntityMessage.class);
@@ -167,6 +168,7 @@ public class OOOMessageHandlerImplTest {
     assertThat(trackedResponsesForClient2Segment1.get(txnId4), is(response4));
   }
 
+  @SuppressWarnings("deprecation")
   @Test
   public void testLoadTrackedResponsesForSegment() throws Exception {
     messageHandler = new OOOMessageHandlerImpl<>(m -> true, 2, m -> 0, () -> {});
@@ -284,6 +286,7 @@ public class OOOMessageHandlerImplTest {
    * @throws EntityUserException
    */
   @Test
+  @SuppressWarnings("deprecation")
   public void testTyping() throws EntityUserException {
     OOOMessageHandler<DummyEntityMessage, DummyEntityResponse> messageHandler = new OOOMessageHandlerImpl<>(msg -> true, 1, m -> 0, () -> {});
 

--- a/client-message-tracker/src/test/java/org/terracotta/client/message/tracker/TrackerImplTest.java
+++ b/client-message-tracker/src/test/java/org/terracotta/client/message/tracker/TrackerImplTest.java
@@ -15,6 +15,7 @@
  */
 package org.terracotta.client.message.tracker;
 
+import java.util.Collection;
 import org.junit.Test;
 import org.terracotta.entity.EntityMessage;
 import org.terracotta.entity.EntityResponse;
@@ -28,6 +29,8 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.mock;
+import org.terracotta.entity.ClientDescriptor;
+import org.terracotta.entity.ClientSourceId;
 
 public class TrackerImplTest {
 
@@ -36,8 +39,8 @@ public class TrackerImplTest {
     EntityMessage message = mock(EntityMessage.class);
     EntityResponse response = mock(EntityResponse.class);
 
-    Tracker<EntityResponse> tracker = new TrackerImpl<>(o -> true);
-    tracker.track(1L, message, response);
+    TrackerImpl<EntityMessage, EntityResponse> tracker = new TrackerImpl<>(o -> true);
+    tracker.track(1L, 1L, message, response);
 
     assertThat(tracker.getTrackedValue(1L), sameInstance(response));
   }
@@ -47,8 +50,8 @@ public class TrackerImplTest {
     EntityMessage message = mock(EntityMessage.class);
     EntityResponse response = mock(EntityResponse.class);
 
-    Tracker<EntityResponse> tracker = new TrackerImpl<>(o -> false);
-    tracker.track(1L, message, response);
+    Tracker<EntityMessage, EntityResponse> tracker = new TrackerImpl<>(o -> false);
+    tracker.track(1L, 1L, message, response);
 
     assertThat(tracker.getTrackedValue(1L), nullValue());
   }
@@ -58,8 +61,8 @@ public class TrackerImplTest {
     EntityMessage message = mock(EntityMessage.class);
     EntityResponse response = mock(EntityResponse.class);
 
-    Tracker<EntityResponse> tracker = new TrackerImpl<>(o -> true);
-    tracker.track(-1L, message, response);  // a message with non-positive message id
+    Tracker<EntityMessage, EntityResponse> tracker = new TrackerImpl<>(o -> true);
+    tracker.track(1L, -1L, message, response);  // a message with non-positive message id
 
     assertThat(tracker.getTrackedValue(-1L), nullValue());
   }
@@ -69,10 +72,10 @@ public class TrackerImplTest {
     EntityMessage message = mock(EntityMessage.class);
     EntityResponse response = mock(EntityResponse.class);
 
-    TrackerImpl<EntityResponse> tracker = new TrackerImpl<>(o -> true);
-    tracker.track(1L, message, response);
-    tracker.track(2L, message, response);
-    tracker.track(3L, message, response);
+    TrackerImpl<EntityMessage, EntityResponse> tracker = new TrackerImpl<>(o -> true);
+    tracker.track(1L, 1L, message, response);
+    tracker.track(2L, 2L, message, response);
+    tracker.track(3L, 3L, message, response);
 
     assertThat(tracker.getTrackedValue(1L), notNullValue());
     assertThat(tracker.getTrackedValue(2L), notNullValue());
@@ -99,10 +102,10 @@ public class TrackerImplTest {
     EntityMessage message = mock(EntityMessage.class);
     EntityResponse response = mock(EntityResponse.class);
 
-    Tracker<EntityResponse> tracker = new TrackerImpl<>(o -> true);
-    tracker.track(1L, message, response);
-    tracker.track(2L, message, response);
-    tracker.track(3L, message, response);
+    Tracker<EntityMessage, EntityResponse> tracker = new TrackerImpl<>(o -> true);
+    tracker.track(1L, 1L, message, response);
+    tracker.track(2L, 2L, message, response);
+    tracker.track(3L, 3L, message, response);
 
     tracker.reconcile(2L);
     assertThat(tracker.getTrackedValue(1L), nullValue());
@@ -112,15 +115,5 @@ public class TrackerImplTest {
     assertThat(tracker.getTrackedValue(1L), nullValue());
     assertThat(tracker.getTrackedValue(2L), notNullValue());
 
-  }
-
-  @Test
-  public void testLoadOnSync() throws Exception {
-    TrackerImpl<Object> tracker = new TrackerImpl<>(o -> true);
-    Map<Long, Object> responses = Collections.singletonMap(1L, "value");
-    tracker.loadOnSync(responses);
-    Map<Long, Object> actual = tracker.getTrackedValues();
-    assertThat(actual.size(), is(1));
-    assertThat(actual.get(1L), is("value"));
   }
 }

--- a/client-message-tracker/src/test/java/org/terracotta/client/message/tracker/demo/DemoActiveEntity.java
+++ b/client-message-tracker/src/test/java/org/terracotta/client/message/tracker/demo/DemoActiveEntity.java
@@ -81,6 +81,7 @@ public class DemoActiveEntity implements ActiveServerEntity<EntityMessage, Entit
     };
   }
 
+  @SuppressWarnings("deprecation")
   @Override
   public void synchronizeKeyToPassive(PassiveSynchronizationChannel<EntityMessage> passiveSynchronizationChannel, int concurrencyKey) {
     // Sync entity data for the given concurrency key

--- a/client-message-tracker/src/test/java/org/terracotta/client/message/tracker/demo/DemoPassiveEntity.java
+++ b/client-message-tracker/src/test/java/org/terracotta/client/message/tracker/demo/DemoPassiveEntity.java
@@ -81,6 +81,7 @@ public class DemoPassiveEntity implements PassiveServerEntity<EntityMessage, Ent
     messageHandler.invoke(realContext, message, this::processMessage);
   }
 
+  @SuppressWarnings({"rawtypes","unchecked","deprecation"})
   private EntityResponse processMessage(InvokeContext context, EntityMessage message) {
     if (message instanceof MessageTrackerSyncMessage) {
       MessageTrackerSyncMessage trackerSyncMessage = (MessageTrackerSyncMessage) message;

--- a/diagnostic/client/pom.xml
+++ b/diagnostic/client/pom.xml
@@ -57,12 +57,6 @@
       <artifactId>connection-api</artifactId>
       <scope>provided</scope>
     </dependency>
-    <!-- Diagnostics interface -->
-    <dependency>
-      <groupId>org.terracotta.internal</groupId>
-      <artifactId>dso-l1</artifactId>
-      <scope>provided</scope>
-    </dependency>
 
     <dependency>
       <groupId>org.terracotta.common</groupId>

--- a/diagnostic/client/src/main/java/org/terracotta/diagnostic/client/DiagnosticService.java
+++ b/diagnostic/client/src/main/java/org/terracotta/diagnostic/client/DiagnosticService.java
@@ -25,12 +25,12 @@ import static org.terracotta.diagnostic.common.DiagnosticConstants.MBEAN_SERVER;
 import static org.terracotta.diagnostic.common.DiagnosticConstants.MBEAN_SHUTDOWN;
 
 /**
- * This class can be used as a replacement of the {@link com.terracotta.diagnostic.Diagnostics} class.
+ * This class can be used as a replacement of the {@link org.terracotta.connection.Diagnostics} class.
  * <p>
  * This class supports exception handling and complex request/response objects thanks to the {@link #getProxy(Class)} method.
  * <p>
  * It also allows to commonly process the responses instead of having each module use directly the
- * {@link com.terracotta.diagnostic.Diagnostics} class and do their own processing and error handling.
+ * {@link org.terracotta.connection.Diagnostics} class and do their own processing and error handling.
  * <p>
  * This class also setup workarounds for several issues related to the use of string and string parsing in the diagnostic handler.
  *

--- a/diagnostic/client/src/main/java/org/terracotta/diagnostic/client/DiagnosticServiceFactory.java
+++ b/diagnostic/client/src/main/java/org/terracotta/diagnostic/client/DiagnosticServiceFactory.java
@@ -15,7 +15,6 @@
  */
 package org.terracotta.diagnostic.client;
 
-import com.terracotta.diagnostic.Diagnostics;
 import org.terracotta.connection.Connection;
 import org.terracotta.connection.ConnectionException;
 import org.terracotta.connection.ConnectionFactory;
@@ -34,6 +33,7 @@ import java.net.InetSocketAddress;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.Properties;
+import org.terracotta.connection.Diagnostics;
 
 /**
  * @author Mathieu Carbou
@@ -96,7 +96,7 @@ public class DiagnosticServiceFactory {
 
   private static DiagnosticService fetch(Connection connection, Duration diagnosticInvokeTimeout)
       throws EntityNotProvidedException, EntityVersionMismatchException, EntityNotFoundException {
-    EntityRef<com.terracotta.diagnostic.Diagnostics, Object, Properties> ref = connection.getEntityRef(com.terracotta.diagnostic.Diagnostics.class, 1, "root");
+    EntityRef<Diagnostics, Object, Properties> ref = connection.getEntityRef(Diagnostics.class, 1, "root");
     Properties properties = new Properties();
     properties.setProperty("request.timeout", String.valueOf(diagnosticInvokeTimeout.toMillis()));
     Diagnostics delegate = ref.fetchEntity(properties);

--- a/diagnostic/client/src/main/java/org/terracotta/diagnostic/client/DiagnosticServiceImpl.java
+++ b/diagnostic/client/src/main/java/org/terracotta/diagnostic/client/DiagnosticServiceImpl.java
@@ -15,7 +15,6 @@
  */
 package org.terracotta.diagnostic.client;
 
-import com.terracotta.diagnostic.Diagnostics;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terracotta.connection.Connection;
@@ -31,6 +30,7 @@ import java.util.function.Supplier;
 
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
+import org.terracotta.connection.Diagnostics;
 import static org.terracotta.diagnostic.common.DiagnosticConstants.MBEAN_DIAGNOSTIC_REQUEST_HANDLER;
 import static org.terracotta.diagnostic.common.DiagnosticConstants.MBEAN_LOGICAL_SERVER_STATE;
 import static org.terracotta.diagnostic.common.DiagnosticConstants.MESSAGE_INVALID_JMX;
@@ -50,7 +50,7 @@ class DiagnosticServiceImpl implements DiagnosticService {
   private final Diagnostics delegate;
   private final DiagnosticCodec<String> codec;
 
-  DiagnosticServiceImpl(Connection connection, com.terracotta.diagnostic.Diagnostics delegate, DiagnosticCodec<?> codec) {
+  DiagnosticServiceImpl(Connection connection, Diagnostics delegate, DiagnosticCodec<?> codec) {
     this.connection = requireNonNull(connection);
     this.delegate = requireNonNull(delegate);
     // we need to ensure the JMX parameter contains no space at all because the DiagnosticsHandler is poorly written

--- a/diagnostic/client/src/test/java/org/terracotta/diagnostic/client/DiagnosticServiceFactoryTest.java
+++ b/diagnostic/client/src/test/java/org/terracotta/diagnostic/client/DiagnosticServiceFactoryTest.java
@@ -15,7 +15,6 @@
  */
 package org.terracotta.diagnostic.client;
 
-import com.terracotta.diagnostic.Diagnostics;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -50,6 +49,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import org.terracotta.connection.Diagnostics;
 
 /**
  * @author Mathieu Carbou

--- a/diagnostic/client/src/test/java/org/terracotta/diagnostic/client/DiagnosticServiceImplTest.java
+++ b/diagnostic/client/src/test/java/org/terracotta/diagnostic/client/DiagnosticServiceImplTest.java
@@ -17,7 +17,6 @@ package org.terracotta.diagnostic.client;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.terracotta.diagnostic.Diagnostics;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -59,6 +58,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
+import org.terracotta.connection.Diagnostics;
 import static org.terracotta.diagnostic.common.DiagnosticConstants.MBEAN_DIAGNOSTIC_REQUEST_HANDLER;
 import static org.terracotta.diagnostic.common.DiagnosticConstants.MBEAN_SERVER;
 import static org.terracotta.diagnostic.common.DiagnosticConstants.MESSAGE_INVALID_JMX;

--- a/diagnostic/service-api/pom.xml
+++ b/diagnostic/service-api/pom.xml
@@ -35,6 +35,11 @@
       <artifactId>diagnostic-model</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.terracotta</groupId>
+      <artifactId>standard-cluster-services</artifactId>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
 
 </project>

--- a/diagnostic/service/pom.xml
+++ b/diagnostic/service/pom.xml
@@ -42,13 +42,13 @@
 
     <!-- provided on server -->
     <dependency>
-      <groupId>org.terracotta.internal</groupId>
-      <artifactId>management</artifactId>
+      <groupId>org.terracotta</groupId>
+      <artifactId>standard-cluster-services</artifactId>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.terracotta.internal</groupId>
-      <artifactId>dso-l2</artifactId>
+      <artifactId>common-spi</artifactId>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/diagnostic/service/src/main/java/org/terracotta/diagnostic/server/DefaultDiagnosticServices.java
+++ b/diagnostic/service/src/main/java/org/terracotta/diagnostic/server/DefaultDiagnosticServices.java
@@ -15,8 +15,6 @@
  */
 package org.terracotta.diagnostic.server;
 
-import com.tc.management.TerracottaMBean;
-import com.tc.management.TerracottaManagement;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terracotta.diagnostic.common.DiagnosticCodec;
@@ -43,7 +41,9 @@ import java.util.function.Consumer;
 
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
+import javax.management.StandardMBean;
 import static org.terracotta.diagnostic.common.DiagnosticConstants.MBEAN_DIAGNOSTIC_REQUEST_HANDLER;
+import org.terracotta.server.ServerMBean;
 
 /**
  * Common manager holding all diagnostic services registered on a server
@@ -145,9 +145,9 @@ public class DefaultDiagnosticServices implements DiagnosticServices, Closeable 
     descriptor.addMBean(name);
   }
 
-  private static void registerMBean(String name, TerracottaMBean mBean) {
+  private static void registerMBean(String name, StandardMBean mBean) {
     try {
-      ObjectName beanName = TerracottaManagement.createObjectName(null, name, TerracottaManagement.MBeanDomain.PUBLIC);
+      ObjectName beanName = ServerMBean.createMBeanName(name);
       ManagementFactory.getPlatformMBeanServer().registerMBean(mBean, beanName);
       LOGGER.info("Registered MBean with name: {}", name);
     } catch (MalformedObjectNameException | NotCompliantMBeanException | InstanceAlreadyExistsException | MBeanRegistrationException e) {
@@ -157,7 +157,7 @@ public class DefaultDiagnosticServices implements DiagnosticServices, Closeable 
 
   private static void unregisterMBean(String name) {
     try {
-      ObjectName beanName = TerracottaManagement.createObjectName(null, name, TerracottaManagement.MBeanDomain.PUBLIC);
+      ObjectName beanName = ServerMBean.createMBeanName(name);
       ManagementFactory.getPlatformMBeanServer().unregisterMBean(beanName);
       LOGGER.info("Unregistered MBean with name: {}", name);
     } catch (MalformedObjectNameException | MBeanRegistrationException e) {

--- a/diagnostic/service/src/main/java/org/terracotta/diagnostic/server/DiagnosticRequestHandler.java
+++ b/diagnostic/service/src/main/java/org/terracotta/diagnostic/server/DiagnosticRequestHandler.java
@@ -15,7 +15,6 @@
  */
 package org.terracotta.diagnostic.server;
 
-import com.tc.management.AbstractTerracottaMBean;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terracotta.diagnostic.common.Base64DiagnosticCodec;
@@ -31,12 +30,13 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 
 import static java.util.Objects.requireNonNull;
+import javax.management.StandardMBean;
 import static org.terracotta.diagnostic.common.DiagnosticConstants.MESSAGE_UNKNOWN_COMMAND;
 
 /**
  * @author Mathieu Carbou
  */
-public class DiagnosticRequestHandler extends AbstractTerracottaMBean implements DiagnosticRequestHandlerMBean {
+public class DiagnosticRequestHandler extends StandardMBean implements DiagnosticRequestHandlerMBean {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(DiagnosticRequestHandler.class);
 
@@ -44,8 +44,8 @@ public class DiagnosticRequestHandler extends AbstractTerracottaMBean implements
   private final Map<String, DiagnosticServiceDescriptor<?>> services = new ConcurrentHashMap<>();
 
   private DiagnosticRequestHandler(DiagnosticCodec<?> codec) throws NotCompliantMBeanException {
-    super(DiagnosticRequestHandlerMBean.class, false);
     // we need this chain of codecs to work around the badly written DiagnosticHandler that has some flaws in String processing.
+    super(DiagnosticRequestHandlerMBean.class, false);
     this.codec = new EmptyParameterDiagnosticCodec()
         .around(new Base64DiagnosticCodec())
         .around(codec);
@@ -57,10 +57,6 @@ public class DiagnosticRequestHandler extends AbstractTerracottaMBean implements
 
   public Collection<DiagnosticServiceDescriptor<?>> getServices() {
     return services.values();
-  }
-
-  @Override
-  public void reset() {
   }
 
   @Override

--- a/diagnostic/service/src/main/java/org/terracotta/diagnostic/server/DiagnosticRequestHandlerMBean.java
+++ b/diagnostic/service/src/main/java/org/terracotta/diagnostic/server/DiagnosticRequestHandlerMBean.java
@@ -15,14 +15,12 @@
  */
 package org.terracotta.diagnostic.server;
 
-import com.tc.management.TerracottaMBean;
-
 /**
  * MBean interface used as a communication layer
  *
  * @author Mathieu Carbou
  */
-public interface DiagnosticRequestHandlerMBean extends TerracottaMBean {
+public interface DiagnosticRequestHandlerMBean {
   boolean hasServiceInterface(String serviceName);
 
   String request(String payload);

--- a/diagnostic/service/src/main/java/org/terracotta/diagnostic/server/extensions/LogicalServerStateServiceProvider.java
+++ b/diagnostic/service/src/main/java/org/terracotta/diagnostic/server/extensions/LogicalServerStateServiceProvider.java
@@ -23,7 +23,6 @@ import org.terracotta.entity.ServiceProvider;
 import org.terracotta.entity.ServiceProviderConfiguration;
 import org.terracotta.entity.StateDumpCollector;
 
-import javax.management.NotCompliantMBeanException;
 import java.util.Collection;
 import java.util.Collections;
 
@@ -33,13 +32,9 @@ public class LogicalServerStateServiceProvider implements ServiceProvider {
 
   @Override
   public boolean initialize(ServiceProviderConfiguration serviceProviderConfiguration, PlatformConfiguration platformConfiguration) {
-    try {
-      logicalServerStateMBean = new LogicalServerStateMBeanImpl();
-      logicalServerStateMBean.expose();
-      return true;
-    } catch (NotCompliantMBeanException e) {
-      throw new RuntimeException(e);
-    }
+    logicalServerStateMBean = new LogicalServerStateMBeanImpl();
+    logicalServerStateMBean.expose();
+    return true;
   }
 
   @Override

--- a/diagnostic/service/src/test/java/org/terracotta/diagnostic/server/DefaultDiagnosticServicesRegistrationTest.java
+++ b/diagnostic/service/src/test/java/org/terracotta/diagnostic/server/DefaultDiagnosticServicesRegistrationTest.java
@@ -23,8 +23,6 @@ import org.terracotta.diagnostic.server.api.Expose;
 
 import javax.management.InstanceNotFoundException;
 
-import static com.tc.management.TerracottaManagement.MBeanDomain.PUBLIC;
-import static com.tc.management.TerracottaManagement.createObjectName;
 import static java.lang.management.ManagementFactory.getPlatformMBeanServer;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
@@ -32,6 +30,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.junit.Assert.assertThat;
+import org.terracotta.server.ServerMBean;
 import static org.terracotta.testing.ExceptionMatcher.throwing;
 
 /**
@@ -58,20 +57,20 @@ public class DefaultDiagnosticServicesRegistrationTest {
     DiagnosticServicesRegistration<MyService2> registration = diagnosticServices.register(MyService2.class, new MyServiceImpl());
 
     assertThat(diagnosticServices.findService(MyService2.class).isPresent(), is(true));
-    assertThat(getPlatformMBeanServer().getMBeanInfo(createObjectName(null, "s2", PUBLIC)), is(not(nullValue())));
+    assertThat(getPlatformMBeanServer().getMBeanInfo(ServerMBean.createMBeanName("s2")), is(not(nullValue())));
 
     assertThat(registration.exposeMBean("AnotherName"), is(true));
 
-    assertThat(getPlatformMBeanServer().getMBeanInfo(createObjectName(null, "AnotherName", PUBLIC)), is(not(nullValue())));
+    assertThat(getPlatformMBeanServer().getMBeanInfo(ServerMBean.createMBeanName("AnotherName")), is(not(nullValue())));
 
     registration.close();
 
     assertThat(diagnosticServices.findService(MyService2.class).isPresent(), is(false));
     assertThat(
-        () -> getPlatformMBeanServer().getMBeanInfo(createObjectName(null, "s2", PUBLIC)),
+        () -> getPlatformMBeanServer().getMBeanInfo(ServerMBean.createMBeanName("s2")),
         is(throwing(instanceOf(InstanceNotFoundException.class)).andMessage(is(equalTo("org.terracotta:name=s2")))));
     assertThat(
-        () -> getPlatformMBeanServer().getMBeanInfo(createObjectName(null, "AnotherName", PUBLIC)),
+        () -> getPlatformMBeanServer().getMBeanInfo(ServerMBean.createMBeanName("AnotherName")),
         is(throwing(instanceOf(InstanceNotFoundException.class)).andMessage(is(equalTo("org.terracotta:name=AnotherName")))));
 
     // subsequent init is not failing
@@ -84,9 +83,9 @@ public class DefaultDiagnosticServicesRegistrationTest {
     assertThat(registration.exposeMBean("foo"), is(true));
     assertThat(registration.exposeMBean("bar"), is(true));
 
-    assertThat(getPlatformMBeanServer().getMBeanInfo(createObjectName(null, "s2", PUBLIC)), is(not(nullValue())));
-    assertThat(getPlatformMBeanServer().getMBeanInfo(createObjectName(null, "foo", PUBLIC)), is(not(nullValue())));
-    assertThat(getPlatformMBeanServer().getMBeanInfo(createObjectName(null, "bar", PUBLIC)), is(not(nullValue())));
+    assertThat(getPlatformMBeanServer().getMBeanInfo(ServerMBean.createMBeanName("s2")), is(not(nullValue())));
+    assertThat(getPlatformMBeanServer().getMBeanInfo(ServerMBean.createMBeanName("foo")), is(not(nullValue())));
+    assertThat(getPlatformMBeanServer().getMBeanInfo(ServerMBean.createMBeanName("bar")), is(not(nullValue())));
 
     registration.close();
 
@@ -94,13 +93,13 @@ public class DefaultDiagnosticServicesRegistrationTest {
     assertThat(registration.exposeMBean("baz"), is(false));
 
     assertThat(
-        () -> getPlatformMBeanServer().getMBeanInfo(createObjectName(null, "s2", PUBLIC)),
+        () -> getPlatformMBeanServer().getMBeanInfo(ServerMBean.createMBeanName("s2")),
         is(throwing(instanceOf(InstanceNotFoundException.class)).andMessage(is(equalTo("org.terracotta:name=s2")))));
     assertThat(
-        () -> getPlatformMBeanServer().getMBeanInfo(createObjectName(null, "foo", PUBLIC)),
+        () -> getPlatformMBeanServer().getMBeanInfo(ServerMBean.createMBeanName("foo")),
         is(throwing(instanceOf(InstanceNotFoundException.class)).andMessage(is(equalTo("org.terracotta:name=foo")))));
     assertThat(
-        () -> getPlatformMBeanServer().getMBeanInfo(createObjectName(null, "bar", PUBLIC)),
+        () -> getPlatformMBeanServer().getMBeanInfo(ServerMBean.createMBeanName("bar")),
         is(throwing(instanceOf(InstanceNotFoundException.class)).andMessage(is(equalTo("org.terracotta:name=bar")))));
   }
 

--- a/diagnostic/service/src/test/java/org/terracotta/diagnostic/server/DefaultDiagnosticServicesTest.java
+++ b/diagnostic/service/src/test/java/org/terracotta/diagnostic/server/DefaultDiagnosticServicesTest.java
@@ -15,7 +15,6 @@
  */
 package org.terracotta.diagnostic.server;
 
-import com.tc.management.TerracottaManagement;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -38,6 +37,7 @@ import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.reset;
+import org.terracotta.server.ServerMBean;
 import static org.terracotta.testing.ExceptionMatcher.throwing;
 
 /**
@@ -113,16 +113,16 @@ public class DefaultDiagnosticServicesTest {
     assertThat(s1Registration, is(instanceOf(DiagnosticServicesRegistration.class)));
     assertThat(diagnosticServices.register(MyService2.class, service2), is(instanceOf(DiagnosticServicesRegistration.class)));
 
-    MBeanInfo s2 = ManagementFactory.getPlatformMBeanServer().getMBeanInfo(TerracottaManagement.createObjectName(null, "s2", TerracottaManagement.MBeanDomain.PUBLIC));
+    MBeanInfo s2 = ManagementFactory.getPlatformMBeanServer().getMBeanInfo(ServerMBean.createMBeanName("s2"));
     assertThat(s2, is(not(nullValue())));
 
     assertThat(
-        () -> ManagementFactory.getPlatformMBeanServer().getMBeanInfo(TerracottaManagement.createObjectName(null, "s1", TerracottaManagement.MBeanDomain.PUBLIC)),
+        () -> ManagementFactory.getPlatformMBeanServer().getMBeanInfo(ServerMBean.createMBeanName("s1")),
         is(throwing(instanceOf(InstanceNotFoundException.class)).andMessage(is(equalTo("org.terracotta:name=s1")))));
 
     s1Registration.exposeMBean("s1");
 
-    MBeanInfo s1 = ManagementFactory.getPlatformMBeanServer().getMBeanInfo(TerracottaManagement.createObjectName(null, "s1", TerracottaManagement.MBeanDomain.PUBLIC));
+    MBeanInfo s1 = ManagementFactory.getPlatformMBeanServer().getMBeanInfo(ServerMBean.createMBeanName("s1"));
     assertThat(s1, is(not(nullValue())));
   }
 
@@ -130,12 +130,12 @@ public class DefaultDiagnosticServicesTest {
   public void test_unexpose() throws Exception {
     assertThat(diagnosticServices.register(MyService2.class, service2), is(instanceOf(DiagnosticServicesRegistration.class)));
 
-    ManagementFactory.getPlatformMBeanServer().getMBeanInfo(TerracottaManagement.createObjectName(null, "s2", TerracottaManagement.MBeanDomain.PUBLIC));
+    ManagementFactory.getPlatformMBeanServer().getMBeanInfo(ServerMBean.createMBeanName("s2"));
 
     diagnosticServices.unregister(MyService2.class);
 
     assertThat(
-        () -> ManagementFactory.getPlatformMBeanServer().getMBeanInfo(TerracottaManagement.createObjectName(null, "s2", TerracottaManagement.MBeanDomain.PUBLIC)),
+        () -> ManagementFactory.getPlatformMBeanServer().getMBeanInfo(ServerMBean.createMBeanName("s2")),
         is(throwing(instanceOf(InstanceNotFoundException.class)).andMessage(is(equalTo("org.terracotta:name=s2")))));
   }
 

--- a/diagnostic/service/src/test/java/org/terracotta/diagnostic/server/extensions/LogicalServerStateTest.java
+++ b/diagnostic/service/src/test/java/org/terracotta/diagnostic/server/extensions/LogicalServerStateTest.java
@@ -15,7 +15,6 @@
  */
 package org.terracotta.diagnostic.server.extensions;
 
-import com.tc.objectserver.impl.JMXSubsystem;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -32,15 +31,21 @@ import static org.terracotta.diagnostic.model.LogicalServerState.ACTIVE;
 import static org.terracotta.diagnostic.model.LogicalServerState.ACTIVE_RECONNECTING;
 import static org.terracotta.diagnostic.model.LogicalServerState.ACTIVE_SUSPENDED;
 import static org.terracotta.diagnostic.model.LogicalServerState.UNKNOWN;
+import org.terracotta.server.Server;
+import org.terracotta.server.ServerEnv;
+import org.terracotta.server.ServerJMX;
 
 public class LogicalServerStateTest {
-  private JMXSubsystem jmxSubsystem;
+  ServerJMX jmxSubsystem;
   private LogicalServerStateMBeanImpl logicalServerState;
 
   @Before
   public void setUp() throws NotCompliantMBeanException {
-    jmxSubsystem = mock(JMXSubsystem.class);
-    logicalServerState = new LogicalServerStateMBeanImpl(jmxSubsystem) {
+    Server s = mock(Server.class);
+    jmxSubsystem = mock(ServerJMX.class);
+    when(s.getManagement()).thenReturn(jmxSubsystem);
+    ServerEnv.setDefaultServer(s);
+    logicalServerState = new LogicalServerStateMBeanImpl() {
       @Override
       boolean hasConsistencyManager() {
         return true;

--- a/dynamic-config/server/configuration-provider/pom.xml
+++ b/dynamic-config/server/configuration-provider/pom.xml
@@ -76,11 +76,20 @@
 
     <!-- Access TcServerMain from TcServer and the exception classes -->
     <dependency>
-      <groupId>org.terracotta.internal</groupId>
-      <artifactId>dso-l2</artifactId>
+      <groupId>org.terracotta</groupId>
+      <artifactId>standard-cluster-services</artifactId>
       <scope>provided</scope>
     </dependency>
-
+    <dependency>
+      <groupId>org.terracotta.internal</groupId>
+      <artifactId>common-spi</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.terracotta.internal</groupId>
+      <artifactId>configuration-provider</artifactId>
+      <scope>provided</scope>
+    </dependency>
     <dependency>
       <groupId>com.github.stefanbirkner</groupId>
       <artifactId>system-rules</artifactId>

--- a/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/service/DynamicConfigServiceImpl.java
+++ b/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/service/DynamicConfigServiceImpl.java
@@ -16,7 +16,6 @@
 package org.terracotta.dynamic_config.server.configuration.service;
 
 import com.fasterxml.jackson.core.type.TypeReference;
-import com.tc.server.TCServerMain;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terracotta.dynamic_config.api.model.Cluster;
@@ -37,7 +36,6 @@ import org.terracotta.dynamic_config.server.api.LicenseService;
 import org.terracotta.entity.StateDumpCollector;
 import org.terracotta.entity.StateDumpable;
 import org.terracotta.json.Json;
-import org.terracotta.monitoring.PlatformService;
 import org.terracotta.nomad.messages.AcceptRejectResponse;
 import org.terracotta.nomad.messages.ChangeDetails;
 import org.terracotta.nomad.messages.CommitMessage;
@@ -61,6 +59,9 @@ import java.util.Optional;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 import static java.util.Objects.requireNonNull;
+import org.terracotta.server.ServerEnv;
+import static org.terracotta.server.StopAction.RESTART;
+import static org.terracotta.server.StopAction.ZAP;
 
 public class DynamicConfigServiceImpl implements TopologyService, DynamicConfigService, DynamicConfigEventService, DynamicConfigListener, StateDumpable {
 
@@ -333,7 +334,7 @@ public class DynamicConfigServiceImpl implements TopologyService, DynamicConfigS
     LOGGER.info("Will restart node in {} seconds", delayInSeconds.getSeconds());
     runAfterDelay(delayInSeconds, () -> {
       LOGGER.info("Restarting node");
-      TCServerMain.getServer().stop(PlatformService.RestartMode.STOP_AND_RESTART);
+      ServerEnv.getServer().stop(RESTART);
     });
   }
 
@@ -342,8 +343,7 @@ public class DynamicConfigServiceImpl implements TopologyService, DynamicConfigS
     LOGGER.info("Will stop node in {} seconds", delayInSeconds.getSeconds());
     runAfterDelay(delayInSeconds, () -> {
       LOGGER.info("Stopping node");
-      //TODO [DYNAMIC-CONFIG]: TDB-4942 - when upgrading to the new core version, use ZAP_AND_STOP instead
-      TCServerMain.getServer().stop(PlatformService.RestartMode.STOP_ONLY);
+      ServerEnv.getServer().stop(ZAP);
     });
   }
 

--- a/dynamic-config/testing/system-tests/pom.xml
+++ b/dynamic-config/testing/system-tests/pom.xml
@@ -74,7 +74,6 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>${logback.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/dynamic-config/testing/system-tests/src/test/resources/tc-logback.xml
+++ b/dynamic-config/testing/system-tests/src/test/resources/tc-logback.xml
@@ -1,0 +1,55 @@
+<configuration>
+
+  <appender name="TC_BASE" class="com.tc.l2.logging.BufferingAppender">
+    <target>System.out</target>
+    <console>false</console>
+    <encoder>
+      <pattern>%d [%t] %p %c - %m%n</pattern>
+    </encoder>
+  </appender>
+
+  <appender name="SYSOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <target>System.out</target>
+    <encoder>
+      <pattern>%d [%t] %p %c - %m%n</pattern>
+    </encoder>
+  </appender>
+  
+  <appender name="IPC" class="ch.qos.logback.core.ConsoleAppender">
+    <target>System.out</target>
+    <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+      <level>WARN</level>
+    </filter>
+    <encoder>
+      <pattern>%d [%t] %p %c - %m%n</pattern>
+    </encoder>
+  </appender>
+  
+  <appender name="LogToJFR" class="org.terracotta.tripwire.EventAppender">
+  </appender>
+
+  <appender name="JFR" class="org.terracotta.tripwire.JFRAppender">
+    <path>artifacts</path>
+    <dumpOnExit>false</dumpOnExit>
+  </appender>
+
+  <root level="INFO">
+    <appender-ref ref="TC_BASE" />
+    <appender-ref ref="IPC"/>
+    <appender-ref ref="LogToJFR"/>
+  </root>
+  
+  <logger name="org.terracotta.console" level="INFO">
+    <appender-ref ref="SYSOUT" />
+  </logger>
+  <logger name="com.tc.async.api" level="WARN">
+    <appender-ref ref="JFR" />
+  </logger>
+  <logger name="org.terracotta.dump" level="INFO">
+    <appender-ref ref="SYSOUT" />
+    <appender-ref ref="JFR" />
+  </logger>
+    
+  <include optional="true" resource="logback-ext-test.xml"/>
+
+</configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -33,10 +33,10 @@
     <maven.version>3.6.3</maven.version>
     <slf4j.version>1.7.25</slf4j.version>
     <logback.version>1.2.3</logback.version>
-    <terracotta-apis.version>1.7.0-pre1</terracotta-apis.version>
+    <terracotta-apis.version>1.7.0-pre2</terracotta-apis.version>
     <terracotta-configuration.version>10.7.0-pre2</terracotta-configuration.version>
-    <passthrough-testing.version>1.7.0-pre12</passthrough-testing.version>
-    <terracotta-core.version>5.7.0-pre25</terracotta-core.version>
+    <passthrough-testing.version>1.7.0-pre13</passthrough-testing.version>
+    <terracotta-core.version>5.7.0-pre28</terracotta-core.version>
     <tripwire.version>1.0.0-pre7</tripwire.version>
     <galvan.version>1.5.0-pre3</galvan.version>
     <angela.version>3.0.23</angela.version>
@@ -111,12 +111,7 @@
       </dependency>
       <dependency>
         <groupId>org.terracotta.internal</groupId>
-        <artifactId>dso-l1</artifactId>
-        <version>${terracotta-core.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.terracotta.internal</groupId>
-        <artifactId>dso-l2</artifactId>
+        <artifactId>common-spi</artifactId>
         <version>${terracotta-core.version}</version>
       </dependency>
       <dependency>


### PR DESCRIPTION
1.  Upgrade to the new tc-api.  This is a step toward not requiring implementation libraries in tc-core as dependencies.  

2. Add functionality to message tracker required for fixing data loss in 3 node clusters.