### PR TITLE
UX fixes

### DIFF
--- a/dynamic-config/cli/config-converter/src/main/java/org/terracotta/dynamic_config/cli/config_converter/ConfigPropertiesProcessor.java
+++ b/dynamic-config/cli/config-converter/src/main/java/org/terracotta/dynamic_config/cli/config_converter/ConfigPropertiesProcessor.java
@@ -30,11 +30,11 @@ import static java.nio.file.StandardOpenOption.CREATE;
 
 public class ConfigPropertiesProcessor {
   private final Path outputDir;
-  private final String clusterName;
+  private final String fileName;
 
-  public ConfigPropertiesProcessor(Path outputDir, String clusterName) {
+  public ConfigPropertiesProcessor(Path outputDir, String fileName) {
     this.outputDir = outputDir;
-    this.clusterName = clusterName;
+    this.fileName = fileName == null ? "cluster" : fileName;
   }
 
   public void process(Cluster cluster) {
@@ -42,7 +42,7 @@ public class ConfigPropertiesProcessor {
     try (StringWriter out = new StringWriter()) {
       Props.store(out, properties, "Converted cluster configuration:");
       Files.createDirectories(outputDir);
-      Files.write(outputDir.resolve(clusterName + ".properties"), out.toString().getBytes(UTF_8), CREATE);
+      Files.write(outputDir.resolve(fileName + ".properties"), out.toString().getBytes(UTF_8), CREATE);
     } catch (IOException e) {
       throw new UncheckedIOException(e);
     }

--- a/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/command/ActivateCommand.java
+++ b/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/command/ActivateCommand.java
@@ -44,7 +44,7 @@ public class ActivateCommand extends RemoteCommand {
   @Parameter(names = {"-s"}, description = "Node to connect to", converter = InetSocketAddressConverter.class)
   private InetSocketAddress node;
 
-  @Parameter(names = {"-f"}, description = "Configuration file", converter = PathConverter.class)
+  @Parameter(names = {"-f"}, description = "Configuration properties file containing nodes to be activated", converter = PathConverter.class)
   private Path configPropertiesFile;
 
   @Parameter(names = {"-n"}, description = "Cluster name")

--- a/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/command/ExportCommand.java
+++ b/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/command/ExportCommand.java
@@ -84,7 +84,7 @@ public class ExportCommand extends RemoteCommand {
         } else {
           // try to create the parent directories
           Path dir = outputFile.toAbsolutePath().getParent();
-          if (dir != null) {
+          if (dir != null && !Files.exists(dir)) {
             Files.createDirectories(dir);
           }
         }

--- a/dynamic-config/model/src/main/java/org/terracotta/dynamic_config/api/service/Props.java
+++ b/dynamic-config/model/src/main/java/org/terracotta/dynamic_config/api/service/Props.java
@@ -15,6 +15,8 @@
  */
 package org.terracotta.dynamic_config.api.service;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -31,6 +33,8 @@ import java.util.Enumeration;
 import java.util.Properties;
 import java.util.TreeSet;
 
+import static java.util.Objects.requireNonNull;
+
 /**
  * Utility class used to write a property file without the date header and with the properties sorted
  *
@@ -42,7 +46,13 @@ public class Props {
     return load(new StringReader(content));
   }
 
+  @SuppressFBWarnings("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE")
   public static Properties load(Path propertiesFile) {
+    requireNonNull(propertiesFile);
+    if (propertiesFile.getFileName() == null || !propertiesFile.getFileName().toString().endsWith(".properties")) {
+      throw new IllegalArgumentException("Expected a properties file, but got " + propertiesFile.getFileName());
+    }
+
     Properties props = new Properties();
     try (Reader in = new InputStreamReader(Files.newInputStream(propertiesFile), StandardCharsets.UTF_8)) {
       props.load(in);

--- a/dynamic-config/model/src/test/java/org/terracotta/dynamic_config/api/service/PropsTest.java
+++ b/dynamic-config/model/src/test/java/org/terracotta/dynamic_config/api/service/PropsTest.java
@@ -19,6 +19,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.io.StringWriter;
+import java.nio.file.Paths;
 import java.util.Properties;
 
 import static java.lang.System.lineSeparator;
@@ -80,4 +81,8 @@ public class PropsTest {
     )));
   }
 
+  @Test(expected = IllegalArgumentException.class)
+  public void testLoadForInvalidFileFormat() {
+    Props.load(Paths.get("tc-config.xml"));
+  }
 }

--- a/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/DynamicConfigConfigurationProvider.java
+++ b/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/DynamicConfigConfigurationProvider.java
@@ -167,7 +167,7 @@ public class DynamicConfigConfigurationProvider implements ConfigurationProvider
 
   @Override
   public String getConfigurationParamsDescription() {
-    StringBuilder out = new StringBuilder(System.lineSeparator());
+    StringBuilder out = new StringBuilder();
     CustomJCommander jCommander = new CustomJCommander(new Options());
     jCommander.usage(out);
     return out.toString();

--- a/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/service/ParameterSubstitutor.java
+++ b/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/service/ParameterSubstitutor.java
@@ -16,6 +16,7 @@
 package org.terracotta.dynamic_config.server.configuration.service;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import org.terracotta.common.struct.Tuple2;
 import org.terracotta.dynamic_config.api.service.IParameterSubstitutor;
 
 import java.io.File;
@@ -24,11 +25,32 @@ import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+import static org.terracotta.common.struct.Tuple2.tuple2;
 
 /**
  * Copy from platform ParameterSubstitutor
  */
 public class ParameterSubstitutor implements IParameterSubstitutor {
+  private static final Map<Character, Tuple2<Supplier<String>, String>> ALL_PARAMS = new LinkedHashMap<>();
+
+  static {
+    ALL_PARAMS.put('D', tuple2(ParameterSubstitutor::getDatestamp, "date stamp corresponding to current time"));
+    ALL_PARAMS.put('H', tuple2(() -> System.getProperty("user.home"), "home directory of the user. Same as java 'user.home' property"));
+    ALL_PARAMS.put('a', tuple2(() -> System.getProperty("os.arch"), "architecture of the machine. Same as java 'os.arch' property"));
+    ALL_PARAMS.put('c', tuple2(ParameterSubstitutor::getCanonicalHostName, "canonical host name of the machine"));
+    ALL_PARAMS.put('d', tuple2(ParameterSubstitutor::getUniqueTempDirectory, "unique temporary directory"));
+    ALL_PARAMS.put('h', tuple2(ParameterSubstitutor::getHostName, "host name of the machine"));
+    ALL_PARAMS.put('i', tuple2(ParameterSubstitutor::getIpAddress, "IP address of the machine corresponding to localhost"));
+    ALL_PARAMS.put('n', tuple2(() -> System.getProperty("user.name"), "username of the user. Same as java 'user.name' property"));
+    ALL_PARAMS.put('o', tuple2(() -> System.getProperty("os.name"), "name of the operating system. Same as java 'os.name' property"));
+    ALL_PARAMS.put('v', tuple2(() -> System.getProperty("os.version"), "version of the operating system. Same as java 'os.version' property"));
+    ALL_PARAMS.put('t', tuple2(() -> System.getProperty("java.io.tmpdir"), "temporary directory of the machine. Same as java 'java.io.tmpdir' property"));
+  }
 
   private static String uniqueTempDirectory = null;
 
@@ -42,50 +64,21 @@ public class ParameterSubstitutor implements IParameterSubstitutor {
     for (int i = 0; i < sourceChars.length; ++i) {
       if (sourceChars[i] == '%') {
         char nextChar = sourceChars[++i];
-        String value = "" + nextChar;
+        String value;
 
         switch (nextChar) {
           case 'd':
-            value = getUniqueTempDirectory();
-            break;
-
-          case 'D':
-            value = getDatestamp();
-            break;
-
-          case 'h':
-            value = getHostName();
-            break;
-          case 'c':
-            value = getCanonicalHostName();
-            break;
-
-          case 'i':
-            value = getIpAddress();
-            break;
-
-          case 'H':
-            value = System.getProperty("user.home");
-            break;
-
-          case 'n':
-            value = System.getProperty("user.name");
-            break;
-
-          case 'o':
-            value = System.getProperty("os.name");
-            break;
-
-          case 'a':
-            value = System.getProperty("os.arch");
-            break;
-
           case 'v':
-            value = System.getProperty("os.version");
-            break;
-
+          case 'a':
+          case 'o':
+          case 'n':
+          case 'H':
+          case 'i':
+          case 'c':
+          case 'h':
+          case 'D':
           case 't':
-            value = System.getProperty("java.io.tmpdir");
+            value = ALL_PARAMS.get(nextChar).getT1().get();
             break;
 
           case '(':
@@ -188,4 +181,11 @@ public class ParameterSubstitutor implements IParameterSubstitutor {
     }
   }
 
+  public static Map<String, String> getAllParams() {
+    return ALL_PARAMS.entrySet().stream()
+        .collect(Collectors.toMap(
+            keyMapper -> "%" + keyMapper.getKey(),
+            valueMapper -> valueMapper.getValue().getT2()
+        ));
+  }
 }

--- a/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/startup/CustomJCommander.java
+++ b/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/startup/CustomJCommander.java
@@ -19,6 +19,7 @@ import com.beust.jcommander.JCommander;
 import com.beust.jcommander.ParameterDescription;
 import com.beust.jcommander.WrappedParameter;
 import org.terracotta.dynamic_config.api.model.Setting;
+import org.terracotta.dynamic_config.server.configuration.service.ParameterSubstitutor;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -53,12 +54,19 @@ public class CustomJCommander extends JCommander {
   @Override
   public void usage(StringBuilder out, String indent) {
     appendOptions(this, out, indent);
+    appendSubstitutionParamsSection(out, indent);
   }
 
   @Override
   public Map<String, JCommander> getCommands() {
     // force an ordering of commands by name
     return new TreeMap<>(super.getCommands());
+  }
+
+  private void appendSubstitutionParamsSection(StringBuilder out, String indent) {
+    out.append(lineSeparator()).append(indent).append("Allowed substitution parameters:").append(lineSeparator());
+    Map<String, String> allParams = ParameterSubstitutor.getAllParams();
+    allParams.forEach((param, explanation) -> out.append(indent).append("    ").append(param).append("    ").append(explanation).append(lineSeparator()));
   }
 
   private void appendOptions(JCommander jCommander, StringBuilder out, String indent) {

--- a/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/startup/Options.java
+++ b/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/startup/Options.java
@@ -61,85 +61,85 @@ import static org.terracotta.dynamic_config.server.configuration.startup.Console
 
 @Parameters(separators = "=")
 public class Options {
-  @Parameter(names = {"-s", "--" + NODE_HOSTNAME})
+  @Parameter(names = {"-s", "--" + NODE_HOSTNAME}, description = "node host name")
   private String nodeHostname;
 
-  @Parameter(names = {"-S", "--" + NODE_PUBLIC_HOSTNAME})
+  @Parameter(names = {"-S", "--" + NODE_PUBLIC_HOSTNAME}, description = "public node host name")
   private String nodePublicHostname;
 
-  @Parameter(names = {"-p", "--" + NODE_PORT})
+  @Parameter(names = {"-p", "--" + NODE_PORT}, description = "node port")
   private String nodePort;
 
-  @Parameter(names = {"-P", "--" + NODE_PUBLIC_PORT})
+  @Parameter(names = {"-P", "--" + NODE_PUBLIC_PORT}, description = "public node port")
   private String nodePublicPort;
 
-  @Parameter(names = {"-g", "--" + NODE_GROUP_PORT})
+  @Parameter(names = {"-g", "--" + NODE_GROUP_PORT}, description = "node port used for intra-stripe communication")
   private String nodeGroupPort;
 
-  @Parameter(names = {"-n", "--" + NODE_NAME})
+  @Parameter(names = {"-n", "--" + NODE_NAME}, description = "node name")
   private String nodeName;
 
-  @Parameter(names = {"-a", "--" + NODE_BIND_ADDRESS})
+  @Parameter(names = {"-a", "--" + NODE_BIND_ADDRESS}, description = "node bind address for port")
   private String nodeBindAddress;
 
-  @Parameter(names = {"-A", "--" + NODE_GROUP_BIND_ADDRESS})
+  @Parameter(names = {"-A", "--" + NODE_GROUP_BIND_ADDRESS}, description = "node bind address for group port")
   private String nodeGroupBindAddress;
 
-  @Parameter(names = {"-r", "--" + NODE_CONFIG_DIR})
+  @Parameter(names = {"-r", "--" + NODE_CONFIG_DIR}, description = "node configuration directory")
   private String nodeConfigDir;
 
-  @Parameter(names = {"-m", "--" + NODE_METADATA_DIR})
+  @Parameter(names = {"-m", "--" + NODE_METADATA_DIR}, description = "node metadata directory")
   private String nodeMetadataDir;
 
-  @Parameter(names = {"-L", "--" + NODE_LOG_DIR})
+  @Parameter(names = {"-L", "--" + NODE_LOG_DIR}, description = "node log directory")
   private String nodeLogDir;
 
-  @Parameter(names = {"-b", "--" + NODE_BACKUP_DIR})
+  @Parameter(names = {"-b", "--" + NODE_BACKUP_DIR}, description = "node backup directory")
   private String nodeBackupDir;
 
-  @Parameter(names = {"-x", "--" + SECURITY_DIR})
+  @Parameter(names = {"-x", "--" + SECURITY_DIR}, description = "security root directory")
   private String securityDir;
 
-  @Parameter(names = {"-u", "--" + SECURITY_AUDIT_LOG_DIR})
+  @Parameter(names = {"-u", "--" + SECURITY_AUDIT_LOG_DIR}, description = "security audit log directory")
   private String securityAuditLogDir;
 
-  @Parameter(names = {"-z", "--" + SECURITY_AUTHC})
+  @Parameter(names = {"-z", "--" + SECURITY_AUTHC}, description = "security authentication setting (file|ldap|certificate)")
   private String securityAuthc;
 
-  @Parameter(names = {"-t", "--" + SECURITY_SSL_TLS})
+  @Parameter(names = {"-t", "--" + SECURITY_SSL_TLS}, description = "ssl-tls setting (true|false)")
   private String securitySslTls;
 
-  @Parameter(names = {"-w", "--" + SECURITY_WHITELIST})
+  @Parameter(names = {"-w", "--" + SECURITY_WHITELIST}, description = "security whitelist (true|false)")
   private String securityWhitelist;
 
-  @Parameter(names = {"-y", "--" + FAILOVER_PRIORITY})
+  @Parameter(names = {"-y", "--" + FAILOVER_PRIORITY}, description = "failover priority setting (availability|consistency)")
   private String failoverPriority;
 
-  @Parameter(names = {"-R", "--" + CLIENT_RECONNECT_WINDOW})
+  @Parameter(names = {"-R", "--" + CLIENT_RECONNECT_WINDOW}, description = "client reconnect window")
   private String clientReconnectWindow;
 
-  @Parameter(names = {"-i", "--" + CLIENT_LEASE_DURATION})
+  @Parameter(names = {"-i", "--" + CLIENT_LEASE_DURATION}, description = "client lease duration")
   private String clientLeaseDuration;
 
-  @Parameter(names = {"-o", "--" + OFFHEAP_RESOURCES})
+  @Parameter(names = {"-o", "--" + OFFHEAP_RESOURCES}, description = "offheap resources")
   private String offheapResources;
 
-  @Parameter(names = {"-d", "--" + DATA_DIRS})
+  @Parameter(names = {"-d", "--" + DATA_DIRS}, description = "data directory")
   private String dataDirs;
 
-  @Parameter(names = {"-f", "--" + CONFIG_FILE})
+  @Parameter(names = {"-f", "--" + CONFIG_FILE}, description = "configuration properties file")
   private String configFile;
 
-  @Parameter(names = {"-T", "--" + TC_PROPERTIES})
+  @Parameter(names = {"-T", "--" + TC_PROPERTIES}, description = "tc-properties")
   private String tcProperties;
 
-  @Parameter(names = {"-N", "--" + CLUSTER_NAME})
+  @Parameter(names = {"-N", "--" + CLUSTER_NAME}, description = "cluster name")
   private String clusterName;
 
   @Parameter(names = {"-l", "--" + LICENSE_FILE}, hidden = true)
   private String licenseFile;
 
-  @Parameter(names = {"-D", "--" + REPAIR_MODE})
+  @Parameter(names = {"-D", "--" + REPAIR_MODE}, description = "node repair mode (true|false)")
   private boolean wantsRepairMode;
 
   // hidden option that won't appear in the help file,

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/diagnostic/NodeStartupIT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/diagnostic/NodeStartupIT.java
@@ -82,7 +82,7 @@ public class NodeStartupIT extends DynamicConfigIT {
 
   @Test
   public void testFailedStartupConfigFile_nonExistentFile() {
-    Path configurationFile = Paths.get(".").resolve("blah");
+    Path configurationFile = Paths.get(".").resolve("blah.properties");
     try {
       startNode(1, 1, "--config-file", configurationFile.toString(), "--config-dir", "config/stripe1/node-1");
       fail();

--- a/galvan-platform-support/src/main/java/org/terracotta/testing/config/ConfigFileStartupBuilder.java
+++ b/galvan-platform-support/src/main/java/org/terracotta/testing/config/ConfigFileStartupBuilder.java
@@ -35,7 +35,7 @@ public class ConfigFileStartupBuilder extends StartupCommandBuilder {
     if (builtCommand == null) {
       try {
         installServer();
-        Path configFile = convertToConfigFile().resolve("null.properties");
+        Path configFile = convertToConfigFile().resolve("cluster.properties");
         configFileStartupCommand(configFile);
       } catch (IOException e) {
         throw new UncheckedIOException(e);


### PR DESCRIPTION
This is how start-tc-server help looks with the changes from https://github.com/Terracotta-OSS/terracotta-core/pull/1151:

```
usage: start-tc-server [options]
Startup options:
    -c,--consistency-on-startup    preserve data consistency on startup
    -h,--help                      display help

Configuration options:
    -u, --audit-log-dir              node security audit log directory
    -z, --authc                      node security authentication setting (file|ldap|certificate)
    -b, --backup-dir                 node backup directory
    -a, --bind-address               bind address for port. Default: 0.0.0.0
    -i, --client-lease-duration      node client lease duration. Default: 150s
    -R, --client-reconnect-window    node client reconnect window. Default: 120s
    -N, --cluster-name               cluster name
    -r, --config-dir                 node configuration directory. Default: %H/terracotta/config
    -f, --config-file                node configuration properties file
    -d, --data-dirs                  node data directory. Default: main:%H/terracotta/user-data/main
    -y, --failover-priority          node failover-priority (availability|consistency)
    -A, --group-bind-address         bind address for group port. Default: 0.0.0.0
    -g, --group-port                 port used for intra-stripe communication. Default: 9430
    -s, --hostname                   node host name. Default: %h
    -L, --log-dir                    node log directory. Default: %H/terracotta/logs
    -m, --metadata-dir               node metadata directory. Default: %H/terracotta/metadata
    -n, --name                       node name. Default: <randomly-generated>
    -o, --offheap-resources          node offheap resources. Default: main:512MB
    -p, --port                       node port. Default: 9410
    -S, --public-hostname            public node host name
    -P, --public-port                public node port
    -D, --repair-mode                node repair mode (true|false)
    -x, --security-dir               node security root directory
    -t, --ssl-tls                    node ssl-tls setting (true|false). Default: false
    -T, --tc-properties              node tc-properties
    -w, --whitelist                  node security whitelist (true|false). Default: false

Allowed substitution parameters:
    %v    version of the operating system. Same as java 'os.version' property
    %H    home directory of the user. Same as java 'user.home' property
    %h    host name of the machine
    %i    IP address of the machine corresponding to localhost
    %n    username of the user. Same as java 'user.name' property
    %o    name of the operating system. Same as java 'os.name' property
    %a    architecture of the machine. Same as java 'os.arch' property
    %c    canonical host name of the machine
    %t    temporary directory of the machine. Same as java 'java.io.tmpdir' property
    %D    date stamp corresponding to current time
    %d    unique temporary directory
```

Config tool definitions section:
```
Definitions:
    namespace
        stripe.<stripeId>.node.<nodeId>    to apply a change only on a specific node
        stripe.<stripeId>                  to apply a change only on a specific stripe
        '' (empty namespace)               to apply a change only on all nodes of the cluster
```