### PR TITLE
Update dynamic config tests to use java home

### DIFF
--- a/common/json-support/src/main/java/org/terracotta/json/Json.java
+++ b/common/json-support/src/main/java/org/terracotta/json/Json.java
@@ -257,7 +257,7 @@ public class Json {
           .enableClassInfo()
           .enableAnnotationInfo()
           .whitelistPackages("org.terracotta")
-          .scan()) {
+          .scan(1)) {
         for (ClassInfo classInfo : scanResult.getClassesWithAnnotation(JsonTypeName.class.getName())) {
           final Class<?> clazz = classInfo.loadClass(true);
           if (clazz == null) {

--- a/dynamic-config/testing/support/src/main/java/org/terracotta/dynamic_config/test_support/DynamicConfigIT.java
+++ b/dynamic-config/testing/support/src/main/java/org/terracotta/dynamic_config/test_support/DynamicConfigIT.java
@@ -276,9 +276,13 @@ public class DynamicConfigIT {
     return customConfigurationContext().tsa(tsa -> tsa
         .clusterName("tc-cluster")
         .license(getLicenceUrl() == null ? null : new License(getLicenceUrl()))
-        .terracottaCommandLineEnvironment(TerracottaCommandLineEnvironment.DEFAULT.withJavaOpts("-Xms32m -Xmx256m"))
+        .terracottaCommandLineEnvironment(TerracottaCommandLineEnvironment.DEFAULT
+                .withJavaOpts("-Xms32m -Xmx256m")
+                .withJavaHome(System.getProperty("java.home")))
         .terracottaCommandLineEnvironment(TsaConfigurationContext.TerracottaCommandLineEnvironmentKeys.CONFIG_TOOL,
-            TerracottaCommandLineEnvironment.DEFAULT.withJavaOpts("-Xms8m -Xmx128m"))
+            TerracottaCommandLineEnvironment.DEFAULT
+                    .withJavaOpts("-Xms8m -Xmx128m")
+                    .withJavaHome(System.getProperty("java.home")))
         .topology(new Topology(
             getDistribution(),
             dynamicCluster(


### PR DESCRIPTION
Dynamic config test servers should use the JVM used to run the test.

the classgraph change is also an attempt to stabilize tests.  Using only one thread should not be significantly slower and will hopefully not saturate machine scheduling when many servers are being started at once in test VMs