### PR TITLE
TDB-4990: Use Runnel for dynamic topology entity to not leak jackson libs on client's classpath

### DIFF
--- a/common/nomad/pom.xml
+++ b/common/nomad/pom.xml
@@ -33,6 +33,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
+      <scope>provided</scope>
     </dependency>
   </dependencies>
 </project>

--- a/data-root-resource/pom.xml
+++ b/data-root-resource/pom.xml
@@ -112,6 +112,16 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <failOnWarning>false</failOnWarning>
+          <compilerArgs>
+            <arg>-Xlint:all</arg>
+          </compilerArgs>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>org.jvnet.jaxb2.maven2</groupId>
         <artifactId>maven-jaxb2-plugin</artifactId>
         <executions>

--- a/dynamic-config/api/pom.xml
+++ b/dynamic-config/api/pom.xml
@@ -48,6 +48,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
+      <scope>provided</scope>
     </dependency>
 
     <dependency>

--- a/dynamic-config/api/src/main/java/org/terracotta/dynamic_config/api/model/Cluster.java
+++ b/dynamic-config/api/src/main/java/org/terracotta/dynamic_config/api/model/Cluster.java
@@ -67,6 +67,7 @@ public class Cluster implements Cloneable, PropertyHolder {
   }
 
   @Override
+  @JsonIgnore
   public Scope getScope() {
     return CLUSTER;
   }
@@ -403,6 +404,7 @@ public class Cluster implements Cloneable, PropertyHolder {
   /**
    * Transform this model into a config file where all the "map" like settings can be expanded (one item per line)
    */
+  @Override
   public Properties toProperties(boolean expanded, boolean includeDefaultValues) {
     Properties properties = Setting.modelToProperties(this, expanded, includeDefaultValues);
     for (int i = 0; i < stripes.size(); i++) {

--- a/dynamic-config/api/src/main/java/org/terracotta/dynamic_config/api/model/Node.java
+++ b/dynamic-config/api/src/main/java/org/terracotta/dynamic_config/api/model/Node.java
@@ -60,6 +60,7 @@ public class Node implements Cloneable, PropertyHolder {
   }
 
   @Override
+  @JsonIgnore
   public Scope getScope() {
     return NODE;
   }
@@ -395,6 +396,7 @@ public class Node implements Cloneable, PropertyHolder {
   /**
    * Transform this model into a config file where all the "map" like settings can be expanded (one item per line)
    */
+  @Override
   public Properties toProperties(boolean expanded, boolean includeDefaultValues) {
     return Setting.modelToProperties(this, expanded, includeDefaultValues);
   }

--- a/dynamic-config/api/src/main/java/org/terracotta/dynamic_config/api/model/Node.java
+++ b/dynamic-config/api/src/main/java/org/terracotta/dynamic_config/api/model/Node.java
@@ -27,6 +27,7 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Properties;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.concurrent.ConcurrentHashMap;
@@ -389,6 +390,13 @@ public class Node implements Cloneable, PropertyHolder {
     }
 
     return thisCopy;
+  }
+
+  /**
+   * Transform this model into a config file where all the "map" like settings can be expanded (one item per line)
+   */
+  public Properties toProperties(boolean expanded, boolean includeDefaultValues) {
+    return Setting.modelToProperties(this, expanded, includeDefaultValues);
   }
 
   public Node fillRequiredSettings() {

--- a/dynamic-config/api/src/main/java/org/terracotta/dynamic_config/api/model/PropertyHolder.java
+++ b/dynamic-config/api/src/main/java/org/terracotta/dynamic_config/api/model/PropertyHolder.java
@@ -15,12 +15,13 @@
  */
 package org.terracotta.dynamic_config.api.model;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
+import java.util.Properties;
 
 /**
  * @author Mathieu Carbou
  */
 public interface PropertyHolder {
-  @JsonIgnore
   Scope getScope();
+
+  Properties toProperties(boolean expanded, boolean includeDefaultValues);
 }

--- a/dynamic-config/api/src/main/java/org/terracotta/dynamic_config/api/model/Stripe.java
+++ b/dynamic-config/api/src/main/java/org/terracotta/dynamic_config/api/model/Stripe.java
@@ -29,6 +29,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalInt;
+import java.util.Properties;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.stream.IntStream;
 
@@ -191,5 +192,18 @@ public class Stripe implements Cloneable {
         .filter(idx -> nodes.get(idx).hasAddress(nodeAddress))
         .map(idx -> idx + 1)
         .findAny();
+  }
+
+  /**
+   * Transform this model into a config file where all the "map" like settings can be expanded (one item per line)
+   */
+  public Properties toProperties(boolean expanded, boolean includeDefaultValues) {
+    Properties properties = new Properties();
+    for (int i = 0; i < nodes.size(); i++) {
+      String prefix = "node." + (i + 1) + ".";
+      Properties props = nodes.get(i).toProperties(expanded, includeDefaultValues);
+      props.stringPropertyNames().forEach(key -> properties.setProperty(prefix + key, props.getProperty(key)));
+    }
+    return properties;
   }
 }

--- a/dynamic-config/api/src/main/java/org/terracotta/dynamic_config/api/model/Stripe.java
+++ b/dynamic-config/api/src/main/java/org/terracotta/dynamic_config/api/model/Stripe.java
@@ -38,7 +38,7 @@ import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toList;
 
 
-public class Stripe implements Cloneable {
+public class Stripe implements Cloneable, PropertyHolder {
   private final List<Node> nodes;
 
   @JsonCreator
@@ -197,6 +197,7 @@ public class Stripe implements Cloneable {
   /**
    * Transform this model into a config file where all the "map" like settings can be expanded (one item per line)
    */
+  @Override
   public Properties toProperties(boolean expanded, boolean includeDefaultValues) {
     Properties properties = new Properties();
     for (int i = 0; i < nodes.size(); i++) {
@@ -205,5 +206,11 @@ public class Stripe implements Cloneable {
       props.stringPropertyNames().forEach(key -> properties.setProperty(prefix + key, props.getProperty(key)));
     }
     return properties;
+  }
+
+  @JsonIgnore
+  @Override
+  public Scope getScope() {
+    return Scope.STRIPE;
   }
 }

--- a/dynamic-config/cli/cli-support/pom.xml
+++ b/dynamic-config/cli/cli-support/pom.xml
@@ -52,4 +52,19 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <failOnWarning>false</failOnWarning>
+          <compilerArgs>
+            <arg>-Xlint:all</arg>
+          </compilerArgs>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/dynamic-config/entities/management-entity/server/pom.xml
+++ b/dynamic-config/entities/management-entity/server/pom.xml
@@ -55,4 +55,19 @@
       <scope>provided</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <failOnWarning>false</failOnWarning>
+          <compilerArgs>
+            <arg>-Xlint:all</arg>
+          </compilerArgs>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/dynamic-config/entities/topology-entity/client/pom.xml
+++ b/dynamic-config/entities/topology-entity/client/pom.xml
@@ -49,4 +49,18 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <failOnWarning>false</failOnWarning>
+          <compilerArgs>
+            <arg>-Xlint:all</arg>
+          </compilerArgs>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/dynamic-config/entities/topology-entity/client/src/main/java/org/terracotta/dynamic_config/entity/topology/client/DynamicTopologyEntityImpl.java
+++ b/dynamic-config/entities/topology-entity/client/src/main/java/org/terracotta/dynamic_config/entity/topology/client/DynamicTopologyEntityImpl.java
@@ -29,6 +29,7 @@ import org.terracotta.entity.MessageCodecException;
 import org.terracotta.exception.EntityException;
 
 import java.time.Duration;
+import java.util.List;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -59,18 +60,18 @@ class DynamicTopologyEntityImpl implements DynamicTopologyEntity {
       public void handleMessage(DynamicTopologyEntityMessage messageFromServer) {
         switch (messageFromServer.getType()) {
           case EVENT_NODE_ADDITION: {
-            Object[] payload = (Object[]) messageFromServer.getPayload();
-            listener.onNodeAddition((int) payload[0], (Node) payload[1]);
+            List<Object> payload = messageFromServer.getPayload();
+            listener.onNodeAddition((int) payload.get(0), (Node) payload.get(1));
             break;
           }
           case EVENT_NODE_REMOVAL: {
-            Object[] payload = (Object[]) messageFromServer.getPayload();
-            listener.onNodeRemoval((int) payload[0], (Node) payload[1]);
+            List<Object> payload = messageFromServer.getPayload();
+            listener.onNodeRemoval((int) payload.get(0), (Node) payload.get(1));
             break;
           }
           case EVENT_SETTING_CHANGED: {
-            Object[] payload = (Object[]) messageFromServer.getPayload();
-            listener.onSettingChange((Configuration) payload[0], (Cluster) payload[1]);
+            List<Object> payload = messageFromServer.getPayload();
+            listener.onSettingChange((Configuration) payload.get(0), (Cluster) payload.get(1));
             break;
           }
           default:

--- a/dynamic-config/entities/topology-entity/common/pom.xml
+++ b/dynamic-config/entities/topology-entity/common/pom.xml
@@ -31,8 +31,13 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.terracotta.common</groupId>
-      <artifactId>common-json-support</artifactId>
+      <groupId>org.terracotta.dynamic-config</groupId>
+      <artifactId>dynamic-config-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.terracotta</groupId>
+      <artifactId>runnel</artifactId>
       <version>${project.version}</version>
     </dependency>
 

--- a/dynamic-config/entities/topology-entity/common/pom.xml
+++ b/dynamic-config/entities/topology-entity/common/pom.xml
@@ -43,4 +43,19 @@
       <scope>provided</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <failOnWarning>false</failOnWarning>
+          <compilerArgs>
+            <arg>-Xlint:all</arg>
+          </compilerArgs>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/dynamic-config/entities/topology-entity/common/src/main/java/org/terracotta/dynamic_config/entity/topology/common/DynamicTopologyEntityMessage.java
+++ b/dynamic-config/entities/topology-entity/common/src/main/java/org/terracotta/dynamic_config/entity/topology/common/DynamicTopologyEntityMessage.java
@@ -15,11 +15,12 @@
  */
 package org.terracotta.dynamic_config.entity.topology.common;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import org.terracotta.entity.EntityMessage;
 import org.terracotta.entity.EntityResponse;
+
+import java.util.Objects;
+
+import static java.util.Objects.requireNonNull;
 
 /**
  * @author Mathieu Carbou
@@ -39,17 +40,14 @@ public class DynamicTopologyEntityMessage implements EntityMessage, EntityRespon
 
   private final Type type;
 
-  @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS)
   private final Object payload;
 
   public DynamicTopologyEntityMessage(Type type) {
     this(type, null);
   }
 
-  @JsonCreator
-  public DynamicTopologyEntityMessage(@JsonProperty(value = "type", required = true) Type type,
-                                      @JsonProperty(value = "payload") Object payload) {
-    this.type = type;
+  public DynamicTopologyEntityMessage(Type type, Object payload) {
+    this.type = requireNonNull(type);
     this.payload = payload;
   }
 
@@ -57,8 +55,9 @@ public class DynamicTopologyEntityMessage implements EntityMessage, EntityRespon
     return type;
   }
 
-  public Object getPayload() {
-    return payload;
+  @SuppressWarnings("unchecked")
+  public <T> T getPayload() {
+    return (T) payload;
   }
 
   @Override
@@ -67,5 +66,19 @@ public class DynamicTopologyEntityMessage implements EntityMessage, EntityRespon
         "type=" + type +
         ", payload=" + payload +
         '}';
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof DynamicTopologyEntityMessage)) return false;
+    DynamicTopologyEntityMessage that = (DynamicTopologyEntityMessage) o;
+    return getType() == that.getType() &&
+        Objects.equals(getPayload(), that.getPayload());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getType(), getPayload());
   }
 }

--- a/dynamic-config/entities/topology-entity/common/src/main/java/org/terracotta/dynamic_config/entity/topology/common/DynamicTopologyMessageCodec.java
+++ b/dynamic-config/entities/topology-entity/common/src/main/java/org/terracotta/dynamic_config/entity/topology/common/DynamicTopologyMessageCodec.java
@@ -15,29 +15,175 @@
  */
 package org.terracotta.dynamic_config.entity.topology.common;
 
+import org.terracotta.dynamic_config.api.model.Cluster;
+import org.terracotta.dynamic_config.api.model.Configuration;
+import org.terracotta.dynamic_config.api.model.License;
+import org.terracotta.dynamic_config.api.model.Node;
+import org.terracotta.dynamic_config.api.model.Stripe;
+import org.terracotta.dynamic_config.api.service.ClusterFactory;
+import org.terracotta.dynamic_config.api.service.Props;
 import org.terracotta.entity.MessageCodec;
 import org.terracotta.entity.MessageCodecException;
-import org.terracotta.json.Json;
+import org.terracotta.runnel.Struct;
+import org.terracotta.runnel.decoding.StructDecoder;
+import org.terracotta.runnel.encoding.StructEncoder;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
+import java.nio.ByteBuffer;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import static java.util.Arrays.asList;
+import static java.util.Objects.requireNonNull;
+import static org.terracotta.dynamic_config.entity.topology.common.DynamicTopologyEntityMessage.Type;
+import static org.terracotta.dynamic_config.entity.topology.common.DynamicTopologyEntityMessage.Type.EVENT_NODE_ADDITION;
+import static org.terracotta.dynamic_config.entity.topology.common.DynamicTopologyEntityMessage.Type.EVENT_NODE_REMOVAL;
+import static org.terracotta.dynamic_config.entity.topology.common.DynamicTopologyEntityMessage.Type.EVENT_SETTING_CHANGED;
+import static org.terracotta.dynamic_config.entity.topology.common.DynamicTopologyEntityMessage.Type.REQ_HAS_INCOMPLETE_CHANGE;
+import static org.terracotta.dynamic_config.entity.topology.common.DynamicTopologyEntityMessage.Type.REQ_LICENSE;
+import static org.terracotta.dynamic_config.entity.topology.common.DynamicTopologyEntityMessage.Type.REQ_MUST_BE_RESTARTED;
+import static org.terracotta.dynamic_config.entity.topology.common.DynamicTopologyEntityMessage.Type.REQ_RUNTIME_CLUSTER;
+import static org.terracotta.dynamic_config.entity.topology.common.DynamicTopologyEntityMessage.Type.REQ_UPCOMING_CLUSTER;
+import static org.terracotta.runnel.EnumMappingBuilder.newEnumMappingBuilder;
+import static org.terracotta.runnel.StructBuilder.newStructBuilder;
 
 /**
  * @author Mathieu Carbou
  */
 public class DynamicTopologyMessageCodec implements MessageCodec<DynamicTopologyEntityMessage, DynamicTopologyEntityMessage> {
+
+  private static final DateTimeFormatter DT_FORMATTER = DateTimeFormatter.ofPattern("yyyy/MM/dd", Locale.ENGLISH);
+
+  private final Struct struct = newStructBuilder()
+      .enm("type", 10, newEnumMappingBuilder(Type.class)
+          .mapping(REQ_LICENSE, 1)
+          .mapping(REQ_HAS_INCOMPLETE_CHANGE, 2)
+          .mapping(REQ_MUST_BE_RESTARTED, 3)
+          .mapping(REQ_RUNTIME_CLUSTER, 4)
+          .mapping(REQ_UPCOMING_CLUSTER, 5)
+          .mapping(EVENT_NODE_ADDITION, 6)
+          .mapping(EVENT_NODE_REMOVAL, 7)
+          .mapping(EVENT_SETTING_CHANGED, 8)
+          .build())
+      .struct(REQ_LICENSE.name(), 20, newStructBuilder()
+          .string("date", 10)
+          .structs("limits", 20, newStructBuilder()
+              .string("name", 10)
+              .int64("value", 20)
+              .build())
+          .build())
+      .bool(REQ_HAS_INCOMPLETE_CHANGE.name(), 30)
+      .bool(REQ_MUST_BE_RESTARTED.name(), 40)
+      .string(REQ_RUNTIME_CLUSTER.name(), 50)
+      .string(REQ_UPCOMING_CLUSTER.name(), 60)
+      .struct(EVENT_NODE_ADDITION.name(), 70, newStructBuilder()
+          .int32("stripeId", 10)
+          .string("node", 20)
+          .build())
+      .struct(EVENT_NODE_REMOVAL.name(), 80, newStructBuilder()
+          .int32("stripeId", 10)
+          .string("node", 20)
+          .build())
+      .struct(EVENT_SETTING_CHANGED.name(), 90, newStructBuilder()
+          .string("configuration", 10)
+          .string("cluster", 20)
+          .build())
+      .build();
+
   @Override
   public byte[] encodeMessage(DynamicTopologyEntityMessage message) throws MessageCodecException {
     try {
-      return Json.toJson(message).getBytes(UTF_8);
+      Type type = message.getType();
+      StructEncoder<Void> encoder = struct.encoder();
+      encoder.enm("type", type);
+      switch (type) {
+        case REQ_LICENSE: {
+          License license = message.getPayload();
+          if (license != null) {
+            encoder.struct(type.name())
+                .string("date", license.getExpiryDate().format(DT_FORMATTER))
+                .structs("limits", license.getCapabilityLimitMap().entrySet(), (entryEncoder, entry) -> entryEncoder
+                    .string("name", entry.getKey())
+                    .int64("value", entry.getValue()));
+          }
+          break;
+        }
+        case REQ_HAS_INCOMPLETE_CHANGE:
+        case REQ_MUST_BE_RESTARTED: {
+          encoder.bool(type.name(), message.getPayload());
+          break;
+        }
+        case REQ_RUNTIME_CLUSTER:
+        case REQ_UPCOMING_CLUSTER: {
+          encoder.string(type.name(), encodeCluster(message.getPayload()));
+          break;
+        }
+        case EVENT_NODE_ADDITION:
+        case EVENT_NODE_REMOVAL: {
+          List<Object> oo = message.getPayload();
+          encoder.struct(type.name())
+              .int32("stripeId", (Integer) oo.get(0))
+              .string("node", encodeNode((Node) oo.get(1)));
+          break;
+        }
+        case EVENT_SETTING_CHANGED: {
+          List<Object> oo = message.getPayload();
+          encoder.struct(type.name())
+              .string("configuration", encodeConfiguration((Configuration) oo.get(0)))
+              .string("cluster", encodeCluster((Cluster) oo.get(1)));
+          break;
+        }
+        default:
+          throw new UnsupportedOperationException(type.name());
+      }
+      return encoder.encode().array();
     } catch (RuntimeException e) {
       throw new MessageCodecException(e.getMessage(), e);
     }
   }
 
   @Override
-  public DynamicTopologyEntityMessage decodeMessage(byte[] payload) throws MessageCodecException {
+  public DynamicTopologyEntityMessage decodeMessage(byte[] bytes) throws MessageCodecException {
     try {
-      return Json.parse(new String(payload, UTF_8), DynamicTopologyEntityMessage.class);
+      StructDecoder<Void> decoder = struct.decoder(ByteBuffer.wrap(bytes));
+      Type type = decoder.<Type>enm("type").get();
+      switch (type) {
+        case REQ_LICENSE: {
+          StructDecoder<StructDecoder<Void>> payload = decoder.struct(type.name());
+          if (payload == null) {
+            return new DynamicTopologyEntityMessage(type, null);
+          } else {
+            LocalDate expiryDate = LocalDate.parse(payload.string("date"), DT_FORMATTER);
+            Map<String, Long> limits = new HashMap<>();
+            payload.structs("limits").forEachRemaining(entry -> limits.put(entry.string("name"), entry.int64("value")));
+            return new DynamicTopologyEntityMessage(type, new License(limits, expiryDate));
+          }
+        }
+        case REQ_HAS_INCOMPLETE_CHANGE:
+        case REQ_MUST_BE_RESTARTED:
+          return new DynamicTopologyEntityMessage(type, decoder.bool(type.name()));
+        case REQ_RUNTIME_CLUSTER:
+        case REQ_UPCOMING_CLUSTER:
+          return new DynamicTopologyEntityMessage(type, decodeCluster(decoder.string(type.name())));
+        case EVENT_NODE_ADDITION:
+        case EVENT_NODE_REMOVAL: {
+          StructDecoder<?> event = decoder.struct(type.name());
+          return new DynamicTopologyEntityMessage(type, asList(
+              event.int32("stripeId"),
+              decodeNode(event.string("node"))));
+        }
+        case EVENT_SETTING_CHANGED: {
+          StructDecoder<?> event = decoder.struct(type.name());
+          return new DynamicTopologyEntityMessage(type, asList(
+              decodeConfiguration(event.string("configuration")),
+              decodeCluster(event.string("cluster"))));
+        }
+        default:
+          throw new UnsupportedOperationException(type.name());
+      }
     } catch (RuntimeException e) {
       throw new MessageCodecException(e.getMessage(), e);
     }
@@ -45,19 +191,46 @@ public class DynamicTopologyMessageCodec implements MessageCodec<DynamicTopology
 
   @Override
   public byte[] encodeResponse(DynamicTopologyEntityMessage response) throws MessageCodecException {
-    try {
-      return Json.toJson(response).getBytes(UTF_8);
-    } catch (RuntimeException e) {
-      throw new MessageCodecException(e.getMessage(), e);
-    }
+    return encodeMessage(response);
   }
 
   @Override
   public DynamicTopologyEntityMessage decodeResponse(byte[] payload) throws MessageCodecException {
-    try {
-      return Json.parse(new String(payload, UTF_8), DynamicTopologyEntityMessage.class);
-    } catch (RuntimeException e) {
-      throw new MessageCodecException(e.getMessage(), e);
-    }
+    return decodeMessage(payload);
+  }
+
+  // the encode / decode methods below re-uses the inner mapping mechanism we have
+
+  private String encodeCluster(Cluster cluster) {
+    requireNonNull(cluster);
+    return Props.toString(cluster.toProperties(false, true));
+  }
+
+  private Cluster decodeCluster(String payload) {
+    requireNonNull(payload);
+    return new ClusterFactory().create(Props.load(payload), configuration -> {
+    });
+  }
+
+  private String encodeNode(Node node) {
+    requireNonNull(node);
+    Cluster container = Cluster.newDefaultCluster(new Stripe(node));
+    return Props.toString(container.toProperties(false, true));
+  }
+
+  private Node decodeNode(String payload) {
+    requireNonNull(payload);
+    return new ClusterFactory().create(Props.load(payload), configuration -> {
+    }).getSingleNode().orElseThrow(() -> new AssertionError("node must be there"));
+  }
+
+  private String encodeConfiguration(Configuration configuration) {
+    requireNonNull(configuration);
+    return configuration.toString();
+  }
+
+  private Configuration decodeConfiguration(String payload) {
+    requireNonNull(payload);
+    return Configuration.valueOf(payload);
   }
 }

--- a/dynamic-config/entities/topology-entity/common/src/test/java/org/terracotta/dynamic_config/entity/topology/common/DynamicTopologyMessageCodecTest.java
+++ b/dynamic-config/entities/topology-entity/common/src/test/java/org/terracotta/dynamic_config/entity/topology/common/DynamicTopologyMessageCodecTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.dynamic_config.entity.topology.common;
+
+import org.junit.Test;
+import org.terracotta.dynamic_config.api.model.Cluster;
+import org.terracotta.dynamic_config.api.model.Configuration;
+import org.terracotta.dynamic_config.api.model.License;
+import org.terracotta.dynamic_config.api.model.Node;
+import org.terracotta.dynamic_config.api.model.Stripe;
+import org.terracotta.entity.MessageCodecException;
+
+import java.time.LocalDate;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.singletonMap;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.terracotta.dynamic_config.entity.topology.common.DynamicTopologyEntityMessage.Type.EVENT_NODE_ADDITION;
+import static org.terracotta.dynamic_config.entity.topology.common.DynamicTopologyEntityMessage.Type.EVENT_NODE_REMOVAL;
+import static org.terracotta.dynamic_config.entity.topology.common.DynamicTopologyEntityMessage.Type.EVENT_SETTING_CHANGED;
+import static org.terracotta.dynamic_config.entity.topology.common.DynamicTopologyEntityMessage.Type.REQ_HAS_INCOMPLETE_CHANGE;
+import static org.terracotta.dynamic_config.entity.topology.common.DynamicTopologyEntityMessage.Type.REQ_LICENSE;
+import static org.terracotta.dynamic_config.entity.topology.common.DynamicTopologyEntityMessage.Type.REQ_MUST_BE_RESTARTED;
+import static org.terracotta.dynamic_config.entity.topology.common.DynamicTopologyEntityMessage.Type.REQ_RUNTIME_CLUSTER;
+import static org.terracotta.dynamic_config.entity.topology.common.DynamicTopologyEntityMessage.Type.REQ_UPCOMING_CLUSTER;
+
+/**
+ * @author Mathieu Carbou
+ */
+public class DynamicTopologyMessageCodecTest {
+  @Test
+  public void test_encode_decode() throws MessageCodecException {
+    Node node = Node.newDefaultNode("foo", "localhost", 9410);
+    Cluster cluster = Cluster.newDefaultCluster("bar", new Stripe(node));
+
+    test(new DynamicTopologyEntityMessage(REQ_LICENSE, null));
+    test(new DynamicTopologyEntityMessage(REQ_LICENSE, new License(emptyMap(), LocalDate.of(2020, 1, 1))));
+    test(new DynamicTopologyEntityMessage(REQ_LICENSE, new License(singletonMap("offheap", 1024L), LocalDate.of(2020, 1, 1))));
+
+    test(new DynamicTopologyEntityMessage(REQ_MUST_BE_RESTARTED, true));
+    test(new DynamicTopologyEntityMessage(REQ_HAS_INCOMPLETE_CHANGE, true));
+
+    test(new DynamicTopologyEntityMessage(REQ_RUNTIME_CLUSTER, cluster));
+    test(new DynamicTopologyEntityMessage(REQ_UPCOMING_CLUSTER, cluster));
+
+    test(new DynamicTopologyEntityMessage(EVENT_NODE_ADDITION, asList(1, node)));
+    test(new DynamicTopologyEntityMessage(EVENT_NODE_REMOVAL, asList(1, node)));
+
+    test(new DynamicTopologyEntityMessage(EVENT_SETTING_CHANGED, asList(Configuration.valueOf("cluster-name=foo"), cluster)));
+  }
+
+  private static void test(DynamicTopologyEntityMessage message) throws MessageCodecException {
+    DynamicTopologyMessageCodec codec = new DynamicTopologyMessageCodec();
+    byte[] bytes = codec.encodeMessage(message);
+    DynamicTopologyEntityMessage decoded = codec.decodeMessage(bytes);
+    assertThat(message, is(equalTo(decoded)));
+  }
+}

--- a/dynamic-config/entities/topology-entity/server/pom.xml
+++ b/dynamic-config/entities/topology-entity/server/pom.xml
@@ -55,4 +55,18 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <failOnWarning>false</failOnWarning>
+          <compilerArgs>
+            <arg>-Xlint:all</arg>
+          </compilerArgs>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/dynamic-config/entities/topology-entity/server/src/main/java/org/terracotta/dynamic_config/entity/topology/server/DynamicTopologyActiveServerEntity.java
+++ b/dynamic-config/entities/topology-entity/server/src/main/java/org/terracotta/dynamic_config/entity/topology/server/DynamicTopologyActiveServerEntity.java
@@ -39,6 +39,7 @@ import org.terracotta.entity.StateDumpCollector;
 import java.util.Collection;
 import java.util.concurrent.ConcurrentHashMap;
 
+import static java.util.Arrays.asList;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
 import static org.terracotta.dynamic_config.entity.topology.common.DynamicTopologyEntityMessage.Type.EVENT_NODE_ADDITION;
@@ -133,18 +134,18 @@ public class DynamicTopologyActiveServerEntity implements ActiveServerEntity<Dyn
       eventRegistration = eventService.register(new DynamicConfigListenerAdapter() {
         @Override
         public void onNodeAddition(int stripeId, Node addedNode) {
-          fire(new DynamicTopologyEntityMessage(EVENT_NODE_ADDITION, new Object[]{stripeId, addedNode}));
+          fire(new DynamicTopologyEntityMessage(EVENT_NODE_ADDITION, asList(stripeId, addedNode)));
         }
 
         @Override
         public void onNodeRemoval(int stripeId, Node removedNode) {
-          fire(new DynamicTopologyEntityMessage(EVENT_NODE_REMOVAL, new Object[]{stripeId, removedNode}));
+          fire(new DynamicTopologyEntityMessage(EVENT_NODE_REMOVAL, asList(stripeId, removedNode)));
         }
 
         @Override
         public void onSettingChanged(SettingNomadChange change, Cluster updated) {
           Configuration configuration = change.toConfiguration(updated);
-          fire(new DynamicTopologyEntityMessage(EVENT_SETTING_CHANGED, new Object[]{configuration, updated}));
+          fire(new DynamicTopologyEntityMessage(EVENT_SETTING_CHANGED, asList(configuration, updated)));
         }
       });
     }

--- a/dynamic-config/server/server-api/pom.xml
+++ b/dynamic-config/server/server-api/pom.xml
@@ -43,4 +43,19 @@
       <scope>provided</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <failOnWarning>false</failOnWarning>
+          <compilerArgs>
+            <arg>-Xlint:all</arg>
+          </compilerArgs>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/dynamic-config/server/services/pom.xml
+++ b/dynamic-config/server/services/pom.xml
@@ -56,4 +56,19 @@
       <scope>provided</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <failOnWarning>false</failOnWarning>
+          <compilerArgs>
+            <arg>-Xlint:all</arg>
+          </compilerArgs>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/dynamic-config/testing/entity/pom.xml
+++ b/dynamic-config/testing/entity/pom.xml
@@ -65,4 +65,19 @@
       <scope>provided</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <failOnWarning>false</failOnWarning>
+          <compilerArgs>
+            <arg>-Xlint:all</arg>
+          </compilerArgs>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/lease/entity-server/pom.xml
+++ b/lease/entity-server/pom.xml
@@ -100,4 +100,19 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <failOnWarning>false</failOnWarning>
+          <compilerArgs>
+            <arg>-Xlint:all</arg>
+          </compilerArgs>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/offheap-resource/pom.xml
+++ b/offheap-resource/pom.xml
@@ -109,6 +109,16 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <failOnWarning>false</failOnWarning>
+          <compilerArgs>
+            <arg>-Xlint:all</arg>
+          </compilerArgs>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>org.jvnet.jaxb2.maven2</groupId>
         <artifactId>maven-jaxb2-plugin</artifactId>
         <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -350,6 +350,16 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <showWarnings>true</showWarnings>
+          <showDeprecation>true</showDeprecation>
+          <failOnWarning>true</failOnWarning>
+          <compilerArgs>
+            <arg>-Xlint:all</arg>
+            <arg>-Xlint:-path</arg>
+            <arg>-Werror</arg>
+          </compilerArgs>
+        </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.felix</groupId>


### PR DESCRIPTION
### REBASED ON #714

Finally I am using Runnel because the topology entity is glued everywhere in EE so replacing it would have been harder.

Topology entity now does not leak any jackson libs anymore, not even the annotations jar. 
But the model classes (which are Json-annotated) are still used. 
This should not cause any issue because these annotations shouldn't been considered at runtime.