### PR TITLE
TDB-5114: Nodes targeted by a DC config change should all be online to be able to validate the change in their PREPARE phase.

### DIFF
--- a/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/command/ConfigurationMutationCommand.java
+++ b/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/command/ConfigurationMutationCommand.java
@@ -51,7 +51,7 @@ public abstract class ConfigurationMutationCommand extends ConfigurationCommand 
     Cluster originalCluster = getUpcomingCluster(node);
     Cluster updatedCluster = originalCluster.clone();
 
-    // will keep track of teh targeted nodes for the changes of a node setting
+    // will keep track of the targeted nodes for the changes of a node setting
     Collection<InetSocketAddress> missingTargetedNodes = new TreeSet<>(Comparator.comparing(InetSocketAddress::toString));
 
     // applying the set/unset operation to the cluster in memory for validation

--- a/dynamic-config/model/src/main/java/org/terracotta/dynamic_config/api/model/Setting.java
+++ b/dynamic-config/model/src/main/java/org/terracotta/dynamic_config/api/model/Setting.java
@@ -192,7 +192,7 @@ public enum Setting {
       node -> {
         throw new UnsupportedOperationException("Unable to get the configuration directory of a node");
       },
-      unsupported(),
+      noop(),
       noneOf(Operation.class),
       noneOf(Requirement.class),
       emptyList(),
@@ -336,7 +336,7 @@ public enum Setting {
       o -> {
         throw new UnsupportedOperationException("Unable to get a license file");
       },
-      unsupported(),
+      noop(),
       of(SET),
       of(ACTIVES_ONLINE),
       emptyList(),
@@ -829,9 +829,8 @@ public enum Setting {
     return (cluster, tuple) -> setter.accept((Cluster) cluster, tuple2(tuple.t1, tuple.t2 == null || tuple.t2.trim().isEmpty() ? null : tuple.t2.trim()));
   }
 
-  private static <U, V> BiConsumer<U, V> unsupported() {
+  private static <U, V> BiConsumer<U, V> noop() {
     return (u, v) -> {
-      throw new UnsupportedOperationException();
     };
   }
 }

--- a/dynamic-config/model/src/test/java/org/terracotta/dynamic_config/api/model/SetSettingTest.java
+++ b/dynamic-config/model/src/test/java/org/terracotta/dynamic_config/api/model/SetSettingTest.java
@@ -81,9 +81,8 @@ public class SetSettingTest {
         () -> LICENSE_FILE.setProperty(node, null),
         is(throwing(instanceOf(IllegalArgumentException.class)).andMessage(is(equalTo("license-file cannot be null")))));
 
-    assertThat(
-        () -> LICENSE_FILE.setProperty(node, "a.xml"),
-        is(throwing(instanceOf(UnsupportedOperationException.class))));
+    // not throwing - noop
+    LICENSE_FILE.setProperty(node, "a.xml");
   }
 
   @Test

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/AttachInConsistency1x4IT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/AttachInConsistency1x4IT.java
@@ -167,7 +167,7 @@ public class AttachInConsistency1x4IT extends DynamicConfigIT {
       configToolInvocation("repair", "-f", "commit", "-s", "localhost:" + getNodePort(1, activeId));
     }
 
-    // all nodes of teh destination cluster now have the updated topology
+    // all nodes of the destination cluster now have the updated topology
     assertThat(getUpcomingCluster("localhost", getNodePort(1, activeId)).getNodeCount(), is(equalTo(4)));
     assertThat(getUpcomingCluster("localhost", getNodePort(1, passiveId1)).getNodeCount(), is(equalTo(4)));
     assertThat(getUpcomingCluster("localhost", getNodePort(1, passiveId2)).getNodeCount(), is(equalTo(4)));

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/SetCommand1x2IT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/SetCommand1x2IT.java
@@ -79,4 +79,23 @@ public class SetCommand1x2IT extends DynamicConfigIT {
         containsOutput(metadataDir.toString()));
 
   }
+
+  @Test
+  public void testTargetOfflineNode() {
+    int activeId = findActive(1).getAsInt();
+    int passiveId = findPassives(1)[0];
+    stopNode(1, passiveId);
+
+    assertThat(
+        configToolInvocation("set", "-s", "localhost:" + getNodePort(1, activeId), "-c", "stripe.1.node." + passiveId + ".log-dir=foo"),
+        containsOutput("Error: Some nodes that are targeted by the change are not reachable and cannot validate. Please ensure these nodes are online, or remove them from the request"));
+
+    assertThat(
+        configToolInvocation("set", "-s", "localhost:" + getNodePort(1, activeId), "-c", "stripe.1.log-dir=foo"),
+        containsOutput("Error: Some nodes that are targeted by the change are not reachable and cannot validate. Please ensure these nodes are online, or remove them from the request"));
+
+    assertThat(
+        configToolInvocation("set", "-s", "localhost:" + getNodePort(1, activeId), "-c", "log-dir=foo"),
+        containsOutput("Error: Some nodes that are targeted by the change are not reachable and cannot validate. Please ensure these nodes are online, or remove them from the request"));
+  }
 }


### PR DESCRIPTION
When we trigger a DC change on a node-specific setting, we need to ensure that all the nodes targeted by the change are online and will all validate the change in their Nomad PREPARE phase.

This is required, otherwise someone could change for example the log directory of a node that is currently down, and when this node will start again, it will  sync, pick the change, but since it was not part of the transaction to validate the change, the node can fail if the log directory is inaccessible. The sync process will fail and this will prevent the node to start again.