### PR TITLE
Added <optional> in dependencies so that felix can generate the right "resolution:=optional" attribute in the Import-Package manifest entry

### DIFF
--- a/common/inet-support/pom.xml
+++ b/common/inet-support/pom.xml
@@ -32,10 +32,12 @@
   <dependencies>
 
     <!-- for json mapping module -->
+    <!-- optional required by felix to correctly create the optional attribute in Import-Package manifest entry -->
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
       <scope>provided</scope>
+      <optional>true</optional>
     </dependency>
 
   </dependencies>

--- a/common/nomad/pom.xml
+++ b/common/nomad/pom.xml
@@ -32,15 +32,18 @@
   <dependencies>
 
     <!-- for json mapping module -->
+    <!-- optional required by felix to correctly create the optional attribute in Import-Package manifest entry -->
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
       <scope>provided</scope>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-jsr310</artifactId>
       <scope>provided</scope>
+      <optional>true</optional>
     </dependency>
 
   </dependencies>

--- a/common/structures/pom.xml
+++ b/common/structures/pom.xml
@@ -32,10 +32,12 @@
   <dependencies>
 
     <!-- for json mapping module -->
+    <!-- optional required by felix to correctly create the optional attribute in Import-Package manifest entry -->
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
       <scope>provided</scope>
+      <optional>true</optional>
     </dependency>
 
     <dependency>

--- a/dynamic-config/api/pom.xml
+++ b/dynamic-config/api/pom.xml
@@ -42,21 +42,25 @@
     </dependency>
 
     <!-- for json mapping module -->
+    <!-- optional required by felix to correctly create the optional attribute in Import-Package manifest entry -->
     <dependency>
       <groupId>org.terracotta.common</groupId>
       <artifactId>common-json-support</artifactId>
       <version>${project.version}</version>
       <scope>provided</scope>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-jdk8</artifactId>
       <scope>provided</scope>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-jsr310</artifactId>
       <scope>provided</scope>
+      <optional>true</optional>
     </dependency>
 
     <dependency>

--- a/dynamic-config/model/pom.xml
+++ b/dynamic-config/model/pom.xml
@@ -42,21 +42,25 @@
     </dependency>
 
     <!-- for json mapping module -->
+    <!-- optional required by felix to correctly create the optional attribute in Import-Package manifest entry -->
     <dependency>
       <groupId>org.terracotta.common</groupId>
       <artifactId>common-json-support</artifactId>
       <version>${project.version}</version>
       <scope>provided</scope>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-jdk8</artifactId>
       <scope>provided</scope>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-jsr310</artifactId>
       <scope>provided</scope>
+      <optional>true</optional>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Felix relies on `<optional>true</optional>` to be there to generate the correct optional imports:

```
Import-Package: com.fasterxml.jackson.annotation;version="[2.10,3)";reso
 lution:=optional,com.fasterxml.jackson.core;version="[2.10,3)";resoluti
 on:=optional,com.fasterxml.jackson.databind.module;version="[2.10,3)";r
 esolution:=optional
```