### PR TITLE
TDB-4445: Fix partially completed TDB-4445

### DIFF
--- a/dynamic-config/api/src/main/java/org/terracotta/dynamic_config/api/model/nomad/NodeAdditionNomadChange.java
+++ b/dynamic-config/api/src/main/java/org/terracotta/dynamic_config/api/model/nomad/NodeAdditionNomadChange.java
@@ -48,7 +48,7 @@ public class NodeAdditionNomadChange extends NodeNomadChange {
       throw new IllegalArgumentException("Node with address: " + getNodeAddress() + " already exists in cluster: " + original);
     }
     Cluster updated = original.clone();
-    updated.getStripe(getStripeId()).get().attachNode(getNode());
+    updated.getStripe(getStripeId()).get().addNode(getNode().clone());
     return updated;
   }
 

--- a/dynamic-config/api/src/main/java/org/terracotta/dynamic_config/api/model/nomad/NodeRemovalNomadChange.java
+++ b/dynamic-config/api/src/main/java/org/terracotta/dynamic_config/api/model/nomad/NodeRemovalNomadChange.java
@@ -41,7 +41,7 @@ public class NodeRemovalNomadChange extends NodeNomadChange {
       throw new IllegalArgumentException("Node with address: " + getNodeAddress() + " is not in cluster: " + original);
     }
     Cluster updated = original.clone();
-    updated.detachNode(getNodeAddress());
+    updated.removeNode(getNodeAddress());
     return updated;
   }
 

--- a/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/command/AttachCommand.java
+++ b/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/command/AttachCommand.java
@@ -145,14 +145,14 @@ public class AttachCommand extends TopologyCommand {
         logger.info("Attaching node: {} to stripe: {}", source, destination);
         Stripe stripe = cluster.getStripe(destination).get();
         Node node = sourceCluster.getNode(this.source).get();
-        stripe.attachNode(node);
+        stripe.addNode(node.clone());
         break;
       }
 
       case STRIPE: {
         Stripe stripe = sourceCluster.getStripe(source).get();
         logger.info("Attaching a new stripe formed with nodes: {} to cluster: {}", toString(stripe.getNodeAddresses()), destination);
-        cluster.attachStripe(stripe);
+        cluster.addStripe(stripe.clone());
         break;
       }
 

--- a/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/command/DetachCommand.java
+++ b/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/command/DetachCommand.java
@@ -129,14 +129,14 @@ public class DetachCommand extends TopologyCommand {
 
       case NODE: {
         logger.info("Detaching node: {} from stripe: {}", source, destination);
-        cluster.detachNode(source);
+        cluster.removeNode(source);
         break;
       }
 
       case STRIPE: {
         Stripe stripe = cluster.getStripe(source).get();
         logger.info("Detaching stripe containing nodes: {} from cluster: {}", toString(stripe.getNodeAddresses()), destination);
-        cluster.detachStripe(stripe);
+        cluster.removeStripe(stripe);
         break;
       }
 

--- a/dynamic-config/cli/upgrade-tools/src/main/java/org/terracotta/dynamic_config/cli/upgrade_tools/config_converter/conversion/AbstractTcConfigMapper.java
+++ b/dynamic-config/cli/upgrade-tools/src/main/java/org/terracotta/dynamic_config/cli/upgrade_tools/config_converter/conversion/AbstractTcConfigMapper.java
@@ -462,7 +462,7 @@ public abstract class AbstractTcConfigMapper implements TcConfigMapper {
       }
     }
     return stripes.stream().reduce((result, stripe) -> result
-        .addStripe(stripe.getSingleStripe().get())) // getSingleStripe() because conversion of xml -> model is for 1 stripe only
+        .addStripe(stripe.getSingleStripe().get().clone())) // getSingleStripe() because conversion of xml -> model is for 1 stripe only
         .orElseThrow(() -> new RuntimeException("No server specified."))
         .setName(clusterName);
   }

--- a/dynamic-config/model/src/main/java/org/terracotta/dynamic_config/api/model/Cluster.java
+++ b/dynamic-config/model/src/main/java/org/terracotta/dynamic_config/api/model/Cluster.java
@@ -278,33 +278,12 @@ public class Cluster implements Cloneable, PropertyHolder {
         .setSecurityWhitelist(securityWhitelist);
   }
 
-  public Cluster attachStripe(Stripe stripe) {
-    if (isEmpty()) {
-      throw new IllegalStateException("Empty cluster.");
-    }
-
-    List<String> duplicates = stripe.getNodes().stream()
-        .map(Node::getNodeAddress)
-        .filter(this::containsNode)
-        .map(InetSocketAddress::toString)
-        .collect(toList());
-    if (!duplicates.isEmpty()) {
-      throw new IllegalArgumentException("Nodes are already in the cluster: " + String.join(", ", duplicates) + ".");
-    }
-
-    Node aNode = stripes.iterator().next().getNodes().iterator().next();
-    Stripe newStripe = stripe.cloneForAttachment(aNode);
-    stripes.add(newStripe);
-
-    return this;
-  }
-
-  public boolean detachStripe(Stripe stripe) {
+  public boolean removeStripe(Stripe stripe) {
     return stripes.remove(stripe);
   }
 
-  public boolean detachNode(InetSocketAddress address) {
-    boolean detached = stripes.stream().anyMatch(stripe -> stripe.detachNode(address));
+  public boolean removeNode(InetSocketAddress address) {
+    boolean detached = stripes.stream().anyMatch(stripe -> stripe.removeNode(address));
     if (detached) {
       stripes.removeIf(Stripe::isEmpty);
     }

--- a/dynamic-config/model/src/main/java/org/terracotta/dynamic_config/api/model/Node.java
+++ b/dynamic-config/model/src/main/java/org/terracotta/dynamic_config/api/model/Node.java
@@ -25,8 +25,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Properties;
-import java.util.Set;
-import java.util.TreeSet;
 import java.util.concurrent.ConcurrentHashMap;
 
 import static org.terracotta.dynamic_config.api.model.Scope.NODE;
@@ -352,38 +350,6 @@ public class Node implements Cloneable, PropertyHolder {
         ", securityAuditLogDir='" + securityAuditLogDir + '\'' +
         ", dataDirs=" + dataDirs +
         '}';
-  }
-
-  public Node cloneForAttachment(Node aNodeFromTargetCluster) {
-    // validate security folder
-    if (aNodeFromTargetCluster.getSecurityDir() != null && securityDir == null) {
-      throw new IllegalArgumentException("Node " + getNodeAddress() + " must be started with a security directory.");
-    }
-
-    // Validate the user data directories.
-    // We validate that the node we want to attach has EXACTLY the same user data directories ID as the destination cluster.
-    Set<String> requiredDataDirs = new TreeSet<>(aNodeFromTargetCluster.getDataDirs().keySet());
-    Set<String> dataDirs = new TreeSet<>(this.dataDirs.keySet());
-    if (!dataDirs.containsAll(requiredDataDirs)) {
-      // case where the attached node would not have all the required IDs
-      requiredDataDirs.removeAll(dataDirs);
-      throw new IllegalArgumentException("Node " + getNodeAddress() + " must declare the following data directories: " + String.join(", ", requiredDataDirs) + ".");
-    }
-    if (dataDirs.size() > requiredDataDirs.size()) {
-      // case where the attached node would have more than the required IDs
-      dataDirs.removeAll(requiredDataDirs);
-      throw new IllegalArgumentException("Node " + getNodeAddress() + " must not declare the following data directories: " + String.join(", ", dataDirs) + ".");
-    }
-
-    // create a copy of the node
-    Node thisCopy = clone();
-
-    if (aNodeFromTargetCluster.getSecurityDir() == null && securityDir != null) {
-      // node was started with a security directory but destination cluster is not secured so we do not need one
-      thisCopy.setSecurityDir(null);
-    }
-
-    return thisCopy;
   }
 
   /**

--- a/dynamic-config/model/src/main/java/org/terracotta/dynamic_config/api/model/NodeContext.java
+++ b/dynamic-config/model/src/main/java/org/terracotta/dynamic_config/api/model/NodeContext.java
@@ -165,7 +165,7 @@ public class NodeContext implements Cloneable {
    */
   public NodeContext withOnlyNode(Node node) {
     Cluster cluster = getCluster().clone().removeStripes();
-    cluster.addStripe(new Stripe(node));
+    cluster.addStripe(new Stripe(node).clone());
     return new NodeContext(cluster, node.getNodeAddress());
   }
 }

--- a/dynamic-config/model/src/main/java/org/terracotta/dynamic_config/api/model/Stripe.java
+++ b/dynamic-config/model/src/main/java/org/terracotta/dynamic_config/api/model/Stripe.java
@@ -107,9 +107,7 @@ public class Stripe implements Cloneable, PropertyHolder {
     return new Stripe(nodes.stream().map(Node::clone).collect(toList()));
   }
 
-  // please keep this package-local:
-  // detachment of a node should be handled by cluster object
-  boolean detachNode(InetSocketAddress address) {
+  public boolean removeNode(InetSocketAddress address) {
     return nodes.removeIf(node -> node.hasAddress(address));
   }
 
@@ -117,41 +115,9 @@ public class Stripe implements Cloneable, PropertyHolder {
     return nodes.isEmpty();
   }
 
-  /**
-   * Attach a node to this stripe.
-   * <p>
-   * The node parameters are expected to be validated before.
-   * <p>
-   * Also, we cannot attach a node to an empty stripe: this is impossible since
-   * attachment needs a source and destination node, which belongs to a non-empty stripe
-   */
-  public Stripe attachNode(Node source) {
-    if (containsNode(source.getNodeAddress())) {
-      throw new IllegalArgumentException("Node " + source.getNodeAddress() + " is already in the stripe.");
-    }
-    if (isEmpty()) {
-      throw new IllegalStateException("Empty stripe.");
-    }
-    Node aNode = nodes.iterator().next();
-    Node newNode = source.cloneForAttachment(aNode);
-    addNode(newNode);
-    return this;
-  }
-
   public Stripe addNode(Node source) {
     nodes.add(source);
     return this;
-  }
-
-  public Stripe cloneForAttachment(Node aNodeFromTargetCluster) {
-    return nodes.stream()
-        .map(node -> node.cloneForAttachment(aNodeFromTargetCluster))
-        .reduce(
-            new Stripe(),
-            Stripe::addNode,
-            (s1, s2) -> {
-              throw new UnsupportedOperationException();
-            });
   }
 
   public int getNodeCount() {

--- a/dynamic-config/model/src/test/java/org/terracotta/dynamic_config/api/model/NodeTest.java
+++ b/dynamic-config/model/src/test/java/org/terracotta/dynamic_config/api/model/NodeTest.java
@@ -48,19 +48,6 @@ public class NodeTest {
       .setSecurityAuditLogDir(Paths.get("audit"))
       .setSecurityDir(Paths.get("sec"));
 
-  Node node1 = Node.newDefaultNode("node1", "localhost", 9410)
-      .setDataDir("data", Paths.get("data"))
-      .setNodeBackupDir(Paths.get("backup"))
-      .setNodeBindAddress("0.0.0.0")
-      .setNodeGroupBindAddress("0.0.0.0")
-      .setNodeGroupPort(9430)
-      .setNodeLogDir(Paths.get("log"))
-      .setNodeMetadataDir(Paths.get("metadata"))
-      .setSecurityAuditLogDir(Paths.get("audit"));
-
-  Node node2 = Node.newDefaultNode("node2", "localhost", 9411)
-      .setDataDir("data", Paths.get("/data/cache2"));
-
   Node node3 = Node.newDefaultNode("node3", "localhost", 9410)
       .setNodeGroupPort(9430)
       .setNodeBindAddress("0.0.0.0")
@@ -150,38 +137,5 @@ public class NodeTest {
             .setNodePublicHostname("foo").setNodePublicPort(1234)
             .hasAddress(InetSocketAddress.createUnresolved("foo", 1234)),
         is(true));
-  }
-
-  @Test
-  public void test_cloneForAttachment() {
-    // attaching a non-secured node to secured nodes
-    node1.setSecurityDir(Paths.get("sec"));
-    assertThat(
-        () -> node2.cloneForAttachment(node1),
-        is(throwing(instanceOf(IllegalArgumentException.class)).andMessage(is(equalTo("Node localhost:9411 must be started with a security directory.")))));
-
-    // attaching a secured node to a non-secured nodes
-    node1.setSecurityDir(null);
-    node2.setSecurityDir(Paths.get("sec"));
-    Node clone = node2.cloneForAttachment(node1);
-    assertThat(clone.getSecurityDir(), is(nullValue()));
-
-    node1.setDataDir("other", Paths.get("other"));
-    assertThat(
-        () -> node2.cloneForAttachment(node1),
-        is(throwing(instanceOf(IllegalArgumentException.class)).andMessage(is(equalTo("Node localhost:9411 must declare the following data directories: other.")))));
-    node1.removeDataDir("other");
-
-    node2.setDataDir("other", Paths.get("other"));
-    assertThat(
-        () -> node2.cloneForAttachment(node1),
-        is(throwing(instanceOf(IllegalArgumentException.class)).andMessage(is(equalTo("Node localhost:9411 must not declare the following data directories: other.")))));
-    node2.removeDataDir("other");
-
-    // attaching
-    node1.setSecurityDir(null);
-    node2.setSecurityDir(Paths.get("Sec2"));
-    clone = node2.cloneForAttachment(node1);
-    assertThat(clone.getSecurityDir(), is(equalTo(null)));
   }
 }

--- a/dynamic-config/server/configuration-provider/src/test/java/org/terracotta/dynamic_config/server/configuration/startup/CommandLineProcessorChainTest.java
+++ b/dynamic-config/server/configuration-provider/src/test/java/org/terracotta/dynamic_config/server/configuration/startup/CommandLineProcessorChainTest.java
@@ -218,7 +218,7 @@ public class CommandLineProcessorChainTest {
     when(clusterCreator.create(Paths.get(CONFIG_FILE))).thenReturn(cluster);
     when(parameterSubstitutor.substitute(CONFIG_FILE)).thenReturn(CONFIG_FILE);
     when(configurationGeneratorVisitor.getMatchingNodeFromConfigFileUsingHostPort(HOST_NAME, NODE_PORT, CONFIG_FILE, cluster)).thenReturn(node1);
-    cluster.getSingleStripe().get().attachNode(node2);
+    cluster.getSingleStripe().get().addNode(node2);
 
     mainCommandLineProcessor.process();
 
@@ -236,7 +236,7 @@ public class CommandLineProcessorChainTest {
     when(clusterCreator.create(Paths.get(CONFIG_FILE))).thenReturn(cluster);
     when(parameterSubstitutor.substitute(CONFIG_FILE)).thenReturn(CONFIG_FILE);
     when(configurationGeneratorVisitor.getMatchingNodeFromConfigFileUsingNodeName(NODE_NAME, CONFIG_FILE, cluster)).thenReturn(node1);
-    cluster.getSingleStripe().get().attachNode(node2);
+    cluster.getSingleStripe().get().addNode(node2);
 
     mainCommandLineProcessor.process();
 


### PR DESCRIPTION
cleaning up now useless attach/detach methods on the model since cluster wide parameters are in the cluster object and ClusterValidator is responsible to do the validation