### PR TITLE
switch to in-house slaves for linux

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,23 +26,27 @@ resources:
 jobs:
 - template: build-templates/maven-common.yml@templates
   parameters:
-    jobName: 'Linux_Java_8'
+    jobName: Linux_Java_8
     timeoutInMinutes: 180
+    pool: tc_linux_pool
+    options: -B -Dtest.parallel.forks=6
 - template: build-templates/maven-common.yml@templates
   parameters:
-    jobName: 'Linux_Java_11'
+    jobName: Linux_Java_11
     timeoutInMinutes: 180
-    options: '-B -Djava.test.version=1.11'
+    pool: tc_linux_pool
+    options: -B -Dtest.parallel.forks=6 -Djava.test.version=1.11
 - template: build-templates/maven-common.yml@templates
   parameters:
-    jobName: 'Windows_Java_8'
+    jobName: Windows_Java_8
     timeoutInMinutes: 180
-    vmImage: 'windows-latest'
+    pool: tc_windows_pool
+    options: -B -Dtest.parallel.forks=4
 - template: build-templates/maven-common.yml@templates
   parameters:
-    jobName: 'Windows_Java_11'
+    jobName: Windows_Java_11
     timeoutInMinutes: 180
-    vmImage: 'windows-latest'
-    options: '-B -Djava.test.version=1.11'
+    pool: tc_windows_pool
+    options: -B -Dtest.parallel.forks=4 -Djava.test.version=1.11
 
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -29,24 +29,24 @@ jobs:
     jobName: Linux_Java_8
     timeoutInMinutes: 180
     pool: tc_linux_pool
-    options: -B -Dtest.parallel.forks=6
+    options: -B -Dtest.parallel.forks=6 -Djava.test.version=1.8 -Djava.test.vendor=zulu
 - template: build-templates/maven-common.yml@templates
   parameters:
     jobName: Linux_Java_11
     timeoutInMinutes: 180
     pool: tc_linux_pool
-    options: -B -Dtest.parallel.forks=6 -Djava.test.version=1.11
+    options: -B -Dtest.parallel.forks=6 -Djava.test.version=1.11 -Djava.test.vendor=zulu
 - template: build-templates/maven-common.yml@templates
   parameters:
     jobName: Windows_Java_8
     timeoutInMinutes: 180
     pool: tc_windows_pool
-    options: -B -Dtest.parallel.forks=4
+    options: -B -Dtest.parallel.forks=4 -Djava.test.version=1.8 -Djava.test.vendor=zulu
 - template: build-templates/maven-common.yml@templates
   parameters:
     jobName: Windows_Java_11
     timeoutInMinutes: 180
     pool: tc_windows_pool
-    options: -B -Dtest.parallel.forks=4 -Djava.test.version=1.11
+    options: -B -Dtest.parallel.forks=4 -Djava.test.version=1.11 -Djava.test.vendor=zulu
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.terracotta</groupId>
     <artifactId>terracotta-parent</artifactId>
-    <version>5.15</version>
+    <version>5.16</version>
   </parent>
 
   <artifactId>platform-root</artifactId>


### PR DESCRIPTION
**Good news**: Builds take <30 minutes on Linux
**Bad news**:
* at `forkCount=20` tests frequently fail (timeouts in server start/stop).  
* at `forkCount=30`, tests consistently fail
* at `forkCount=10`, tests seem to fail as well (but it's just as fast as with 20)
* at `forkCount=6`, builds take ~32 minutes.
* at `forkCount=2`, builds take 45-50 minutes.

Slaves have 40 cores.  