### PR TITLE
Fixing Maven warnings

### DIFF
--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -34,6 +34,7 @@
       <plugin>
         <groupId>org.asciidoctor</groupId>
         <artifactId>asciidoctor-maven-plugin</artifactId>
+        <version>1.5.6</version>
         <executions>
           <execution>
             <id>output-html</id>

--- a/docs/src/main/asciidoc/dynamic-config/ConfigRepository.adoc
+++ b/docs/src/main/asciidoc/dynamic-config/ConfigRepository.adoc
@@ -124,8 +124,7 @@ attribute and ```tsa-port``` element. Then traverse the ```<cluster>``` element 
 to find out the stripe in which the current server belongs to.
 ** pass:q[*<u>sanskrit</u>*]
 *** Contains append log and other metadata files.
-**** There will be a file called ```state.log``` which is used as an append log. There will be two files called ```hash0``` and ```hash1``` which contain hash information based on recent records in
-```state.log``` to resist tampering where records are removed from the end of the append log.
+**** There will be a file called ```state.log``` which is used as an append log. There will be two files called ```hash0``` and ```hash1``` which contain hash information based on recent records in ```state.log``` to resist tampering where records are removed from the end of the append log.
 
 ===== Note :
 ** Each node will have private repository location. Repository location can be passed from command line.
@@ -140,8 +139,7 @@ Whenever we generate a tamper-resistant hash, we will use SHA-512 truncated to 1
 represented using 40 lowercase hex characters (i.e. 0 to 9 and a to f).
 
 We will have a static byte array in a Java class containing 64 bytes that we will append to any input to the hash
-function. These 64 bytes must not change. They should be randomly generated in advance and then hard-coded in a
-```.java``` file.
+function. These 64 bytes must not change. They should be randomly generated in advance and then hard-coded in a ```.java``` file.
 
 ==== Newlines
 
@@ -174,8 +172,7 @@ A newline appears between records.
 
 ==== Timestamp
 
-The timestamp will appear on its own line. It will be formatted using the ISO standard. For example:
-```2018-10-18T16:52:28```. The timestamp will be in UTC.
+The timestamp will appear on its own line. It will be formatted using the ISO standard. For example: ```2018-10-18T16:52:28```. The timestamp will be in UTC.
 
 ==== JSON
 

--- a/dynamic-config/server/configuration-provider/pom.xml
+++ b/dynamic-config/server/configuration-provider/pom.xml
@@ -68,11 +68,6 @@
       <artifactId>packaging-support</artifactId>
       <scope>provided</scope>
     </dependency>
-    <dependency>
-      <groupId>org.terracotta.internal</groupId>
-      <artifactId>configuration-provider</artifactId>
-      <scope>provided</scope>
-    </dependency>
 
     <!-- Access TcServerMain from TcServer and the exception classes -->
     <dependency>


### PR DESCRIPTION
```
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for org.terracotta.dynamic-config.server:dynamic-config-configuration-provider:jar:5.8-SNAPSHOT
[WARNING] 'dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: org.terracotta.internal:configuration-provider:jar -> duplicate declaration of version (?) @ line 88, column 17
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for org.terracotta:docs:jar:5.8-SNAPSHOT
[WARNING] 'build.plugins.plugin.version' for org.asciidoctor:asciidoctor-maven-plugin is missing. @ line 34, column 15
[WARNING] 
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING] 
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING] 
```

Node: asciidoc plugin was failing with some lines starting with: ```