### PR TITLE
Correct and simplify logging for tooling scripts

### DIFF
--- a/dynamic-config/cli/cli-support/src/main/java/org/terracotta/dynamic_config/cli/command/LocalMainCommand.java
+++ b/dynamic-config/cli/cli-support/src/main/java/org/terracotta/dynamic_config/cli/command/LocalMainCommand.java
@@ -17,9 +17,14 @@ package org.terracotta.dynamic_config.cli.command;
 
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.encoder.PatternLayoutEncoder;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.ConsoleAppender;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
 import org.slf4j.LoggerFactory;
+
+import static org.slf4j.Logger.ROOT_LOGGER_NAME;
 
 @Parameters(commandNames = LocalMainCommand.NAME)
 public class LocalMainCommand extends Command {
@@ -30,18 +35,19 @@ public class LocalMainCommand extends Command {
 
   @Override
   public void run() {
-    Logger rootLogger = (Logger) LoggerFactory.getLogger(org.slf4j.Logger.ROOT_LOGGER_NAME);
+    Logger rootLogger = (Logger) LoggerFactory.getLogger(ROOT_LOGGER_NAME);
 
     if (verbose) {
-      rootLogger.setLevel(Level.INFO);
-      rootLogger.getLoggerContext().getLoggerList().forEach(logger -> logger.detachAppender("STDOUT"));
-      rootLogger.getLoggerContext().getLoggerList()
-          .stream()
-          .filter(logger -> logger.getName().startsWith("org.terracotta") || logger.getName().startsWith("com.terracottatech") || logger.getName().startsWith("com.tc"))
-          .forEach(logger -> logger.setLevel(Level.TRACE));
+      ConsoleAppender<ILoggingEvent> appender = (ConsoleAppender<ILoggingEvent>) rootLogger.getLoggerContext()
+          .getLogger("org.terracotta.dynamic_config.cli").getAppender("STDOUT");
+      PatternLayoutEncoder ple = new PatternLayoutEncoder();
+      ple.setPattern("%d{yyyy-MM-dd HH:mm:ss.SSS} %-5p %c{1}:%L - %msg%n");
+      ple.setContext(appender.getContext());
+      ple.start();
 
-    } else {
-      rootLogger.getLoggerContext().getLoggerList().forEach(logger -> logger.detachAppender("STDOUT-DETAIL"));
+      appender.setEncoder(ple);
+      rootLogger.setLevel(Level.TRACE);
+      rootLogger.getLoggerContext().getLoggerList().forEach(logger -> logger.setLevel(Level.TRACE));
     }
   }
 

--- a/dynamic-config/cli/config-converter/src/main/java/org/terracotta/dynamic_config/cli/config_converter/ConfigConverterTool.java
+++ b/dynamic-config/cli/config-converter/src/main/java/org/terracotta/dynamic_config/cli/config_converter/ConfigConverterTool.java
@@ -34,14 +34,9 @@ public class ConfigConverterTool {
       ConfigConverterTool.start(args);
     } catch (Exception e) {
       String message = e.getMessage();
-      if (message == null || message.isEmpty()) {
-        // an unexpected error without message
-        LOGGER.error("Internal error:", e);
-      } else if (LOGGER.isDebugEnabled()) {
-        // equivalent to verbose mode
+      if (LOGGER.isDebugEnabled() || (message == null || message.isEmpty())) {
         LOGGER.error("Error:", e);
       } else {
-        // normal mode: only display message
         LOGGER.error("Error: {}", message);
       }
       System.exit(1);

--- a/dynamic-config/cli/config-converter/src/main/resources/logback.xml
+++ b/dynamic-config/cli/config-converter/src/main/resources/logback.xml
@@ -19,41 +19,17 @@
 <configuration debug="false">
 
   <statusListener class="ch.qos.logback.core.status.NopStatusListener"/>
-
-  <!--
-    Default appender which will be used to log lines in normal mode
-  -->
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-    <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
-      <level>INFO</level>
-    </filter>
     <layout class="ch.qos.logback.classic.PatternLayout">
       <pattern>%msg%n</pattern>
     </layout>
   </appender>
 
-  <!--
-    If verbose is activated, the STDOUT appender will be disabled and this one will
-    be set to accept levels between TRACE and INFO
-  -->
-  <appender name="STDOUT-DETAIL" class="ch.qos.logback.core.ConsoleAppender">
-    <layout class="ch.qos.logback.classic.PatternLayout">
-      <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-5p %c{1}:%L - %msg%n</pattern>
-    </layout>
-  </appender>
-
-  <root level="WARN">
+  <root level="OFF">
     <appender-ref ref="STDOUT"/>
-    <appender-ref ref="STDOUT-DETAIL"/>
   </root>
 
-  <logger name="org.terracotta" level="WARN"/>
-  <logger name="com.terracottatech" level="WARN"/>
-  <logger name="com.tc" level="WARN"/>
-
-  <logger name="org.terracotta.dynamic_config" level="INFO"/>
-  <logger name="org.terracotta.nomad" level="INFO"/>
-  <logger name="org.terracotta.persistence.sanskrit" level="INFO"/>
-  <logger name="org.terracotta.diagnostic" level="INFO"/>
-
+  <logger name="org.terracotta.dynamic_config.cli" level="INFO" additivity="false">
+    <appender-ref ref="STDOUT"/>
+  </logger>
 </configuration>

--- a/dynamic-config/cli/config-tool/src/main/resources/logback.xml
+++ b/dynamic-config/cli/config-tool/src/main/resources/logback.xml
@@ -19,41 +19,17 @@
 <configuration debug="false">
 
   <statusListener class="ch.qos.logback.core.status.NopStatusListener"/>
-
-  <!--
-    Default appender which will be used to log lines in normal mode
-  -->
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-    <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
-      <level>INFO</level>
-    </filter>
     <layout class="ch.qos.logback.classic.PatternLayout">
       <pattern>%msg%n</pattern>
     </layout>
   </appender>
 
-  <!--
-    If verbose is activated, the STDOUT appender will be disabled and this one will
-    be set to accept levels between TRACE and INFO
-  -->
-  <appender name="STDOUT-DETAIL" class="ch.qos.logback.core.ConsoleAppender">
-    <layout class="ch.qos.logback.classic.PatternLayout">
-      <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-5p %c{1}:%L - %msg%n</pattern>
-    </layout>
-  </appender>
-
-  <root level="WARN">
+  <root level="OFF">
     <appender-ref ref="STDOUT"/>
-    <appender-ref ref="STDOUT-DETAIL"/>
   </root>
 
-  <logger name="org.terracotta" level="WARN"/>
-  <logger name="com.terracottatech" level="WARN"/>
-  <logger name="com.tc" level="WARN"/>
-
-  <logger name="org.terracotta.dynamic_config" level="INFO"/>
-  <logger name="org.terracotta.nomad" level="INFO"/>
-  <logger name="org.terracotta.persistence.sanskrit" level="INFO"/>
-  <logger name="org.terracotta.diagnostic" level="INFO"/>
-
+  <logger name="org.terracotta.dynamic_config.cli" level="INFO" additivity="false">
+    <appender-ref ref="STDOUT"/>
+  </logger>
 </configuration>


### PR DESCRIPTION
Removes `STDOUT-DETAIL` appender, and configures the pattern of `STDOUT` appender in-place if `-v` flag is passed.

The old approach had problems:
1. Having two appenders was tedious and error-prone.
2. For error cases where we didn't get to configure the logging before JCommander failed the parameter parsing. We had both the appenders logging to console in this case.
3. Warn/error messages were interfering with the config tool output even for non-verbose cases