### PR TITLE
Better diagnostic command message about pending restarts

### DIFF
--- a/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/command/DiagnosticCommand.java
+++ b/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/command/DiagnosticCommand.java
@@ -30,10 +30,13 @@ import java.time.Clock;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.Map;
+import java.util.TreeSet;
 
 import static java.lang.System.lineSeparator;
 import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.toSet;
 
 /**
  * @author Mathieu Carbou
@@ -57,10 +60,14 @@ public class DiagnosticCommand extends RemoteCommand {
     Map<InetSocketAddress, LogicalServerState> allNodes = findRuntimePeersStatus(node);
 
     ConsistencyAnalyzer<NodeContext> consistencyAnalyzer = analyzeNomadConsistency(allNodes);
-    Collection<InetSocketAddress> onlineNodes = consistencyAnalyzer.getOnlineNodes().keySet();
-    Collection<InetSocketAddress> onlineActivatedNodes = consistencyAnalyzer.getOnlineActivatedNodes().keySet();
-    Collection<InetSocketAddress> onlineInConfigurationNodes = consistencyAnalyzer.getOnlineInConfigurationNodes().keySet();
-    Collection<InetSocketAddress> onlineInRepairNodes = consistencyAnalyzer.getOnlineInRepairNodes().keySet();
+    Collection<InetSocketAddress> onlineNodes = sort(consistencyAnalyzer.getOnlineNodes().keySet());
+    Collection<InetSocketAddress> onlineActivatedNodes = sort(consistencyAnalyzer.getOnlineActivatedNodes().keySet());
+    Collection<InetSocketAddress> onlineInConfigurationNodes = sort(consistencyAnalyzer.getOnlineInConfigurationNodes().keySet());
+    Collection<InetSocketAddress> onlineInRepairNodes = sort(consistencyAnalyzer.getOnlineInRepairNodes().keySet());
+    Collection<InetSocketAddress> nodesPendingRestart = sort(allNodes.keySet().stream()
+        .filter(onlineNodes::contains)
+        .filter(this::mustBeRestarted)
+        .collect(toSet()));
 
     Clock clock = Clock.systemDefaultZone();
     ZoneId zoneId = clock.getZone();
@@ -77,21 +84,29 @@ public class DiagnosticCommand extends RemoteCommand {
     sb.append("[Cluster]")
         .append(lineSeparator());
     sb.append(" - Nodes: ")
-        .append(consistencyAnalyzer.getNodeCount())
+        .append(allNodes.size())
+        .append(details(allNodes.keySet()))
         .append(lineSeparator());
     sb.append(" - Nodes online: ")
         .append(onlineNodes.size())
+        .append(details(onlineNodes))
         .append(lineSeparator());
     sb.append(" - Nodes online, configured and activated: ")
         .append(onlineActivatedNodes.size())
+        .append(details(onlineActivatedNodes))
         .append(lineSeparator());
     sb.append(" - Nodes online, configured and in repair: ")
         .append(onlineInRepairNodes.size())
+        .append(details(onlineInRepairNodes))
         .append(lineSeparator());
     sb.append(" - Nodes online, new and being configured: ")
         .append(onlineInConfigurationNodes.size())
+        .append(details(onlineInConfigurationNodes))
         .append(lineSeparator());
-
+    sb.append(" - Nodes pending restart: ")
+        .append(nodesPendingRestart.size())
+        .append(details(nodesPendingRestart))
+        .append(lineSeparator());
     sb.append(" - Configuration state: ")
         .append(meaningOf(consistencyAnalyzer))
         .append(lineSeparator());
@@ -129,7 +144,7 @@ public class DiagnosticCommand extends RemoteCommand {
       if (onlineNodes.contains(nodeAddress)) {
 
         sb.append(" - Node restart required: ")
-            .append(mustBeRestarted(nodeAddress) ?
+            .append(nodesPendingRestart.contains(nodeAddress) ?
                 "YES" :
                 "NO")
             .append(lineSeparator());
@@ -186,6 +201,16 @@ public class DiagnosticCommand extends RemoteCommand {
       }
     });
     logger.info(sb.toString());
+  }
+
+  private static String details(Collection<InetSocketAddress> addresses) {
+    return addresses.isEmpty() ? "" : " (" + toString(addresses) + ")";
+  }
+
+  private static Collection<InetSocketAddress> sort(Collection<InetSocketAddress> addrs) {
+    TreeSet<InetSocketAddress> sorted = new TreeSet<>(Comparator.comparing(InetSocketAddress::toString));
+    sorted.addAll(addrs);
+    return sorted;
   }
 
   private static String meaningOf(ConsistencyAnalyzer<NodeContext> consistencyAnalyzer) {


### PR DESCRIPTION
- Added the list of nodes in parenthesis after the count in the cluster section
- Added a global hint about the pending restarts to do in case a change requires a rolling restart: `- Nodes pending restart: 2 (localhost:40706, localhost:41755)`

```
[Cluster]
 - Nodes: 2 (localhost:40706, localhost:41755)
 - Nodes online: 2 (localhost:40706, localhost:41755)
 - Nodes online, configured and activated: 2 (localhost:40706, localhost:41755)
 - Nodes online, configured and in repair: 0
 - Nodes online, new and being configured: 0
 - Nodes pending restart: 2 (localhost:40706, localhost:41755)
 - Configuration state: The cluster configuration is healthy. New configuration changes are possible.
 - Configuration checkpoint found across all online configured nodes (activated or in repair): YES (Version: 2, UUID: 08651049-18be-4d8d-8d5c-aa5a6f00a407, At: 2020-07-10T13:24:31.612, Details: set cluster-name=new-cluster-name)
[localhost:40706]
 - Node state: ACTIVE
 - Node online, configured and activated: YES
 - Node online, configured and in repair: NO
 - Node online, new and being configured: NO
 - Node restart required: YES
 - Node configuration change in progress: NO
 - Node can accept new changes: YES
 - Node current configuration version: 2
 - Node highest configuration version: 2
 - Node last configuration change UUID: 08651049-18be-4d8d-8d5c-aa5a6f00a407
 - Node last configuration state: COMMITTED
 - Node last configuration created at: 2020-07-10T13:24:31.612
 - Node last configuration created from: C02YJ2F2JGH6.local
 - Node last configuration created by: matc
 - Node last configuration change details: set cluster-name=new-cluster-name
 - Node last mutation at: 2020-07-10T13:24:31.671
 - Node last mutation from: C02YJ2F2JGH6.local
 - Node last mutation by: matc
[localhost:41755]
 - Node state: PASSIVE
 - Node online, configured and activated: YES
 - Node online, configured and in repair: NO
 - Node online, new and being configured: NO
 - Node restart required: YES
 - Node configuration change in progress: NO
 - Node can accept new changes: YES
 - Node current configuration version: 2
 - Node highest configuration version: 2
 - Node last configuration change UUID: 08651049-18be-4d8d-8d5c-aa5a6f00a407
 - Node last configuration state: COMMITTED
 - Node last configuration created at: 2020-07-10T13:24:31.612
 - Node last configuration created from: C02YJ2F2JGH6.local
 - Node last configuration created by: matc
 - Node last configuration change details: set cluster-name=new-cluster-name
 - Node last mutation at: 2020-07-10T13:24:31.671
 - Node last mutation from: C02YJ2F2JGH6.local
 - Node last mutation by: matc
```