### PR TITLE
Tweaked test timeouts

### DIFF
--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activation/ActivateCommand1x2IT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activation/ActivateCommand1x2IT.java
@@ -83,7 +83,6 @@ public class ActivateCommand1x2IT extends DynamicConfigIT {
   public void testMultiNodeSingleStripeActivationWithConfigFile() throws TimeoutException {
     assertThat(
         configToolInvocation(
-            "-r", timeout + "s",
             "activate",
             "-f", copyConfigProperty("/config-property-files/single-stripe_multi-node.properties").toString()),
         allOf(is(successful()), containsOutput("No license installed"), containsOutput("came back up")));
@@ -96,7 +95,6 @@ public class ActivateCommand1x2IT extends DynamicConfigIT {
   public void testRestrictedActivationToActivateNodesAtDifferentTime() throws Exception {
     assertThat(
         configToolInvocation(
-            "-r", timeout + "s",
             "activate",
             "-R",
             "-s", "localhost:" + getNodePort(1, 1),
@@ -112,7 +110,6 @@ public class ActivateCommand1x2IT extends DynamicConfigIT {
 
     assertThat(
         configToolInvocation(
-            "-r", timeout + "s",
             "activate",
             "-R",
             "-s", "localhost:" + getNodePort(1, 2),


### PR DESCRIPTION
- Individual operation timeout should not be the same as global test timeout - introduced a per-operation timeout
- Use the operation timeout for config tool and diagnostic connections