### PR TITLE
TDB-4990: Refactoring of Model <=> Properties mapping:

### DIFF
--- a/dynamic-config/api/src/main/java/org/terracotta/dynamic_config/api/model/Node.java
+++ b/dynamic-config/api/src/main/java/org/terracotta/dynamic_config/api/model/Node.java
@@ -27,6 +27,7 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Properties;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.concurrent.ConcurrentHashMap;
@@ -389,6 +390,13 @@ public class Node implements Cloneable, PropertyHolder {
     }
 
     return thisCopy;
+  }
+
+  /**
+   * Transform this model into a config file where all the "map" like settings can be expanded (one item per line)
+   */
+  public Properties toProperties(boolean expanded, boolean includeDefaultValues) {
+    return Setting.modelToProperties(this, expanded, includeDefaultValues);
   }
 
   public Node fillRequiredSettings() {

--- a/dynamic-config/api/src/main/java/org/terracotta/dynamic_config/api/model/Stripe.java
+++ b/dynamic-config/api/src/main/java/org/terracotta/dynamic_config/api/model/Stripe.java
@@ -29,6 +29,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalInt;
+import java.util.Properties;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.stream.IntStream;
 
@@ -191,5 +192,18 @@ public class Stripe implements Cloneable {
         .filter(idx -> nodes.get(idx).hasAddress(nodeAddress))
         .map(idx -> idx + 1)
         .findAny();
+  }
+
+  /**
+   * Transform this model into a config file where all the "map" like settings can be expanded (one item per line)
+   */
+  public Properties toProperties(boolean expanded, boolean includeDefaultValues) {
+    Properties properties = new Properties();
+    for (int i = 0; i < nodes.size(); i++) {
+      String prefix = "node." + (i + 1) + ".";
+      Properties props = nodes.get(i).toProperties(expanded, includeDefaultValues);
+      props.stringPropertyNames().forEach(key -> properties.setProperty(prefix + key, props.getProperty(key)));
+    }
+    return properties;
   }
 }


### PR DESCRIPTION
- Kept the exact same logic as before, but split the code
- But now we can map a Node, Stripe or Cluster to some Properties with Node#toProperties(), Stripe#toProperties(), Cluster#toProperties()

### Required for #710 