### PR TITLE
Dynamic config fixes + Required failover priority + 5.8-SNAPSHOT

### DIFF
--- a/client-message-tracker/pom.xml
+++ b/client-message-tracker/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>platform-root</artifactId>
     <groupId>org.terracotta</groupId>
-    <version>5.7-SNAPSHOT</version>
+    <version>5.8-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/common/inet-support/pom.xml
+++ b/common/inet-support/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.terracotta.common</groupId>
     <artifactId>common</artifactId>
-    <version>5.7-SNAPSHOT</version>
+    <version>5.8-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/common/json-support/pom.xml
+++ b/common/json-support/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.terracotta.common</groupId>
     <artifactId>common</artifactId>
-    <version>5.7-SNAPSHOT</version>
+    <version>5.8-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/common/nomad/pom.xml
+++ b/common/nomad/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.terracotta.common</groupId>
     <artifactId>common</artifactId>
-    <version>5.7-SNAPSHOT</version>
+    <version>5.8-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.terracotta</groupId>
     <artifactId>platform-root</artifactId>
-    <version>5.7-SNAPSHOT</version>
+    <version>5.8-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/common/port-locking/pom.xml
+++ b/common/port-locking/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.terracotta.common</groupId>
     <artifactId>common</artifactId>
-    <version>5.7-SNAPSHOT</version>
+    <version>5.8-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/common/sanskrit/pom.xml
+++ b/common/sanskrit/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.terracotta.common</groupId>
     <artifactId>common</artifactId>
-    <version>5.7-SNAPSHOT</version>
+    <version>5.8-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/common/structures/pom.xml
+++ b/common/structures/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.terracotta.common</groupId>
     <artifactId>common</artifactId>
-    <version>5.7-SNAPSHOT</version>
+    <version>5.8-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/common/test-utilities/pom.xml
+++ b/common/test-utilities/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.terracotta.common</groupId>
     <artifactId>common</artifactId>
-    <version>5.7-SNAPSHOT</version>
+    <version>5.8-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/communicator-support/communicator-support-client/pom.xml
+++ b/communicator-support/communicator-support-client/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>communicator-support</artifactId>
     <groupId>org.terracotta.voltron.communicator</groupId>
-    <version>5.7-SNAPSHOT</version>
+    <version>5.8-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/communicator-support/communicator-support-common/pom.xml
+++ b/communicator-support/communicator-support-common/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>communicator-support</artifactId>
     <groupId>org.terracotta.voltron.communicator</groupId>
-    <version>5.7-SNAPSHOT</version>
+    <version>5.8-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/communicator-support/communicator-support-server/pom.xml
+++ b/communicator-support/communicator-support-server/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>communicator-support</artifactId>
     <groupId>org.terracotta.voltron.communicator</groupId>
-    <version>5.7-SNAPSHOT</version>
+    <version>5.8-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/communicator-support/pom.xml
+++ b/communicator-support/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>platform-root</artifactId>
     <groupId>org.terracotta</groupId>
-    <version>5.7-SNAPSHOT</version>
+    <version>5.8-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <packaging>pom</packaging>

--- a/concurrent-map-entity/client/pom.xml
+++ b/concurrent-map-entity/client/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.terracotta</groupId>
     <artifactId>platform-root</artifactId>
-    <version>5.7-SNAPSHOT</version>
+    <version>5.8-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
 

--- a/concurrent-map-entity/common/pom.xml
+++ b/concurrent-map-entity/common/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.terracotta</groupId>
     <artifactId>platform-root</artifactId>
-    <version>5.7-SNAPSHOT</version>
+    <version>5.8-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
 

--- a/concurrent-map-entity/integration-tests/pom.xml
+++ b/concurrent-map-entity/integration-tests/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.terracotta</groupId>
     <artifactId>platform-root</artifactId>
-    <version>5.7-SNAPSHOT</version>
+    <version>5.8-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
 

--- a/concurrent-map-entity/server/pom.xml
+++ b/concurrent-map-entity/server/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.terracotta</groupId>
     <artifactId>platform-root</artifactId>
-    <version>5.7-SNAPSHOT</version>
+    <version>5.8-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
 

--- a/data-root-resource/pom.xml
+++ b/data-root-resource/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.terracotta</groupId>
     <artifactId>platform-root</artifactId>
-    <version>5.7-SNAPSHOT</version>
+    <version>5.8-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/diagnostic/client/pom.xml
+++ b/diagnostic/client/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.terracotta.diagnostic</groupId>
     <artifactId>diagnostic</artifactId>
-    <version>5.7-SNAPSHOT</version>
+    <version>5.8-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/diagnostic/common/pom.xml
+++ b/diagnostic/common/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.terracotta.diagnostic</groupId>
     <artifactId>diagnostic</artifactId>
-    <version>5.7-SNAPSHOT</version>
+    <version>5.8-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/diagnostic/model/pom.xml
+++ b/diagnostic/model/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.terracotta.diagnostic</groupId>
     <artifactId>diagnostic</artifactId>
-    <version>5.7-SNAPSHOT</version>
+    <version>5.8-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/diagnostic/pom.xml
+++ b/diagnostic/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.terracotta</groupId>
     <artifactId>platform-root</artifactId>
-    <version>5.7-SNAPSHOT</version>
+    <version>5.8-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/diagnostic/service-api/pom.xml
+++ b/diagnostic/service-api/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.terracotta.diagnostic</groupId>
     <artifactId>diagnostic</artifactId>
-    <version>5.7-SNAPSHOT</version>
+    <version>5.8-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/diagnostic/service/pom.xml
+++ b/diagnostic/service/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.terracotta.diagnostic</groupId>
     <artifactId>diagnostic</artifactId>
-    <version>5.7-SNAPSHOT</version>
+    <version>5.8-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/dynamic-config/api/pom.xml
+++ b/dynamic-config/api/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.terracotta.dynamic-config</groupId>
     <artifactId>dynamic-config</artifactId>
-    <version>5.7-SNAPSHOT</version>
+    <version>5.8-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/dynamic-config/api/src/main/java/org/terracotta/dynamic_config/api/model/Cluster.java
+++ b/dynamic-config/api/src/main/java/org/terracotta/dynamic_config/api/model/Cluster.java
@@ -55,11 +55,11 @@ public class Cluster implements Cloneable, PropertyHolder {
   private String name;
   private Measure<TimeUnit> clientReconnectWindow;
   private Measure<TimeUnit> clientLeaseDuration;
-  private Map<String, Measure<MemoryUnit>> offheapResources = new ConcurrentHashMap<>();
   private String securityAuthc;
   private boolean securitySslTls = Boolean.parseBoolean(Setting.SECURITY_SSL_TLS.getDefaultValue());
   private boolean securityWhitelist = Boolean.parseBoolean(Setting.SECURITY_WHITELIST.getDefaultValue());
   private FailoverPriority failoverPriority = FailoverPriority.availability();
+  private final Map<String, Measure<MemoryUnit>> offheapResources = new ConcurrentHashMap<>();
 
   @JsonCreator
   Cluster(@JsonProperty("name") String name,

--- a/dynamic-config/api/src/main/java/org/terracotta/dynamic_config/api/model/Configuration.java
+++ b/dynamic-config/api/src/main/java/org/terracotta/dynamic_config/api/model/Configuration.java
@@ -441,7 +441,7 @@ public class Configuration {
     }
 
     if (value == null) {
-      targetContexts.forEach(ctx -> setting.getProperty(ctx).ifPresent(value -> setting.setProperty(ctx.getNode(), key, null)));
+      targetContexts.forEach(ctx -> setting.getProperty(ctx).ifPresent(value -> setting.setProperty(ctx, key, null)));
 
     } else {
       if (setting == Setting.LICENSE_FILE) {

--- a/dynamic-config/api/src/main/java/org/terracotta/dynamic_config/api/model/Node.java
+++ b/dynamic-config/api/src/main/java/org/terracotta/dynamic_config/api/model/Node.java
@@ -51,9 +51,9 @@ public class Node implements Cloneable, PropertyHolder {
   private Path nodeBackupDir;
   private Path securityDir;
   private Path securityAuditLogDir;
-  private Map<String, String> tcProperties = new ConcurrentHashMap<>();
-  private Map<String, Level> nodeLoggerOverrides = new ConcurrentHashMap<>();
-  private Map<String, Path> dataDirs = new ConcurrentHashMap<>();
+  private final Map<String, String> tcProperties = new ConcurrentHashMap<>();
+  private final Map<String, Level> nodeLoggerOverrides = new ConcurrentHashMap<>();
+  private final Map<String, Path> dataDirs = new ConcurrentHashMap<>();
 
   Node() {
   }

--- a/dynamic-config/api/src/main/java/org/terracotta/dynamic_config/api/model/Setting.java
+++ b/dynamic-config/api/src/main/java/org/terracotta/dynamic_config/api/model/Setting.java
@@ -299,7 +299,7 @@ public enum Setting {
   ),
   FAILOVER_PRIORITY(SettingName.FAILOVER_PRIORITY,
       false,
-      "availability",
+      null,
       CLUSTER,
       fromCluster(Cluster::getFailoverPriority),
       intoCluster((cluster, value) -> cluster.setFailoverPriority(FailoverPriority.valueOf(value))),
@@ -638,7 +638,8 @@ public enum Setting {
   }
 
   public boolean isRequired() {
-    return !allowsOperation(UNSET) && (!allowsOperation(CONFIG) || getDefaultValue() != null);
+    //TODO [DYNAMIC-CONFIG]: TDB-4898 - correctly handle required settings
+    return this == FAILOVER_PRIORITY || !allowsOperation(UNSET) && (!allowsOperation(CONFIG) || getDefaultValue() != null);
   }
 
   public boolean isReadOnly() {

--- a/dynamic-config/api/src/main/java/org/terracotta/dynamic_config/api/service/ClusterValidator.java
+++ b/dynamic-config/api/src/main/java/org/terracotta/dynamic_config/api/service/ClusterValidator.java
@@ -49,6 +49,13 @@ public class ClusterValidator {
     validateNodeName();
     validateServerSettings();
     validateSecurityDir();
+    validateFailoverSetting();
+  }
+
+  private void validateFailoverSetting() {
+    if (cluster.getFailoverPriority() == null) {
+      throw new MalformedClusterException(Setting.FAILOVER_PRIORITY + " setting is missing");
+    }
   }
 
   @SuppressWarnings("OptionalGetWithoutIsPresent")

--- a/dynamic-config/api/src/test/java/org/terracotta/dynamic_config/api/model/ConfigurationTest.java
+++ b/dynamic-config/api/src/test/java/org/terracotta/dynamic_config/api/model/ConfigurationTest.java
@@ -88,7 +88,13 @@ public class ConfigurationTest {
         LICENSE_FILE
     ).forEach(setting -> assertThat(
         () -> Configuration.valueOf(setting),
-        is(throwing(instanceOf(IllegalArgumentException.class)).andMessage(is(equalTo("Invalid input: 'license-file='. Reason: license-file requires a value"))))));
+        is(throwing(instanceOf(IllegalArgumentException.class)).andMessage(is(equalTo("Invalid input: '" + setting + "='. Reason: license-file requires a value"))))));
+
+    Stream.of(
+        FAILOVER_PRIORITY
+    ).forEach(setting -> assertThat(
+        () -> Configuration.valueOf(setting),
+        is(throwing(instanceOf(IllegalArgumentException.class)).andMessage(is(equalTo("Invalid input: '" + setting + "='. Reason: failover-priority requires a value"))))));
 
     Stream.of(
         NODE_HOSTNAME,
@@ -103,7 +109,6 @@ public class ConfigurationTest {
         CLIENT_RECONNECT_WINDOW,
         CLUSTER_NAME,
         DATA_DIRS,
-        FAILOVER_PRIORITY,
         NODE_BACKUP_DIR,
         NODE_BIND_ADDRESS,
         NODE_GROUP_BIND_ADDRESS,

--- a/dynamic-config/api/src/test/java/org/terracotta/dynamic_config/api/service/ClusterFactoryTest.java
+++ b/dynamic-config/api/src/test/java/org/terracotta/dynamic_config/api/service/ClusterFactoryTest.java
@@ -59,27 +59,28 @@ public class ClusterFactoryTest {
 
   @Test
   public void test_create_cli() {
-    assertCliEquals(cli(), Cluster.newDefaultCluster(new Stripe(Node.newDefaultNode("<GENERATED>", "localhost"))));
-    assertCliEquals(cli("node-hostname=%c"), Cluster.newDefaultCluster(new Stripe(Node.newDefaultNode("<GENERATED>", "localhost.home"))));
-    assertCliEquals(cli("node-hostname=foo"), Cluster.newDefaultCluster(new Stripe(Node.newDefaultNode("<GENERATED>", "foo"))));
+    assertCliEquals(cli("failover-priority=availability"), Cluster.newDefaultCluster(new Stripe(Node.newDefaultNode("<GENERATED>", "localhost"))));
+    assertCliEquals(cli("failover-priority=availability", "node-hostname=%c"), Cluster.newDefaultCluster(new Stripe(Node.newDefaultNode("<GENERATED>", "localhost.home"))));
+    assertCliEquals(cli("failover-priority=availability", "node-hostname=foo"), Cluster.newDefaultCluster(new Stripe(Node.newDefaultNode("<GENERATED>", "foo"))));
   }
 
   @Test
   public void test_create_cli_validated() {
-    assertCliFail(cli("security-ssl-tls=false", "security-authc=certificate"), "security-ssl-tls is required for security-authc=certificate");
-    assertCliFail(cli("security-ssl-tls=true", "security-authc=certificate"), "security-dir is mandatory for any of the security configuration");
-    assertCliFail(cli("security-ssl-tls=true"), "security-dir is mandatory for any of the security configuration");
-    assertCliFail(cli("security-authc=file"), "security-dir is mandatory for any of the security configuration");
-    assertCliFail(cli("security-authc=ldap"), "security-dir is mandatory for any of the security configuration");
-    assertCliFail(cli("security-audit-log-dir=foo"), "security-dir is mandatory for any of the security configuration");
-    assertCliFail(cli("security-whitelist=true"), "security-dir is mandatory for any of the security configuration");
-    assertCliFail(cli("security-dir=foo"), "One of security-ssl-tls, security-authc, or security-whitelist is required for security configuration");
+    assertCliFail(cli("failover-priority=availability", "security-ssl-tls=false", "security-authc=certificate"), "security-ssl-tls is required for security-authc=certificate");
+    assertCliFail(cli("failover-priority=availability", "security-ssl-tls=true", "security-authc=certificate"), "security-dir is mandatory for any of the security configuration");
+    assertCliFail(cli("failover-priority=availability", "security-ssl-tls=true"), "security-dir is mandatory for any of the security configuration");
+    assertCliFail(cli("failover-priority=availability", "security-authc=file"), "security-dir is mandatory for any of the security configuration");
+    assertCliFail(cli("failover-priority=availability", "security-authc=ldap"), "security-dir is mandatory for any of the security configuration");
+    assertCliFail(cli("failover-priority=availability", "security-audit-log-dir=foo"), "security-dir is mandatory for any of the security configuration");
+    assertCliFail(cli("failover-priority=availability", "security-whitelist=true"), "security-dir is mandatory for any of the security configuration");
+    assertCliFail(cli("failover-priority=availability", "security-dir=foo"), "One of security-ssl-tls, security-authc, or security-whitelist is required for security configuration");
   }
 
   @Test
   public void test_create_config() {
     assertConfigEquals(
         config(
+            "failover-priority=availability",
             "stripe.1.node.1.node-name=node1",
             "stripe.1.node.1.node-name=real",
             "stripe.1.node.1.node-hostname=localhost",
@@ -89,6 +90,7 @@ public class ClusterFactoryTest {
 
     assertConfigEquals(
         config(
+            "failover-priority=availability",
             "stripe.1.node.1.node-name=node1",
             "stripe.1.node.1.node-hostname=localhost"
         ),
@@ -96,6 +98,7 @@ public class ClusterFactoryTest {
 
     assertConfigEquals(
         config(
+            "failover-priority=availability",
             "stripe.1.node.1.node-name=node1",
             "stripe.1.node.1.node-hostname=localhost",
             "stripe.1.node.2.node-name=node2",
@@ -171,33 +174,34 @@ public class ClusterFactoryTest {
   public void test_create_config_validated() {
     // security
     assertConfigFail(
-        config("stripe.1.node.1.node-hostname=localhost", "security-ssl-tls=false", "security-authc=certificate"),
+        config("failover-priority=availability", "stripe.1.node.1.node-hostname=localhost", "security-ssl-tls=false", "security-authc=certificate"),
         "security-ssl-tls is required for security-authc=certificate");
     assertConfigFail(
-        config("stripe.1.node.1.node-hostname=localhost", "security-ssl-tls=true", "security-authc=certificate"),
+        config("failover-priority=availability", "stripe.1.node.1.node-hostname=localhost", "security-ssl-tls=true", "security-authc=certificate"),
         "security-dir is mandatory for any of the security configuration");
     assertConfigFail(
-        config("stripe.1.node.1.node-hostname=localhost", "security-ssl-tls=true"),
+        config("failover-priority=availability", "stripe.1.node.1.node-hostname=localhost", "security-ssl-tls=true"),
         "security-dir is mandatory for any of the security configuration");
     assertConfigFail(
-        config("stripe.1.node.1.node-hostname=localhost", "security-authc=file"),
+        config("failover-priority=availability", "stripe.1.node.1.node-hostname=localhost", "security-authc=file"),
         "security-dir is mandatory for any of the security configuration");
     assertConfigFail(
-        config("stripe.1.node.1.node-hostname=localhost", "security-authc=ldap"),
+        config("failover-priority=availability", "stripe.1.node.1.node-hostname=localhost", "security-authc=ldap"),
         "security-dir is mandatory for any of the security configuration");
     assertConfigFail(
-        config("stripe.1.node.1.node-hostname=localhost", "stripe.1.node.1.security-audit-log-dir=foo"),
+        config("failover-priority=availability", "stripe.1.node.1.node-hostname=localhost", "stripe.1.node.1.security-audit-log-dir=foo"),
         "security-dir is mandatory for any of the security configuration");
     assertConfigFail(
-        config("stripe.1.node.1.node-hostname=localhost", "security-whitelist=true"),
+        config("failover-priority=availability", "stripe.1.node.1.node-hostname=localhost", "security-whitelist=true"),
         "security-dir is mandatory for any of the security configuration");
     assertConfigFail(
-        config("stripe.1.node.1.node-hostname=localhost", "stripe.1.node.1.security-dir=foo"),
+        config("failover-priority=availability", "stripe.1.node.1.node-hostname=localhost", "stripe.1.node.1.security-dir=foo"),
         "One of security-ssl-tls, security-authc, or security-whitelist is required for security configuration");
 
     // duplicate node name
     assertConfigFail(
         config(
+            "failover-priority=availability",
             "stripe.1.node.1.node-hostname=localhost1", "stripe.1.node.1.node-name=foo",
             "stripe.1.node.2.node-hostname=localhost2", "stripe.1.node.2.node-name=foo"
         ),

--- a/dynamic-config/api/src/test/resources/config1_without_defaults.properties
+++ b/dynamic-config/api/src/test/resources/config1_without_defaults.properties
@@ -16,6 +16,7 @@
 
 #Configuration for node 'testServer0' in stripe ID 1
 cluster-name=tc-cluster
+failover-priority=availability
 offheap-resources=primary-server-resource\:64MB
 stripe.1.node.1.data-dirs=
 stripe.1.node.1.node-group-port=23634

--- a/dynamic-config/cli/cli-support/pom.xml
+++ b/dynamic-config/cli/cli-support/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.terracotta.dynamic-config.cli</groupId>
     <artifactId>dynamic-config-cli</artifactId>
-    <version>5.7-SNAPSHOT</version>
+    <version>5.8-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/dynamic-config/cli/config-converter-oss/pom.xml
+++ b/dynamic-config/cli/config-converter-oss/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.terracotta.dynamic-config.cli</groupId>
     <artifactId>dynamic-config-cli</artifactId>
-    <version>5.7-SNAPSHOT</version>
+    <version>5.8-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/dynamic-config/cli/config-converter-oss/src/main/java/org/terracotta/dynamic_config/xml/oss/OssTcConfigMapper.java
+++ b/dynamic-config/cli/config-converter-oss/src/main/java/org/terracotta/dynamic_config/xml/oss/OssTcConfigMapper.java
@@ -33,8 +33,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import static java.util.concurrent.TimeUnit.SECONDS;
-
 /**
  * @author Mathieu Carbou
  */
@@ -74,7 +72,7 @@ public class OssTcConfigMapper extends AbstractTcConfigMapper implements TcConfi
       return Cluster.newCluster(new Stripe(nodes))
           .setClientLeaseDuration(commonMapper.toClientLeaseDuration(xmlPlugins))
           .setOffheapResources(commonMapper.toOffheapResources(xmlPlugins))
-          .setClientReconnectWindow(tcConfig.getServers().getClientReconnectWindow(), SECONDS)
+          .setClientReconnectWindow(commonMapper.toClientReconnectWindow(tcConfig))
           .setFailoverPriority(commonMapper.toFailoverPriority(tcConfig.getFailoverPriority()));
     } catch (IOException e) {
       throw new UncheckedIOException(e);

--- a/dynamic-config/cli/config-converter-oss/src/test/resources/cluster-1.properties
+++ b/dynamic-config/cli/config-converter-oss/src/test/resources/cluster-1.properties
@@ -15,6 +15,7 @@
 #
 
 #Configuration for node 'testServer0' in stripe ID 1
+failover-priority=availability
 cluster-name=my-cluster
 offheap-resources=primary-server-resource\:64MB
 stripe.1.node.1.data-dirs=

--- a/dynamic-config/cli/config-converter/pom.xml
+++ b/dynamic-config/cli/config-converter/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.terracotta.dynamic-config.cli</groupId>
     <artifactId>dynamic-config-cli</artifactId>
-    <version>5.7-SNAPSHOT</version>
+    <version>5.8-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/dynamic-config/cli/config-converter/src/main/java/org/terracotta/dynamic_config/cli/config_converter/xml/CommonMapper.java
+++ b/dynamic-config/cli/config-converter/src/main/java/org/terracotta/dynamic_config/cli/config_converter/xml/CommonMapper.java
@@ -28,6 +28,7 @@ import org.terracotta.config.service.ExtendedConfigParser;
 import org.terracotta.config.service.ServiceConfigParser;
 import org.terracotta.data.config.DataRootMapping;
 import org.terracotta.dynamic_config.api.model.FailoverPriority;
+import org.terracotta.dynamic_config.api.model.Setting;
 import org.terracotta.lease.service.config.LeaseConfigurationParser;
 import org.terracotta.lease.service.config.LeaseElement;
 import org.terracotta.offheapresource.OffHeapResourceConfigurationParser;
@@ -178,5 +179,11 @@ public class CommonMapper {
     // First try to find a deprecated service tag "<persistence:platform-persistence data-directory-id="root1"/>"
     // that will give us the ID of the dataroot to use for platform persistence
     return toDataDirs(plugins, DataRootMapping::isUseForPlatform).entrySet().stream().findFirst();
+  }
+
+  public Measure<TimeUnit> toClientReconnectWindow(TcConfig tcConfig) {
+    return tcConfig == null || tcConfig.getServers() == null || tcConfig.getServers().getClientReconnectWindow() == null ?
+        Measure.parse(Setting.CLIENT_RECONNECT_WINDOW.getDefaultValue(), TimeUnit.class) :
+        Measure.of(tcConfig.getServers().getClientReconnectWindow(), TimeUnit.SECONDS);
   }
 }

--- a/dynamic-config/cli/config-tool/pom.xml
+++ b/dynamic-config/cli/config-tool/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.terracotta.dynamic-config.cli</groupId>
     <artifactId>dynamic-config-cli</artifactId>
-    <version>5.7-SNAPSHOT</version>
+    <version>5.8-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/command/RemoteCommand.java
+++ b/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/command/RemoteCommand.java
@@ -388,12 +388,12 @@ public abstract class RemoteCommand extends Command {
     }
   }
 
-  protected final void resetAndRestart(InetSocketAddress expectedOnlineNode) {
-    logger.info("Reset node: {}. Will restart in 5 seconds", expectedOnlineNode);
+  protected final void resetAndStop(InetSocketAddress expectedOnlineNode) {
+    logger.info("Reset node: {}. Node will stop in 5 seconds", expectedOnlineNode);
     try (DiagnosticService diagnosticService = diagnosticServiceProvider.fetchDiagnosticService(expectedOnlineNode)) {
       DynamicConfigService proxy = diagnosticService.getProxy(DynamicConfigService.class);
       proxy.reset();
-      proxy.restart(Duration.ofSeconds(5));
+      proxy.stop(Duration.ofSeconds(5));
     }
   }
 

--- a/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/command/RepairCommand.java
+++ b/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/command/RepairCommand.java
@@ -56,7 +56,7 @@ public class RepairCommand extends RemoteCommand {
   @Override
   public final void run() {
     if (forcedRepairAction == RepairAction.RESET) {
-      resetAndRestart(node);
+      resetAndStop(node);
     } else {
       nomadRepair();
     }

--- a/dynamic-config/cli/pom.xml
+++ b/dynamic-config/cli/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.terracotta.dynamic-config</groupId>
     <artifactId>dynamic-config</artifactId>
-    <version>5.7-SNAPSHOT</version>
+    <version>5.8-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/dynamic-config/entities/management-entity/server/pom.xml
+++ b/dynamic-config/entities/management-entity/server/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.terracotta.dynamic-config.entities</groupId>
     <artifactId>dynamic-config-entities</artifactId>
-    <version>5.7-SNAPSHOT</version>
+    <version>5.8-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/dynamic-config/entities/nomad-entity/client/pom.xml
+++ b/dynamic-config/entities/nomad-entity/client/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.terracotta.dynamic-config.entities</groupId>
     <artifactId>dynamic-config-entities</artifactId>
-    <version>5.7-SNAPSHOT</version>
+    <version>5.8-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/dynamic-config/entities/nomad-entity/common/pom.xml
+++ b/dynamic-config/entities/nomad-entity/common/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.terracotta.dynamic-config.entities</groupId>
     <artifactId>dynamic-config-entities</artifactId>
-    <version>5.7-SNAPSHOT</version>
+    <version>5.8-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/dynamic-config/entities/nomad-entity/server/pom.xml
+++ b/dynamic-config/entities/nomad-entity/server/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.terracotta.dynamic-config.entities</groupId>
     <artifactId>dynamic-config-entities</artifactId>
-    <version>5.7-SNAPSHOT</version>
+    <version>5.8-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/dynamic-config/entities/pom.xml
+++ b/dynamic-config/entities/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.terracotta.dynamic-config</groupId>
     <artifactId>dynamic-config</artifactId>
-    <version>5.7-SNAPSHOT</version>
+    <version>5.8-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/dynamic-config/entities/topology-entity/client/pom.xml
+++ b/dynamic-config/entities/topology-entity/client/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.terracotta.dynamic-config.entities</groupId>
     <artifactId>dynamic-config-entities</artifactId>
-    <version>5.7-SNAPSHOT</version>
+    <version>5.8-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/dynamic-config/entities/topology-entity/common/pom.xml
+++ b/dynamic-config/entities/topology-entity/common/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.terracotta.dynamic-config.entities</groupId>
     <artifactId>dynamic-config-entities</artifactId>
-    <version>5.7-SNAPSHOT</version>
+    <version>5.8-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/dynamic-config/entities/topology-entity/server/pom.xml
+++ b/dynamic-config/entities/topology-entity/server/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.terracotta.dynamic-config.entities</groupId>
     <artifactId>dynamic-config-entities</artifactId>
-    <version>5.7-SNAPSHOT</version>
+    <version>5.8-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/dynamic-config/pom.xml
+++ b/dynamic-config/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.terracotta</groupId>
     <artifactId>platform-root</artifactId>
-    <version>5.7-SNAPSHOT</version>
+    <version>5.8-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/dynamic-config/server/configuration-provider/pom.xml
+++ b/dynamic-config/server/configuration-provider/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.terracotta.dynamic-config.server</groupId>
     <artifactId>dynamic-config-server</artifactId>
-    <version>5.7-SNAPSHOT</version>
+    <version>5.8-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/service/DynamicConfigServiceImpl.java
+++ b/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/service/DynamicConfigServiceImpl.java
@@ -85,6 +85,7 @@ public class DynamicConfigServiceImpl implements TopologyService, DynamicConfigS
     if (hasLicenseFile()) {
       validateAgainstLicense(upcomingNodeContext.getCluster());
     }
+    new ClusterValidator(nodeContext.getCluster()).validate();
   }
 
   /**

--- a/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/startup/CustomJCommander.java
+++ b/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/startup/CustomJCommander.java
@@ -31,6 +31,7 @@ import java.util.Optional;
 import java.util.TreeMap;
 
 import static java.lang.System.lineSeparator;
+import static org.terracotta.dynamic_config.api.model.Setting.NODE_NAME;
 
 public class CustomJCommander extends JCommander {
   private final Collection<String> userSpecifiedOptions = new HashSet<>();
@@ -75,7 +76,14 @@ public class CustomJCommander extends JCommander {
         out.append(indent).append("    ").append(pd.getNames()).append(parameter.required() ? " (required)" : "");
         Optional<Setting> settingOptional = Setting.findSetting(ConsoleParamsUtils.stripDashDash(pd.getLongestName()));
         if (settingOptional.isPresent()) {
-          String defaultValue = settingOptional.get().getDefaultValue();
+          Setting setting = settingOptional.get();
+          String defaultValue = setting.getDefaultValue();
+
+          // special handling
+          if (setting == NODE_NAME) {
+            defaultValue = "<randomly-generated>";
+          }
+
           if (defaultValue != null) {
             out.append(indent).append("    ");
             for (int i = 0; i < maxParamLength - pd.getNames().length(); i++) {

--- a/dynamic-config/server/configuration-repository/pom.xml
+++ b/dynamic-config/server/configuration-repository/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.terracotta.dynamic-config.server</groupId>
     <artifactId>dynamic-config-server</artifactId>
-    <version>5.7-SNAPSHOT</version>
+    <version>5.8-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/dynamic-config/server/configuration-repository/src/test/resources/config.properties
+++ b/dynamic-config/server/configuration-repository/src/test/resources/config.properties
@@ -16,6 +16,7 @@
 
 #Configuration for node 'node-1' in stripe ID 1
 cluster-name=bar
+failover-priority=availability
 stripe.1.node.1.node-hostname=localhost
 stripe.1.node.1.node-name=node-1
 this.node-id=1

--- a/dynamic-config/server/pom.xml
+++ b/dynamic-config/server/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.terracotta.dynamic-config</groupId>
     <artifactId>dynamic-config</artifactId>
-    <version>5.7-SNAPSHOT</version>
+    <version>5.8-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/dynamic-config/server/server-api/pom.xml
+++ b/dynamic-config/server/server-api/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.terracotta.dynamic-config.server</groupId>
     <artifactId>dynamic-config-server</artifactId>
-    <version>5.7-SNAPSHOT</version>
+    <version>5.8-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/dynamic-config/server/services/pom.xml
+++ b/dynamic-config/server/services/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.terracotta.dynamic-config.server</groupId>
     <artifactId>dynamic-config-server</artifactId>
-    <version>5.7-SNAPSHOT</version>
+    <version>5.8-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/dynamic-config/testing/entity/pom.xml
+++ b/dynamic-config/testing/entity/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.terracotta.dynamic-config.testing</groupId>
     <artifactId>dynamic-config-testing</artifactId>
-    <version>5.7-SNAPSHOT</version>
+    <version>5.8-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/dynamic-config/testing/pom.xml
+++ b/dynamic-config/testing/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.terracotta.dynamic-config</groupId>
     <artifactId>dynamic-config</artifactId>
-    <version>5.7-SNAPSHOT</version>
+    <version>5.8-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/dynamic-config/testing/support/pom.xml
+++ b/dynamic-config/testing/support/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.terracotta.dynamic-config.testing</groupId>
     <artifactId>dynamic-config-testing</artifactId>
-    <version>5.7-SNAPSHOT</version>
+    <version>5.8-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/dynamic-config/testing/support/src/main/java/org/terracotta/dynamic_config/test_support/DynamicConfigIT.java
+++ b/dynamic-config/testing/support/src/main/java/org/terracotta/dynamic_config/test_support/DynamicConfigIT.java
@@ -71,6 +71,7 @@ import static org.terracotta.angela.common.AngelaProperties.DISTRIBUTION;
 import static org.terracotta.angela.common.TerracottaServerState.STARTED_AS_ACTIVE;
 import static org.terracotta.angela.common.TerracottaServerState.STARTED_AS_PASSIVE;
 import static org.terracotta.angela.common.TerracottaServerState.STARTED_IN_DIAGNOSTIC_MODE;
+import static org.terracotta.angela.common.TerracottaServerState.STOPPED;
 import static org.terracotta.angela.common.distribution.Distribution.distribution;
 import static org.terracotta.angela.common.dynamic_cluster.Stripe.stripe;
 import static org.terracotta.angela.common.provider.DynamicConfigManager.dynamicCluster;
@@ -368,6 +369,10 @@ public class DynamicConfigIT {
 
   protected final void waitForDiagnostic(int stripeId, int nodeId) throws TimeoutException {
     waitUntil(() -> angela.tsa().getState(getNode(stripeId, nodeId)), is(equalTo(STARTED_IN_DIAGNOSTIC_MODE)));
+  }
+
+  protected final void waitForStopped(int stripeId, int nodeId) throws TimeoutException {
+    waitUntil(() -> angela.tsa().getState(getNode(stripeId, nodeId)), is(equalTo(STOPPED)));
   }
 
   protected final void waitForPassives(int stripeId) throws TimeoutException {

--- a/dynamic-config/testing/system-tests/pom.xml
+++ b/dynamic-config/testing/system-tests/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.terracotta.dynamic-config.testing</groupId>
     <artifactId>dynamic-config-testing</artifactId>
-    <version>5.7-SNAPSHOT</version>
+    <version>5.8-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/RepairCommand1x2IT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/RepairCommand1x2IT.java
@@ -222,6 +222,8 @@ public class RepairCommand1x2IT extends DynamicConfigIT {
 
     // we can reset this node
     configToolInvocation("-r", "5s", "repair", "-f", "reset", "-s", "localhost:" + getNodePort(1, passiveId));
+    waitForStopped(1, passiveId);
+    startNode(1, passiveId, "--failover-priority", "availability");
     waitForDiagnostic(1, passiveId);
   }
 
@@ -231,12 +233,16 @@ public class RepairCommand1x2IT extends DynamicConfigIT {
     startNode(1, 1);
     waitForDiagnostic(1, 1);
     assertThat(configToolInvocation("-r", "5s", "repair", "-f", "reset", "-s", "localhost:" + getNodePort()), is(successful()));
+    waitForStopped(1, 1);
+    startNode(1, 1);
     waitForDiagnostic(1, 1);
 
     // reset activated node
     assertThat(configToolInvocation("activate", "-n", "my-cluster", "-s", "localhost:" + getNodePort()), is(successful()));
     waitForActive(1, 1);
     assertThat(configToolInvocation("-r", "5s", "repair", "-f", "reset", "-s", "localhost:" + getNodePort()), is(successful()));
+    waitForStopped(1, 1);
+    startNode(1, 1);
     waitForDiagnostic(1, 1);
 
     // reset node restarted in repair mode
@@ -246,6 +252,8 @@ public class RepairCommand1x2IT extends DynamicConfigIT {
     startNode(1, 1, "-r", getNode(1, 1).getConfigRepo(), "--repair-mode");
     waitForDiagnostic(1, 1);
     assertThat(configToolInvocation("-r", "5s", "repair", "-f", "reset", "-s", "localhost:" + getNodePort()), is(successful()));
+    waitForStopped(1, 1);
+    startNode(1, 1);
     waitForDiagnostic(1, 1);
 
     // ensure we still can re-activate the node

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activation/Ipv6CliActivationIT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activation/Ipv6CliActivationIT.java
@@ -32,6 +32,7 @@ public class Ipv6CliActivationIT extends DynamicConfigIT {
   protected void startNode(int stripeId, int nodeId) {
     startNode(stripeId, nodeId,
         "--node-name", getNodeName(stripeId, nodeId),
+        "--failover-priority", "availability",
         "--node-hostname", "::1",
         "--node-bind-address", "::",
         "--node-group-bind-address", "::",

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activation/PreActivatedNodeStartup1x2IT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activation/PreActivatedNodeStartup1x2IT.java
@@ -56,11 +56,12 @@ public class PreActivatedNodeStartup1x2IT extends DynamicConfigIT {
   public void testPreventConcurrentUseOfRepository() throws Exception {
     // Angela work dirs are different for each server instance. We'd need to create a repo at a common place for this test
     String sharedRepo = Files.createDirectories(getBaseDir()).toAbsolutePath().toString();
-    startNode(1, 1, "--node-name", "node-1-1", "-r", sharedRepo, "-p", String.valueOf(getNodePort()), "-g", String.valueOf(getNodeGroupPort(1, 1)), "-N", "tc-cluster");
+    startNode(1, 1, "--failover-priority", "availability", "--node-name", "node-1-1", "-r", sharedRepo, "-p", String.valueOf(getNodePort()), "-g", String.valueOf(getNodeGroupPort(1, 1)), "-N", "tc-cluster");
     waitForActive(1, 1);
 
     try {
       startNode(1, 2,
+          "--failover-priority", "availability",
           "--node-name", getNodeName(1, 2),
           "--node-repository-dir", sharedRepo,
           "-p", String.valueOf(getNodePort(1, 2)),
@@ -79,6 +80,7 @@ public class PreActivatedNodeStartup1x2IT extends DynamicConfigIT {
   private void startSingleNode(String... args) {
     // these arguments are required to be added to isolate the node data files into the build/test-data directory to not conflict with other processes
     Collection<String> defaultArgs = new ArrayList<>(Arrays.asList(
+        "--failover-priority", "availability",
         "--node-name", getNodeName(1, 1),
         "--node-hostname", "localhost",
         "--node-log-dir", getNodePath(1, 1).resolve("logs").toString(),

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/diagnostic/NodeStartupIT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/diagnostic/NodeStartupIT.java
@@ -155,7 +155,7 @@ public class NodeStartupIT extends DynamicConfigIT {
   @Test
   public void testFailedStartupCliParams_invalidFailoverPriority() throws TimeoutException {
     try {
-      startSingleNode("--failover-priority=blah", "-r", getNodeRepositoryDir(1, 1).toString());
+      startSingleNode("--failover-priority", "blah", "-r", getNodeRepositoryDir(1, 1).toString());
       fail();
     } catch (Exception e) {
       waitUntil(err::getLog, containsString("failover-priority should be either 'availability', 'consistency', or 'consistency:N' (where 'N' is the voter count expressed as a non-negative integer)"));
@@ -222,6 +222,7 @@ public class NodeStartupIT extends DynamicConfigIT {
   private void startSingleNode(String... args) {
     // these arguments are required to be added to isolate the node data files into the build/test-data directory to not conflict with other processes
     Collection<String> defaultArgs = new ArrayList<>(Arrays.asList(
+        "--failover-priority", "availability",
         "--node-name", getNodeName(1, 1),
         "--node-hostname", "localhost",
         "--node-log-dir", getNodePath(1, 1).resolve("logs").toString(),
@@ -240,6 +241,10 @@ public class NodeStartupIT extends DynamicConfigIT {
     if (provided.contains("-s") || provided.contains("--node-hostname")) {
       defaultArgs.remove("--node-hostname");
       defaultArgs.remove("localhost");
+    }
+    if (provided.contains("--failover-priority")) {
+      defaultArgs.remove("--failover-priority");
+      defaultArgs.remove("availability");
     }
     defaultArgs.addAll(provided);
     startNode(1, 1, defaultArgs.toArray(new String[0]));

--- a/galvan-platform-support/pom.xml
+++ b/galvan-platform-support/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.terracotta</groupId>
     <artifactId>platform-root</artifactId>
-    <version>5.7-SNAPSHOT</version>
+    <version>5.8-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/healthchecker-entity/api/pom.xml
+++ b/healthchecker-entity/api/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.terracotta</groupId>
     <artifactId>healthchecker-entity</artifactId>
-    <version>5.7-SNAPSHOT</version>
+    <version>5.8-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/healthchecker-entity/client-impl/pom.xml
+++ b/healthchecker-entity/client-impl/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.terracotta</groupId>
     <artifactId>healthchecker-entity</artifactId>
-    <version>5.7-SNAPSHOT</version>
+    <version>5.8-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/healthchecker-entity/common/pom.xml
+++ b/healthchecker-entity/common/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.terracotta</groupId>
     <artifactId>healthchecker-entity</artifactId>
-    <version>5.7-SNAPSHOT</version>
+    <version>5.8-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/healthchecker-entity/pom.xml
+++ b/healthchecker-entity/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.terracotta</groupId>
     <artifactId>platform-root</artifactId>
-    <version>5.7-SNAPSHOT</version>
+    <version>5.8-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/healthchecker-entity/server-impl/pom.xml
+++ b/healthchecker-entity/server-impl/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.terracotta</groupId>
     <artifactId>healthchecker-entity</artifactId>
-    <version>5.7-SNAPSHOT</version>
+    <version>5.8-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/kit/pom.xml
+++ b/kit/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.terracotta</groupId>
     <artifactId>platform-root</artifactId>
-    <version>5.7-SNAPSHOT</version>
+    <version>5.8-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/lease/api/pom.xml
+++ b/lease/api/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.terracotta</groupId>
     <artifactId>lease</artifactId>
-    <version>5.7-SNAPSHOT</version>
+    <version>5.8-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/lease/common/pom.xml
+++ b/lease/common/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.terracotta</groupId>
     <artifactId>lease</artifactId>
-    <version>5.7-SNAPSHOT</version>
+    <version>5.8-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/lease/entity-api/pom.xml
+++ b/lease/entity-api/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.terracotta</groupId>
     <artifactId>lease</artifactId>
-    <version>5.7-SNAPSHOT</version>
+    <version>5.8-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/lease/entity-client/pom.xml
+++ b/lease/entity-client/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.terracotta</groupId>
     <artifactId>lease</artifactId>
-    <version>5.7-SNAPSHOT</version>
+    <version>5.8-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/lease/entity-common/pom.xml
+++ b/lease/entity-common/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.terracotta</groupId>
     <artifactId>lease</artifactId>
-    <version>5.7-SNAPSHOT</version>
+    <version>5.8-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/lease/entity-server/pom.xml
+++ b/lease/entity-server/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.terracotta</groupId>
     <artifactId>lease</artifactId>
-    <version>5.7-SNAPSHOT</version>
+    <version>5.8-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/lease/passthrough-leased-connection-api/pom.xml
+++ b/lease/passthrough-leased-connection-api/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.terracotta</groupId>
     <artifactId>lease</artifactId>
-    <version>5.7-SNAPSHOT</version>
+    <version>5.8-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/lease/pom.xml
+++ b/lease/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.terracotta</groupId>
     <artifactId>platform-root</artifactId>
-    <version>5.7-SNAPSHOT</version>
+    <version>5.8-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/lease/system-test/pom.xml
+++ b/lease/system-test/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.terracotta</groupId>
     <artifactId>lease</artifactId>
-    <version>5.7-SNAPSHOT</version>
+    <version>5.8-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/management/cluster-topology/pom.xml
+++ b/management/cluster-topology/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>terracotta-management</artifactId>
     <groupId>org.terracotta.management</groupId>
-    <version>5.7-SNAPSHOT</version>
+    <version>5.8-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/management/management-model/pom.xml
+++ b/management/management-model/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.terracotta.management</groupId>
     <artifactId>terracotta-management</artifactId>
-    <version>5.7-SNAPSHOT</version>
+    <version>5.8-SNAPSHOT</version>
   </parent>
 
   <artifactId>management-model</artifactId>

--- a/management/management-registry/pom.xml
+++ b/management/management-registry/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.terracotta.management</groupId>
     <artifactId>terracotta-management</artifactId>
-    <version>5.7-SNAPSHOT</version>
+    <version>5.8-SNAPSHOT</version>
   </parent>
 
   <artifactId>management-registry</artifactId>

--- a/management/monitoring-service-api/pom.xml
+++ b/management/monitoring-service-api/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>terracotta-management</artifactId>
     <groupId>org.terracotta.management</groupId>
-    <version>5.7-SNAPSHOT</version>
+    <version>5.8-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/management/monitoring-service/pom.xml
+++ b/management/monitoring-service/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>terracotta-management</artifactId>
     <groupId>org.terracotta.management</groupId>
-    <version>5.7-SNAPSHOT</version>
+    <version>5.8-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/management/nms-agent-entity/nms-agent-entity-client/pom.xml
+++ b/management/nms-agent-entity/nms-agent-entity-client/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>nms-agent-entity</artifactId>
     <groupId>org.terracotta.management</groupId>
-    <version>5.7-SNAPSHOT</version>
+    <version>5.8-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/management/nms-agent-entity/nms-agent-entity-common/pom.xml
+++ b/management/nms-agent-entity/nms-agent-entity-common/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>nms-agent-entity</artifactId>
     <groupId>org.terracotta.management</groupId>
-    <version>5.7-SNAPSHOT</version>
+    <version>5.8-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/management/nms-agent-entity/nms-agent-entity-server/pom.xml
+++ b/management/nms-agent-entity/nms-agent-entity-server/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>nms-agent-entity</artifactId>
     <groupId>org.terracotta.management</groupId>
-    <version>5.7-SNAPSHOT</version>
+    <version>5.8-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/management/nms-agent-entity/pom.xml
+++ b/management/nms-agent-entity/pom.xml
@@ -31,7 +31,7 @@
   <parent>
     <groupId>org.terracotta.management</groupId>
     <artifactId>terracotta-management</artifactId>
-    <version>5.7-SNAPSHOT</version>
+    <version>5.8-SNAPSHOT</version>
   </parent>
 
   <artifactId>nms-agent-entity</artifactId>

--- a/management/nms-entity/nms-entity-client/pom.xml
+++ b/management/nms-entity/nms-entity-client/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>nms-entity</artifactId>
     <groupId>org.terracotta.management</groupId>
-    <version>5.7-SNAPSHOT</version>
+    <version>5.8-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/management/nms-entity/nms-entity-common/pom.xml
+++ b/management/nms-entity/nms-entity-common/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>nms-entity</artifactId>
     <groupId>org.terracotta.management</groupId>
-    <version>5.7-SNAPSHOT</version>
+    <version>5.8-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/management/nms-entity/nms-entity-server/pom.xml
+++ b/management/nms-entity/nms-entity-server/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>nms-entity</artifactId>
     <groupId>org.terracotta.management</groupId>
-    <version>5.7-SNAPSHOT</version>
+    <version>5.8-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/management/nms-entity/pom.xml
+++ b/management/nms-entity/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>terracotta-management</artifactId>
     <groupId>org.terracotta.management</groupId>
-    <version>5.7-SNAPSHOT</version>
+    <version>5.8-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/management/pom.xml
+++ b/management/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.terracotta</groupId>
     <artifactId>platform-root</artifactId>
-    <version>5.7-SNAPSHOT</version>
+    <version>5.8-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/management/sequence-generator/pom.xml
+++ b/management/sequence-generator/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>terracotta-management</artifactId>
     <groupId>org.terracotta.management</groupId>
-    <version>5.7-SNAPSHOT</version>
+    <version>5.8-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/management/testing/doc/pom.xml
+++ b/management/testing/doc/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>terracotta-management</artifactId>
     <groupId>org.terracotta.management</groupId>
-    <version>5.7-SNAPSHOT</version>
+    <version>5.8-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/management/testing/integration-tests/pom.xml
+++ b/management/testing/integration-tests/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>terracotta-management</artifactId>
     <groupId>org.terracotta.management</groupId>
-    <version>5.7-SNAPSHOT</version>
+    <version>5.8-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/management/testing/sample-entity/pom.xml
+++ b/management/testing/sample-entity/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>terracotta-management</artifactId>
     <groupId>org.terracotta.management</groupId>
-    <version>5.7-SNAPSHOT</version>
+    <version>5.8-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/offheap-resource/pom.xml
+++ b/offheap-resource/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.terracotta</groupId>
     <artifactId>platform-root</artifactId>
-    <version>5.7-SNAPSHOT</version>
+    <version>5.8-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/platform-base/pom.xml
+++ b/platform-base/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.terracotta</groupId>
     <artifactId>platform-root</artifactId>
-    <version>5.7-SNAPSHOT</version>
+    <version>5.8-SNAPSHOT</version>
   </parent>
 
   <artifactId>platform-base</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
   </parent>
 
   <artifactId>platform-root</artifactId>
-  <version>5.7-SNAPSHOT</version>
+  <version>5.8-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <properties>

--- a/runnel/pom.xml
+++ b/runnel/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.terracotta</groupId>
     <artifactId>platform-root</artifactId>
-    <version>5.7-SNAPSHOT</version>
+    <version>5.8-SNAPSHOT</version>
   </parent>
 
   <artifactId>runnel</artifactId>

--- a/voltron-proxy/pom.xml
+++ b/voltron-proxy/pom.xml
@@ -29,7 +29,7 @@
   <parent>
     <groupId>org.terracotta</groupId>
     <artifactId>platform-root</artifactId>
-    <version>5.7-SNAPSHOT</version>
+    <version>5.8-SNAPSHOT</version>
   </parent>
 
   <groupId>org.terracotta.voltron.proxy</groupId>

--- a/voltron-proxy/voltron-proxy-client/pom.xml
+++ b/voltron-proxy/voltron-proxy-client/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>voltron-proxy</artifactId>
     <groupId>org.terracotta.voltron.proxy</groupId>
-    <version>5.7-SNAPSHOT</version>
+    <version>5.8-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/voltron-proxy/voltron-proxy-common/pom.xml
+++ b/voltron-proxy/voltron-proxy-common/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>voltron-proxy</artifactId>
     <groupId>org.terracotta.voltron.proxy</groupId>
-    <version>5.7-SNAPSHOT</version>
+    <version>5.8-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/voltron-proxy/voltron-proxy-server/pom.xml
+++ b/voltron-proxy/voltron-proxy-server/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>voltron-proxy</artifactId>
     <groupId>org.terracotta.voltron.proxy</groupId>
-    <version>5.7-SNAPSHOT</version>
+    <version>5.8-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
### Changes

- failover priority is now required in CLI if using CLI, or required in config if using config file
- `<randomly-generated>` in help for node name
- several fixes
- 5.7-SNAPSHOT => 5.8-SNAPSHOT

### Important note:

1) The failover priority change now makes failover priority required. 

But the way I did it, I hard-coded the fact that this setting is required instead of using the `Setting` class definition. So correctly fix that, a much bigger refactoring needs to be done to correctly support settings that are required, must be set and have no default. TDB-4898 is already opened for that, because this refactoring also touches how defaults are handled. **So This is something that I will be able to improve in the background, without impacting the UX.**

2) The repair command `-t reset`, when resetting a node, does not restart a node anymore but stop it. The reason is that this is impossible to restart a node with the same CLI tha twas used before because this CLI can now be incorrect. **This is caused by the failover priority now being required.**

Example: 
 1. start a node with a given config repo with `-r path/to/repo`
 2. reset the node
 3. Before, it would restart with `-r path/to/repo`. But the repo is empty, so not config file, so we look at the CLI options, and failover priority is missing so the startup fails.

**A consequence of the failover priority being required is that it can prevent a node to be restarted with the default CLI and thus from being accessible and repaired. The default CLI was  initially designed to have defaults so that a node can always start.**

### Help:

```
❯  ./kit/target/platform-kit-5.8-SNAPSHOT/platform-kit-5.8-SNAPSHOT/server/bin/start-tc-server.sh -h
2020-04-29 01:01:45,450 INFO - PID is 52065
usage: [start-tc-server.sh|bat] [options]
Options:
 -c,--consistency-on-startup   ensure that data consistency is preserved
                               on startup
 -h,--help
 -u,--upgrade-compatiblity     enable rolling upgrade compatiblity mode

Dynamic Configuration Options:
    -i, --client-lease-duration      (Default: 150s)
    -R, --client-reconnect-window    (Default: 120s)
    -N, --cluster-name
    -f, --config-file
    -d, --data-dirs                  (Default: main:%H/terracotta/user-data/main)
    -y, --failover-priority
    -l, --license-file
    -b, --node-backup-dir
    -a, --node-bind-address          (Default: 0.0.0.0)
    -A, --node-group-bind-address    (Default: 0.0.0.0)
    -g, --node-group-port            (Default: 9430)
    -s, --node-hostname              (Default: %h)
    -L, --node-log-dir               (Default: %H/terracotta/logs)
    -m, --node-metadata-dir          (Default: %H/terracotta/metadata)
    -n, --node-name                  (Default: <randomly-generated>)
    -p, --node-port                  (Default: 9410)
    -S, --node-public-hostname
    -P, --node-public-port
    -r, --node-repository-dir        (Default: %H/terracotta/repository)
    -o, --offheap-resources          (Default: main:512MB)
    -D, --repair-mode
    -u, --security-audit-log-dir
    -z, --security-authc
    -x, --security-dir
    -t, --security-ssl-tls           (Default: false)
    -w, --security-whitelist         (Default: false)
    -T, --tc-properties
```