### PR TITLE
Fixes

### DIFF
--- a/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/command/AttachCommand.java
+++ b/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/command/AttachCommand.java
@@ -106,8 +106,12 @@ public class AttachCommand extends TopologyCommand {
         int nodeCount = destinationStripe.getNodes().size();
         int sum = voterCount + nodeCount;
         if (sum > 1 && sum % 2 != 0) {
-          logger.warn("WARNING: The sum of voter count ({}) and number of nodes ({}) in this stripe is an odd number," +
-              " but will become even with the addition of node {}", voterCount, nodeCount, source);
+          logger.warn(lineSeparator() +
+              "==============================================================================" + lineSeparator() +
+              "WARNING: The sum (" + sum + ") of voter count (" + voterCount + ") and number of nodes " +
+              "(" + nodeCount + ") in this stripe " + lineSeparator() +
+              "is an odd number, but will become even with the addition of node " + source + lineSeparator() +
+              "==============================================================================" + lineSeparator());
         }
       }
     }

--- a/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/command/DetachCommand.java
+++ b/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/command/DetachCommand.java
@@ -32,6 +32,7 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
 
+import static java.lang.System.lineSeparator;
 import static org.terracotta.dynamic_config.api.model.FailoverPriority.consistency;
 import static org.terracotta.dynamic_config.cli.config_tool.converter.OperationType.NODE;
 
@@ -76,9 +77,14 @@ public class DetachCommand extends TopologyCommand {
       if (failoverPriority.equals(consistency()) && destinationClusterActivated) {
         int voterCount = failoverPriority.getVoters();
         int nodeCount = destinationStripe.getNodes().size();
-        if ((voterCount + nodeCount) % 2 != 0) {
-          logger.warn("WARNING: The sum of voter count ({}) and number of nodes ({}) in this stripe is an odd number," +
-              " but will become even with the removal of node {}", voterCount, nodeCount, source);
+        int sum = voterCount + nodeCount;
+        if (sum % 2 != 0) {
+          logger.warn(lineSeparator() +
+              "==============================================================================" + lineSeparator() +
+              "WARNING: The sum (" + sum + ") of voter count (" + voterCount + ") and number of nodes " +
+              "(" + nodeCount + ") in this stripe " + lineSeparator() +
+              "is an odd number, but will become even with the removal of node " + source + lineSeparator() +
+              "==============================================================================" + lineSeparator());
         }
       }
 
@@ -110,9 +116,8 @@ public class DetachCommand extends TopologyCommand {
 
     // if the nodes are activated, the user must first stop them because they are part of a working cluster
     if (!onlineNodesToRemove.isEmpty() && areAllNodesActivated(onlineNodesToRemove)) {
-      validateLogOrFail(onlineNodesToRemove::isEmpty, "Nodes to detach: " + toString(onlineNodesToRemove) + " are online. " +
-          "The nodes should be safely shutdown first. " +
-          "Use -f to force the node removal by the detach command: the nodes will first reset and stop before being detached");
+      validateLogOrFail(onlineNodesToRemove::isEmpty, "Nodes to be detached: " + toString(onlineNodesToRemove) + " are online. " +
+          "Safely shutdown the nodes first, or use the force option to reset and stop the target nodes before detaching them");
     }
   }
 

--- a/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/command/DetachCommand.java
+++ b/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/command/DetachCommand.java
@@ -67,15 +67,15 @@ public class DetachCommand extends TopologyCommand {
         throw new IllegalStateException("Source node: " + source + " is not present in the same stripe as destination: " + destination);
       }
 
-      Stripe stripe = destinationCluster.getStripe(source).get();
-      if (stripe.getNodeCount() == 1) {
+      Stripe destinationStripe = destinationCluster.getStripe(destination).get();
+      if (destinationStripe.getNodeCount() == 1) {
         throw new IllegalStateException("Unable to detach since destination stripe contains only 1 node");
       }
 
       FailoverPriority failoverPriority = destinationCluster.getFailoverPriority();
       if (failoverPriority.equals(consistency()) && destinationClusterActivated) {
         int voterCount = failoverPriority.getVoters();
-        int nodeCount = destinationCluster.getNodes().size();
+        int nodeCount = destinationStripe.getNodes().size();
         if ((voterCount + nodeCount) % 2 != 0) {
           logger.warn("WARNING: The sum of voter count ({}) and number of nodes ({}) in this stripe is an odd number," +
               " but will become even with the removal of node {}", voterCount, nodeCount, source);

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/DetachCommand1x2IT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/DetachCommand1x2IT.java
@@ -98,7 +98,7 @@ public class DetachCommand1x2IT extends DynamicConfigIT {
     // detaching an online node needs to be forced
     assertThat(
         configToolInvocation("detach", "-d", "localhost:" + getNodePort(1, activeId), "-s", "localhost:" + getNodePort(1, passiveId)),
-        containsOutput("The nodes should be safely shutdown first."));
+        containsOutput("Safely shutdown the nodes first"));
 
     configToolInvocation("detach", "-d", "localhost:" + getNodePort(1, activeId), "-s", "localhost:" + getNodePort(1, passiveId), "-f");
 


### PR DESCRIPTION
**- Display the warning message more clearly**
Prior to this change, it was easy enough to miss the warning.

**- Use destinationStripe instead of destinationCluster to display consistency warning during nodes attach and detach**
This was wrong because we need to check the voter count + node count within the stripe, not the whole cluster.
