### PR TITLE
[BUGFIX] Prevent failure when concurrent forked JVM create the target/galvan folder

### DIFF
--- a/galvan-platform-support/src/main/java/org/terracotta/testing/rules/BasicExternalCluster.java
+++ b/galvan-platform-support/src/main/java/org/terracotta/testing/rules/BasicExternalCluster.java
@@ -92,7 +92,7 @@ class BasicExternalCluster extends Cluster {
       }
     } else {
       boolean didCreateDirectories = clusterDirectory.toFile().mkdirs();
-      if (!didCreateDirectories) {
+      if (!didCreateDirectories && !Files.exists(clusterDirectory)) {
         throw new IllegalArgumentException("Cluster directory could not be created: " + clusterDirectory);
       }
     }


### PR DESCRIPTION
You could end up with Windows builds failing with this error:

```
java.lang.IllegalArgumentException: Cluster directory could not be created: target\galvan
	at org.terracotta.testing.rules.BasicExternalCluster.<init>(BasicExternalCluster.java:96)
	at org.terracotta.testing.rules.BasicExternalClusterBuilder.build(BasicExternalClusterBuilder.java:155)
	at org.terracotta.management.integration.tests.AbstractSingleTest.<init>(AbstractSingleTest.java:46)
	at org.terracotta.management.integration.tests.ClientCacheRemoteManagementIT.<init>(ClientCacheRemoteManagementIT.java:34)
```

Example: https://dev.azure.com/TerracottaCI/terracotta/_build/results?buildId=4484&view=ms.vss-test-web.build-test-results-tab&runId=1009560&resultId=100872&paneView=debug