### PR TITLE
Cluster validation should happen after all Nomad processors have executed

### DIFF
--- a/dynamic-config/server/configuration-repository/src/main/java/org/terracotta/dynamic_config/server/configuration/nomad/ConfigChangeApplicator.java
+++ b/dynamic-config/server/configuration-repository/src/main/java/org/terracotta/dynamic_config/server/configuration/nomad/ConfigChangeApplicator.java
@@ -20,6 +20,7 @@ import org.slf4j.LoggerFactory;
 import org.terracotta.dynamic_config.api.model.Cluster;
 import org.terracotta.dynamic_config.api.model.NodeContext;
 import org.terracotta.dynamic_config.api.model.nomad.DynamicConfigNomadChange;
+import org.terracotta.dynamic_config.api.service.ClusterValidator;
 import org.terracotta.dynamic_config.server.api.NomadChangeProcessor;
 import org.terracotta.nomad.client.change.NomadChange;
 import org.terracotta.nomad.server.ChangeApplicator;
@@ -60,6 +61,8 @@ public class ConfigChangeApplicator implements ChangeApplicator<NodeContext> {
       Cluster updated = dynamicConfigNomadChange.apply(original);
       if (updated == null) {
         throw new AssertionError();
+      } else {
+        new ClusterValidator(updated).validate();
       }
 
       return PotentialApplicationResult.allow(newConfiguration(baseConfig, updated));

--- a/dynamic-config/server/configuration-repository/src/main/java/org/terracotta/dynamic_config/server/configuration/nomad/processor/SettingNomadChangeProcessor.java
+++ b/dynamic-config/server/configuration-repository/src/main/java/org/terracotta/dynamic_config/server/configuration/nomad/processor/SettingNomadChangeProcessor.java
@@ -21,7 +21,6 @@ import org.terracotta.dynamic_config.api.model.Cluster;
 import org.terracotta.dynamic_config.api.model.Configuration;
 import org.terracotta.dynamic_config.api.model.NodeContext;
 import org.terracotta.dynamic_config.api.model.nomad.SettingNomadChange;
-import org.terracotta.dynamic_config.api.service.ClusterValidator;
 import org.terracotta.dynamic_config.api.service.TopologyService;
 import org.terracotta.dynamic_config.server.api.ConfigChangeHandler;
 import org.terracotta.dynamic_config.server.api.ConfigChangeHandlerManager;
@@ -62,9 +61,6 @@ public class SettingNomadChangeProcessor implements NomadChangeProcessor<Setting
       // validate through external handlers
       ConfigChangeHandler configChangeHandler = getConfigChangeHandlerManager(change);
       configChangeHandler.validate(baseConfig, configuration);
-
-      Cluster updated = change.apply(original);
-      new ClusterValidator(updated).validate();
     } catch (InvalidConfigChangeException | RuntimeException e) {
       throw new NomadException("Error when trying to apply setting change '" + change.getSummary() + "': " + e.getMessage(), e);
     }

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/SetCommand1x2IT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/SetCommand1x2IT.java
@@ -35,4 +35,12 @@ public class SetCommand1x2IT extends DynamicConfigIT {
     assertThat(configToolInvocation("get", "-s", "localhost:" + getNodePort(), "-c", "client-reconnect-window"),
         allOf(hasExitStatus(0), containsOutput("client-reconnect-window=10s")));
   }
+
+  @Test
+  public void testCluster_setDataDirs_postActivation() throws Exception {
+    assertThat(configToolInvocation("set", "-s", "localhost:" + getNodePort(),
+        "-c", "stripe.1.node.1.data-dirs.foo=foo/node-1-1",
+        "-c", "stripe.1.node.2.data-dirs.foo=foo/node-1-2"
+    ), is(successful()));
+  }
 }

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/SetCommand1x2IT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/SetCommand1x2IT.java
@@ -20,6 +20,7 @@ import org.terracotta.dynamic_config.test_support.ClusterDefinition;
 import org.terracotta.dynamic_config.test_support.DynamicConfigIT;
 
 import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.terracotta.angela.client.support.hamcrest.AngelaMatchers.containsOutput;
@@ -42,5 +43,8 @@ public class SetCommand1x2IT extends DynamicConfigIT {
         "-c", "stripe.1.node.1.data-dirs.foo=foo/node-1-1",
         "-c", "stripe.1.node.2.data-dirs.foo=foo/node-1-2"
     ), is(successful()));
+
+    assertThat(getRuntimeCluster(1, 1).getNode(1, 1).get().getDataDirs(), hasKey("foo"));
+    assertThat(getRuntimeCluster(1, 1).getNode(1, 2).get().getDataDirs(), hasKey("foo"));
   }
 }


### PR DESCRIPTION
Cluster validation should happen after all Nomad processors have executed, not only after 1 specific change has been applied. This is to support multiple changes sent at once in the same Nomad transaction.