### PR TITLE
Made forkCount updatable through CLI with -Dtest.parallel.forks=N

### DIFF
--- a/dynamic-config/testing/system-tests/pom.xml
+++ b/dynamic-config/testing/system-tests/pom.xml
@@ -159,7 +159,7 @@
         <groupId>org.terracotta</groupId>
         <artifactId>maven-forge-plugin</artifactId>
         <configuration>
-          <forkCount>2</forkCount>
+          <forkCount>${test.parallel.forks}</forkCount>
           <systemPropertyVariables>
             <angela.rootDir>${project.build.directory}/angela</angela.rootDir>
             <angela.skipUninstall>true</angela.skipUninstall>
@@ -182,7 +182,7 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
         <configuration>
-          <forkCount>2</forkCount>
+          <forkCount>${test.parallel.forks}</forkCount>
           <systemPropertyVariables>
             <angela.rootDir>${project.build.directory}/angela</angela.rootDir>
             <angela.skipUninstall>true</angela.skipUninstall>

--- a/management/testing/integration-tests/pom.xml
+++ b/management/testing/integration-tests/pom.xml
@@ -175,7 +175,7 @@
         <groupId>org.terracotta</groupId>
         <artifactId>maven-forge-plugin</artifactId>
         <configuration>
-          <forkCount>2</forkCount>
+          <forkCount>${test.parallel.forks}</forkCount>
           <systemPropertyVariables>
             <kitInstallationPath>${project.build.directory}/platform-kit-${project.version}</kitInstallationPath>
           </systemPropertyVariables>
@@ -190,7 +190,7 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
         <configuration>
-          <forkCount>2</forkCount>
+          <forkCount>${test.parallel.forks}</forkCount>
           <systemPropertyVariables>
             <kitInstallationPath>${project.build.directory}/platform-kit-${project.version}</kitInstallationPath>
             <!--            <serverDebugPortStart>5005</serverDebugPortStart>-->

--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,7 @@
     <statistics.version>2.1</statistics.version>
     <jackson.version>2.10.1</jackson.version>
     <terracotta-utilities.version>0.0.3</terracotta-utilities.version>
+    <test.parallel.forks>2</test.parallel.forks>
   </properties>
 
   <modules>


### PR DESCRIPTION
forkCount was not updatable since fixed in the POM directly.

With this PR (which is a part from #713 actually) this is possible.

Example locally:

```
> ./mvnw verify -f management/testing/integration-tests/ -Dtest.parallel.forks=6
```

```
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  02:09 min
[INFO] Finished at: 2020-05-11T17:56:31-04:00
[INFO] ------------------------------------------------------------------------
```

And...

```
> ./mvnw verify -f dynamic-config/testing/system-tests/ -Dtest.parallel.forks=1C
```

```
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  15:57 min
[INFO] Finished at: 2020-05-11T18:18:51-04:00
[INFO] ------------------------------------------------------------------------
```