### PR TITLE
Several small fixes around angela tests and logging in tools

### DIFF
--- a/dynamic-config/cli/cli-support/src/main/java/org/terracotta/dynamic_config/cli/command/LocalMainCommand.java
+++ b/dynamic-config/cli/cli-support/src/main/java/org/terracotta/dynamic_config/cli/command/LocalMainCommand.java
@@ -17,13 +17,9 @@ package org.terracotta.dynamic_config.cli.command;
 
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
-import ch.qos.logback.classic.spi.ILoggingEvent;
-import ch.qos.logback.core.Appender;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
 import org.slf4j.LoggerFactory;
-
-import java.util.stream.Stream;
 
 @Parameters(commandNames = LocalMainCommand.NAME)
 public class LocalMainCommand extends Command {
@@ -34,23 +30,18 @@ public class LocalMainCommand extends Command {
 
   @Override
   public void run() {
-    if (verbose) {
-      Logger rootLogger = (Logger) LoggerFactory.getLogger(org.slf4j.Logger.ROOT_LOGGER_NAME);
-      rootLogger.setLevel(Level.INFO);
-      Appender<ILoggingEvent> detailAppender = rootLogger.getAppender("STDOUT-DETAIL");
+    Logger rootLogger = (Logger) LoggerFactory.getLogger(org.slf4j.Logger.ROOT_LOGGER_NAME);
 
-      Stream.of(
-          "org.terracotta.dynamic_config",
-          "org.terracotta.nomad",
-          "org.terracotta.persistence.sanskrit",
-          "org.terracotta.diagnostic"
-      ).forEach(name -> {
-        Logger logger = (Logger) LoggerFactory.getLogger(name);
-        logger.setLevel(Level.TRACE);
-        //Detach the STDOUT appender which logs in a minimal pattern and attached STDOUT-DETAIL appender
-        logger.detachAppender("STDOUT");
-        logger.addAppender(detailAppender);
-      });
+    if (verbose) {
+      rootLogger.setLevel(Level.INFO);
+      rootLogger.getLoggerContext().getLoggerList().forEach(logger -> logger.detachAppender("STDOUT"));
+      rootLogger.getLoggerContext().getLoggerList()
+          .stream()
+          .filter(logger -> logger.getName().startsWith("org.terracotta") || logger.getName().startsWith("com.terracottatech") || logger.getName().startsWith("com.tc"))
+          .forEach(logger -> logger.setLevel(Level.TRACE));
+
+    } else {
+      rootLogger.getLoggerContext().getLoggerList().forEach(logger -> logger.detachAppender("STDOUT-DETAIL"));
     }
   }
 

--- a/dynamic-config/cli/config-converter/src/main/java/org/terracotta/dynamic_config/cli/config_converter/ConfigConverterTool.java
+++ b/dynamic-config/cli/config-converter/src/main/java/org/terracotta/dynamic_config/cli/config_converter/ConfigConverterTool.java
@@ -26,8 +26,6 @@ import org.terracotta.dynamic_config.cli.config_converter.command.ConvertCommand
 import java.util.Arrays;
 import java.util.HashSet;
 
-import static java.lang.System.lineSeparator;
-
 public class ConfigConverterTool {
   private static final Logger LOGGER = LoggerFactory.getLogger(ConfigConverterTool.class);
 
@@ -36,15 +34,15 @@ public class ConfigConverterTool {
       ConfigConverterTool.start(args);
     } catch (Exception e) {
       String message = e.getMessage();
-      if (message != null && !message.isEmpty()) {
-        String errorMessage = String.format("%sError:%s%s%s", lineSeparator(), lineSeparator(), message, lineSeparator());
-        if (LOGGER.isDebugEnabled()) {
-          LOGGER.error("{}Error:", lineSeparator(), e); // do not output e.getMassage() because it duplicates the output
-        } else {
-          LOGGER.error(errorMessage);
-        }
+      if (message == null || message.isEmpty()) {
+        // an unexpected error without message
+        LOGGER.error("Internal error:", e);
+      } else if (LOGGER.isDebugEnabled()) {
+        // equivalent to verbose mode
+        LOGGER.error("Error:", e);
       } else {
-        LOGGER.error("{}Internal error:", lineSeparator(), e);
+        // normal mode: only display message
+        LOGGER.error("Error: {}", message);
       }
       System.exit(1);
     }

--- a/dynamic-config/cli/config-converter/src/main/resources/logback.xml
+++ b/dynamic-config/cli/config-converter/src/main/resources/logback.xml
@@ -20,6 +20,9 @@
 
   <statusListener class="ch.qos.logback.core.status.NopStatusListener"/>
 
+  <!--
+    Default appender which will be used to log lines in normal mode
+  -->
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
       <level>INFO</level>
@@ -29,26 +32,28 @@
     </layout>
   </appender>
 
+  <!--
+    If verbose is activated, the STDOUT appender will be disabled and this one will
+    be set to accept levels between TRACE and INFO
+  -->
   <appender name="STDOUT-DETAIL" class="ch.qos.logback.core.ConsoleAppender">
     <layout class="ch.qos.logback.classic.PatternLayout">
       <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-5p %c{1}:%L - %msg%n</pattern>
     </layout>
   </appender>
 
-  <root level="OFF">
+  <root level="WARN">
+    <appender-ref ref="STDOUT"/>
     <appender-ref ref="STDOUT-DETAIL"/>
   </root>
 
-  <logger name="org.terracotta.dynamic_config" level="INFO" additivity="false">
-    <appender-ref ref="STDOUT"/>
-  </logger>
-  <logger name="org.terracotta.nomad" level="INFO" additivity="false">
-    <appender-ref ref="STDOUT"/>
-  </logger>
-  <logger name="org.terracotta.persistence.sanskrit" level="INFO" additivity="false">
-    <appender-ref ref="STDOUT"/>
-  </logger>
-  <logger name="org.terracotta.diagnostic" level="INFO" additivity="false">
-    <appender-ref ref="STDOUT"/>
-  </logger>
+  <logger name="org.terracotta" level="WARN"/>
+  <logger name="com.terracottatech" level="WARN"/>
+  <logger name="com.tc" level="WARN"/>
+
+  <logger name="org.terracotta.dynamic_config" level="INFO"/>
+  <logger name="org.terracotta.nomad" level="INFO"/>
+  <logger name="org.terracotta.persistence.sanskrit" level="INFO"/>
+  <logger name="org.terracotta.diagnostic" level="INFO"/>
+
 </configuration>

--- a/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/ConfigTool.java
+++ b/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/ConfigTool.java
@@ -49,8 +49,6 @@ import java.time.Duration;
 import java.util.Arrays;
 import java.util.HashSet;
 
-import static java.lang.System.lineSeparator;
-
 public class ConfigTool {
   private static final Logger LOGGER = LoggerFactory.getLogger(ConfigTool.class);
 
@@ -59,14 +57,15 @@ public class ConfigTool {
       ConfigTool.start(args);
     } catch (Exception e) {
       String message = e.getMessage();
-      if (message != null && !message.isEmpty()) {
-        if (LOGGER.isDebugEnabled()) {
-          LOGGER.error("{}Error:", lineSeparator(), e); // do not output e.getMassage() because it duplicates the output
-        } else {
-          LOGGER.error("{}Error:{}{}{}", lineSeparator(), lineSeparator(), message, lineSeparator());
-        }
+      if (message == null || message.isEmpty()) {
+        // an unexpected error without message
+        LOGGER.error("Internal error:", e);
+      } else if (LOGGER.isDebugEnabled()) {
+        // equivalent to verbose mode
+        LOGGER.error("Error:", e);
       } else {
-        LOGGER.error("{}Internal error:", lineSeparator(), e);
+        // normal mode: only display message
+        LOGGER.error("Error: {}", message);
       }
       System.exit(1);
     }
@@ -107,7 +106,7 @@ public class ConfigTool {
     Duration requestTimeout = Duration.ofMillis(mainCommand.getRequestTimeout().getQuantity(TimeUnit.MILLISECONDS));
     Duration entityOperationTimeout = Duration.ofMillis(mainCommand.getEntityOperationTimeout().getQuantity(TimeUnit.MILLISECONDS));
     Duration entityConnectionTimeout = Duration.ofMillis(mainCommand.getEntityConnectionTimeout().getQuantity(TimeUnit.MILLISECONDS));
-    
+
     // create services
     DiagnosticServiceProvider diagnosticServiceProvider = new DiagnosticServiceProvider("CONFIG-TOOL", connectionTimeout, requestTimeout, mainCommand.getSecurityRootDirectory());
     MultiDiagnosticServiceProvider multiDiagnosticServiceProvider = new ConcurrentDiagnosticServiceProvider(diagnosticServiceProvider, connectionTimeout, concurrencySizing);

--- a/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/command/ExportCommand.java
+++ b/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/command/ExportCommand.java
@@ -71,7 +71,7 @@ public class ExportCommand extends RemoteCommand {
     String output = buildOutput(cluster, outputFormat);
 
     if (outputFile == null) {
-      logger.info("{}", output);
+      logger.info(output);
 
     } else {
       try {
@@ -108,12 +108,11 @@ public class ExportCommand extends RemoteCommand {
       case PROPERTIES:
         Properties nonDefaults = cluster.toProperties(false, false);
         try (StringWriter out = new StringWriter()) {
-          Props.store(out, nonDefaults, "Non-default configurations:");
+          Props.store(out, nonDefaults, "Non-default configurations");
           if (includeDefaultValues) {
             Properties defaults = cluster.toProperties(false, true);
             defaults.keySet().removeAll(nonDefaults.keySet());
-            out.write(System.lineSeparator());
-            Props.store(out, defaults, "Default configurations:");
+            Props.store(out, defaults, "Default configurations");
           }
           return out.toString();
         } catch (IOException e) {

--- a/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/command/GetCommand.java
+++ b/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/command/GetCommand.java
@@ -54,7 +54,7 @@ public class GetCommand extends ConfigurationCommand {
         .sorted()
         .reduce((result, line) -> result + System.lineSeparator() + line)
         .orElseThrow(() -> new ParameterException("No configuration found for: " + configurations.stream().map(Configuration::toString).collect(Collectors.joining(", "))));
-    logger.info(output + System.lineSeparator());
+    logger.info(output);
   }
 
   private boolean acceptKey(String key) {

--- a/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/command/RemoteCommand.java
+++ b/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/command/RemoteCommand.java
@@ -135,7 +135,7 @@ public abstract class RemoteCommand extends Command {
    * Ensure that the input address is really an address that can be used to connect to a node of a cluster
    */
   protected final void validateAddress(InetSocketAddress expectedOnlineNode) {
-    logger.info("Validating node address: {} (this can take time if the node is not reachable)", expectedOnlineNode);
+    logger.trace("Validating node address: {} (this can take time if the node is not reachable)", expectedOnlineNode);
     getRuntimeCluster(expectedOnlineNode).getNode(expectedOnlineNode)
         .orElseGet(() -> getUpcomingCluster(expectedOnlineNode).getNode(expectedOnlineNode)
             .orElseThrow(() -> new IllegalArgumentException("Targeted cluster does not contain any node with this address: " + expectedOnlineNode + ". Is it a mistake ? Are you connecting to the wrong cluster ? If not, please use the configured node hostname and port to connect.")));

--- a/dynamic-config/cli/config-tool/src/main/resources/logback.xml
+++ b/dynamic-config/cli/config-tool/src/main/resources/logback.xml
@@ -20,6 +20,9 @@
 
   <statusListener class="ch.qos.logback.core.status.NopStatusListener"/>
 
+  <!--
+    Default appender which will be used to log lines in normal mode
+  -->
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
       <level>INFO</level>
@@ -29,26 +32,28 @@
     </layout>
   </appender>
 
+  <!--
+    If verbose is activated, the STDOUT appender will be disabled and this one will
+    be set to accept levels between TRACE and INFO
+  -->
   <appender name="STDOUT-DETAIL" class="ch.qos.logback.core.ConsoleAppender">
     <layout class="ch.qos.logback.classic.PatternLayout">
       <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-5p %c{1}:%L - %msg%n</pattern>
     </layout>
   </appender>
 
-  <root level="OFF">
+  <root level="WARN">
+    <appender-ref ref="STDOUT"/>
     <appender-ref ref="STDOUT-DETAIL"/>
   </root>
 
-  <logger name="org.terracotta.dynamic_config" level="INFO" additivity="false">
-    <appender-ref ref="STDOUT"/>
-  </logger>
-  <logger name="org.terracotta.nomad" level="INFO" additivity="false">
-    <appender-ref ref="STDOUT"/>
-  </logger>
-  <logger name="org.terracotta.persistence.sanskrit" level="INFO" additivity="false">
-    <appender-ref ref="STDOUT"/>
-  </logger>
-  <logger name="org.terracotta.diagnostic" level="INFO" additivity="false">
-    <appender-ref ref="STDOUT"/>
-  </logger>
+  <logger name="org.terracotta" level="WARN"/>
+  <logger name="com.terracottatech" level="WARN"/>
+  <logger name="com.tc" level="WARN"/>
+
+  <logger name="org.terracotta.dynamic_config" level="INFO"/>
+  <logger name="org.terracotta.nomad" level="INFO"/>
+  <logger name="org.terracotta.persistence.sanskrit" level="INFO"/>
+  <logger name="org.terracotta.diagnostic" level="INFO"/>
+
 </configuration>

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activation/PreActivatedNodeStartup1x2IT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activation/PreActivatedNodeStartup1x2IT.java
@@ -17,7 +17,7 @@ package org.terracotta.dynamic_config.system_tests.activation;
 
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.contrib.java.lang.system.SystemErrRule;
+import org.terracotta.angela.client.support.junit.NodeOutputRule;
 import org.terracotta.dynamic_config.test_support.ClusterDefinition;
 import org.terracotta.dynamic_config.test_support.DynamicConfigIT;
 import org.terracotta.dynamic_config.test_support.util.ConfigurationGenerator;
@@ -30,14 +30,14 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
-import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.fail;
+import static org.terracotta.angela.client.support.hamcrest.AngelaMatchers.containsLog;
 
 @ClusterDefinition(nodesPerStripe = 2, autoStart = false)
 public class PreActivatedNodeStartup1x2IT extends DynamicConfigIT {
 
-  @Rule public final SystemErrRule err = new SystemErrRule().enableLog();
+  @Rule public final NodeOutputRule out = new NodeOutputRule();
 
   @Test
   public void testStartingWithSingleStripeSingleNodeRepo() throws Exception {
@@ -68,6 +68,7 @@ public class PreActivatedNodeStartup1x2IT extends DynamicConfigIT {
     waitForActive(1, 1);
 
     try {
+      out.clearLog(1, 2);
       startNode(1, 2,
           "--auto-activate",
           "--failover-priority", "availability",
@@ -82,7 +83,7 @@ public class PreActivatedNodeStartup1x2IT extends DynamicConfigIT {
           "--data-dirs", "main:" + getNodePath(1, 2).resolve("data-dir").toString());
       fail();
     } catch (Exception e) {
-      waitUntil(err::getLog, containsString("Exception initializing Nomad Server: java.io.IOException: File lock already held: " + Paths.get(sharedRepo, "changes")));
+      waitUntil(out.getLog(1, 2), containsLog("Exception initializing Nomad Server: java.io.IOException: File lock already held: " + Paths.get(sharedRepo, "changes")));
     }
   }
 

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/diagnostic/NodeStartupIT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/diagnostic/NodeStartupIT.java
@@ -17,7 +17,6 @@ package org.terracotta.dynamic_config.system_tests.diagnostic;
 
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.contrib.java.lang.system.SystemErrRule;
 import org.terracotta.angela.client.support.junit.NodeOutputRule;
 import org.terracotta.dynamic_config.test_support.ClusterDefinition;
 import org.terracotta.dynamic_config.test_support.DynamicConfigIT;
@@ -32,18 +31,17 @@ import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.TimeoutException;
 
-import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
+import static org.terracotta.angela.client.support.hamcrest.AngelaMatchers.containsLog;
 
 @ClusterDefinition(autoStart = false)
 public class NodeStartupIT extends DynamicConfigIT {
 
   @Rule public final NodeOutputRule out = new NodeOutputRule();
-  @Rule public final SystemErrRule err = new SystemErrRule().enableLog();
 
   @Test
   public void testStartingWithNonExistentRepo() throws TimeoutException {
@@ -82,7 +80,7 @@ public class NodeStartupIT extends DynamicConfigIT {
       startNode(1, 1, "--config-file", configurationFile.toString(), "--config-dir", "config/stripe1/node-1");
       fail();
     } catch (Exception e) {
-      waitUntil(err::getLog, containsString("Failed to read config file"));
+      waitUntil(out.getLog(1, 1), containsLog("Failed to read config file"));
     }
   }
 
@@ -94,7 +92,7 @@ public class NodeStartupIT extends DynamicConfigIT {
       startNode(1, 1, "--config-file", configurationFile.toString(), "--hostname", "localhost", "--port", port, "--config-dir", "config/stripe1/node-1");
       fail();
     } catch (Exception e) {
-      waitUntil(err::getLog, containsString("<port> specified in port=<port> must be an integer between 1 and 65535"));
+      waitUntil(out.getLog(1, 1), containsLog("<port> specified in port=<port> must be an integer between 1 and 65535"));
     }
   }
 
@@ -106,7 +104,7 @@ public class NodeStartupIT extends DynamicConfigIT {
       startNode(1, 1, "--config-file", configurationFile.toString(), "--hostname", "localhost", "--port", port, "--config-dir", "config/stripe1/node-1");
       fail();
     } catch (Exception e) {
-      waitUntil(err::getLog, containsString("security-dir is mandatory for any of the security configuration"));
+      waitUntil(out.getLog(1, 1), containsLog("security-dir is mandatory for any of the security configuration"));
     }
   }
 
@@ -117,7 +115,7 @@ public class NodeStartupIT extends DynamicConfigIT {
       startSingleNode("--config-file", configurationFile.toString(), "--bind-address", "::1");
       fail();
     } catch (Exception e) {
-      waitUntil(err::getLog, containsString("'--config-file' parameter can only be used with '--repair-mode', '--license-file', '--hostname', '--port' and '--config-dir' parameters"));
+      waitUntil(out.getLog(1, 1), containsLog("'--config-file' parameter can only be used with '--repair-mode', '--license-file', '--hostname', '--port' and '--config-dir' parameters"));
     }
   }
 
@@ -128,7 +126,7 @@ public class NodeStartupIT extends DynamicConfigIT {
       startNode(1, 1, "-f", configurationFile.toString(), "-m", getNodeConfigDir(1, 1).toString());
       fail();
     } catch (Exception e) {
-      waitUntil(err::getLog, containsString("'--config-file' parameter can only be used with '--repair-mode', '--license-file', '--hostname', '--port' and '--config-dir' parameters"));
+      waitUntil(out.getLog(1, 1), containsLog("'--config-file' parameter can only be used with '--repair-mode', '--license-file', '--hostname', '--port' and '--config-dir' parameters"));
     }
   }
 
@@ -138,7 +136,7 @@ public class NodeStartupIT extends DynamicConfigIT {
       startSingleNode("--authc=blah", "-r", getNodeConfigDir(1, 1).toString());
       fail();
     } catch (Exception e) {
-      waitUntil(err::getLog, containsString("authc should be one of: [file, ldap, certificate]"));
+      waitUntil(out.getLog(1, 1), containsLog("authc should be one of: [file, ldap, certificate]"));
     }
   }
 
@@ -148,7 +146,7 @@ public class NodeStartupIT extends DynamicConfigIT {
       startNode(1, 1, "--hostname=:::", "-r", getNodeConfigDir(1, 1).toString());
       fail();
     } catch (Exception e) {
-      waitUntil(err::getLog, containsString("<address> specified in hostname=<address> must be a valid hostname or IP address"));
+      waitUntil(out.getLog(1, 1), containsLog("<address> specified in hostname=<address> must be a valid hostname or IP address"));
     }
   }
 
@@ -158,7 +156,7 @@ public class NodeStartupIT extends DynamicConfigIT {
       startSingleNode("--failover-priority", "blah", "-r", getNodeConfigDir(1, 1).toString());
       fail();
     } catch (Exception e) {
-      waitUntil(err::getLog, containsString("failover-priority should be either 'availability', 'consistency', or 'consistency:N' (where 'N' is the voter count expressed as a non-negative integer)"));
+      waitUntil(out.getLog(1, 1), containsLog("failover-priority should be either 'availability', 'consistency', or 'consistency:N' (where 'N' is the voter count expressed as a non-negative integer)"));
     }
   }
 
@@ -168,7 +166,7 @@ public class NodeStartupIT extends DynamicConfigIT {
       startSingleNode("--audit-log-dir", "audit-dir", "-r", getNodeConfigDir(1, 1).toString());
       fail();
     } catch (Exception e) {
-      waitUntil(err::getLog, containsString("security-dir is mandatory for any of the security configuration"));
+      waitUntil(out.getLog(1, 1), containsLog("security-dir is mandatory for any of the security configuration"));
     }
   }
 
@@ -203,7 +201,7 @@ public class NodeStartupIT extends DynamicConfigIT {
       );
       fail();
     } catch (Exception e) {
-      waitUntil(err::getLog, containsString("'--config-file' parameter can only be used with '--repair-mode', '--license-file', '--hostname', '--port' and '--config-dir' parameters"));
+      waitUntil(out.getLog(1, 1), containsLog("'--config-file' parameter can only be used with '--repair-mode', '--license-file', '--hostname', '--port' and '--config-dir' parameters"));
     }
   }
 
@@ -214,8 +212,8 @@ public class NodeStartupIT extends DynamicConfigIT {
       startSingleNode("--config-dir", configurationRepo.toString());
       fail();
     } catch (Exception e) {
-      waitUntil(err::getLog, containsString("Node has not been activated or migrated properly: unable find the latest committed configuration to use at startup. Please delete the configuration directory and try again."));
-      waitUntil(err::getLog, not(containsString("Moved to State[ ACTIVE-COORDINATOR ]")));
+      waitUntil(out.getLog(1, 1), containsLog("Node has not been activated or migrated properly: unable find the latest committed configuration to use at startup. Please delete the configuration directory and try again."));
+      waitUntil(out.getLog(1, 1), not(containsLog("Moved to State[ ACTIVE-COORDINATOR ]")));
     }
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
     <terracotta-core.version>5.7.0-pre29</terracotta-core.version>
     <tripwire.version>1.0.0-pre7</tripwire.version>
     <galvan.version>1.5.0-pre3</galvan.version>
-    <angela.version>3.0.25</angela.version>
+    <angela.version>3.0.27</angela.version>
     <statistics.version>2.1</statistics.version>
     <jackson.version>2.10.1</jackson.version>
     <terracotta-utilities.version>0.0.3</terracotta-utilities.version>


### PR DESCRIPTION
- Update to Angela 3.0.27 (fix for stderr redirection) + Remove usages of Junit SystemErrRule
- Fixing logger that should be in TRACE mode
- Fixing line separations for get / export to have a better output
- Aligning error output for config tool and converter tool and removing extra lines
- Fixing several issues in the tools logging:
  * Errors and warnings coming from not declared packages were hidden
  * packages were hardcoded in java code
  * in verbose mode, not all terracotta packages were put in trace mode

Note for @chrisdennis : this is not the stdout/stderr rework from #719 but I have extracted the fixes I did in #719