### PR TITLE
TDB-5110 + TDB-5105 : Change how settings are defined + allowing to change node name when configuring

### DIFF
--- a/dynamic-config/api/src/main/java/org/terracotta/dynamic_config/api/model/nomad/SettingNomadChange.java
+++ b/dynamic-config/api/src/main/java/org/terracotta/dynamic_config/api/model/nomad/SettingNomadChange.java
@@ -18,12 +18,12 @@ package org.terracotta.dynamic_config.api.model.nomad;
 import org.terracotta.dynamic_config.api.model.Cluster;
 import org.terracotta.dynamic_config.api.model.Configuration;
 import org.terracotta.dynamic_config.api.model.Operation;
-import org.terracotta.dynamic_config.api.model.Requirement;
 import org.terracotta.dynamic_config.api.model.Setting;
 
 import java.util.Objects;
 
 import static java.util.Objects.requireNonNull;
+import static org.terracotta.dynamic_config.api.model.ClusterState.ACTIVATED;
 
 /**
  * Nomad change that supports any dynamic config change (see Cluster-tool.adoc)
@@ -38,10 +38,10 @@ public class SettingNomadChange extends FilteredNomadChange {
   private final String value;
 
   protected SettingNomadChange(Applicability applicability,
-                             Operation operation,
-                             Setting setting,
-                             String name,
-                             String value) {
+                               Operation operation,
+                               Setting setting,
+                               String name,
+                               String value) {
     super(applicability);
     this.operation = requireNonNull(operation);
     this.setting = requireNonNull(setting);
@@ -69,14 +69,14 @@ public class SettingNomadChange extends FilteredNomadChange {
   public Cluster apply(Cluster original) {
     Cluster updated = original.clone();
     Configuration configuration = toConfiguration(updated);
-    configuration.validate(getOperation());
+    configuration.validate(ACTIVATED, getOperation());
     configuration.apply(updated);
     return updated;
   }
 
   @Override
   public boolean canApplyAtRuntime() {
-    return !getSetting().requires(Requirement.RESTART);
+    return !getSetting().isRestartRequired();
   }
 
   public String getName() {

--- a/dynamic-config/api/src/test/java/org/terracotta/dynamic_config/api/model/nomad/SettingNomadChangeTest.java
+++ b/dynamic-config/api/src/test/java/org/terracotta/dynamic_config/api/model/nomad/SettingNomadChangeTest.java
@@ -27,6 +27,7 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assert.assertThat;
+import static org.terracotta.dynamic_config.api.model.Operation.IMPORT;
 import static org.terracotta.dynamic_config.api.model.Setting.CLUSTER_NAME;
 import static org.terracotta.dynamic_config.api.model.Setting.NODE_BACKUP_DIR;
 import static org.terracotta.dynamic_config.api.model.Setting.NODE_LOG_DIR;
@@ -79,8 +80,8 @@ public class SettingNomadChangeTest {
     assertThat(change.getOperation(), is(equalTo(Operation.UNSET)));
 
     assertThat(
-        () -> fromConfiguration(Configuration.valueOf("backup-dir"), Operation.CONFIG, Cluster.newDefaultCluster()),
-        is(throwing(instanceOf(IllegalArgumentException.class)).andMessage(is(equalTo("Operation config cannot be converted to a Nomad change for an active cluster")))));
+        () -> fromConfiguration(Configuration.valueOf("backup-dir"), IMPORT, Cluster.newDefaultCluster()),
+        is(throwing(instanceOf(IllegalArgumentException.class)).andMessage(is(equalTo("Operation import cannot be converted to a Nomad change for an active cluster")))));
     assertThat(
         () -> fromConfiguration(Configuration.valueOf("backup-dir"), Operation.GET, Cluster.newDefaultCluster()),
         is(throwing(instanceOf(IllegalArgumentException.class)).andMessage(is(equalTo("Operation get cannot be converted to a Nomad change for an active cluster")))));

--- a/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/command/ConfigurationCommand.java
+++ b/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/command/ConfigurationCommand.java
@@ -17,6 +17,7 @@ package org.terracotta.dynamic_config.cli.config_tool.command;
 
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.ParameterException;
+import org.terracotta.dynamic_config.api.model.ClusterState;
 import org.terracotta.dynamic_config.api.model.Configuration;
 import org.terracotta.dynamic_config.api.model.Operation;
 import org.terracotta.dynamic_config.cli.converter.ConfigurationConverter;
@@ -27,6 +28,8 @@ import java.net.InetSocketAddress;
 import java.util.List;
 
 import static java.util.Objects.requireNonNull;
+import static org.terracotta.dynamic_config.api.model.ClusterState.ACTIVATED;
+import static org.terracotta.dynamic_config.api.model.ClusterState.CONFIGURING;
 
 public abstract class ConfigurationCommand extends RemoteCommand {
 
@@ -38,6 +41,9 @@ public abstract class ConfigurationCommand extends RemoteCommand {
 
   protected final Operation operation;
 
+  protected boolean isActivated;
+  protected ClusterState clusterState;
+
   protected ConfigurationCommand(Operation operation) {
     this.operation = operation;
   }
@@ -47,9 +53,12 @@ public abstract class ConfigurationCommand extends RemoteCommand {
     requireNonNull(node);
     requireNonNull(configurations);
 
+    isActivated = isActivated(node);
+    clusterState = isActivated ? ACTIVATED : CONFIGURING;
+
     // validate all configurations passes on CLI
     for (Configuration configuration : configurations) {
-      configuration.validate(operation);
+      configuration.validate(clusterState, operation);
     }
 
     // once valid, check for duplicates

--- a/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/command/ConfigurationMutationCommand.java
+++ b/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/command/ConfigurationMutationCommand.java
@@ -22,7 +22,6 @@ import org.terracotta.dynamic_config.api.model.Cluster;
 import org.terracotta.dynamic_config.api.model.Configuration;
 import org.terracotta.dynamic_config.api.model.NodeContext;
 import org.terracotta.dynamic_config.api.model.Operation;
-import org.terracotta.dynamic_config.api.model.Scope;
 import org.terracotta.dynamic_config.api.model.nomad.MultiSettingNomadChange;
 import org.terracotta.dynamic_config.api.model.nomad.SettingNomadChange;
 import org.terracotta.dynamic_config.api.service.ClusterValidator;
@@ -36,6 +35,7 @@ import java.util.TreeSet;
 import static java.lang.System.lineSeparator;
 import static java.util.stream.Collectors.toList;
 import static org.terracotta.dynamic_config.api.model.Requirement.ALL_NODES_ONLINE;
+import static org.terracotta.dynamic_config.api.model.Scope.NODE;
 
 public abstract class ConfigurationMutationCommand extends ConfigurationCommand {
 
@@ -61,7 +61,7 @@ public abstract class ConfigurationMutationCommand extends ConfigurationCommand 
       // if the setting is a node setting, keep track of the node targeted by this configuration line
       // remember: a node setting can be set using a cluster or stripe namespace to target several nodes at once
       // Note: this validation is only for node-specific settings
-      if (c.getSetting().getScope() == Scope.NODE) {
+      if (c.getSetting().isScope(NODE)) {
         targeted.stream().map(nodeContext -> nodeContext.getNode().getNodeAddress()).forEach(missingTargetedNodes::add);
       }
     }
@@ -127,7 +127,7 @@ public abstract class ConfigurationMutationCommand extends ConfigurationCommand 
     // MultiSettingNomadChange will apply to whole change set given by the user as an atomic operation
     return new MultiSettingNomadChange(configurations.stream()
         .map(configuration -> {
-          configuration.validate(operation);
+          configuration.validate(clusterState, operation);
           return SettingNomadChange.fromConfiguration(configuration, operation, cluster);
         })
         .collect(toList()));

--- a/dynamic-config/model/src/main/java/org/terracotta/dynamic_config/api/model/ClusterState.java
+++ b/dynamic-config/model/src/main/java/org/terracotta/dynamic_config/api/model/ClusterState.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.dynamic_config.api.model;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.stream.Stream;
+
+import static org.terracotta.dynamic_config.api.model.Operation.GET;
+import static org.terracotta.dynamic_config.api.model.Operation.IMPORT;
+import static org.terracotta.dynamic_config.api.model.Operation.SET;
+import static org.terracotta.dynamic_config.api.model.Operation.UNSET;
+
+/**
+ * @author Mathieu Carbou
+ */
+public enum ClusterState {
+
+  ACTIVATED(GET, SET, UNSET),
+  CONFIGURING(GET, SET, UNSET, IMPORT);
+
+  private final Collection<Operation> supportedOperations;
+
+  ClusterState(Operation... operations) {
+    this.supportedOperations = Arrays.asList(operations);
+  }
+
+  public Collection<Operation> getOperations() {
+    return Collections.unmodifiableCollection(supportedOperations);
+  }
+
+  public Stream<Operation> filter(Operation... superset) {
+    return Stream.of(superset).filter(supportedOperations::contains);
+  }
+
+  public boolean supports(Operation operation) {
+    return supportedOperations.contains(operation);
+  }
+
+  @Override
+  public String toString() {
+    return "node is " + name().toLowerCase();
+  }
+}

--- a/dynamic-config/model/src/main/java/org/terracotta/dynamic_config/api/model/Operation.java
+++ b/dynamic-config/model/src/main/java/org/terracotta/dynamic_config/api/model/Operation.java
@@ -36,9 +36,9 @@ public enum Operation {
   UNSET,
 
   /**
-   * Property config loading
+   * <pre>config-tool import</pre> command (equivalent to property config loading, importing, startup script, etc)
    */
-  CONFIG;
+  IMPORT;
 
   @Override
   public String toString() {

--- a/dynamic-config/model/src/main/java/org/terracotta/dynamic_config/api/model/Permission.java
+++ b/dynamic-config/model/src/main/java/org/terracotta/dynamic_config/api/model/Permission.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.dynamic_config.api.model;
+
+import java.util.Collection;
+import java.util.EnumSet;
+import java.util.HashSet;
+import java.util.Objects;
+
+import static java.util.Arrays.asList;
+import static org.terracotta.dynamic_config.api.model.ClusterState.CONFIGURING;
+import static org.terracotta.dynamic_config.api.model.Operation.GET;
+import static org.terracotta.dynamic_config.api.model.Operation.IMPORT;
+import static org.terracotta.dynamic_config.api.model.Operation.SET;
+import static org.terracotta.dynamic_config.api.model.Operation.UNSET;
+import static org.terracotta.dynamic_config.api.model.Scope.CLUSTER;
+import static org.terracotta.dynamic_config.api.model.Scope.NODE;
+import static org.terracotta.dynamic_config.api.model.Scope.STRIPE;
+
+/**
+ * @author Mathieu Carbou
+ */
+public class Permission {
+
+  private final Collection<ClusterState> clusterStates;
+  private final Collection<Operation> operations;
+  private final Collection<Scope> levels;
+
+  private Permission(Collection<ClusterState> clusterStates, Collection<Operation> operations, Collection<Scope> levels) {
+    this.clusterStates = new HashSet<>(clusterStates);
+    this.operations = new HashSet<>(operations);
+    this.levels = new HashSet<>(levels);
+  }
+
+  public boolean allows(Scope scope) {
+    return levels.contains(scope);
+  }
+
+  public boolean allows(Operation operation) {
+    return operations.contains(operation);
+  }
+
+  public boolean allows(ClusterState clusterState) {
+    return this.clusterStates.contains(clusterState);
+  }
+
+  public boolean isExportable() {
+    return allows(CONFIGURING) && allows(GET);
+  }
+
+  public boolean isWritableWhen(ClusterState clusterState) {
+    return allows(clusterState) && (allows(SET) || allows(UNSET) || allows(IMPORT));
+  }
+
+  @Override
+  public String toString() {
+    return "Permission: " +
+        "when: " + clusterStates +
+        " allow: " + operations +
+        " at levels: " + levels;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof Permission)) return false;
+    Permission that = (Permission) o;
+    return clusterStates.equals(that.clusterStates) &&
+        operations.equals(that.operations) &&
+        levels.equals(that.levels);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(clusterStates, operations, levels);
+  }
+
+  public static class Builder {
+
+    private final Collection<ClusterState> clusterStates = new HashSet<>();
+    private final Collection<Operation> operations = new HashSet<>();
+
+    private Builder(Collection<ClusterState> clusterStates) {
+      this.clusterStates.addAll(clusterStates);
+    }
+
+    public static Builder when(ClusterState... clusterStates) {
+      return new Builder(asList(clusterStates));
+    }
+
+    public Builder allow(Operation... operations) {
+      for (ClusterState clusterState : clusterStates) {
+        for (Operation operation : operations) {
+          if (!clusterState.supports(operation)) {
+            throw new IllegalArgumentException("state: " + clusterState + " is not compatible with operation: " + operation);
+          }
+        }
+      }
+      this.operations.addAll(asList(operations));
+      return this;
+    }
+
+    public Builder allowAnyOperations() {
+      return allow(EnumSet.allOf(Operation.class).toArray(new Operation[0]));
+    }
+
+    public Permission atLevel(Scope level) {
+      return atLevels(level);
+    }
+
+    public Permission atAnyLevels() {
+      return atLevels(EnumSet.allOf(Scope.class).toArray(new Scope[0]));
+    }
+
+    public Permission atLevels(Scope... levels) {
+      Collection<Scope> l = asList(levels);
+      if (operations.contains(IMPORT) && (l.contains(STRIPE) || l.size() != 1)) {
+        throw new IllegalArgumentException(IMPORT + " operation is only compatible with " + NODE + " or " + CLUSTER);
+      }
+      return new Permission(clusterStates, operations, l);
+    }
+
+  }
+}

--- a/dynamic-config/model/src/main/java/org/terracotta/dynamic_config/api/model/Requirement.java
+++ b/dynamic-config/model/src/main/java/org/terracotta/dynamic_config/api/model/Requirement.java
@@ -21,9 +21,14 @@ package org.terracotta.dynamic_config.api.model;
 public enum Requirement {
 
   /**
-   * Setting change needs a restart
+   * Setting change needs a restart of all the nodes
    */
-  RESTART,
+  CLUSTER_RESTART,
+
+  /**
+   * Setting change needs a restart of only the impacted nodes
+   */
+  NODE_RESTART,
 
   /**
    * Setting change needs only active servers to be online plus eventually some passive servers, but not all
@@ -34,4 +39,21 @@ public enum Requirement {
    * Setting change needs all nodes online (active and passives)
    */
   ALL_NODES_ONLINE,
+
+  /**
+   * A setting that must be eagerly resolved (placeholders) on server-side as soon as possible before any configuration parsing.
+   * Settings requering that are those used to identify nodes such as hostname and port.
+   */
+  RESOLVE_EAGERLY,
+
+  /**
+   * A setting requiring a resolve is a setting that is needed and either we can use a default or the user has to set it.
+   * But at the end of the configuration parsing, the value MUST be present in the topology
+   */
+  PRESENCE,
+
+  /**
+   * A setting that requires the user to provide a value for it in the configuration or CLI. It cannot be left blank.
+   */
+  CONFIG
 }

--- a/dynamic-config/model/src/main/java/org/terracotta/dynamic_config/api/model/SettingValidator.java
+++ b/dynamic-config/model/src/main/java/org/terracotta/dynamic_config/api/model/SettingValidator.java
@@ -49,7 +49,7 @@ class SettingValidator {
     requireNonNull(kv);
     requireNull(s, kv.t1);
     // prevent null if property is required
-    if (s.isRequired() && kv.t2 == null) {
+    if (s.mustBePresent() && kv.t2 == null) {
       throw new IllegalArgumentException(s + " cannot be null");
     }
     // whether required or optional, prevent empty strings

--- a/dynamic-config/model/src/test/java/org/terracotta/dynamic_config/api/model/ConfigurationTest.java
+++ b/dynamic-config/model/src/test/java/org/terracotta/dynamic_config/api/model/ConfigurationTest.java
@@ -21,8 +21,10 @@ import org.junit.Test;
 
 import java.io.File;
 import java.nio.file.Paths;
+import java.util.List;
 import java.util.stream.Stream;
 
+import static java.util.Arrays.asList;
 import static org.hamcrest.Matchers.both;
 import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.equalTo;
@@ -37,8 +39,10 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.terracotta.common.struct.Tuple2.tuple2;
 import static org.terracotta.common.struct.Tuple3.tuple3;
-import static org.terracotta.dynamic_config.api.model.Operation.CONFIG;
+import static org.terracotta.dynamic_config.api.model.ClusterState.ACTIVATED;
+import static org.terracotta.dynamic_config.api.model.ClusterState.CONFIGURING;
 import static org.terracotta.dynamic_config.api.model.Operation.GET;
+import static org.terracotta.dynamic_config.api.model.Operation.IMPORT;
 import static org.terracotta.dynamic_config.api.model.Operation.SET;
 import static org.terracotta.dynamic_config.api.model.Operation.UNSET;
 import static org.terracotta.dynamic_config.api.model.Scope.CLUSTER;
@@ -77,7 +81,7 @@ public class ConfigurationTest {
   @Test
   public void test_valueOf_settings_cluster_level() {
     Stream.of(NODE_CONFIG_DIR).forEach(setting -> {
-      String err = "Invalid input: 'config-dir=%H/terracotta/config'. Reason: config-dir does not allow any operation at cluster level".replace("/", File.separator); // unix/win compat'
+      String err = "Invalid input: 'config-dir=%H/terracotta/config'. Reason: Setting 'config-dir' does not allow any operation at cluster level".replace("/", File.separator); // unix/win compat'
       assertThat(
           () -> Configuration.valueOf(setting),
           is(throwing(instanceOf(IllegalArgumentException.class))
@@ -88,13 +92,13 @@ public class ConfigurationTest {
         LICENSE_FILE
     ).forEach(setting -> assertThat(
         () -> Configuration.valueOf(setting),
-        is(throwing(instanceOf(IllegalArgumentException.class)).andMessage(is(equalTo("Invalid input: '" + setting + "='. Reason: license-file requires a value"))))));
+        is(throwing(instanceOf(IllegalArgumentException.class)).andMessage(is(equalTo("Invalid input: '" + setting + "='. Reason: Setting 'license-file' requires a value"))))));
 
     Stream.of(
         FAILOVER_PRIORITY
     ).forEach(setting -> assertThat(
         () -> Configuration.valueOf(setting),
-        is(throwing(instanceOf(IllegalArgumentException.class)).andMessage(is(equalTo("Invalid input: '" + setting + "='. Reason: failover-priority requires a value"))))));
+        is(throwing(instanceOf(IllegalArgumentException.class)).andMessage(is(equalTo("Invalid input: '" + setting + "='. Reason: Setting 'failover-priority' requires a value"))))));
 
     Stream.of(
         NODE_HOSTNAME,
@@ -102,7 +106,7 @@ public class ConfigurationTest {
         NODE_PORT
     ).forEach(setting -> assertThat(
         () -> Configuration.valueOf(setting),
-        is(throwing(instanceOf(IllegalArgumentException.class)).andMessage(is(endsWith("Reason: " + setting + " cannot be set at cluster level"))))));
+        is(throwing(instanceOf(IllegalArgumentException.class)).andMessage(is(endsWith("Reason: Setting '" + setting + "' cannot be set at cluster level"))))));
 
     Stream.of(
         CLIENT_LEASE_DURATION,
@@ -165,7 +169,7 @@ public class ConfigurationTest {
         is(throwing(instanceOf(IllegalArgumentException.class))
             .andMessage(both(
                 startsWith("Invalid input: 'stripe.1." + setting + "="))
-                .and(endsWith("'. Reason: " + setting + " does not allow any operation at stripe level"))))));
+                .and(endsWith("'. Reason: Setting '" + setting + "' does not allow any operation at stripe level"))))));
 
 
     Stream.of(
@@ -177,7 +181,7 @@ public class ConfigurationTest {
         is(throwing(instanceOf(IllegalArgumentException.class))
             .andMessage(both(
                 startsWith("Invalid input: 'stripe.1." + setting + "="))
-                .and(endsWith("'. Reason: " + setting + " cannot be set at stripe level"))))));
+                .and(endsWith("'. Reason: Setting '" + setting + "' cannot be set at stripe level"))))));
 
     Stream.of(
         DATA_DIRS,
@@ -233,7 +237,7 @@ public class ConfigurationTest {
         is(throwing(instanceOf(IllegalArgumentException.class))
             .andMessage(both(
                 startsWith("Invalid input: 'stripe.1.node.1." + setting + "="))
-                .and(endsWith("'. Reason: " + setting + " does not allow any operation at node level"))))));
+                .and(endsWith("'. Reason: Setting '" + setting + "' does not allow any operation at node level"))))));
 
     Stream.of(
         NODE_NAME,
@@ -287,15 +291,15 @@ public class ConfigurationTest {
           tuple2(NODE_PORT, "9410")
       ).forEach(tuple -> {
         allowInput(tuple.t1.toString(), tuple.t1, CLUSTER, null, null, null, null);
-        rejectInput(tuple.t1 + "=", "Invalid input: '" + tuple.t1 + "='. Reason: " + tuple.t1 + " requires a value");
-        rejectInput(tuple.t1 + "=" + tuple.t2, "Invalid input: '" + tuple.t1 + "=" + tuple.t2 + "'. Reason: " + tuple.t1 + " cannot be set at cluster level");
+        rejectInput(tuple.t1 + "=", "Invalid input: '" + tuple.t1 + "='. Reason: Setting '" + tuple.t1 + "' requires a value");
+        rejectInput(tuple.t1 + "=" + tuple.t2, "Invalid input: '" + tuple.t1 + "=" + tuple.t2 + "'. Reason: Setting '" + tuple.t1 + "' cannot be set at cluster level");
 
         allowInput("stripe.1" + ns + tuple.t1, tuple.t1, STRIPE, 1, null, null, null);
-        rejectInput("stripe.1" + ns + tuple.t1 + "=", "Invalid input: 'stripe.1" + ns + tuple.t1 + "='. Reason: " + tuple.t1 + " requires a value");
-        rejectInput("stripe.1" + ns + tuple.t1 + "=" + tuple.t2, "Invalid input: 'stripe.1" + ns + tuple.t1 + "=" + tuple.t2 + "'. Reason: " + tuple.t1 + " cannot be set at stripe level");
+        rejectInput("stripe.1" + ns + tuple.t1 + "=", "Invalid input: 'stripe.1" + ns + tuple.t1 + "='. Reason: Setting '" + tuple.t1 + "' requires a value");
+        rejectInput("stripe.1" + ns + tuple.t1 + "=" + tuple.t2, "Invalid input: 'stripe.1" + ns + tuple.t1 + "=" + tuple.t2 + "'. Reason: Setting '" + tuple.t1 + "' cannot be set at stripe level");
 
         allowInput("stripe.1.node.1" + ns + tuple.t1, tuple.t1, NODE, 1, 1, null, null);
-        rejectInput("stripe.1.node.1" + ns + tuple.t1 + "=", "Invalid input: 'stripe.1.node.1" + ns + tuple.t1 + "='. Reason: " + tuple.t1 + " requires a value");
+        rejectInput("stripe.1.node.1" + ns + tuple.t1 + "=", "Invalid input: 'stripe.1.node.1" + ns + tuple.t1 + "='. Reason: Setting '" + tuple.t1 + "' requires a value");
         allowInput("stripe.1.node.1" + ns + tuple.t1 + "=" + tuple.t2, tuple.t1, NODE, 1, 1, null, tuple.t2);
       });
 
@@ -309,15 +313,15 @@ public class ConfigurationTest {
           tuple2(NODE_LOG_DIR, "foo/bar")
       ).forEach(tuple -> {
         allowInput(tuple.t1.toString(), tuple.t1, CLUSTER, null, null, null, null);
-        rejectInput(tuple.t1 + "=", "Invalid input: '" + tuple.t1 + "='. Reason: " + tuple.t1 + " requires a value");
+        rejectInput(tuple.t1 + "=", "Invalid input: '" + tuple.t1 + "='. Reason: Setting '" + tuple.t1 + "' requires a value");
         allowInput(tuple.t1 + "=" + tuple.t2, tuple.t1, CLUSTER, null, null, null, tuple.t2);
 
         allowInput("stripe.1" + ns + tuple.t1, tuple.t1, STRIPE, 1, null, null, null);
-        rejectInput("stripe.1" + ns + tuple.t1 + "=", "Invalid input: 'stripe.1" + ns + tuple.t1 + "='. Reason: " + tuple.t1 + " requires a value");
+        rejectInput("stripe.1" + ns + tuple.t1 + "=", "Invalid input: 'stripe.1" + ns + tuple.t1 + "='. Reason: Setting '" + tuple.t1 + "' requires a value");
         allowInput("stripe.1" + ns + tuple.t1 + "=" + tuple.t2, tuple.t1, STRIPE, null, null, null, tuple.t2);
 
         allowInput("stripe.1.node.1" + ns + tuple.t1, tuple.t1, NODE, 1, 1, null, null);
-        rejectInput("stripe.1.node.1" + ns + tuple.t1 + "=", "Invalid input: 'stripe.1.node.1" + ns + tuple.t1 + "='. Reason: " + tuple.t1 + " requires a value");
+        rejectInput("stripe.1.node.1" + ns + tuple.t1 + "=", "Invalid input: 'stripe.1.node.1" + ns + tuple.t1 + "='. Reason: Setting '" + tuple.t1 + "' requires a value");
         allowInput("stripe.1.node.1" + ns + tuple.t1 + "=" + tuple.t2, tuple.t1, NODE, 1, 1, null, tuple.t2);
       });
 
@@ -354,16 +358,16 @@ public class ConfigurationTest {
           tuple2(SECURITY_WHITELIST, "true")
       ).forEach(tuple -> {
         allowInput(tuple.t1.toString(), tuple.t1, CLUSTER, null, null, null, null);
-        rejectInput(tuple.t1 + "=", "Invalid input: '" + tuple.t1 + "='. Reason: " + tuple.t1 + " requires a value");
+        rejectInput(tuple.t1 + "=", "Invalid input: '" + tuple.t1 + "='. Reason: Setting '" + tuple.t1 + "' requires a value");
         allowInput(tuple.t1 + "=" + tuple.t2, tuple.t1, CLUSTER, null, null, null, tuple.t2);
 
-        rejectInput("stripe.1" + ns + tuple.t1, "Invalid input: 'stripe.1" + ns + tuple.t1 + "'. Reason: " + tuple.t1 + " does not allow any operation at stripe level");
-        rejectInput("stripe.1" + ns + tuple.t1 + "=", "Invalid input: 'stripe.1" + ns + tuple.t1 + "='. Reason: " + tuple.t1 + " does not allow any operation at stripe level");
-        rejectInput("stripe.1" + ns + tuple.t1 + "=" + tuple.t2, "Invalid input: 'stripe.1" + ns + tuple.t1 + "=" + tuple.t2 + "'. Reason: " + tuple.t1 + " does not allow any operation at stripe level");
+        rejectInput("stripe.1" + ns + tuple.t1, "Invalid input: 'stripe.1" + ns + tuple.t1 + "'. Reason: Setting '" + tuple.t1 + "' does not allow any operation at stripe level");
+        rejectInput("stripe.1" + ns + tuple.t1 + "=", "Invalid input: 'stripe.1" + ns + tuple.t1 + "='. Reason: Setting '" + tuple.t1 + "' does not allow any operation at stripe level");
+        rejectInput("stripe.1" + ns + tuple.t1 + "=" + tuple.t2, "Invalid input: 'stripe.1" + ns + tuple.t1 + "=" + tuple.t2 + "'. Reason: Setting '" + tuple.t1 + "' does not allow any operation at stripe level");
 
-        rejectInput("stripe.1.node.1" + ns + tuple.t1, "Invalid input: 'stripe.1.node.1" + ns + tuple.t1 + "'. Reason: " + tuple.t1 + " does not allow any operation at node level");
-        rejectInput("stripe.1.node.1" + ns + tuple.t1 + "=", "Invalid input: 'stripe.1.node.1" + ns + tuple.t1 + "='. Reason: " + tuple.t1 + " does not allow any operation at node level");
-        rejectInput("stripe.1.node.1" + ns + tuple.t1 + "=" + tuple.t2, "Invalid input: 'stripe.1.node.1" + ns + tuple.t1 + "=" + tuple.t2 + "'. Reason: " + tuple.t1 + " does not allow any operation at node level");
+        rejectInput("stripe.1.node.1" + ns + tuple.t1, "Invalid input: 'stripe.1.node.1" + ns + tuple.t1 + "'. Reason: Setting '" + tuple.t1 + "' does not allow any operation at node level");
+        rejectInput("stripe.1.node.1" + ns + tuple.t1 + "=", "Invalid input: 'stripe.1.node.1" + ns + tuple.t1 + "='. Reason: Setting '" + tuple.t1 + "' does not allow any operation at node level");
+        rejectInput("stripe.1.node.1" + ns + tuple.t1 + "=" + tuple.t2, "Invalid input: 'stripe.1.node.1" + ns + tuple.t1 + "=" + tuple.t2 + "'. Reason: Setting '" + tuple.t1 + "' does not allow any operation at node level");
       });
 
       // get allowed for scope cluster
@@ -377,13 +381,13 @@ public class ConfigurationTest {
         allowInput(tuple.t1 + "=", tuple.t1, CLUSTER, null, null, null, null);
         allowInput(tuple.t1 + "=" + tuple.t2, tuple.t1, CLUSTER, null, null, null, tuple.t2);
 
-        rejectInput("stripe.1" + ns + tuple.t1, "Invalid input: 'stripe.1" + ns + tuple.t1 + "'. Reason: " + tuple.t1 + " does not allow any operation at stripe level");
-        rejectInput("stripe.1" + ns + tuple.t1 + "=", "Invalid input: 'stripe.1" + ns + tuple.t1 + "='. Reason: " + tuple.t1 + " does not allow any operation at stripe level");
-        rejectInput("stripe.1" + ns + tuple.t1 + "=" + tuple.t2, "Invalid input: 'stripe.1" + ns + tuple.t1 + "=" + tuple.t2 + "'. Reason: " + tuple.t1 + " does not allow any operation at stripe level");
+        rejectInput("stripe.1" + ns + tuple.t1, "Invalid input: 'stripe.1" + ns + tuple.t1 + "'. Reason: Setting '" + tuple.t1 + "' does not allow any operation at stripe level");
+        rejectInput("stripe.1" + ns + tuple.t1 + "=", "Invalid input: 'stripe.1" + ns + tuple.t1 + "='. Reason: Setting '" + tuple.t1 + "' does not allow any operation at stripe level");
+        rejectInput("stripe.1" + ns + tuple.t1 + "=" + tuple.t2, "Invalid input: 'stripe.1" + ns + tuple.t1 + "=" + tuple.t2 + "'. Reason: Setting '" + tuple.t1 + "' does not allow any operation at stripe level");
 
-        rejectInput("stripe.1.node.1" + ns + tuple.t1, "Invalid input: 'stripe.1.node.1" + ns + tuple.t1 + "'. Reason: " + tuple.t1 + " does not allow any operation at node level");
-        rejectInput("stripe.1.node.1" + ns + tuple.t1 + "=", "Invalid input: 'stripe.1.node.1" + ns + tuple.t1 + "='. Reason: " + tuple.t1 + " does not allow any operation at node level");
-        rejectInput("stripe.1.node.1" + ns + tuple.t1 + "=" + tuple.t2, "Invalid input: 'stripe.1.node.1" + ns + tuple.t1 + "=" + tuple.t2 + "'. Reason: " + tuple.t1 + " does not allow any operation at node level");
+        rejectInput("stripe.1.node.1" + ns + tuple.t1, "Invalid input: 'stripe.1.node.1" + ns + tuple.t1 + "'. Reason: Setting '" + tuple.t1 + "' does not allow any operation at node level");
+        rejectInput("stripe.1.node.1" + ns + tuple.t1 + "=", "Invalid input: 'stripe.1.node.1" + ns + tuple.t1 + "='. Reason: Setting '" + tuple.t1 + "' does not allow any operation at node level");
+        rejectInput("stripe.1.node.1" + ns + tuple.t1 + "=" + tuple.t2, "Invalid input: 'stripe.1.node.1" + ns + tuple.t1 + "=" + tuple.t2 + "'. Reason: Setting '" + tuple.t1 + "' does not allow any operation at node level");
       });
 
       // get not allowed
@@ -392,17 +396,17 @@ public class ConfigurationTest {
       Stream.of(
           tuple2(NODE_CONFIG_DIR, "foo/bar")
       ).forEach(tuple -> {
-        rejectInput(tuple.t1.toString(), "Invalid input: '" + tuple.t1 + "'. Reason: " + tuple.t1 + " does not allow any operation at cluster level");
-        rejectInput(tuple.t1 + "=", "Invalid input: '" + tuple.t1 + "='. Reason: " + tuple.t1 + " does not allow any operation at cluster level");
-        rejectInput(tuple.t1 + "=" + tuple.t2, "Invalid input: '" + tuple.t1 + "=" + tuple.t2 + "'. Reason: " + tuple.t1 + " does not allow any operation at cluster level");
+        rejectInput(tuple.t1.toString(), "Invalid input: '" + tuple.t1 + "'. Reason: Setting '" + tuple.t1 + "' does not allow any operation at cluster level");
+        rejectInput(tuple.t1 + "=", "Invalid input: '" + tuple.t1 + "='. Reason: Setting '" + tuple.t1 + "' does not allow any operation at cluster level");
+        rejectInput(tuple.t1 + "=" + tuple.t2, "Invalid input: '" + tuple.t1 + "=" + tuple.t2 + "'. Reason: Setting '" + tuple.t1 + "' does not allow any operation at cluster level");
 
-        rejectInput("stripe.1" + ns + tuple.t1, "Invalid input: 'stripe.1" + ns + tuple.t1 + "'. Reason: " + tuple.t1 + " does not allow any operation at stripe level");
-        rejectInput("stripe.1" + ns + tuple.t1 + "=", "Invalid input: 'stripe.1" + ns + tuple.t1 + "='. Reason: " + tuple.t1 + " does not allow any operation at stripe level");
-        rejectInput("stripe.1" + ns + tuple.t1 + "=" + tuple.t2, "Invalid input: 'stripe.1" + ns + tuple.t1 + "=" + tuple.t2 + "'. Reason: " + tuple.t1 + " does not allow any operation at stripe level");
+        rejectInput("stripe.1" + ns + tuple.t1, "Invalid input: 'stripe.1" + ns + tuple.t1 + "'. Reason: Setting '" + tuple.t1 + "' does not allow any operation at stripe level");
+        rejectInput("stripe.1" + ns + tuple.t1 + "=", "Invalid input: 'stripe.1" + ns + tuple.t1 + "='. Reason: Setting '" + tuple.t1 + "' does not allow any operation at stripe level");
+        rejectInput("stripe.1" + ns + tuple.t1 + "=" + tuple.t2, "Invalid input: 'stripe.1" + ns + tuple.t1 + "=" + tuple.t2 + "'. Reason: Setting '" + tuple.t1 + "' does not allow any operation at stripe level");
 
-        rejectInput("stripe.1.node.1" + ns + tuple.t1, "Invalid input: 'stripe.1.node.1" + ns + tuple.t1 + "'. Reason: " + tuple.t1 + " does not allow any operation at node level");
-        rejectInput("stripe.1.node.1" + ns + tuple.t1 + "=", "Invalid input: 'stripe.1.node.1" + ns + tuple.t1 + "='. Reason: " + tuple.t1 + " does not allow any operation at node level");
-        rejectInput("stripe.1.node.1" + ns + tuple.t1 + "=" + tuple.t2, "Invalid input: 'stripe.1.node.1" + ns + tuple.t1 + "=" + tuple.t2 + "'. Reason: " + tuple.t1 + " does not allow any operation at node level");
+        rejectInput("stripe.1.node.1" + ns + tuple.t1, "Invalid input: 'stripe.1.node.1" + ns + tuple.t1 + "'. Reason: Setting '" + tuple.t1 + "' does not allow any operation at node level");
+        rejectInput("stripe.1.node.1" + ns + tuple.t1 + "=", "Invalid input: 'stripe.1.node.1" + ns + tuple.t1 + "='. Reason: Setting '" + tuple.t1 + "' does not allow any operation at node level");
+        rejectInput("stripe.1.node.1" + ns + tuple.t1 + "=" + tuple.t2, "Invalid input: 'stripe.1.node.1" + ns + tuple.t1 + "=" + tuple.t2 + "'. Reason: Setting '" + tuple.t1 + "' does not allow any operation at node level");
       });
 
       // get not allowed
@@ -411,17 +415,17 @@ public class ConfigurationTest {
       Stream.of(
           tuple2(LICENSE_FILE, "/path/to/license.xml")
       ).forEach(tuple -> {
-        rejectInput(tuple.t1.toString(), "Invalid input: '" + tuple.t1 + "'. Reason: " + tuple.t1 + " cannot be read or cleared");
-        rejectInput(tuple.t1 + "=", "Invalid input: '" + tuple.t1 + "='. Reason: " + tuple.t1 + " requires a value");
+        rejectInput(tuple.t1.toString(), "Invalid input: '" + tuple.t1 + "'. Reason: Setting '" + tuple.t1 + "' cannot be read or cleared");
+        rejectInput(tuple.t1 + "=", "Invalid input: '" + tuple.t1 + "='. Reason: Setting '" + tuple.t1 + "' requires a value");
         allowInput(tuple.t1 + "=" + tuple.t2, tuple.t1, CLUSTER, null, null, null, tuple.t2);
 
-        rejectInput("stripe.1" + ns + tuple.t1, "Invalid input: 'stripe.1" + ns + tuple.t1 + "'. Reason: " + tuple.t1 + " does not allow any operation at stripe level");
-        rejectInput("stripe.1" + ns + tuple.t1 + "=", "Invalid input: 'stripe.1" + ns + tuple.t1 + "='. Reason: " + tuple.t1 + " does not allow any operation at stripe level");
-        rejectInput("stripe.1" + ns + tuple.t1 + "=" + tuple.t2, "Invalid input: 'stripe.1" + ns + tuple.t1 + "=" + tuple.t2 + "'. Reason: " + tuple.t1 + " does not allow any operation at stripe level");
+        rejectInput("stripe.1" + ns + tuple.t1, "Invalid input: 'stripe.1" + ns + tuple.t1 + "'. Reason: Setting '" + tuple.t1 + "' does not allow any operation at stripe level");
+        rejectInput("stripe.1" + ns + tuple.t1 + "=", "Invalid input: 'stripe.1" + ns + tuple.t1 + "='. Reason: Setting '" + tuple.t1 + "' does not allow any operation at stripe level");
+        rejectInput("stripe.1" + ns + tuple.t1 + "=" + tuple.t2, "Invalid input: 'stripe.1" + ns + tuple.t1 + "=" + tuple.t2 + "'. Reason: Setting '" + tuple.t1 + "' does not allow any operation at stripe level");
 
-        rejectInput("stripe.1.node.1" + ns + tuple.t1, "Invalid input: 'stripe.1.node.1" + ns + tuple.t1 + "'. Reason: " + tuple.t1 + " does not allow any operation at node level");
-        rejectInput("stripe.1.node.1" + ns + tuple.t1 + "=", "Invalid input: 'stripe.1.node.1" + ns + tuple.t1 + "='. Reason: " + tuple.t1 + " does not allow any operation at node level");
-        rejectInput("stripe.1.node.1" + ns + tuple.t1 + "=" + tuple.t2, "Invalid input: 'stripe.1.node.1" + ns + tuple.t1 + "=" + tuple.t2 + "'. Reason: " + tuple.t1 + " does not allow any operation at node level");
+        rejectInput("stripe.1.node.1" + ns + tuple.t1, "Invalid input: 'stripe.1.node.1" + ns + tuple.t1 + "'. Reason: Setting '" + tuple.t1 + "' does not allow any operation at node level");
+        rejectInput("stripe.1.node.1" + ns + tuple.t1 + "=", "Invalid input: 'stripe.1.node.1" + ns + tuple.t1 + "='. Reason: Setting '" + tuple.t1 + "' does not allow any operation at node level");
+        rejectInput("stripe.1.node.1" + ns + tuple.t1 + "=" + tuple.t2, "Invalid input: 'stripe.1.node.1" + ns + tuple.t1 + "=" + tuple.t2 + "'. Reason: Setting '" + tuple.t1 + "' does not allow any operation at node level");
       });
 
       // get allowed for all scopes
@@ -470,21 +474,21 @@ public class ConfigurationTest {
         allowInput(tuple.t1 + "." + tuple.t2 + "=", tuple.t1, CLUSTER, null, null, tuple.t2, null);
         allowInput(tuple.t1 + "." + tuple.t2 + "=" + tuple.t3, tuple.t1, CLUSTER, null, null, tuple.t2, tuple.t3);
 
-        rejectInput("stripe.1" + ns + tuple.t1, "Invalid input: 'stripe.1" + ns + tuple.t1 + "'. Reason: " + tuple.t1 + " does not allow any operation at stripe level");
-        rejectInput("stripe.1" + ns + tuple.t1 + "=", "Invalid input: 'stripe.1" + ns + tuple.t1 + "='. Reason: " + tuple.t1 + " does not allow any operation at stripe level");
-        rejectInput("stripe.1" + ns + tuple.t1 + "=" + tuple.t2 + ":" + tuple.t3, "Invalid input: 'stripe.1" + ns + tuple.t1 + "=" + tuple.t2 + ":" + tuple.t3 + "'. Reason: " + tuple.t1 + " does not allow any operation at stripe level");
+        rejectInput("stripe.1" + ns + tuple.t1, "Invalid input: 'stripe.1" + ns + tuple.t1 + "'. Reason: Setting '" + tuple.t1 + "' does not allow any operation at stripe level");
+        rejectInput("stripe.1" + ns + tuple.t1 + "=", "Invalid input: 'stripe.1" + ns + tuple.t1 + "='. Reason: Setting '" + tuple.t1 + "' does not allow any operation at stripe level");
+        rejectInput("stripe.1" + ns + tuple.t1 + "=" + tuple.t2 + ":" + tuple.t3, "Invalid input: 'stripe.1" + ns + tuple.t1 + "=" + tuple.t2 + ":" + tuple.t3 + "'. Reason: Setting '" + tuple.t1 + "' does not allow any operation at stripe level");
 
-        rejectInput("stripe.1" + ns + tuple.t1 + "." + tuple.t2, "Invalid input: 'stripe.1" + ns + tuple.t1 + "." + tuple.t2 + "'. Reason: " + tuple.t1 + " does not allow any operation at stripe level");
-        rejectInput("stripe.1" + ns + tuple.t1 + "." + tuple.t2 + "=", "Invalid input: 'stripe.1" + ns + tuple.t1 + "." + tuple.t2 + "='. Reason: " + tuple.t1 + " does not allow any operation at stripe level");
-        rejectInput("stripe.1" + ns + tuple.t1 + "." + tuple.t2 + "=" + tuple.t3, "Invalid input: 'stripe.1" + ns + tuple.t1 + "." + tuple.t2 + "=" + tuple.t3 + "'. Reason: " + tuple.t1 + " does not allow any operation at stripe level");
+        rejectInput("stripe.1" + ns + tuple.t1 + "." + tuple.t2, "Invalid input: 'stripe.1" + ns + tuple.t1 + "." + tuple.t2 + "'. Reason: Setting '" + tuple.t1 + "' does not allow any operation at stripe level");
+        rejectInput("stripe.1" + ns + tuple.t1 + "." + tuple.t2 + "=", "Invalid input: 'stripe.1" + ns + tuple.t1 + "." + tuple.t2 + "='. Reason: Setting '" + tuple.t1 + "' does not allow any operation at stripe level");
+        rejectInput("stripe.1" + ns + tuple.t1 + "." + tuple.t2 + "=" + tuple.t3, "Invalid input: 'stripe.1" + ns + tuple.t1 + "." + tuple.t2 + "=" + tuple.t3 + "'. Reason: Setting '" + tuple.t1 + "' does not allow any operation at stripe level");
 
-        rejectInput("stripe.1.node.1" + ns + tuple.t1, "Invalid input: 'stripe.1.node.1" + ns + tuple.t1 + "'. Reason: " + tuple.t1 + " does not allow any operation at node level");
-        rejectInput("stripe.1.node.1" + ns + tuple.t1 + "=", "Invalid input: 'stripe.1.node.1" + ns + tuple.t1 + "='. Reason: " + tuple.t1 + " does not allow any operation at node level");
-        rejectInput("stripe.1.node.1" + ns + tuple.t1 + "=" + tuple.t2 + ":" + tuple.t3, "Invalid input: 'stripe.1.node.1" + ns + tuple.t1 + "=" + tuple.t2 + ":" + tuple.t3 + "'. Reason: " + tuple.t1 + " does not allow any operation at node level");
+        rejectInput("stripe.1.node.1" + ns + tuple.t1, "Invalid input: 'stripe.1.node.1" + ns + tuple.t1 + "'. Reason: Setting '" + tuple.t1 + "' does not allow any operation at node level");
+        rejectInput("stripe.1.node.1" + ns + tuple.t1 + "=", "Invalid input: 'stripe.1.node.1" + ns + tuple.t1 + "='. Reason: Setting '" + tuple.t1 + "' does not allow any operation at node level");
+        rejectInput("stripe.1.node.1" + ns + tuple.t1 + "=" + tuple.t2 + ":" + tuple.t3, "Invalid input: 'stripe.1.node.1" + ns + tuple.t1 + "=" + tuple.t2 + ":" + tuple.t3 + "'. Reason: Setting '" + tuple.t1 + "' does not allow any operation at node level");
 
-        rejectInput("stripe.1.node.1" + ns + tuple.t1 + "." + tuple.t2, "Invalid input: 'stripe.1.node.1" + ns + tuple.t1 + "." + tuple.t2 + "'. Reason: " + tuple.t1 + " does not allow any operation at node level");
-        rejectInput("stripe.1.node.1" + ns + tuple.t1 + "." + tuple.t2 + "=", "Invalid input: 'stripe.1.node.1" + ns + tuple.t1 + "." + tuple.t2 + "='. Reason: " + tuple.t1 + " does not allow any operation at node level");
-        rejectInput("stripe.1.node.1" + ns + tuple.t1 + "." + tuple.t2 + "=" + tuple.t3, "Invalid input: 'stripe.1.node.1" + ns + tuple.t1 + "." + tuple.t2 + "=" + tuple.t3 + "'. Reason: " + tuple.t1 + " does not allow any operation at node level");
+        rejectInput("stripe.1.node.1" + ns + tuple.t1 + "." + tuple.t2, "Invalid input: 'stripe.1.node.1" + ns + tuple.t1 + "." + tuple.t2 + "'. Reason: Setting '" + tuple.t1 + "' does not allow any operation at node level");
+        rejectInput("stripe.1.node.1" + ns + tuple.t1 + "." + tuple.t2 + "=", "Invalid input: 'stripe.1.node.1" + ns + tuple.t1 + "." + tuple.t2 + "='. Reason: Setting '" + tuple.t1 + "' does not allow any operation at node level");
+        rejectInput("stripe.1.node.1" + ns + tuple.t1 + "." + tuple.t2 + "=" + tuple.t3, "Invalid input: 'stripe.1.node.1" + ns + tuple.t1 + "." + tuple.t2 + "=" + tuple.t3 + "'. Reason: Setting '" + tuple.t1 + "' does not allow any operation at node level");
       });
     });
   }
@@ -524,369 +528,232 @@ public class ConfigurationTest {
       rejectInput("stripe" + ns + "backup-dir", "Invalid input: 'stripe" + ns + "backup-dir'");
 
       // bad settings combinations
-      rejectInput("backup-dir.key", "Invalid input: 'backup-dir.key'. Reason: backup-dir is not a map and must not have a key");
-      rejectInput("stripe.1.node.1.failover-priority", "Invalid input: 'stripe.1.node.1.failover-priority'. Reason: failover-priority does not allow any operation at node level");
+      rejectInput("backup-dir.key", "Invalid input: 'backup-dir.key'. Reason: Setting 'backup-dir' is not a map and must not have a key");
+      rejectInput("stripe.1.node.1.failover-priority", "Invalid input: 'stripe.1.node.1.failover-priority'. Reason: Setting 'failover-priority' does not allow any operation at node level");
     });
   }
 
   @Test
   public void test_validate() {
-    assertThat(
-        () -> Configuration.valueOf("failover-priority=availability").validate(GET),
-        is(throwing(instanceOf(IllegalArgumentException.class)).andMessage(is(equalTo("Invalid input: 'failover-priority=availability'. Reason: Operation get must not have a value")))));
-    assertThat(
-        () -> Configuration.valueOf("offheap-resources=main:1GB").validate(UNSET),
-        is(throwing(instanceOf(IllegalArgumentException.class)).andMessage(is(equalTo("Invalid input: 'offheap-resources=main:1GB'. Reason: Operation unset must not have a value")))));
-    assertThat(
-        () -> Configuration.valueOf("failover-priority").validate(SET),
-        is(throwing(instanceOf(IllegalArgumentException.class)).andMessage(is(equalTo("Invalid input: 'failover-priority'. Reason: Operation set requires a value")))));
-    assertThat(
-        () -> Configuration.valueOf("failover-priority").validate(CONFIG),
-        is(throwing(instanceOf(IllegalArgumentException.class)).andMessage(is(equalTo("Invalid input: 'failover-priority'. Reason: Operation config requires a value")))));
+    List<String> NS = asList("", "stripe.1.", "stripe.1.node.1.");
 
-    // get allowed for all scopes
-    // unset not allowed for all scopes
-    // set not allowed for all scopes
-    // config allowed for scope node
-    Stream.of(
-        tuple2(NODE_NAME, "foo"),
-        tuple2(NODE_HOSTNAME, "foo"),
-        tuple2(NODE_PORT, "9410")
-    ).forEach(tuple -> {
-      allow(GET, tuple.t1.toString());
-      reject(UNSET, tuple.t1.toString(), "Invalid input: '" + tuple.t1 + "'. Reason: " + tuple.t1 + " does not allow operation unset at cluster level");
-      reject(SET, tuple.t1 + "=" + tuple.t2, "Invalid input: '" + tuple.t1 + "=" + tuple.t2 + "'. Reason: " + tuple.t1 + " cannot be set at cluster level");
-      reject(SET, tuple.t1 + "=", "Invalid input: '" + tuple.t1 + "=" + "'. Reason: " + tuple.t1 + " requires a value");
-      reject(CONFIG, tuple.t1 + "=" + tuple.t2, "Invalid input: '" + tuple.t1 + "=" + tuple.t2 + "'. Reason: " + tuple.t1 + " cannot be set at cluster level");
-      reject(CONFIG, tuple.t1 + "=", "Invalid input: '" + tuple.t1 + "=" + "'. Reason: " + tuple.t1 + " requires a value");
+    // config-dir
+    Stream.of(CONFIGURING, ACTIVATED).forEach(state -> state.filter(GET, UNSET).forEach(op -> NS.forEach(ns -> reject(state, op, ns + "config-dir"))));
+    Stream.of(CONFIGURING, ACTIVATED).forEach(state -> state.filter(SET, IMPORT).forEach(op -> NS.forEach(ns -> reject(state, op, "config-dir=foo"))));
 
-      allow(GET, "stripe.1." + tuple.t1);
-      reject(UNSET, "stripe.1." + tuple.t1, "Invalid input: 'stripe.1." + tuple.t1 + "'. Reason: " + tuple.t1 + " does not allow operation unset at stripe level");
-      reject(SET, "stripe.1." + tuple.t1 + "=" + tuple.t2, "Invalid input: 'stripe.1." + tuple.t1 + "=" + tuple.t2 + "'. Reason: " + tuple.t1 + " cannot be set at stripe level");
-      reject(SET, "stripe.1." + tuple.t1 + "=", "Invalid input: 'stripe.1." + tuple.t1 + "=" + "'. Reason: " + tuple.t1 + " requires a value");
-      reject(CONFIG, "stripe.1." + tuple.t1 + "=" + tuple.t2, "Invalid input: 'stripe.1." + tuple.t1 + "=" + tuple.t2 + "'. Reason: " + tuple.t1 + " cannot be set at stripe level");
-      reject(CONFIG, "stripe.1." + tuple.t1 + "=", "Invalid input: 'stripe.1." + tuple.t1 + "=" + "'. Reason: " + tuple.t1 + " requires a value");
+    // license-file
+    Stream.of(CONFIGURING, ACTIVATED).forEach(state -> state.filter(GET, UNSET).forEach(op -> NS.forEach(ns -> reject(state, op, ns + "license-file"))));
+    Stream.of(CONFIGURING, ACTIVATED).forEach(state -> state.filter(SET).forEach(op -> {
+      allow(state, op, "license-file=foo");
+      reject(state, op, "license-file=");
+      reject(state, op, "stripe.1.license-file=foo");
+      reject(state, op, "stripe.1.node.1.license-file=foo");
+    }));
+    Stream.of(CONFIGURING).forEach(state -> state.filter(IMPORT).forEach(op -> NS.forEach(ns -> reject(state, op, ns + "license-file=foo"))));
+    Stream.of(CONFIGURING).forEach(state -> state.filter(IMPORT).forEach(op -> NS.forEach(ns -> reject(state, op, ns + "license-file="))));
 
-      allow(GET, "stripe.1.node.1." + tuple.t1);
-      reject(UNSET, "stripe.1.node.1." + tuple.t1, "Invalid input: 'stripe.1.node.1." + tuple.t1 + "'. Reason: " + tuple.t1 + " does not allow operation unset at node level");
-      reject(SET, "stripe.1.node.1." + tuple.t1 + "=" + tuple.t2, "Invalid input: 'stripe.1.node.1." + tuple.t1 + "=" + tuple.t2 + "'. Reason: " + tuple.t1 + " does not allow operation set at node level");
-      reject(SET, "stripe.1.node.1." + tuple.t1 + "=", "Invalid input: 'stripe.1.node.1." + tuple.t1 + "=" + "'. Reason: " + tuple.t1 + " requires a value");
-      allow(CONFIG, "stripe.1.node.1." + tuple.t1 + "=" + tuple.t2);
-      reject(CONFIG, "stripe.1.node.1." + tuple.t1 + "=", "Invalid input: 'stripe.1.node.1." + tuple.t1 + "=" + "'. Reason: " + tuple.t1 + " requires a value");
+    // metadata-dir
+    Stream.of(CONFIGURING, ACTIVATED).forEach(state -> state.filter(GET).forEach(op -> NS.forEach(ns -> allow(state, op, ns + "metadata-dir"))));
+    Stream.of(CONFIGURING, ACTIVATED).forEach(state -> state.filter(UNSET).forEach(op -> NS.forEach(ns -> reject(state, op, ns + "metadata-dir"))));
+    Stream.of(CONFIGURING).forEach(state -> state.filter(SET).forEach(op -> NS.forEach(ns -> allow(state, op, ns + "metadata-dir=foo"))));
+    Stream.of(CONFIGURING).forEach(state -> state.filter(SET).forEach(op -> NS.forEach(ns -> reject(state, op, ns + "metadata-dir="))));
+    Stream.of(ACTIVATED).forEach(state -> state.filter(SET).forEach(op -> NS.forEach(ns -> reject(state, op, ns + "metadata-dir=foo"))));
+    Stream.of(ACTIVATED).forEach(state -> state.filter(SET).forEach(op -> NS.forEach(ns -> reject(state, op, ns + "metadata-dir="))));
+    Stream.of(CONFIGURING).forEach(state -> state.filter(IMPORT).forEach(op -> {
+      reject(state, op, "metadata-dir=foo");
+      reject(state, op, "stripe.1.metadata-dir=foo");
+      allow(state, op, "stripe.1.node.1.metadata-dir=foo");
+      allow(state, op, "stripe.1.node.1.metadata-dir=");
+    }));
+
+    // hostname, port
+    Stream.of("hostname", "port").forEach(setting -> {
+      Stream.of(CONFIGURING, ACTIVATED).forEach(state -> state.filter(GET).forEach(op -> NS.forEach(ns -> allow(state, op, ns + setting))));
+      Stream.of(CONFIGURING).forEach(state -> state.filter(IMPORT).forEach(op -> {
+        reject(state, op, setting + "=1234");
+        reject(state, op, "stripe.1." + setting + "=1234");
+        allow(state, op, "stripe.1.node.1." + setting + "=1234");
+        reject(state, op, "stripe.1.node.1." + setting + "=");
+      }));
+      Stream.of(CONFIGURING, ACTIVATED).forEach(state -> state.filter(SET).forEach(op -> NS.forEach(ns -> reject(state, op, ns + setting + "=1234"))));
+      Stream.of(CONFIGURING, ACTIVATED).forEach(state -> state.filter(SET).forEach(op -> NS.forEach(ns -> reject(state, op, ns + setting + "="))));
+      Stream.of(CONFIGURING, ACTIVATED).forEach(state -> state.filter(UNSET).forEach(op -> NS.forEach(ns -> reject(state, op, ns + setting))));
     });
 
-    // get allowed for all scopes
-    // unset not allowed for all scopes
-    // set allowed for all scopes
-    // config allowed for scope node
-    Stream.of(
-        tuple2(NODE_GROUP_PORT, "9410"),
-        tuple2(NODE_BIND_ADDRESS, "0.0.0.0"),
-        tuple2(NODE_GROUP_BIND_ADDRESS, "0.0.0.0"),
-        tuple2(NODE_LOG_DIR, "foo/bar")
-    ).forEach(tuple -> {
-      allow(GET, tuple.t1.toString());
-      reject(UNSET, tuple.t1.toString(), "Invalid input: '" + tuple.t1 + "'. Reason: " + tuple.t1 + " does not allow operation unset at cluster level");
-      allow(SET, tuple.t1 + "=" + tuple.t2);
-      reject(SET, tuple.t1 + "=", "Invalid input: '" + tuple.t1 + "=" + "'. Reason: " + tuple.t1 + " requires a value");
-      reject(CONFIG, tuple.t1 + "=" + tuple.t2, "Invalid input: '" + tuple.t1 + "=" + tuple.t2 + "'. Reason: " + tuple.t1 + " does not allow operation config at cluster level");
-      reject(CONFIG, tuple.t1 + "=", "Invalid input: '" + tuple.t1 + "=" + "'. Reason: " + tuple.t1 + " requires a value");
-
-      allow(GET, "stripe.1." + tuple.t1);
-      reject(UNSET, "stripe.1." + tuple.t1, "Invalid input: 'stripe.1." + tuple.t1 + "'. Reason: " + tuple.t1 + " does not allow operation unset at stripe level");
-      allow(SET, "stripe.1." + tuple.t1 + "=" + tuple.t2);
-      reject(SET, "stripe.1." + tuple.t1 + "=", "Invalid input: 'stripe.1." + tuple.t1 + "=" + "'. Reason: " + tuple.t1 + " requires a value");
-      reject(CONFIG, "stripe.1." + tuple.t1 + "=" + tuple.t2, "Invalid input: 'stripe.1." + tuple.t1 + "=" + tuple.t2 + "'. Reason: " + tuple.t1 + " does not allow operation config at stripe level");
-      reject(CONFIG, "stripe.1." + tuple.t1 + "=", "Invalid input: 'stripe.1." + tuple.t1 + "=" + "'. Reason: " + tuple.t1 + " requires a value");
-
-      allow(GET, "stripe.1.node.1." + tuple.t1);
-      reject(UNSET, "stripe.1.node.1." + tuple.t1, "Invalid input: 'stripe.1.node.1." + tuple.t1 + "'. Reason: " + tuple.t1 + " does not allow operation unset at node level");
-      allow(SET, "stripe.1.node.1." + tuple.t1 + "=" + tuple.t2);
-      reject(SET, "stripe.1.node.1." + tuple.t1 + "=", "Invalid input: 'stripe.1.node.1." + tuple.t1 + "=" + "'. Reason: " + tuple.t1 + " requires a value");
-      allow(CONFIG, "stripe.1.node.1." + tuple.t1 + "=" + tuple.t2);
-      reject(CONFIG, "stripe.1.node.1." + tuple.t1 + "=", "Invalid input: 'stripe.1.node.1." + tuple.t1 + "=" + "'. Reason: " + tuple.t1 + " requires a value");
+    // group-port, bind-address, group-bind-address
+    Stream.of("bind-address", "group-bind-address").forEach(setting -> {
+      Stream.of(CONFIGURING, ACTIVATED).forEach(state -> state.filter(GET).forEach(op -> NS.forEach(ns -> allow(state, op, ns + setting))));
+      Stream.of(CONFIGURING).forEach(state -> state.filter(IMPORT).forEach(op -> {
+        reject(state, op, setting + "=0.0.0.0");
+        reject(state, op, "stripe.1." + setting + "=0.0.0.0");
+        allow(state, op, "stripe.1.node.1." + setting + "=0.0.0.0");
+        reject(state, op, "stripe.1.node.1." + setting + "=");
+      }));
+      Stream.of(CONFIGURING, ACTIVATED).forEach(state -> state.filter(UNSET).forEach(op -> NS.forEach(ns -> reject(state, op, ns + setting))));
+      Stream.of(CONFIGURING).forEach(state -> state.filter(SET).forEach(op -> NS.forEach(ns -> allow(state, op, ns + setting + "=0.0.0.0"))));
+      Stream.of(CONFIGURING).forEach(state -> state.filter(SET).forEach(op -> NS.forEach(ns -> reject(state, op, ns + setting + "="))));
+      Stream.of(ACTIVATED).forEach(state -> state.filter(SET).forEach(op -> NS.forEach(ns -> reject(state, op, ns + setting + "=0.0.0.0"))));
+      Stream.of(ACTIVATED).forEach(state -> state.filter(SET).forEach(op -> NS.forEach(ns -> reject(state, op, ns + setting + "="))));
+    });
+    Stream.of("group-port").forEach(setting -> {
+      Stream.of(CONFIGURING, ACTIVATED).forEach(state -> state.filter(GET).forEach(op -> NS.forEach(ns -> allow(state, op, ns + setting))));
+      Stream.of(CONFIGURING).forEach(state -> state.filter(IMPORT).forEach(op -> {
+        reject(state, op, setting + "=1234");
+        reject(state, op, "stripe.1." + setting + "=1234");
+        allow(state, op, "stripe.1.node.1." + setting + "=1234");
+        reject(state, op, "stripe.1.node.1." + setting + "=");
+      }));
+      Stream.of(CONFIGURING, ACTIVATED).forEach(state -> state.filter(UNSET).forEach(op -> NS.forEach(ns -> reject(state, op, ns + setting))));
+      Stream.of(CONFIGURING).forEach(state -> state.filter(SET).forEach(op -> NS.forEach(ns -> allow(state, op, ns + setting + "=1234"))));
+      Stream.of(CONFIGURING).forEach(state -> state.filter(SET).forEach(op -> NS.forEach(ns -> reject(state, op, ns + setting + "="))));
+      Stream.of(ACTIVATED).forEach(state -> state.filter(SET).forEach(op -> NS.forEach(ns -> reject(state, op, ns + setting + "=1234"))));
+      Stream.of(ACTIVATED).forEach(state -> state.filter(SET).forEach(op -> NS.forEach(ns -> reject(state, op, ns + setting + "="))));
     });
 
-    // get allowed for all scopes
-    // unset allowed for all scopes
-    // set allowed for all scopes
-    // config allowed for scope node
-    Stream.of(
-        tuple2(NODE_BACKUP_DIR, "foo/bar"),
-        tuple2(SECURITY_DIR, "foo/bar"),
-        tuple2(SECURITY_AUDIT_LOG_DIR, "foo/bar"),
-        tuple2(NODE_METADATA_DIR, "foo/bar")
-    ).forEach(tuple -> {
-      allow(GET, tuple.t1.toString());
-      allow(UNSET, tuple.t1.toString());
-      allow(SET, tuple.t1 + "=" + tuple.t2);
-      reject(SET, tuple.t1 + "=", "Invalid input: '" + tuple.t1 + "=" + "'. Reason: Operation set requires a value");
-      reject(CONFIG, tuple.t1 + "=" + tuple.t2, "Invalid input: '" + tuple.t1 + "=" + tuple.t2 + "'. Reason: " + tuple.t1 + " does not allow operation config at cluster level");
-      reject(CONFIG, tuple.t1 + "=", "Invalid input: '" + tuple.t1 + "=" + "'. Reason: " + tuple.t1 + " does not allow operation config at cluster level");
-
-      allow(GET, "stripe.1." + tuple.t1);
-      allow(UNSET, "stripe.1." + tuple.t1);
-      allow(SET, "stripe.1." + tuple.t1 + "=" + tuple.t2);
-      reject(SET, "stripe.1." + tuple.t1 + "=", "Invalid input: 'stripe.1." + tuple.t1 + "=" + "'. Reason: Operation set requires a value");
-      reject(CONFIG, "stripe.1." + tuple.t1 + "=" + tuple.t2, "Invalid input: 'stripe.1." + tuple.t1 + "=" + tuple.t2 + "'. Reason: " + tuple.t1 + " does not allow operation config at stripe level");
-      reject(CONFIG, "stripe.1." + tuple.t1 + "=", "Invalid input: 'stripe.1." + tuple.t1 + "=" + "'. Reason: " + tuple.t1 + " does not allow operation config at stripe level");
-
-      allow(GET, "stripe.1.node.1." + tuple.t1);
-      allow(UNSET, "stripe.1.node.1." + tuple.t1);
-      allow(SET, "stripe.1.node.1." + tuple.t1 + "=" + tuple.t2);
-      reject(SET, "stripe.1.node.1." + tuple.t1 + "=", "Invalid input: 'stripe.1.node.1." + tuple.t1 + "=" + "'. Reason: Operation set requires a value");
-      allow(CONFIG, "stripe.1.node.1." + tuple.t1 + "=" + tuple.t2);
-      allow(CONFIG, "stripe.1.node.1." + tuple.t1 + "=");
+    // data-dirs
+    Stream.of("data-dirs").forEach(setting -> {
+      Stream.of(CONFIGURING, ACTIVATED).forEach(state -> state.filter(GET).forEach(op -> NS.forEach(ns -> allow(state, op, ns + setting))));
+      Stream.of(CONFIGURING, ACTIVATED).forEach(state -> state.filter(SET).forEach(op -> NS.forEach(ns -> allow(state, op, ns + setting + "=foo:foo"))));
+      Stream.of(CONFIGURING, ACTIVATED).forEach(state -> state.filter(SET).forEach(op -> NS.forEach(ns -> reject(state, op, ns + setting + "="))));
+      Stream.of(CONFIGURING).forEach(state -> state.filter(IMPORT).forEach(op -> {
+        reject(state, op, setting + "=foo:foo");
+        reject(state, op, "stripe.1." + setting + "=foo:foo");
+        allow(state, op, "stripe.1.node.1." + setting + "=foo:foo");
+        allow(state, op, "stripe.1.node.1." + setting + "=");
+      }));
+      Stream.of(CONFIGURING).forEach(state -> state.filter(UNSET).forEach(op -> NS.forEach(ns -> allow(state, op, ns + setting))));
+      Stream.of(ACTIVATED).forEach(state -> state.filter(UNSET).forEach(op -> NS.forEach(ns -> reject(state, op, ns + setting))));
     });
 
-    // get allowed for scope cluster
-    // unset not allowed for all scopes
-    // set allowed for scope cluster
-    // config allowed for scope cluster
-    Stream.of(
-        tuple2(CLIENT_RECONNECT_WINDOW, "20s"),
-        tuple2(FAILOVER_PRIORITY, "availability"),
-        tuple2(CLIENT_LEASE_DURATION, "20s"),
-        tuple2(SECURITY_SSL_TLS, "true"),
-        tuple2(SECURITY_WHITELIST, "true")
-    ).forEach(tuple -> {
-      allow(GET, tuple.t1.toString());
-      reject(UNSET, tuple.t1.toString(), "Invalid input: '" + tuple.t1 + "'. Reason: " + tuple.t1 + " does not allow operation unset at cluster level");
-      allow(SET, tuple.t1 + "=" + tuple.t2);
-      reject(SET, tuple.t1 + "=", "Invalid input: '" + tuple.t1 + "=" + "'. Reason: " + tuple.t1 + " requires a value");
-      allow(CONFIG, tuple.t1 + "=" + tuple.t2);
-      reject(CONFIG, tuple.t1 + "=", "Invalid input: '" + tuple.t1 + "=" + "'. Reason: " + tuple.t1 + " requires a value");
-
-      reject(GET, "stripe.1." + tuple.t1, "Invalid input: 'stripe.1." + tuple.t1 + "'. Reason: " + tuple.t1 + " does not allow any operation at stripe level");
-      reject(UNSET, "stripe.1." + tuple.t1, "Invalid input: 'stripe.1." + tuple.t1 + "'. Reason: " + tuple.t1 + " does not allow any operation at stripe level");
-      reject(SET, "stripe.1." + tuple.t1 + "=" + tuple.t2, "Invalid input: 'stripe.1." + tuple.t1 + "=" + tuple.t2 + "'. Reason: " + tuple.t1 + " does not allow any operation at stripe level");
-      reject(SET, "stripe.1." + tuple.t1 + "=", "Invalid input: 'stripe.1." + tuple.t1 + "=" + "'. Reason: " + tuple.t1 + " does not allow any operation at stripe level");
-      reject(CONFIG, "stripe.1." + tuple.t1 + "=" + tuple.t2, "Invalid input: 'stripe.1." + tuple.t1 + "=" + tuple.t2 + "'. Reason: " + tuple.t1 + " does not allow any operation at stripe level");
-      reject(CONFIG, "stripe.1." + tuple.t1 + "=", "Invalid input: 'stripe.1." + tuple.t1 + "=" + "'. Reason: " + tuple.t1 + " does not allow any operation at stripe level");
-
-      reject(GET, "stripe.1.node.1." + tuple.t1, "Invalid input: 'stripe.1.node.1." + tuple.t1 + "'. Reason: " + tuple.t1 + " does not allow any operation at node level");
-      reject(UNSET, "stripe.1.node.1." + tuple.t1, "Invalid input: 'stripe.1.node.1." + tuple.t1 + "'. Reason: " + tuple.t1 + " does not allow any operation at node level");
-      reject(SET, "stripe.1.node.1." + tuple.t1 + "=" + tuple.t2, "Invalid input: 'stripe.1.node.1." + tuple.t1 + "=" + tuple.t2 + "'. Reason: " + tuple.t1 + " does not allow any operation at node level");
-      reject(SET, "stripe.1.node.1." + tuple.t1 + "=", "Invalid input: 'stripe.1.node.1." + tuple.t1 + "=" + "'. Reason: " + tuple.t1 + " does not allow any operation at node level");
-      reject(CONFIG, "stripe.1.node.1." + tuple.t1 + "=" + tuple.t2, "Invalid input: 'stripe.1.node.1." + tuple.t1 + "=" + tuple.t2 + "'. Reason: " + tuple.t1 + " does not allow any operation at node level");
-      reject(CONFIG, "stripe.1.node.1." + tuple.t1 + "=", "Invalid input: 'stripe.1.node.1." + tuple.t1 + "=" + "'. Reason: " + tuple.t1 + " does not allow any operation at node level");
+    // name
+    Stream.of("name").forEach(setting -> {
+      Stream.of(CONFIGURING, ACTIVATED).forEach(state -> state.filter(GET).forEach(op -> NS.forEach(ns -> allow(state, op, ns + setting))));
+      Stream.of(CONFIGURING).forEach(state -> state.filter(SET, IMPORT).forEach(op -> {
+        reject(state, op, setting + "=foo");
+        reject(state, op, "stripe.1." + setting + "=foo");
+        allow(state, op, "stripe.1.node.1." + setting + "=foo");
+        reject(state, op, "stripe.1.node.1." + setting + "=");
+      }));
+      Stream.of(ACTIVATED).forEach(state -> state.filter(SET).forEach(op -> NS.forEach(ns -> reject(state, op, ns + setting))));
+      Stream.of(CONFIGURING, ACTIVATED).forEach(state -> state.filter(UNSET).forEach(op -> NS.forEach(ns -> reject(state, op, ns + setting))));
     });
 
-    // get allowed for scope cluster
-    // unset not allowed for all scopes
-    // set allowed for scope cluster
-    // config allowed for scope cluster
-    Stream.of(
-        tuple2(CLUSTER_NAME, "foo")
-    ).forEach(tuple -> {
-      allow(GET, tuple.t1.toString());
-      reject(UNSET, tuple.t1.toString(), "Invalid input: '" + tuple.t1 + "'. Reason: " + tuple.t1 + " does not allow operation unset at cluster level");
-      allow(SET, tuple.t1 + "=" + tuple.t2);
-      reject(SET, tuple.t1 + "=", "Invalid input: '" + tuple.t1 + "=" + "'. Reason: Operation set requires a value");
-      allow(CONFIG, tuple.t1 + "=" + tuple.t2);
-      allow(CONFIG, tuple.t1 + "=");
-
-      reject(GET, "stripe.1." + tuple.t1, "Invalid input: 'stripe.1." + tuple.t1 + "'. Reason: " + tuple.t1 + " does not allow any operation at stripe level");
-      reject(UNSET, "stripe.1." + tuple.t1, "Invalid input: 'stripe.1." + tuple.t1 + "'. Reason: " + tuple.t1 + " does not allow any operation at stripe level");
-      reject(SET, "stripe.1." + tuple.t1 + "=" + tuple.t2, "Invalid input: 'stripe.1." + tuple.t1 + "=" + tuple.t2 + "'. Reason: " + tuple.t1 + " does not allow any operation at stripe level");
-      reject(SET, "stripe.1." + tuple.t1 + "=", "Invalid input: 'stripe.1." + tuple.t1 + "=" + "'. Reason: " + tuple.t1 + " does not allow any operation at stripe level");
-      reject(CONFIG, "stripe.1." + tuple.t1 + "=" + tuple.t2, "Invalid input: 'stripe.1." + tuple.t1 + "=" + tuple.t2 + "'. Reason: " + tuple.t1 + " does not allow any operation at stripe level");
-      reject(CONFIG, "stripe.1." + tuple.t1 + "=", "Invalid input: 'stripe.1." + tuple.t1 + "=" + "'. Reason: " + tuple.t1 + " does not allow any operation at stripe level");
-
-      reject(GET, "stripe.1.node.1." + tuple.t1, "Invalid input: 'stripe.1.node.1." + tuple.t1 + "'. Reason: " + tuple.t1 + " does not allow any operation at node level");
-      reject(UNSET, "stripe.1.node.1." + tuple.t1, "Invalid input: 'stripe.1.node.1." + tuple.t1 + "'. Reason: " + tuple.t1 + " does not allow any operation at node level");
-      reject(SET, "stripe.1.node.1." + tuple.t1 + "=" + tuple.t2, "Invalid input: 'stripe.1.node.1." + tuple.t1 + "=" + tuple.t2 + "'. Reason: " + tuple.t1 + " does not allow any operation at node level");
-      reject(SET, "stripe.1.node.1." + tuple.t1 + "=", "Invalid input: 'stripe.1.node.1." + tuple.t1 + "=" + "'. Reason: " + tuple.t1 + " does not allow any operation at node level");
-      reject(CONFIG, "stripe.1.node.1." + tuple.t1 + "=" + tuple.t2, "Invalid input: 'stripe.1.node.1." + tuple.t1 + "=" + tuple.t2 + "'. Reason: " + tuple.t1 + " does not allow any operation at node level");
-      reject(CONFIG, "stripe.1.node.1." + tuple.t1 + "=", "Invalid input: 'stripe.1.node.1." + tuple.t1 + "=" + "'. Reason: " + tuple.t1 + " does not allow any operation at node level");
+    // public-hostname, public-port, backup-dir, tc-properties, logger-overrides, security-dir, audit-log-dir
+    Stream.of("public-hostname", "public-port", "backup-dir", "security-dir", "audit-log-dir").forEach(setting -> {
+      Stream.of(CONFIGURING, ACTIVATED).forEach(state -> state.filter(GET, UNSET).forEach(op -> NS.forEach(ns -> allow(state, op, ns + setting))));
+      Stream.of(CONFIGURING, ACTIVATED).forEach(state -> state.filter(SET).forEach(op -> NS.forEach(ns -> allow(state, op, ns + setting + "=1234"))));
+      Stream.of(CONFIGURING, ACTIVATED).forEach(state -> state.filter(SET).forEach(op -> NS.forEach(ns -> reject(state, op, ns + setting + "="))));
+      Stream.of(CONFIGURING).forEach(state -> state.filter(IMPORT).forEach(op -> {
+        reject(state, op, setting + "=1234");
+        reject(state, op, "stripe.1." + setting + "=1234");
+        allow(state, op, "stripe.1.node.1." + setting + "=1234");
+        allow(state, op, "stripe.1.node.1." + setting + "=");
+      }));
+    });
+    Stream.of("tc-properties", "logger-overrides").forEach(setting -> {
+      Stream.of(CONFIGURING, ACTIVATED).forEach(state -> state.filter(GET, UNSET).forEach(op -> NS.forEach(ns -> allow(state, op, ns + setting))));
+      Stream.of(CONFIGURING, ACTIVATED).forEach(state -> state.filter(SET).forEach(op -> NS.forEach(ns -> allow(state, op, ns + setting + "=foo:TRACE"))));
+      Stream.of(CONFIGURING, ACTIVATED).forEach(state -> state.filter(SET).forEach(op -> NS.forEach(ns -> reject(state, op, ns + setting + "="))));
+      Stream.of(CONFIGURING).forEach(state -> state.filter(IMPORT).forEach(op -> {
+        reject(state, op, setting + "=foo:TRACE");
+        reject(state, op, "stripe.1." + setting + "=foo:TRACE");
+        allow(state, op, "stripe.1.node.1." + setting + "=foo:TRACE");
+        allow(state, op, "stripe.1.node.1." + setting + "=");
+      }));
     });
 
-    // get allowed for scope cluster
-    // unset allowed for all scopes
-    // set allowed for scope cluster
-    // config allowed for scope cluster
-    Stream.of(
-        tuple2(SECURITY_AUTHC, "certificate")
-    ).forEach(tuple -> {
-      allow(GET, tuple.t1.toString());
-      allow(UNSET, tuple.t1.toString());
-      allow(SET, tuple.t1 + "=" + tuple.t2);
-      reject(SET, tuple.t1 + "=", "Invalid input: '" + tuple.t1 + "=" + "'. Reason: Operation set requires a value");
-      allow(CONFIG, tuple.t1 + "=" + tuple.t2);
-      allow(CONFIG, tuple.t1 + "=");
-
-      reject(GET, "stripe.1." + tuple.t1, "Invalid input: 'stripe.1." + tuple.t1 + "'. Reason: " + tuple.t1 + " does not allow any operation at stripe level");
-      reject(UNSET, "stripe.1." + tuple.t1, "Invalid input: 'stripe.1." + tuple.t1 + "'. Reason: " + tuple.t1 + " does not allow any operation at stripe level");
-      reject(SET, "stripe.1." + tuple.t1 + "=" + tuple.t2, "Invalid input: 'stripe.1." + tuple.t1 + "=" + tuple.t2 + "'. Reason: " + tuple.t1 + " does not allow any operation at stripe level");
-      reject(SET, "stripe.1." + tuple.t1 + "=", "Invalid input: 'stripe.1." + tuple.t1 + "=" + "'. Reason: " + tuple.t1 + " does not allow any operation at stripe level");
-      reject(CONFIG, "stripe.1." + tuple.t1 + "=" + tuple.t2, "Invalid input: 'stripe.1." + tuple.t1 + "=" + tuple.t2 + "'. Reason: " + tuple.t1 + " does not allow any operation at stripe level");
-      reject(CONFIG, "stripe.1." + tuple.t1 + "=", "Invalid input: 'stripe.1." + tuple.t1 + "=" + "'. Reason: " + tuple.t1 + " does not allow any operation at stripe level");
-
-      reject(GET, "stripe.1.node.1." + tuple.t1, "Invalid input: 'stripe.1.node.1." + tuple.t1 + "'. Reason: " + tuple.t1 + " does not allow any operation at node level");
-      reject(UNSET, "stripe.1.node.1." + tuple.t1, "Invalid input: 'stripe.1.node.1." + tuple.t1 + "'. Reason: " + tuple.t1 + " does not allow any operation at node level");
-      reject(SET, "stripe.1.node.1." + tuple.t1 + "=" + tuple.t2, "Invalid input: 'stripe.1.node.1." + tuple.t1 + "=" + tuple.t2 + "'. Reason: " + tuple.t1 + " does not allow any operation at node level");
-      reject(SET, "stripe.1.node.1." + tuple.t1 + "=", "Invalid input: 'stripe.1.node.1." + tuple.t1 + "=" + "'. Reason: " + tuple.t1 + " does not allow any operation at node level");
-      reject(CONFIG, "stripe.1.node.1." + tuple.t1 + "=" + tuple.t2, "Invalid input: 'stripe.1.node.1." + tuple.t1 + "=" + tuple.t2 + "'. Reason: " + tuple.t1 + " does not allow any operation at node level");
-      reject(CONFIG, "stripe.1.node.1." + tuple.t1 + "=", "Invalid input: 'stripe.1.node.1." + tuple.t1 + "=" + "'. Reason: " + tuple.t1 + " does not allow any operation at node level");
+    // authc
+    Stream.of("authc").forEach(setting -> {
+      Stream.of(CONFIGURING, ACTIVATED).forEach(state -> state.filter(GET, UNSET).forEach(op -> {
+        allow(state, op, setting);
+        reject(state, op, "stripe.1." + setting);
+        reject(state, op, "stripe.1.node.1." + setting);
+      }));
+      Stream.of(CONFIGURING, ACTIVATED).forEach(state -> state.filter(SET).forEach(op -> {
+        allow(state, op, setting + "=file");
+        reject(state, op, setting + "=");
+        reject(state, op, "stripe.1." + setting + "=file");
+        reject(state, op, "stripe.1.node.1." + setting + "=file");
+      }));
+      Stream.of(CONFIGURING).forEach(state -> state.filter(IMPORT).forEach(op -> {
+        allow(state, op, setting + "=file");
+        allow(state, op, setting + "=");
+        reject(state, op, "stripe.1." + setting + "=file");
+        reject(state, op, "stripe.1.node.1." + setting + "=file");
+      }));
     });
 
-    // get not allowed for all scopes
-    // unset not allowed for all scopes
-    // set not allowed for all scopes
-    // config not allowed for all scopes
-    Stream.of(
-        tuple2(NODE_CONFIG_DIR, "foo/bar")
-    ).forEach(tuple -> {
-      reject(GET, tuple.t1.toString(), "Invalid input: '" + tuple.t1 + "'. Reason: " + tuple.t1 + " does not allow any operation at cluster level");
-      reject(UNSET, tuple.t1.toString(), "Invalid input: '" + tuple.t1 + "'. Reason: " + tuple.t1 + " does not allow any operation at cluster level");
-      reject(SET, tuple.t1 + "=" + tuple.t2, "Invalid input: '" + tuple.t1 + "=" + tuple.t2 + "'. Reason: " + tuple.t1 + " does not allow any operation at cluster level");
-      reject(SET, tuple.t1 + "=", "Invalid input: '" + tuple.t1 + "=" + "'. Reason: " + tuple.t1 + " does not allow any operation at cluster level");
-      reject(CONFIG, tuple.t1 + "=" + tuple.t2, "Invalid input: '" + tuple.t1 + "=" + tuple.t2 + "'. Reason: " + tuple.t1 + " does not allow any operation at cluster level");
-      reject(CONFIG, tuple.t1 + "=", "Invalid input: '" + tuple.t1 + "=" + "'. Reason: " + tuple.t1 + " does not allow any operation at cluster level");
-
-      reject(GET, "stripe.1." + tuple.t1, "Invalid input: 'stripe.1." + tuple.t1 + "'. Reason: " + tuple.t1 + " does not allow any operation at stripe level");
-      reject(UNSET, "stripe.1." + tuple.t1, "Invalid input: 'stripe.1." + tuple.t1 + "'. Reason: " + tuple.t1 + " does not allow any operation at stripe level");
-      reject(SET, "stripe.1." + tuple.t1 + "=" + tuple.t2, "Invalid input: 'stripe.1." + tuple.t1 + "=" + tuple.t2 + "'. Reason: " + tuple.t1 + " does not allow any operation at stripe level");
-      reject(SET, "stripe.1." + tuple.t1 + "=", "Invalid input: 'stripe.1." + tuple.t1 + "=" + "'. Reason: " + tuple.t1 + " does not allow any operation at stripe level");
-      reject(CONFIG, "stripe.1." + tuple.t1 + "=" + tuple.t2, "Invalid input: 'stripe.1." + tuple.t1 + "=" + tuple.t2 + "'. Reason: " + tuple.t1 + " does not allow any operation at stripe level");
-      reject(CONFIG, "stripe.1." + tuple.t1 + "=", "Invalid input: 'stripe.1." + tuple.t1 + "=" + "'. Reason: " + tuple.t1 + " does not allow any operation at stripe level");
-
-      reject(GET, "stripe.1.node.1." + tuple.t1, "Invalid input: 'stripe.1.node.1." + tuple.t1 + "'. Reason: " + tuple.t1 + " does not allow any operation at node level");
-      reject(UNSET, "stripe.1.node.1." + tuple.t1, "Invalid input: 'stripe.1.node.1." + tuple.t1 + "'. Reason: " + tuple.t1 + " does not allow any operation at node level");
-      reject(SET, "stripe.1.node.1." + tuple.t1 + "=" + tuple.t2, "Invalid input: 'stripe.1.node.1." + tuple.t1 + "=" + tuple.t2 + "'. Reason: " + tuple.t1 + " does not allow any operation at node level");
-      reject(SET, "stripe.1.node.1." + tuple.t1 + "=", "Invalid input: 'stripe.1.node.1." + tuple.t1 + "=" + "'. Reason: " + tuple.t1 + " does not allow any operation at node level");
-      reject(CONFIG, "stripe.1.node.1." + tuple.t1 + "=" + tuple.t2, "Invalid input: 'stripe.1.node.1." + tuple.t1 + "=" + tuple.t2 + "'. Reason: " + tuple.t1 + " does not allow any operation at node level");
-      reject(CONFIG, "stripe.1.node.1." + tuple.t1 + "=", "Invalid input: 'stripe.1.node.1." + tuple.t1 + "=" + "'. Reason: " + tuple.t1 + " does not allow any operation at node level");
+    // client-reconnect-window, client-lease-duration, failover-priority
+    Stream.of("client-reconnect-window", "client-lease-duration", "failover-priority", "ssl-tls", "whitelist").forEach(setting -> {
+      Stream.of(CONFIGURING, ACTIVATED).forEach(state -> state.filter(UNSET).forEach(op -> NS.forEach(ns -> reject(state, op, ns + setting))));
+      Stream.of(CONFIGURING).forEach(state -> state.filter(GET).forEach(op -> {
+        allow(state, op, setting);
+        reject(state, op, "stripe.1." + setting);
+        reject(state, op, "stripe.1.node.1." + setting);
+      }));
+    });
+    Stream.of("client-reconnect-window", "client-lease-duration").forEach(setting -> {
+      Stream.of(CONFIGURING, ACTIVATED).forEach(state -> state.filter(SET, IMPORT).forEach(op -> {
+        allow(state, op, setting + "=1s");
+        reject(state, op, setting + "=");
+        reject(state, op, "stripe.1." + setting + "=1s");
+        reject(state, op, "stripe.1.node.1." + setting + "=1s");
+      }));
+    });
+    Stream.of("failover-priority").forEach(setting -> {
+      Stream.of(CONFIGURING, ACTIVATED).forEach(state -> state.filter(SET, IMPORT).forEach(op -> {
+        allow(state, op, setting + "=availability");
+        reject(state, op, setting + "=");
+        reject(state, op, "stripe.1." + setting + "=availability");
+        reject(state, op, "stripe.1.node.1." + setting + "=availability");
+      }));
+    });
+    Stream.of("ssl-tls", "whitelist").forEach(setting -> {
+      Stream.of(CONFIGURING, ACTIVATED).forEach(state -> state.filter(SET, IMPORT).forEach(op -> {
+        allow(state, op, setting + "=true");
+        reject(state, op, setting + "=");
+        reject(state, op, "stripe.1." + setting + "=true");
+        reject(state, op, "stripe.1.node.1." + setting + "=true");
+      }));
     });
 
-    // get not allowed for all scopes
-    // unset not allowed for all scopes
-    // set allowed for scope cluster
-    // config not allowed for all scopes
-    Stream.of(
-        tuple2(LICENSE_FILE, "/path/to/license.xml")
-    ).forEach(tuple -> {
-      reject(GET, tuple.t1.toString(), "Invalid input: '" + tuple.t1 + "'. Reason: " + tuple.t1 + " cannot be read or cleared");
-      reject(UNSET, tuple.t1.toString(), "Invalid input: '" + tuple.t1 + "'. Reason: " + tuple.t1 + " cannot be read or cleared");
-      allow(SET, tuple.t1 + "=" + tuple.t2);
-      reject(SET, tuple.t1 + "=", "Invalid input: '" + tuple.t1 + "=" + "'. Reason: " + tuple.t1 + " requires a value");
-      reject(CONFIG, tuple.t1 + "=" + tuple.t2, "Invalid input: '" + tuple.t1 + "=" + tuple.t2 + "'. Reason: " + tuple.t1 + " does not allow operation config at cluster level");
-      reject(CONFIG, tuple.t1 + "=", "Invalid input: '" + tuple.t1 + "=" + "'. Reason: " + tuple.t1 + " requires a value");
+    // log-dir
+    Stream.of(CONFIGURING, ACTIVATED).forEach(state -> state.filter(GET).forEach(op -> NS.forEach(ns -> allow(state, op, ns + "log-dir"))));
+    Stream.of(CONFIGURING, ACTIVATED).forEach(state -> state.filter(UNSET).forEach(op -> NS.forEach(ns -> reject(state, op, ns + "log-dir"))));
+    Stream.of(CONFIGURING, ACTIVATED).forEach(state -> state.filter(SET).forEach(op -> NS.forEach(ns -> allow(state, op, ns + "log-dir=foo"))));
+    Stream.of(CONFIGURING, ACTIVATED).forEach(state -> state.filter(SET).forEach(op -> NS.forEach(ns -> reject(state, op, ns + "log-dir="))));
+    Stream.of(CONFIGURING).forEach(state -> state.filter(IMPORT).forEach(op -> {
+      reject(state, op, "log-dir=foo");
+      reject(state, op, "stripe.1.log-dir=foo");
+      allow(state, op, "stripe.1.node.1.log-dir=foo");
+      reject(state, op, "stripe.1.node.1.log-dir=");
+    }));
 
-      reject(GET, "stripe.1." + tuple.t1, "Invalid input: 'stripe.1." + tuple.t1 + "'. Reason: " + tuple.t1 + " does not allow any operation at stripe level");
-      reject(UNSET, "stripe.1." + tuple.t1, "Invalid input: 'stripe.1." + tuple.t1 + "'. Reason: " + tuple.t1 + " does not allow any operation at stripe level");
-      reject(SET, "stripe.1." + tuple.t1 + "=" + tuple.t2, "Invalid input: 'stripe.1." + tuple.t1 + "=" + tuple.t2 + "'. Reason: " + tuple.t1 + " does not allow any operation at stripe level");
-      reject(SET, "stripe.1." + tuple.t1 + "=", "Invalid input: 'stripe.1." + tuple.t1 + "=" + "'. Reason: " + tuple.t1 + " does not allow any operation at stripe level");
-      reject(CONFIG, "stripe.1." + tuple.t1 + "=" + tuple.t2, "Invalid input: 'stripe.1." + tuple.t1 + "=" + tuple.t2 + "'. Reason: " + tuple.t1 + " does not allow any operation at stripe level");
-      reject(CONFIG, "stripe.1." + tuple.t1 + "=", "Invalid input: 'stripe.1." + tuple.t1 + "=" + "'. Reason: " + tuple.t1 + " does not allow any operation at stripe level");
-
-      reject(GET, "stripe.1.node.1." + tuple.t1, "Invalid input: 'stripe.1.node.1." + tuple.t1 + "'. Reason: " + tuple.t1 + " does not allow any operation at node level");
-      reject(UNSET, "stripe.1.node.1." + tuple.t1, "Invalid input: 'stripe.1.node.1." + tuple.t1 + "'. Reason: " + tuple.t1 + " does not allow any operation at node level");
-      reject(SET, "stripe.1.node.1." + tuple.t1 + "=" + tuple.t2, "Invalid input: 'stripe.1.node.1." + tuple.t1 + "=" + tuple.t2 + "'. Reason: " + tuple.t1 + " does not allow any operation at node level");
-      reject(SET, "stripe.1.node.1." + tuple.t1 + "=", "Invalid input: 'stripe.1.node.1." + tuple.t1 + "=" + "'. Reason: " + tuple.t1 + " does not allow any operation at node level");
-      reject(CONFIG, "stripe.1.node.1." + tuple.t1 + "=" + tuple.t2, "Invalid input: 'stripe.1.node.1." + tuple.t1 + "=" + tuple.t2 + "'. Reason: " + tuple.t1 + " does not allow any operation at node level");
-      reject(CONFIG, "stripe.1.node.1." + tuple.t1 + "=", "Invalid input: 'stripe.1.node.1." + tuple.t1 + "=" + "'. Reason: " + tuple.t1 + " does not allow any operation at node level");
-    });
-
-    // get allowed for all scopes
-    // unset allowed for all scopes
-    // set allowed for all scopes
-    // config allowed for scope node
-    Stream.of(
-        tuple3(TC_PROPERTIES, "a.b.c", "d.e.f"),
-        tuple3(DATA_DIRS, "a.b.c", "foo/bar")
-    ).forEach(tuple -> {
-      allow(GET, tuple.t1.toString());
-      allow(UNSET, tuple.t1.toString());
-      reject(SET, tuple.t1 + "=", "Invalid input: '" + tuple.t1 + "=" + "'. Reason: Operation set requires a value");
-      allow(SET, tuple.t1 + "=" + tuple.t2 + ":" + tuple.t3);
-      reject(CONFIG, tuple.t1 + "=", "Invalid input: '" + tuple.t1 + "=" + "'. Reason: " + tuple.t1 + " does not allow operation config at cluster level");
-      reject(CONFIG, tuple.t1 + "=" + tuple.t2 + ":" + tuple.t3, "Invalid input: '" + tuple.t1 + "=" + tuple.t2 + ":" + tuple.t3 + "'. Reason: " + tuple.t1 + " does not allow operation config at cluster level");
-
-      allow(GET, tuple.t1 + "." + tuple.t2);
-      allow(UNSET, tuple.t1 + "." + tuple.t2);
-      reject(SET, tuple.t1 + "." + tuple.t2 + "=", "Invalid input: '" + tuple.t1 + "." + tuple.t2 + "=" + "'. Reason: Operation set requires a value");
-      allow(SET, tuple.t1 + "." + tuple.t2 + "=" + tuple.t3);
-      reject(CONFIG, tuple.t1 + "." + tuple.t2 + "=", "Invalid input: '" + tuple.t1 + "." + tuple.t2 + "=" + "'. Reason: " + tuple.t1 + " does not allow operation config at cluster level");
-      reject(CONFIG, tuple.t1 + "." + tuple.t2 + "=" + tuple.t3, "Invalid input: '" + tuple.t1 + "." + tuple.t2 + "=" + tuple.t3 + "'. Reason: " + tuple.t1 + " does not allow operation config at cluster level");
-
-      allow(GET, "stripe.1." + tuple.t1);
-      allow(UNSET, "stripe.1." + tuple.t1);
-      reject(SET, "stripe.1." + tuple.t1 + "=", "Invalid input: 'stripe.1." + tuple.t1 + "=" + "'. Reason: Operation set requires a value");
-      allow(SET, "stripe.1." + tuple.t1 + "=" + tuple.t2 + ":" + tuple.t3);
-      reject(CONFIG, "stripe.1." + tuple.t1 + "=", "Invalid input: 'stripe.1." + tuple.t1 + "=" + "'. Reason: " + tuple.t1 + " does not allow operation config at stripe level");
-      reject(CONFIG, "stripe.1." + tuple.t1 + "=" + tuple.t2 + ":" + tuple.t3, "Invalid input: 'stripe.1." + tuple.t1 + "=" + tuple.t2 + ":" + tuple.t3 + "'. Reason: " + tuple.t1 + " does not allow operation config at stripe level");
-
-      allow(GET, "stripe.1." + tuple.t1 + "." + tuple.t2);
-      allow(UNSET, "stripe.1." + tuple.t1 + "." + tuple.t2);
-      reject(SET, "stripe.1." + tuple.t1 + "." + tuple.t2 + "=", "Invalid input: 'stripe.1." + tuple.t1 + "." + tuple.t2 + "=" + "'. Reason: Operation set requires a value");
-      allow(SET, "stripe.1." + tuple.t1 + "." + tuple.t2 + "=" + tuple.t3);
-      reject(CONFIG, "stripe.1." + tuple.t1 + "." + tuple.t2 + "=", "Invalid input: 'stripe.1." + tuple.t1 + "." + tuple.t2 + "=" + "'. Reason: " + tuple.t1 + " does not allow operation config at stripe level");
-      reject(CONFIG, "stripe.1." + tuple.t1 + "." + tuple.t2 + "=" + tuple.t3, "Invalid input: 'stripe.1." + tuple.t1 + "." + tuple.t2 + "=" + tuple.t3 + "'. Reason: " + tuple.t1 + " does not allow operation config at stripe level");
-
-      allow(GET, "stripe.1.node.1." + tuple.t1);
-      allow(UNSET, "stripe.1.node.1." + tuple.t1);
-      reject(SET, "stripe.1.node.1." + tuple.t1 + "=", "Invalid input: 'stripe.1.node.1." + tuple.t1 + "=" + "'. Reason: Operation set requires a value");
-      allow(SET, "stripe.1.node.1." + tuple.t1 + "=" + tuple.t2 + ":" + tuple.t3);
-      allow(CONFIG, "stripe.1.node.1." + tuple.t1 + "=");
-      allow(CONFIG, "stripe.1.node.1." + tuple.t1 + "=" + tuple.t2 + ":" + tuple.t3);
-
-      allow(GET, "stripe.1.node.1." + tuple.t1 + "." + tuple.t2);
-      allow(UNSET, "stripe.1.node.1." + tuple.t1 + "." + tuple.t2);
-      reject(SET, "stripe.1.node.1." + tuple.t1 + "." + tuple.t2 + "=", "Invalid input: 'stripe.1.node.1." + tuple.t1 + "." + tuple.t2 + "=" + "'. Reason: Operation set requires a value");
-      allow(SET, "stripe.1.node.1." + tuple.t1 + "." + tuple.t2 + "=" + tuple.t3);
-      allow(CONFIG, "stripe.1.node.1." + tuple.t1 + "." + tuple.t2 + "=");
-      allow(CONFIG, "stripe.1.node.1." + tuple.t1 + "." + tuple.t2 + "=" + tuple.t3);
-    });
-
-    // get allowed for scope cluster
-    // unset allowed for scope cluster
-    // set allowed for scope cluster
-    // config allowed for scope cluster
-    Stream.of(
-        tuple3(OFFHEAP_RESOURCES, "a.b.c", "1GB")
-    ).forEach(tuple -> {
-      allow(GET, tuple.t1.toString());
-      allow(UNSET, tuple.t1.toString());
-      reject(SET, tuple.t1 + "=", "Invalid input: '" + tuple.t1 + "=" + "'. Reason: Operation set requires a value");
-      allow(SET, tuple.t1 + "=" + tuple.t2 + ":" + tuple.t3);
-      allow(CONFIG, tuple.t1 + "=");
-      allow(CONFIG, tuple.t1 + "=" + tuple.t2 + ":" + tuple.t3);
-
-      allow(GET, tuple.t1 + "." + tuple.t2);
-      allow(UNSET, tuple.t1 + "." + tuple.t2);
-      reject(SET, tuple.t1 + "." + tuple.t2 + "=", "Invalid input: '" + tuple.t1 + "." + tuple.t2 + "=" + "'. Reason: Operation set requires a value");
-      allow(SET, tuple.t1 + "." + tuple.t2 + "=" + tuple.t3);
-      allow(CONFIG, tuple.t1 + "." + tuple.t2 + "=");
-      allow(CONFIG, tuple.t1 + "." + tuple.t2 + "=" + tuple.t3);
-
-      reject(GET, "stripe.1." + tuple.t1, "Invalid input: 'stripe.1." + tuple.t1 + "'. Reason: " + tuple.t1 + " does not allow any operation at stripe level");
-      reject(UNSET, "stripe.1." + tuple.t1, "Invalid input: 'stripe.1." + tuple.t1 + "'. Reason: " + tuple.t1 + " does not allow any operation at stripe level");
-      reject(SET, "stripe.1." + tuple.t1 + "=", "Invalid input: 'stripe.1." + tuple.t1 + "='. Reason: " + tuple.t1 + " does not allow any operation at stripe level");
-      reject(SET, "stripe.1." + tuple.t1 + "=" + tuple.t2 + ":" + tuple.t3, "Invalid input: 'stripe.1." + tuple.t1 + "=" + tuple.t2 + ":" + tuple.t3 + "'. Reason: " + tuple.t1 + " does not allow any operation at stripe level");
-      reject(CONFIG, "stripe.1." + tuple.t1 + "=", "Invalid input: 'stripe.1." + tuple.t1 + "=" + "'. Reason: " + tuple.t1 + " does not allow any operation at stripe level");
-      reject(CONFIG, "stripe.1." + tuple.t1 + "=" + tuple.t2 + ":" + tuple.t3, "Invalid input: 'stripe.1." + tuple.t1 + "=" + tuple.t2 + ":" + tuple.t3 + "'. Reason: " + tuple.t1 + " does not allow any operation at stripe level");
-
-      reject(GET, "stripe.1." + tuple.t1 + "." + tuple.t2, "Invalid input: 'stripe.1." + tuple.t1 + "." + tuple.t2 + "'. Reason: " + tuple.t1 + " does not allow any operation at stripe level");
-      reject(UNSET, "stripe.1." + tuple.t1 + "." + tuple.t2, "Invalid input: 'stripe.1." + tuple.t1 + "." + tuple.t2 + "'. Reason: " + tuple.t1 + " does not allow any operation at stripe level");
-      reject(SET, "stripe.1." + tuple.t1 + "." + tuple.t2 + "=", "Invalid input: 'stripe.1." + tuple.t1 + "." + tuple.t2 + "='. Reason: " + tuple.t1 + " does not allow any operation at stripe level");
-      reject(SET, "stripe.1." + tuple.t1 + "." + tuple.t2 + "=" + tuple.t3, "Invalid input: 'stripe.1." + tuple.t1 + "." + tuple.t2 + "=" + tuple.t3 + "'. Reason: " + tuple.t1 + " does not allow any operation at stripe level");
-      reject(CONFIG, "stripe.1." + tuple.t1 + "." + tuple.t2 + "=", "Invalid input: 'stripe.1." + tuple.t1 + "." + tuple.t2 + "=" + "'. Reason: " + tuple.t1 + " does not allow any operation at stripe level");
-      reject(CONFIG, "stripe.1." + tuple.t1 + "." + tuple.t2 + "=" + tuple.t3, "Invalid input: 'stripe.1." + tuple.t1 + "." + tuple.t2 + "=" + tuple.t3 + "'. Reason: " + tuple.t1 + " does not allow any operation at stripe level");
-
-      reject(GET, "stripe.1.node.1." + tuple.t1, "Invalid input: 'stripe.1.node.1." + tuple.t1 + "'. Reason: " + tuple.t1 + " does not allow any operation at node level");
-      reject(UNSET, "stripe.1.node.1." + tuple.t1, "Invalid input: 'stripe.1.node.1." + tuple.t1 + "'. Reason: " + tuple.t1 + " does not allow any operation at node level");
-      reject(SET, "stripe.1.node.1." + tuple.t1 + "=", "Invalid input: 'stripe.1.node.1." + tuple.t1 + "='. Reason: " + tuple.t1 + " does not allow any operation at node level");
-      reject(SET, "stripe.1.node.1." + tuple.t1 + "=" + tuple.t2 + ":" + tuple.t3, "Invalid input: 'stripe.1.node.1." + tuple.t1 + "=" + tuple.t2 + ":" + tuple.t3 + "'. Reason: " + tuple.t1 + " does not allow any operation at node level");
-      reject(CONFIG, "stripe.1.node.1." + tuple.t1 + "=", "Invalid input: 'stripe.1.node.1." + tuple.t1 + "=" + "'. Reason: " + tuple.t1 + " does not allow any operation at node level");
-      reject(CONFIG, "stripe.1.node.1." + tuple.t1 + "=" + tuple.t2 + ":" + tuple.t3, "Invalid input: 'stripe.1.node.1." + tuple.t1 + "=" + tuple.t2 + ":" + tuple.t3 + "'. Reason: " + tuple.t1 + " does not allow any operation at node level");
-
-      reject(GET, "stripe.1.node.1." + tuple.t1 + "." + tuple.t2, "Invalid input: 'stripe.1.node.1." + tuple.t1 + "." + tuple.t2 + "'. Reason: " + tuple.t1 + " does not allow any operation at node level");
-      reject(UNSET, "stripe.1.node.1." + tuple.t1 + "." + tuple.t2, "Invalid input: 'stripe.1.node.1." + tuple.t1 + "." + tuple.t2 + "'. Reason: " + tuple.t1 + " does not allow any operation at node level");
-      reject(SET, "stripe.1.node.1." + tuple.t1 + "." + tuple.t2 + "=", "Invalid input: 'stripe.1.node.1." + tuple.t1 + "." + tuple.t2 + "='. Reason: " + tuple.t1 + " does not allow any operation at node level");
-      reject(SET, "stripe.1.node.1." + tuple.t1 + "." + tuple.t2 + "=" + tuple.t3, "Invalid input: 'stripe.1.node.1." + tuple.t1 + "." + tuple.t2 + "=" + tuple.t3 + "'. Reason: " + tuple.t1 + " does not allow any operation at node level");
-      reject(CONFIG, "stripe.1.node.1." + tuple.t1 + "." + tuple.t2 + "=", "Invalid input: 'stripe.1.node.1." + tuple.t1 + "." + tuple.t2 + "=" + "'. Reason: " + tuple.t1 + " does not allow any operation at node level");
-      reject(CONFIG, "stripe.1.node.1." + tuple.t1 + "." + tuple.t2 + "=" + tuple.t3, "Invalid input: 'stripe.1.node.1." + tuple.t1 + "." + tuple.t2 + "=" + tuple.t3 + "'. Reason: " + tuple.t1 + " does not allow any operation at node level");
+    // cluster-name, offheap-resources
+    Stream.of("cluster-name", "offheap-resources").forEach(setting -> {
+      Stream.of(ACTIVATED).forEach(state -> state.filter(UNSET).forEach(op -> NS.forEach(ns -> reject(state, op, ns + setting))));
+      Stream.of(ACTIVATED).forEach(state -> state.filter(GET).forEach(op -> {
+        allow(state, op, setting);
+        reject(state, op, "stripe.1." + setting);
+        reject(state, op, "stripe.1.node.1." + setting);
+      }));
+      Stream.of(CONFIGURING).forEach(state -> state.filter(GET, UNSET).forEach(op -> {
+        allow(state, op, setting);
+        reject(state, op, "stripe.1." + setting);
+        reject(state, op, "stripe.1.node.1." + setting);
+      }));
+      Stream.of(CONFIGURING, ACTIVATED).forEach(state -> state.filter(SET).forEach(op -> {
+        allow(state, op, setting + "=foo:123GB");
+        reject(state, op, setting + "=");
+        reject(state, op, "stripe.1." + setting + "=foo:123GB");
+        reject(state, op, "stripe.1.node.1." + setting + "=foo:123GB");
+      }));
+      Stream.of(CONFIGURING).forEach(state -> state.filter(IMPORT).forEach(op -> {
+        allow(state, op, setting + "=foo:123GB");
+        allow(state, op, setting + "=");
+        reject(state, op, "stripe.1." + setting + "=foo:123GB");
+        reject(state, op, "stripe.1.node.1." + setting + "=foo:123GB");
+      }));
     });
   }
 
@@ -1058,16 +925,20 @@ public class ConfigurationTest {
     }
   }
 
-  private void reject(Operation operation, String input, String err) {
-    assertThat(() -> Configuration.valueOf(input).validate(operation), is(throwing(instanceOf(IllegalArgumentException.class)).andMessage(is(equalTo(err)))));
+  private void reject(ClusterState clusterState, Operation operation, String input) {
+    assertThat(input, () -> Configuration.valueOf(input).validate(clusterState, operation), is(throwing(instanceOf(IllegalArgumentException.class))));
   }
 
-  private void allow(Operation operation, String input) {
-    Configuration.valueOf(input).validate(operation);
+  private void reject(ClusterState clusterState, Operation operation, String input, String err) {
+    assertThat(input, () -> Configuration.valueOf(input).validate(clusterState, operation), is(throwing(instanceOf(IllegalArgumentException.class)).andMessage(is(equalTo("Invalid input: '" + input + "'. Reason: " + err)))));
+  }
+
+  private void allow(ClusterState clusterState, Operation operation, String input) {
+    Configuration.valueOf(input).validate(clusterState, operation);
   }
 
   private void rejectInput(String input, String msg) {
-    assertThat(() -> Configuration.valueOf(input), is(throwing(instanceOf(IllegalArgumentException.class)).andMessage(is(equalTo(msg)))));
+    assertThat(input, () -> Configuration.valueOf(input), is(throwing(instanceOf(IllegalArgumentException.class)).andMessage(is(equalTo(msg)))));
   }
 
   private void allowInput(String input, Setting setting, Scope scope, Integer stripeId, Integer nodeId, String key, String value) {

--- a/dynamic-config/model/src/test/java/org/terracotta/dynamic_config/api/model/SetSettingTest.java
+++ b/dynamic-config/model/src/test/java/org/terracotta/dynamic_config/api/model/SetSettingTest.java
@@ -22,7 +22,6 @@ import java.nio.file.Paths;
 
 import static java.io.File.separator;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
@@ -36,7 +35,6 @@ import static org.terracotta.dynamic_config.api.model.Setting.OFFHEAP_RESOURCES;
 import static org.terracotta.dynamic_config.api.model.Setting.SECURITY_AUDIT_LOG_DIR;
 import static org.terracotta.dynamic_config.api.model.Setting.SECURITY_DIR;
 import static org.terracotta.dynamic_config.api.model.Setting.TC_PROPERTIES;
-import static org.terracotta.testing.ExceptionMatcher.throwing;
 
 /**
  * only test the necessary setters having some logic
@@ -76,12 +74,8 @@ public class SetSettingTest {
   public void test_setProperty_LICENSE_FILE() {
     Node node = Node.newDefaultNode("localhost");
 
-    // exception comes from validate call
-    assertThat(
-        () -> LICENSE_FILE.setProperty(node, null),
-        is(throwing(instanceOf(IllegalArgumentException.class)).andMessage(is(equalTo("license-file cannot be null")))));
-
     // not throwing - noop
+    LICENSE_FILE.setProperty(node, null);
     LICENSE_FILE.setProperty(node, "a.xml");
   }
 

--- a/dynamic-config/model/src/test/java/org/terracotta/dynamic_config/api/model/SettingValidatorTest.java
+++ b/dynamic-config/model/src/test/java/org/terracotta/dynamic_config/api/model/SettingValidatorTest.java
@@ -124,7 +124,7 @@ public class SettingValidatorTest {
 
   @Test
   public void test_paths() {
-    Stream.of(NODE_CONFIG_DIR, NODE_LOG_DIR, LICENSE_FILE).forEach(setting -> {
+    Stream.of(NODE_CONFIG_DIR, NODE_LOG_DIR).forEach(setting -> {
       validateDefaults(setting);
       assertThat(
           () -> setting.validate("/\u0000/"),
@@ -135,7 +135,7 @@ public class SettingValidatorTest {
       setting.validate(".");
     });
 
-    Stream.of(NODE_BACKUP_DIR, NODE_METADATA_DIR, SECURITY_DIR, SECURITY_AUDIT_LOG_DIR).forEach(setting -> {
+    Stream.of(NODE_BACKUP_DIR, NODE_METADATA_DIR, SECURITY_DIR, SECURITY_AUDIT_LOG_DIR, LICENSE_FILE).forEach(setting -> {
       validateDefaults(setting);
       assertThat(
           () -> setting.validate("/\u0000/"),

--- a/dynamic-config/model/src/test/java/org/terracotta/dynamic_config/api/service/ConfigurationParserTest.java
+++ b/dynamic-config/model/src/test/java/org/terracotta/dynamic_config/api/service/ConfigurationParserTest.java
@@ -189,7 +189,7 @@ public class ConfigurationParserTest {
     ), "Invalid input: 'stripe.1.node.2.hostname=%h'. Placeholders are not allowed");
 
     // scope
-    assertConfigFail(config("failover-priority=availability", "hostname=foo"), "Invalid input: 'hostname=foo'. Reason: hostname cannot be set at cluster level");
+    assertConfigFail(config("failover-priority=availability", "hostname=foo"), "Invalid input: 'hostname=foo'. Reason: Setting 'hostname' cannot be set at cluster level");
     assertConfigFail(config(
         "failover-priority=availability",
         "stripe.1.node.1.hostname=localhost",
@@ -204,7 +204,7 @@ public class ConfigurationParserTest {
         "failover-priority=availability",
         "stripe.1.node.1.hostname=localhost",
         "stripe.1.node.1.failover-priority=availability"
-    ), "Invalid input: 'stripe.1.node.1.failover-priority=availability'. Reason: failover-priority does not allow any operation at node level");
+    ), "Invalid input: 'stripe.1.node.1.failover-priority=availability'. Reason: Setting 'failover-priority' does not allow any operation at node level");
 
     // node and stripe ids
     assertConfigFail(config("failover-priority=availability", "stripe.1.node.2.hostname=localhost"), "Node ID must start at 1 in stripe 1");
@@ -227,7 +227,7 @@ public class ConfigurationParserTest {
         "failover-priority=availability",
         "stripe.1.node.1.hostname=localhost",
         "stripe.1.node.1.config-dir=foo/bar"
-    ), "Invalid input: 'stripe.1.node.1.config-dir=foo/bar'. Reason: config-dir does not allow any operation at node level");
+    ), "Invalid input: 'stripe.1.node.1.config-dir=foo/bar'. Reason: Setting 'config-dir' does not allow any operation at node level");
     assertConfigFail(config(
         "failover-priority=availability",
         "stripe.1.node.1.hostname=localhost",

--- a/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/service/ConfigChangeHandlerManagerImpl.java
+++ b/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/service/ConfigChangeHandlerManagerImpl.java
@@ -58,12 +58,12 @@ public class ConfigChangeHandlerManagerImpl implements ConfigChangeHandlerManage
     StateDumpCollector configChangeHandlers = stateDumpCollector.subStateDumpCollector("configChangeHandlers");
     this.changeHandlers.entrySet()
         .stream()
-        .sorted(Comparator.comparing(e -> e.getKey().getName()))
+        .sorted(Comparator.comparing(e -> e.getKey().toString()))
         .forEach(e -> {
           if (e.getValue() instanceof StateDumpable) {
-            ((StateDumpable) e.getValue()).addStateTo(configChangeHandlers.subStateDumpCollector(e.getKey().getName()));
+            ((StateDumpable) e.getValue()).addStateTo(configChangeHandlers.subStateDumpCollector(e.getKey().toString()));
           } else {
-            configChangeHandlers.addState(e.getKey().getName(), e.getValue().toString());
+            configChangeHandlers.addState(e.getKey().toString(), e.getValue().toString());
           }
         });
   }

--- a/dynamic-config/server/services/src/main/java/org/terracotta/dynamic_config/server/service/DisallowSettingChanges.java
+++ b/dynamic-config/server/services/src/main/java/org/terracotta/dynamic_config/server/service/DisallowSettingChanges.java
@@ -22,36 +22,17 @@ import org.terracotta.dynamic_config.api.model.nomad.SettingNomadChange;
 import org.terracotta.dynamic_config.server.api.NomadPermissionChangeProcessor;
 import org.terracotta.nomad.server.NomadException;
 
-import java.util.EnumSet;
-
-import static org.terracotta.dynamic_config.api.model.Setting.NODE_BIND_ADDRESS;
-import static org.terracotta.dynamic_config.api.model.Setting.NODE_GROUP_BIND_ADDRESS;
-import static org.terracotta.dynamic_config.api.model.Setting.NODE_GROUP_PORT;
-import static org.terracotta.dynamic_config.api.model.Setting.NODE_HOSTNAME;
-import static org.terracotta.dynamic_config.api.model.Setting.NODE_METADATA_DIR;
-import static org.terracotta.dynamic_config.api.model.Setting.NODE_NAME;
-import static org.terracotta.dynamic_config.api.model.Setting.NODE_PORT;
+import static org.terracotta.dynamic_config.api.model.ClusterState.ACTIVATED;
 
 /**
  * @author Mathieu Carbou
  */
 class DisallowSettingChanges implements NomadPermissionChangeProcessor.Check {
-
-  private static final EnumSet<Setting> DISALLOWED = EnumSet.of(
-      NODE_NAME,
-      NODE_HOSTNAME,
-      NODE_PORT,
-      NODE_BIND_ADDRESS,
-      NODE_GROUP_PORT,
-      NODE_GROUP_BIND_ADDRESS,
-      NODE_METADATA_DIR
-  );
-
   @Override
   public void check(NodeContext config, DynamicConfigNomadChange change) throws NomadException {
     if (change instanceof SettingNomadChange) {
       Setting setting = ((SettingNomadChange) change).getSetting();
-      if (DISALLOWED.contains(setting)) {
+      if (!setting.isWritableWhen(ACTIVATED)) {
         throw new NomadException("Error when applying setting change: '" + change.getSummary() + "': " + "Setting '" + setting + "' cannot be changed once a node is activated");
       }
     }

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/DiagnosticCommand1x2IT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/DiagnosticCommand1x2IT.java
@@ -26,10 +26,9 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 
 import static java.util.stream.Collectors.toList;
-import static org.hamcrest.CoreMatchers.allOf;
+import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 import static org.terracotta.angela.client.support.hamcrest.AngelaMatchers.containsLinesInOrderStartingWith;
-import static org.terracotta.angela.client.support.hamcrest.AngelaMatchers.containsOutput;
 import static org.terracotta.angela.client.support.hamcrest.AngelaMatchers.successful;
 
 /**
@@ -98,8 +97,7 @@ public class DiagnosticCommand1x2IT extends DynamicConfigIT {
     waitForActive(1);
     waitForPassives(1);
 
-    assertThat(configToolInvocation("set", "-s", "localhost:" + getNodePort(1, 1), "-c", "cluster-name=new-cluster-name"),
-        allOf(containsOutput("restart of the cluster is required"), successful()));
+    assertThat(configToolInvocation("set", "-s", "localhost:" + getNodePort(1, 1), "-c", "cluster-name=new-cluster-name"), is(successful()));
 
     // Diagnostic result from all nodes must be the same
     assertThat(configToolInvocation("diagnostic", "-s", "localhost:" + getNodePort(1, 1)),

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/SetCommand1x1IT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/SetCommand1x1IT.java
@@ -198,7 +198,7 @@ public class SetCommand1x1IT extends DynamicConfigIT {
 
     // Restart node and verify that the change has taken effect
     stopNode(1, 1);
-    startNode(1,1);
+    startNode(1, 1);
 
     assertThat(configToolInvocation("get", "-s", "localhost:" + getNodePort(), "-r", "-c", "log-dir"),
         allOf(hasExitStatus(0), containsOutput("stripe.1.node.1.log-dir=logs" + separator + "stripe1")));
@@ -216,21 +216,28 @@ public class SetCommand1x1IT extends DynamicConfigIT {
   public void setNodeBindAddress() {
     assertThat(
         configToolInvocation("set", "-s", "localhost:" + getNodePort(), "-c", "stripe.1.node.1.bind-address=127.0.0.1"),
-        containsOutput("Setting 'bind-address' cannot be changed once a node is activated"));
+        containsOutput("Reason: Setting 'bind-address' cannot be set when node is activated"));
+  }
+
+  @Test
+  public void setNodeName() {
+    assertThat(
+        configToolInvocation("set", "-s", "localhost:" + getNodePort(), "-c", "stripe.1.node.1.name=foo"),
+        containsOutput("Error: Invalid input: 'stripe.1.node.1.name=foo'. Reason: Setting 'name' cannot be set when node is activated"));
   }
 
   @Test
   public void setNodeGroupPort() {
     assertThat(
         configToolInvocation("set", "-s", "localhost:" + getNodePort(), "-c", "stripe.1.node.1.group-port=1024"),
-        containsOutput("Setting 'group-port' cannot be changed once a node is activated"));
+        containsOutput("Reason: Setting 'group-port' cannot be set when node is activated"));
   }
 
   @Test
   public void setNodeGroupBindAddress() {
     assertThat(
         configToolInvocation("set", "-s", "localhost:" + getNodePort(), "-c", "stripe.1.node.1.group-bind-address=127.0.0.1"),
-        containsOutput("Setting 'group-bind-address' cannot be changed once a node is activated"));
+        containsOutput("Reason: Setting 'group-bind-address' cannot be set when node is activated"));
   }
 
   @Test
@@ -268,9 +275,9 @@ public class SetCommand1x1IT extends DynamicConfigIT {
     // TDB-5067
     String clusterName = usingTopologyService(1, 1, topologyService -> topologyService.getUpcomingNodeContext().getCluster().getName());
     assertThat(configToolInvocation("set", "-s", "localhost:" + getNodePort(), "-c", "cluster-name=new-name"),
-        allOf(is(successful()), containsOutput("IMPORTANT: A restart of the cluster is required to apply the changes")));
+        allOf(is(successful()), not(containsOutput("IMPORTANT: A restart of the cluster is required to apply the changes"))));
     assertThat(configToolInvocation("diagnostic", "-s", "localhost:" + getNodePort(1, 1)),
-        allOf(containsOutput("Node restart required: YES"), containsOutput("Node last configuration change details: set cluster-name=new-name")));
+        allOf(containsOutput("Node restart required: NO"), containsOutput("Node last configuration change details: set cluster-name=new-name")));
     assertThat(configToolInvocation("set", "-s", "localhost:" + getNodePort(), "-c", "cluster-name=" + clusterName),
         allOf(is(successful()), not(containsOutput("IMPORTANT: A restart of the cluster is required to apply the changes"))));
     assertThat(configToolInvocation("diagnostic", "-s", "localhost:" + getNodePort(1, 1)),
@@ -282,12 +289,12 @@ public class SetCommand1x1IT extends DynamicConfigIT {
     // TDB-5092
     assertThat(
         configToolInvocation("set", "-s", "localhost:" + getNodePort(), "-c", "metadata-dir=foo"),
-        containsOutput("Reason: Error when applying setting change: 'set metadata-dir=foo': Setting 'metadata-dir' cannot be changed once a node is activated"));
+        containsOutput("Error: Invalid input: 'metadata-dir=foo'. Reason: Setting 'metadata-dir' cannot be set when node is activated"));
     assertThat(
         configToolInvocation("set", "-s", "localhost:" + getNodePort(), "-c", "stripe.1.metadata-dir=foo"),
-        containsOutput("Reason: Error when applying setting change: 'set metadata-dir=foo (stripe ID: 1)': Setting 'metadata-dir' cannot be changed once a node is activated"));
+        containsOutput("Error: Invalid input: 'stripe.1.metadata-dir=foo'. Reason: Setting 'metadata-dir' cannot be set when node is activated"));
     assertThat(
         configToolInvocation("set", "-s", "localhost:" + getNodePort(), "-c", "stripe.1.node.1.metadata-dir=foo"),
-        containsOutput("Reason: Error when applying setting change: 'set metadata-dir=foo (stripe ID: 1, node: node-1-1)': Setting 'metadata-dir' cannot be changed once a node is activated"));
+        containsOutput("Error: Invalid input: 'stripe.1.node.1.metadata-dir=foo'. Reason: Setting 'metadata-dir' cannot be set when node is activated"));
   }
 }

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/SetCommand1x2IT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/SetCommand1x2IT.java
@@ -59,6 +59,7 @@ public class SetCommand1x2IT extends DynamicConfigIT {
     assertThat(getRuntimeCluster(1, 1).getNode(1, 1).get().getDataDirs(), hasKey("foo"));
     assertThat(getRuntimeCluster(1, 1).getNode(1, 2).get().getDataDirs(), hasKey("foo"));
   }
+
   @Test
   public void testCluster_setDataDirs() throws Exception {
     assertThat(configToolInvocation("set", "-s", "localhost:" + getNodePort(),
@@ -82,7 +83,7 @@ public class SetCommand1x2IT extends DynamicConfigIT {
     Path metadataDir = usingTopologyService(1, passiveId, topologyService -> topologyService.getUpcomingNodeContext().getNode().getNodeMetadataDir());
     assertThat(
         configToolInvocation("set", "-s", "localhost:" + getNodePort(), "-c", "stripe.1.node." + passiveId + ".metadata-dir=foo"),
-        containsOutput("Setting 'metadata-dir' cannot be changed once a node is activated"));
+        containsOutput("Setting 'metadata-dir' cannot be set when node is activated"));
 
     // kill active and wait for passive to become active
     stopNode(1, passiveId == 1 ? 2 : 1);

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activation/ActivateCommand1x2IT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activation/ActivateCommand1x2IT.java
@@ -57,6 +57,15 @@ public class ActivateCommand1x2IT extends DynamicConfigIT {
   }
 
   @Test
+  public void changeNodeNameAndActivate() throws Exception {
+    assertThat(usingTopologyService(1, 1, topologyService -> topologyService.getUpcomingNodeContext().getNode().getNodeName()), is(equalTo("node-1-1")));
+    assertThat(configToolInvocation("set", "-s", "localhost:" + getNodePort(), "-c", "stripe.1.node.1.name=foo"), is(successful()));
+    assertThat(usingTopologyService(1, 1, topologyService -> topologyService.getUpcomingNodeContext().getNode().getNodeName()), is(equalTo("foo")));
+    activateCluster();
+    assertThat(usingTopologyService(1, 1, topologyService -> topologyService.getUpcomingNodeContext().getNode().getNodeName()), is(equalTo("foo")));
+  }
+
+  @Test
   public void testSingleNodeActivationWithConfigFile() throws Exception {
     assertThat(
         configToolInvocation("activate", "-f", copyConfigProperty("/config-property-files/single-stripe.properties").toString(), "-n", "my-cluster"),

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/diagnostic/SetCommand1x1IT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/diagnostic/SetCommand1x1IT.java
@@ -23,6 +23,7 @@ import org.terracotta.dynamic_config.test_support.DynamicConfigIT;
 
 import static java.io.File.separator;
 import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.terracotta.angela.client.support.hamcrest.AngelaMatchers.containsOutput;
@@ -90,5 +91,12 @@ public class SetCommand1x1IT extends DynamicConfigIT {
 
     assertThat(configToolInvocation("get", "-s", "localhost:" + getNodePort(), "-c", "offheap-resources.main", "-c", "stripe.1.node.1.data-dirs.main"),
         allOf(hasExitStatus(0), containsOutput("offheap-resources.main=1GB"), containsOutput("stripe.1.node.1.data-dirs.main=stripe1-node1-data-dir")));
+  }
+
+  @Test
+  public void setNodeName() throws Exception {
+    assertThat(usingTopologyService(1, 1, topologyService -> topologyService.getUpcomingNodeContext().getNode().getNodeName()), is(equalTo("node-1-1")));
+    assertThat(configToolInvocation("set", "-s", "localhost:" + getNodePort(), "-c", "stripe.1.node.1.name=foo"), is(successful()));
+    assertThat(usingTopologyService(1, 1, topologyService -> topologyService.getUpcomingNodeContext().getNode().getNodeName()), is(equalTo("foo")));
   }
 }

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/diagnostic/SetCommand1x2IT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/diagnostic/SetCommand1x2IT.java
@@ -15,6 +15,7 @@
  */
 package org.terracotta.dynamic_config.system_tests.diagnostic;
 
+import org.hamcrest.MatcherAssert;
 import org.junit.Before;
 import org.junit.Test;
 import org.terracotta.dynamic_config.test_support.ClusterDefinition;
@@ -102,5 +103,12 @@ public class SetCommand1x2IT extends DynamicConfigIT {
 
     assertThat(configToolInvocation("get", "-s", "localhost:" + getNodePort(), "-c", "client-reconnect-window"),
         allOf(hasExitStatus(0), containsOutput("client-reconnect-window=10s")));
+  }
+
+  @Test
+  public void setDuplicateNodeName() {
+    MatcherAssert.assertThat(
+        configToolInvocation("set", "-s", "localhost:" + getNodePort(), "-c", "stripe.1.node.1.name=node-1-2"),
+        containsOutput("Error: Found duplicate node name: node-1-2"));
   }
 }

--- a/dynamic-config/testing/system-tests/src/test/resources/diagnostic6-1.txt
+++ b/dynamic-config/testing/system-tests/src/test/resources/diagnostic6-1.txt
@@ -10,7 +10,7 @@ Diagnostic result:
  - Node online, configured and activated: YES
  - Node online, configured and in repair: NO
  - Node online, new and being configured: NO
- - Node restart required: YES
+ - Node restart required: NO
  - Node configuration change in progress: NO
  - Node can accept new changes: YES
  - Node current configuration version: 2
@@ -28,7 +28,7 @@ Diagnostic result:
  - Node online, configured and activated: YES
  - Node online, configured and in repair: NO
  - Node online, new and being configured: NO
- - Node restart required: YES
+ - Node restart required: NO
  - Node configuration change in progress: NO
  - Node can accept new changes: YES
  - Node current configuration version: 2


### PR DESCRIPTION
Change how settings are defined by introducing a more fine grained permission api.

 - This will fix a lot of inconsistencies and missing information in the setting class
 - This allows more granularity when defining Setting
 - This will allow to do some validation more easily prior to sending a change
 - This will allow to more easily open the door to name change but only when configuring
- This automatically solves TDB-5105 (being able to change node name when a node is unconfigured)

How to read:

* get == get command
* set == set command
* unset == unset command
* import == import command, or startup CLI, or starting with a config file (==what is configuring from CLI or file)

Here is a list of permissions per setting:

```
   Here is below a summary of all the settings and their permissions, which can be generated with the following code:
  
    Stream.of(Setting.values()).collect(Collectors.groupingBy(Setting::getPermissions)).entrySet().forEach(System.out::println);
  
    config-dir
    No permission
  
    license-file
    Permission: when: [activated, configuring] allow: [set] at levels: [cluster]
  
    metadata-dir
      * Permission: when: [configuring] allow: [import] at levels: [node],
      * Permission: when: [configuring] allow: [set, get] at levels: [node, stripe, cluster],
      * Permission: when: [activated] allow: [get] at levels: [node, stripe, cluster]
  
    hostname, port
      * Permission: when: [activated, configuring] allow: [get] at levels: [node, stripe, cluster],
      * Permission: when: [configuring] allow: [import] at levels: [node]
  
    group-port, bind-address, group-bind-address
      * Permission: when: [activated, configuring] allow: [get] at levels: [node, stripe, cluster],
      * Permission: when: [configuring] allow: [set] at levels: [node, stripe, cluster],
      * Permission: when: [configuring] allow: [import] at levels: [node]
  
    data-dirs
      * Permission: when: [configuring] allow: [import] at levels: [node]
      * Permission: when: [configuring] allow: [set, get, unset] at levels: [node, stripe, cluster]
      * Permission: when: [activated, configuring] allow: [set, get] at levels: [node, stripe, cluster]
  
    name
      * Permission: when: [activated, configuring] allow: [get] at levels: [node, stripe, cluster],
      * Permission: when: [configuring] allow: [set, import] at levels: [node]
  
    public-hostname, public-port, backup-dir, tc-properties, logger-overrides, security-dir, audit-log-dir
      * Permission: when: [configuring] allow: [import] at levels: [node],
      * Permission: when: [activated, configuring] allow: [set, get, unset] at levels: [node, stripe, cluster]
  
    authc
      * Permission: when: [configuring] allow: [import] at levels: [cluster],
      * Permission: when: [activated, configuring] allow: [set, get, unset] at levels: [cluster]
  
    client-reconnect-window, failover-priority, client-lease-duration, ssl-tls, whitelist
      * Permission: when: [configuring] allow: [import] at levels: [cluster],
      * Permission: when: [activated, configuring] allow: [set, get] at levels: [cluster]
  
    log-dir
      * Permission: when: [configuring] allow: [import] at levels: [node],
      * Permission: when: [configuring] allow: [set, get] at levels: [node, stripe, cluster],
      * Permission: when: [activated] allow: [set, get] at levels: [node, stripe, cluster]
  
    cluster-name, offheap-resources
      * Permission: when: [configuring] allow: [set, get, import, unset] at levels: [cluster],
      * Permission: when: [activated] allow: [set, get] at levels: [cluster]
```