### PR TITLE
Fix angela server memory settings for dynamic tests

### DIFF
--- a/dynamic-config/testing/support/src/main/java/org/terracotta/dynamic_config/test_support/DynamicConfigIT.java
+++ b/dynamic-config/testing/support/src/main/java/org/terracotta/dynamic_config/test_support/DynamicConfigIT.java
@@ -275,8 +275,9 @@ public class DynamicConfigIT {
     return customConfigurationContext().tsa(tsa -> tsa
         .clusterName("tc-cluster")
         .license(getLicenceUrl() == null ? null : new License(getLicenceUrl()))
-        .terracottaCommandLineEnvironment(TsaConfigurationContext.TerracottaCommandLineEnvironmentKeys.CONFIG_TOOL, TerracottaCommandLineEnvironment.DEFAULT.withJavaOpts("-Xms8m -Xmx32m"))
-        .terracottaCommandLineEnvironment(TsaConfigurationContext.TerracottaCommandLineEnvironmentKeys.SERVER_START_PREFIX, TerracottaCommandLineEnvironment.DEFAULT.withJavaOpts("-Xms64m -Xmx128m"))
+        .terracottaCommandLineEnvironment(TerracottaCommandLineEnvironment.DEFAULT.withJavaOpts("-Xms32m -Xmx256m"))
+        .terracottaCommandLineEnvironment(TsaConfigurationContext.TerracottaCommandLineEnvironmentKeys.CONFIG_TOOL,
+                TerracottaCommandLineEnvironment.DEFAULT.withJavaOpts("-Xms8m -Xmx128m"))
         .topology(new Topology(
             getDistribution(),
             dynamicCluster(


### PR DESCRIPTION
The wrong prefixes are set for angela tests.  These settings will reduce memory requirements on server startup.