### PR TITLE
TDB-5091: Preventing removal of leading stripe

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This project is big and development and testing times are impacted by Maven buil
 So we need to be able several times per day to build the project *fast*.
 
 ```bash
-./mvnw clean install -DskipTests -Dfast
+./mvnw clean install -DskipTests -Dfast -Djava.build.vendor=openjdk
 ```
 
 The command should only do the minimal required steps:
@@ -54,7 +54,7 @@ Skip Galvan and Angela IT tests but run unit tests (*last ~2-3min*)
 Run everything, like on Azure. *Lasts ~1h20min*
 
 ```bash
-./mvnw clean verify
+./mvnw clean verify -Dtest.parallel.forks=1C -Djava.test.vendor=openjdk -Djava.build.vendor=openjdk
 ``` 
 
 ### Concurrent Maven executions
@@ -80,13 +80,13 @@ We can run the tests with one of the JVM on the toolchain but compilation is don
 Run a test with Java 11 (will look at your toolchains.xml file to fine the JVM):
 
 ```bash
-./mvnw verify -f management/testing/integration-tests/pom.xml -Dit.test=DiagnosticIT -Djava.test.version=1.11
+./mvnw verify -f management/testing/integration-tests/pom.xml -Dit.test=DiagnosticIT -Djava.test.version=1.11 -Dtest.parallel.forks=1C -Djava.test.vendor=openjdk -Djava.build.vendor=openjdk
 ```
 
 Run a test with Java 8 (will look at your toolchains.xml file to fine the JVM):
 
 ```bash
-./mvnw verify -f management/testing/integration-tests/pom.xml -Dit.test=DiagnosticIT -Djava.test.version=1.8
+./mvnw verify -f management/testing/integration-tests/pom.xml -Dit.test=DiagnosticIT -Djava.test.version=1.8 -Dtest.parallel.forks=1C -Djava.test.vendor=openjdk -Djava.build.vendor=openjdk
 ```
 
 Run a test with Java 8 (will look at your toolchains.xml file to fine the JVM):

--- a/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/command/AttachCommand.java
+++ b/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/command/AttachCommand.java
@@ -62,6 +62,10 @@ public class AttachCommand extends TopologyCommand {
   public void validate() {
     super.validate();
 
+    if (destinationClusterActivated && operationType == STRIPE) {
+      throw new UnsupportedOperationException("Topology modifications of whole stripes on an activated cluster is not yet supported");
+    }
+
     validateAddress(source);
 
     sourceCluster = getUpcomingCluster(source);

--- a/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/command/TopologyCommand.java
+++ b/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/command/TopologyCommand.java
@@ -34,7 +34,6 @@ import java.util.Map;
 import java.util.function.Supplier;
 
 import static java.lang.System.lineSeparator;
-import static org.terracotta.dynamic_config.cli.config_tool.converter.OperationType.STRIPE;
 
 /**
  * @author Mathieu Carbou
@@ -94,9 +93,6 @@ public abstract class TopologyCommand extends RemoteCommand {
     if (destinationClusterActivated) {
       ensureNodesAreEitherActiveOrPassive(destinationOnlineNodes);
       ensureActivesAreAllOnline(destinationCluster, destinationOnlineNodes);
-      if (operationType == STRIPE) {
-        throw new UnsupportedOperationException("Topology modifications of whole stripes on an activated cluster is not yet supported");
-      }
     }
   }
 

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/DetachCommand2x1IT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/DetachCommand2x1IT.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.dynamic_config.system_tests.activated;
+
+import org.junit.Test;
+import org.terracotta.dynamic_config.test_support.ClusterDefinition;
+import org.terracotta.dynamic_config.test_support.DynamicConfigIT;
+
+import java.time.Duration;
+
+import static org.junit.Assert.assertThat;
+import static org.terracotta.angela.client.support.hamcrest.AngelaMatchers.containsOutput;
+
+/**
+ * @author Mathieu Carbou
+ */
+@ClusterDefinition(stripes = 2, nodesPerStripe = 1, autoActivate = true)
+public class DetachCommand2x1IT extends DynamicConfigIT {
+
+  public DetachCommand2x1IT() {
+    super(Duration.ofSeconds(180));
+  }
+
+  @Test
+  public void test_cannot_detach_leading_stripe() {
+    assertThat(
+        configToolInvocation("detach", "-t", "stripe", "-d", "localhost:" + getNodePort(2, 1), "-s", "localhost:" + getNodePort(1, 1)),
+        containsOutput("Removing the leading stripe is not allowed"));
+  }
+}


### PR DESCRIPTION
Added a validation to ensure that we cannot remove the leading stripe on an activated cluster.
Note: currently, removing a stripe is not allowed anyway.
This validation is added to not forget about it when we will allow and when the UnsupportedOperationException will be removed.

**Note: this PR is rebased on #761** 