### PR TITLE
Remove all the short diagnostic connection and request timeouts from the CLI invocations to use the global timeouts automatically added by the super class, which is higher (30sec by default)

### DIFF
--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/AttachCommandWithVoter1x3IT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/AttachCommandWithVoter1x3IT.java
@@ -90,7 +90,7 @@ public class AttachCommandWithVoter1x3IT extends DynamicConfigIT {
 
       // kill the old passive and detach it from cluster
       stopNode(1, passiveId);
-      assertThat(configToolInvocation("-t", "5s", "detach", "-d", "localhost:" + getNodePort(1, activeId), "-s", "localhost:" + getNodePort(1, passiveId)), is(successful()));
+      assertThat(configToolInvocation("detach", "-d", "localhost:" + getNodePort(1, activeId), "-s", "localhost:" + getNodePort(1, passiveId)), is(successful()));
 
       nodes = new String[]{
           getNode(1, activeId).getHostPort(),

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/AttachInConsistency1x3IT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/AttachInConsistency1x3IT.java
@@ -137,7 +137,7 @@ public class AttachInConsistency1x3IT extends DynamicConfigIT {
 
     // active died and passive can't become active
     assertThat(
-        configToolInvocation("-er", "40s", "-r", "5s", "-t", "5s", "attach", "-f", "-d", "localhost:" + getNodePort(1, activeId),
+        configToolInvocation("-er", "40s", "attach", "-f", "-d", "localhost:" + getNodePort(1, activeId),
             "-s", "localhost:" + getNodePort(1, 3)),
         containsOutput("Two-Phase commit failed"));
 

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/AttachInConsistency1x4IT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/AttachInConsistency1x4IT.java
@@ -150,7 +150,7 @@ public class AttachInConsistency1x4IT extends DynamicConfigIT {
     // 1. but the 2 other passives cannot decide which one will become active because they are only 2 nodes so no majority
     //    so the command will block... Until the thread has time to restart the old active (which will become passive and vote)!
     // 2. or it might be possible that one of the passive has time ot become active
-    ConfigToolExecutionResult output = configToolInvocation("-er", "40s", "-r", "5s", "-t", "5s", "attach", "-f", "-d", "localhost:" + getNodePort(1, activeId), "-s", "localhost:" + getNodePort(1, 4));
+    ConfigToolExecutionResult output = configToolInvocation("-er", "40s", "attach", "-f", "-d", "localhost:" + getNodePort(1, activeId), "-s", "localhost:" + getNodePort(1, 4));
     assertThat(output, either(is(successful())).or(containsOutput("Two-Phase commit failed")));
 
     //start the old active and verify it becomes passive
@@ -164,7 +164,7 @@ public class AttachInConsistency1x4IT extends DynamicConfigIT {
       // change was not committed on the active that has crashed, but id the passive replication was done,
       // it is possible that one of the passive that became active got the change and committed.
       // repair command will be able to replay the commit if necessary
-      configToolInvocation("-t", "5s", "repair", "-f", "commit", "-s", "localhost:" + getNodePort(1, activeId));
+      configToolInvocation("repair", "-f", "commit", "-s", "localhost:" + getNodePort(1, activeId));
     }
 
     // all nodes of teh destination cluster now have the updated topology

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/DetachCommand1x2IT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/DetachCommand1x2IT.java
@@ -100,7 +100,7 @@ public class DetachCommand1x2IT extends DynamicConfigIT {
         configToolInvocation("detach", "-d", "localhost:" + getNodePort(1, activeId), "-s", "localhost:" + getNodePort(1, passiveId)),
         containsOutput("The nodes should be safely shutdown first."));
 
-    configToolInvocation("-t", "5s", "detach", "-d", "localhost:" + getNodePort(1, activeId), "-s", "localhost:" + getNodePort(1, passiveId), "-f");
+    configToolInvocation("detach", "-d", "localhost:" + getNodePort(1, activeId), "-s", "localhost:" + getNodePort(1, passiveId), "-f");
 
     waitUntil(() -> angela.tsa().getStopped().size(), is(1));
     assertTopologyChanged(activeId);
@@ -170,7 +170,7 @@ public class DetachCommand1x2IT extends DynamicConfigIT {
 
     // detach failure (forcing detach otherwise we have to restart cluster)
     assertThat(
-        configToolInvocation("-t", "5s", "detach", "-f", "-d", "localhost:" + getNodePort(1, activeId),
+        configToolInvocation("detach", "-f", "-d", "localhost:" + getNodePort(1, activeId),
             "-s", "localhost:" + getNodePort(1, passiveId)),
         containsOutput("Two-Phase commit failed"));
 
@@ -191,7 +191,7 @@ public class DetachCommand1x2IT extends DynamicConfigIT {
 
     //Both active and passive are down.
     assertThat(
-        configToolInvocation("-er", "40s", "-r", "5s", "-t", "5s", "detach", "-f", "-d", "localhost:" + getNodePort(1, activeId),
+        configToolInvocation("-er", "40s", "detach", "-f", "-d", "localhost:" + getNodePort(1, activeId),
             "-s", "localhost:" + getNodePort(1, passiveId)),
         containsOutput("Two-Phase commit failed"));
 

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/DetachInConsistency1x2IT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/DetachInConsistency1x2IT.java
@@ -76,7 +76,7 @@ public class DetachInConsistency1x2IT extends DynamicConfigIT {
 
     stopNode(1, passiveId);
 
-    configToolInvocation("-t", "5s", "detach", "-d", "localhost:" + getNodePort(1, activeId), "-s", "localhost:" + getNodePort(1, passiveId));
+    configToolInvocation("detach", "-d", "localhost:" + getNodePort(1, activeId), "-s", "localhost:" + getNodePort(1, passiveId));
 
     withTopologyService(1, activeId, topologyService -> assertTrue(topologyService.isActivated()));
     assertThat(getUpcomingCluster("localhost", getNodePort(1, activeId)).getNodeCount(), is(equalTo(1)));
@@ -129,7 +129,7 @@ public class DetachInConsistency1x2IT extends DynamicConfigIT {
 
     // Force the commit 
     assertThat(
-        configToolInvocation("-t", "5s", "repair", "-f", "commit", "-s", "localhost:" + getNodePort(1, activeId)),
+        configToolInvocation("repair", "-f", "commit", "-s", "localhost:" + getNodePort(1, activeId)),
         is(successful()));
 
     withTopologyService(1, activeId, topologyService -> assertTrue(topologyService.isActivated()));
@@ -151,7 +151,7 @@ public class DetachInConsistency1x2IT extends DynamicConfigIT {
 
     // detach failure (forcing detach otherwise we have to restart cluster)
     assertThat(
-        configToolInvocation("-t", "5s", "detach", "-f", "-d", "localhost:" + getNodePort(1, activeId),
+        configToolInvocation("detach", "-f", "-d", "localhost:" + getNodePort(1, activeId),
             "-s", "localhost:" + getNodePort(1, passiveId)),
         containsOutput("Two-Phase commit failed"));
 
@@ -173,7 +173,7 @@ public class DetachInConsistency1x2IT extends DynamicConfigIT {
 
     //Both active and passive is down.
     assertThat(
-        configToolInvocation("-er", "40s", "-r", "5s", "-t", "5s", "detach", "-f", "-d", "localhost:" + getNodePort(1, activeId),
+        configToolInvocation("-er", "40s", "detach", "-f", "-d", "localhost:" + getNodePort(1, activeId),
             "-s", "localhost:" + getNodePort(1, passiveId)),
         containsOutput("Two-Phase commit failed"));
 
@@ -182,7 +182,7 @@ public class DetachInConsistency1x2IT extends DynamicConfigIT {
 
     // Force the commit 
     assertThat(
-        configToolInvocation("-t", "5s", "repair", "-f", "commit", "-s", "localhost:" + getNodePort(1, activeId)),
+        configToolInvocation("repair", "-f", "commit", "-s", "localhost:" + getNodePort(1, activeId)),
         is(successful()));
 
     withTopologyService(1, activeId, topologyService -> assertTrue(topologyService.isActivated()));

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/DetachInConsistency1x3IT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/DetachInConsistency1x3IT.java
@@ -101,7 +101,7 @@ public class DetachInConsistency1x3IT extends DynamicConfigIT {
 
     stopNode(1, passiveId);
 
-    configToolInvocation("-t", "5s", "detach", "-d", "localhost:" + getNodePort(1, activeId), "-s", "localhost:" + getNodePort(1, passiveId));
+    configToolInvocation("detach", "-d", "localhost:" + getNodePort(1, activeId), "-s", "localhost:" + getNodePort(1, passiveId));
 
     withTopologyService(1, activeId, topologyService -> assertTrue(topologyService.isActivated()));
     assertThat(getUpcomingCluster("localhost", getNodePort(1, activeId)).getNodeCount(), is(equalTo(2)));
@@ -190,7 +190,7 @@ public class DetachInConsistency1x3IT extends DynamicConfigIT {
 
     // detach failure (forcing detach otherwise we have to restart cluster)
     assertThat(
-        configToolInvocation("-t", "5s", "detach", "-f", "-d", "localhost:" + getNodePort(1, activeId),
+        configToolInvocation("detach", "-f", "-d", "localhost:" + getNodePort(1, activeId),
             "-s", "localhost:" + getNodePort(1, passiveId)),
         containsOutput("Two-Phase commit failed"));
 
@@ -218,7 +218,7 @@ public class DetachInConsistency1x3IT extends DynamicConfigIT {
 
     //Both active and one passive is down.
     assertThat(
-        configToolInvocation("-er", "40s", "-r", "5s", "-t", "5s", "detach", "-f", "-d", "localhost:" + getNodePort(1, activeId),
+        configToolInvocation("-er", "40s", "detach", "-f", "-d", "localhost:" + getNodePort(1, activeId),
             "-s", "localhost:" + getNodePort(1, passiveId)),
         containsOutput("Two-Phase commit failed"));
 

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/RepairCommand1x2IT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/RepairCommand1x2IT.java
@@ -67,11 +67,11 @@ public class RepairCommand1x2IT extends DynamicConfigIT {
 
     // cannot automatic repair since 1 node is down
     assertThat(
-        configToolInvocation("-t", "5s", "repair", "-s", "localhost:" + getNodePort(1, activeId)),
+        configToolInvocation("repair", "-s", "localhost:" + getNodePort(1, activeId)),
         containsOutput("Please run the 'diagnostic' command to diagnose the configuration state and try to run the 'repair' command and force either a commit or rollback."));
 
     // forces a repair
-    assertThat(configToolInvocation("-t", "5s", "repair", "-f", "commit", "-s", "localhost:" + getNodePort(1, activeId)), containsOutput("Configuration is repaired."));
+    assertThat(configToolInvocation("repair", "-f", "commit", "-s", "localhost:" + getNodePort(1, activeId)), containsOutput("Configuration is repaired."));
     withTopologyService(1, activeId, topologyService -> assertFalse(topologyService.hasIncompleteChange()));
 
     // restart passive - it should sync
@@ -98,7 +98,7 @@ public class RepairCommand1x2IT extends DynamicConfigIT {
 
     // detach command will kill the active, so the stripe will go down
     assertThat(
-        configToolInvocation("-er", "40s", "-r", "5s", "-t", "5s", "detach", "-f", "-d", "localhost:" + getNodePort(1, activeId),
+        configToolInvocation("-er", "40s", "detach", "-f", "-d", "localhost:" + getNodePort(1, activeId),
             "-s", "localhost:" + getNodePort(1, passiveId)),
         containsOutput("Two-Phase commit failed"));
 
@@ -114,7 +114,7 @@ public class RepairCommand1x2IT extends DynamicConfigIT {
 
     // we force a commit on the active
     assertThat(
-        configToolInvocation("-r", "15s", "repair", "-f", "commit", "-s", "localhost:" + getNodePort(1, activeId)),
+        configToolInvocation("repair", "-f", "commit", "-s", "localhost:" + getNodePort(1, activeId)),
         allOf(
             containsOutput("Attempting an automatic repair of the configuration on nodes"),
             containsOutput("Forcing a commit"),
@@ -161,11 +161,11 @@ public class RepairCommand1x2IT extends DynamicConfigIT {
     assertThat(getUpcomingCluster(1, activeId).getNodeCount(), is(equalTo(2)));
     assertThat(getRuntimeCluster(1, activeId).getNodeCount(), is(equalTo(2)));
 
-    assertThat(configToolInvocation("-r", "15s", "diagnostic", "-s", "localhost:" + getNodePort(1, activeId)),
+    assertThat(configToolInvocation("diagnostic", "-s", "localhost:" + getNodePort(1, activeId)),
         containsLinesStartingWith(Files.lines(Paths.get(getClass().getResource("/diagnostic5.txt").toURI())).collect(toList())));
 
     assertThat(
-        configToolInvocation("-r", "15s", "repair", "-f", "commit", "-s", "localhost:" + getNodePort(1, activeId)),
+        configToolInvocation("repair", "-f", "commit", "-s", "localhost:" + getNodePort(1, activeId)),
         allOf(
             containsOutput("Attempting an automatic repair of the configuration on nodes"),
             containsOutput("Configuration is repaired")));
@@ -192,7 +192,7 @@ public class RepairCommand1x2IT extends DynamicConfigIT {
 
     //Both active and passive is down.
     assertThat(
-        configToolInvocation("-er", "40s", "-r", "5s", "-t", "5s", "detach", "-f", "-d", "localhost:" + getNodePort(1, activeId),
+        configToolInvocation("-er", "40s", "detach", "-f", "-d", "localhost:" + getNodePort(1, activeId),
             "-s", "localhost:" + getNodePort(1, passiveId)),
         containsOutput("Two-Phase commit failed"));
 
@@ -205,7 +205,7 @@ public class RepairCommand1x2IT extends DynamicConfigIT {
     assertThat(getRuntimeCluster("localhost", getNodePort(1, activeId)).getNodeCount(), is(equalTo(2)));
 
     assertThat(
-        configToolInvocation("-r", "5s", "repair", "-f", "commit", "-s", "localhost:" + getNodePort(1, activeId)),
+        configToolInvocation("repair", "-f", "commit", "-s", "localhost:" + getNodePort(1, activeId)),
         allOf(
             containsOutput("Attempting an automatic repair of the configuration on nodes"),
             containsOutput("Forcing a commit"),
@@ -221,7 +221,7 @@ public class RepairCommand1x2IT extends DynamicConfigIT {
     withTopologyService(1, passiveId, topologyService -> assertTrue(topologyService.isActivated()));
 
     // we can reset this node
-    configToolInvocation("-r", "5s", "repair", "-f", "reset", "-s", "localhost:" + getNodePort(1, passiveId));
+    configToolInvocation("repair", "-f", "reset", "-s", "localhost:" + getNodePort(1, passiveId));
     waitForStopped(1, passiveId);
     startNode(1, passiveId, "--failover-priority", "availability");
     waitForDiagnostic(1, passiveId);
@@ -232,7 +232,7 @@ public class RepairCommand1x2IT extends DynamicConfigIT {
     // reset diagnostic node
     startNode(1, 1);
     waitForDiagnostic(1, 1);
-    assertThat(configToolInvocation("-r", "5s", "repair", "-f", "reset", "-s", "localhost:" + getNodePort()), is(successful()));
+    assertThat(configToolInvocation("repair", "-f", "reset", "-s", "localhost:" + getNodePort()), is(successful()));
     waitForStopped(1, 1);
     startNode(1, 1);
     waitForDiagnostic(1, 1);
@@ -240,7 +240,7 @@ public class RepairCommand1x2IT extends DynamicConfigIT {
     // reset activated node
     assertThat(configToolInvocation("activate", "-n", "my-cluster", "-s", "localhost:" + getNodePort()), is(successful()));
     waitForActive(1, 1);
-    assertThat(configToolInvocation("-r", "5s", "repair", "-f", "reset", "-s", "localhost:" + getNodePort()), is(successful()));
+    assertThat(configToolInvocation("repair", "-f", "reset", "-s", "localhost:" + getNodePort()), is(successful()));
     waitForStopped(1, 1);
     startNode(1, 1);
     waitForDiagnostic(1, 1);
@@ -251,7 +251,7 @@ public class RepairCommand1x2IT extends DynamicConfigIT {
     stopNode(1, 1);
     startNode(1, 1, "-r", getNode(1, 1).getConfigRepo(), "--repair-mode");
     waitForDiagnostic(1, 1);
-    assertThat(configToolInvocation("-r", "5s", "repair", "-f", "reset", "-s", "localhost:" + getNodePort()), is(successful()));
+    assertThat(configToolInvocation("repair", "-f", "reset", "-s", "localhost:" + getNodePort()), is(successful()));
     waitForStopped(1, 1);
     startNode(1, 1);
     waitForDiagnostic(1, 1);


### PR DESCRIPTION
@saurabhagas : this PR completes the work you did previously to introduce a global diagnostic request timeout.