### PR TITLE
TDB-5045: Prevent any Nomad transaction to happen if not all the append.log ends with the same change UUID

### DIFF
--- a/common/nomad/src/main/java/org/terracotta/nomad/client/BaseNomadDecider.java
+++ b/common/nomad/src/main/java/org/terracotta/nomad/client/BaseNomadDecider.java
@@ -21,6 +21,7 @@ import org.terracotta.nomad.server.NomadServerMode;
 
 import java.net.InetSocketAddress;
 import java.util.Collection;
+import java.util.Map;
 import java.util.UUID;
 
 import static org.terracotta.nomad.client.Consistency.CONSISTENT;
@@ -32,6 +33,7 @@ import static org.terracotta.nomad.server.NomadServerMode.PREPARED;
 public abstract class BaseNomadDecider<T> implements NomadDecider<T>, AllResultsReceiver<T> {
   private volatile boolean discoverFail;
   private volatile boolean discoveryInconsistentCluster;
+  private volatile boolean discoveryDesynchronizedCluster;
   private volatile boolean preparedServer;
   private volatile boolean prepareFail;
   private volatile boolean takeoverFail;
@@ -60,6 +62,10 @@ public abstract class BaseNomadDecider<T> implements NomadDecider<T>, AllResults
   @Override
   public Consistency getConsistency() {
     if (discoveryInconsistentCluster) {
+      return UNRECOVERABLY_INCONSISTENT;
+    }
+
+    if (discoveryDesynchronizedCluster) {
       return UNRECOVERABLY_INCONSISTENT;
     }
 
@@ -95,6 +101,12 @@ public abstract class BaseNomadDecider<T> implements NomadDecider<T>, AllResults
   public void discoverClusterInconsistent(UUID changeUuid, Collection<InetSocketAddress> committedServers, Collection<InetSocketAddress> rolledBackServers) {
     discoverFail = true;
     discoveryInconsistentCluster = true;
+  }
+
+  @Override
+  public void discoverClusterDesynchronized(Map<UUID, Collection<InetSocketAddress>> lastChangeUuids) {
+    discoverFail = true;
+    discoveryDesynchronizedCluster = true;
   }
 
   @Override

--- a/common/nomad/src/main/java/org/terracotta/nomad/client/change/ChangeAllResultsReceiverAdapter.java
+++ b/common/nomad/src/main/java/org/terracotta/nomad/client/change/ChangeAllResultsReceiverAdapter.java
@@ -21,6 +21,7 @@ import org.terracotta.nomad.messages.DiscoverResponse;
 
 import java.net.InetSocketAddress;
 import java.util.Collection;
+import java.util.Map;
 import java.util.UUID;
 
 public class ChangeAllResultsReceiverAdapter<T> implements AllResultsReceiver<T> {
@@ -48,6 +49,11 @@ public class ChangeAllResultsReceiverAdapter<T> implements AllResultsReceiver<T>
   @Override
   public void discoverClusterInconsistent(UUID changeUuid, Collection<InetSocketAddress> committedServers, Collection<InetSocketAddress> rolledBackServers) {
     changeResultReceiver.discoverClusterInconsistent(changeUuid, committedServers, rolledBackServers);
+  }
+
+  @Override
+  public void discoverClusterDesynchronized(Map<UUID, Collection<InetSocketAddress>> lastChangeUuids) {
+    changeResultReceiver.discoverClusterDesynchronized(lastChangeUuids);
   }
 
   @Override

--- a/common/nomad/src/main/java/org/terracotta/nomad/client/recovery/RecoveryAllResultsReceiverAdapter.java
+++ b/common/nomad/src/main/java/org/terracotta/nomad/client/recovery/RecoveryAllResultsReceiverAdapter.java
@@ -21,6 +21,7 @@ import org.terracotta.nomad.messages.DiscoverResponse;
 
 import java.net.InetSocketAddress;
 import java.util.Collection;
+import java.util.Map;
 import java.util.UUID;
 
 public class RecoveryAllResultsReceiverAdapter<T> implements AllResultsReceiver<T> {
@@ -48,6 +49,11 @@ public class RecoveryAllResultsReceiverAdapter<T> implements AllResultsReceiver<
   @Override
   public void discoverClusterInconsistent(UUID changeUuid, Collection<InetSocketAddress> committedServers, Collection<InetSocketAddress> rolledBackServers) {
     recoveryResultReceiver.discoverClusterInconsistent(changeUuid, committedServers, rolledBackServers);
+  }
+
+  @Override
+  public void discoverClusterDesynchronized(Map<UUID, Collection<InetSocketAddress>> lastChangeUuids) {
+    recoveryResultReceiver.discoverClusterDesynchronized(lastChangeUuids);
   }
 
   @Override

--- a/common/nomad/src/main/java/org/terracotta/nomad/client/results/DiscoverResultsReceiver.java
+++ b/common/nomad/src/main/java/org/terracotta/nomad/client/results/DiscoverResultsReceiver.java
@@ -19,6 +19,7 @@ import org.terracotta.nomad.messages.DiscoverResponse;
 
 import java.net.InetSocketAddress;
 import java.util.Collection;
+import java.util.Map;
 import java.util.UUID;
 
 public interface DiscoverResultsReceiver<T> extends WrapUpResultsReceiver {
@@ -29,6 +30,8 @@ public interface DiscoverResultsReceiver<T> extends WrapUpResultsReceiver {
   default void discoverFail(InetSocketAddress endpoint, String reason) {}
 
   default void discoverClusterInconsistent(UUID changeUuid, Collection<InetSocketAddress> committedServers, Collection<InetSocketAddress> rolledBackServers) {}
+
+  default void discoverClusterDesynchronized(Map<UUID, Collection<InetSocketAddress>> lastChangeUuids) {}
 
   default void endDiscovery() {}
 

--- a/common/nomad/src/main/java/org/terracotta/nomad/client/results/LoggingResultReceiver.java
+++ b/common/nomad/src/main/java/org/terracotta/nomad/client/results/LoggingResultReceiver.java
@@ -24,6 +24,7 @@ import org.terracotta.nomad.messages.DiscoverResponse;
 
 import java.net.InetSocketAddress;
 import java.util.Collection;
+import java.util.Map;
 import java.util.UUID;
 
 public class LoggingResultReceiver<T> implements ChangeResultReceiver<T>, RecoveryResultReceiver<T> {
@@ -77,6 +78,11 @@ public class LoggingResultReceiver<T> implements ChangeResultReceiver<T>, Recove
   @Override
   public void discoverClusterInconsistent(UUID changeUuid, Collection<InetSocketAddress> committedServers, Collection<InetSocketAddress> rolledBackServers) {
     error("UNRECOVERABLE: Inconsistent cluster for change: " + changeUuid + ". Committed on: " + committedServers + "; rolled back on: " + rolledBackServers);
+  }
+
+  @Override
+  public void discoverClusterDesynchronized(Map<UUID, Collection<InetSocketAddress>> lastChangeUuids) {
+    error("UNRECOVERABLE: Desynchronized cluster for last changes: " + lastChangeUuids);
   }
 
   @Override

--- a/common/nomad/src/main/java/org/terracotta/nomad/client/results/MultiChangeResultReceiver.java
+++ b/common/nomad/src/main/java/org/terracotta/nomad/client/results/MultiChangeResultReceiver.java
@@ -21,6 +21,7 @@ import org.terracotta.nomad.messages.DiscoverResponse;
 
 import java.net.InetSocketAddress;
 import java.util.Collection;
+import java.util.Map;
 import java.util.UUID;
 
 /**
@@ -59,6 +60,13 @@ public class MultiChangeResultReceiver<T> implements ChangeResultReceiver<T> {
   public void discoverClusterInconsistent(UUID changeUuid, Collection<InetSocketAddress> committedServers, Collection<InetSocketAddress> rolledBackServers) {
     for (ChangeResultReceiver<T> changeResultReceiver : changeResultReceivers) {
       changeResultReceiver.discoverClusterInconsistent(changeUuid, committedServers, rolledBackServers);
+    }
+  }
+
+  @Override
+  public void discoverClusterDesynchronized(Map<UUID, Collection<InetSocketAddress>> lastChangeUuids) {
+    for (ChangeResultReceiver<T> changeResultReceiver : changeResultReceivers) {
+      changeResultReceiver.discoverClusterDesynchronized(lastChangeUuids);
     }
   }
 

--- a/common/nomad/src/main/java/org/terracotta/nomad/client/results/MultiRecoveryResultReceiver.java
+++ b/common/nomad/src/main/java/org/terracotta/nomad/client/results/MultiRecoveryResultReceiver.java
@@ -21,6 +21,7 @@ import org.terracotta.nomad.messages.DiscoverResponse;
 
 import java.net.InetSocketAddress;
 import java.util.Collection;
+import java.util.Map;
 import java.util.UUID;
 
 /**
@@ -94,6 +95,13 @@ public class MultiRecoveryResultReceiver<T> implements RecoveryResultReceiver<T>
   public void discoverClusterInconsistent(UUID changeUuid, Collection<InetSocketAddress> committedServers, Collection<InetSocketAddress> rolledBackServers) {
     for (RecoveryResultReceiver<T> recoveryResultReceiver : recoveryResultReceivers) {
       recoveryResultReceiver.discoverClusterInconsistent(changeUuid, committedServers, rolledBackServers);
+    }
+  }
+
+  @Override
+  public void discoverClusterDesynchronized(Map<UUID, Collection<InetSocketAddress>> lastChangeUuids) {
+    for (RecoveryResultReceiver<T> recoveryResultReceiver : recoveryResultReceivers) {
+      recoveryResultReceiver.discoverClusterDesynchronized(lastChangeUuids);
     }
   }
 

--- a/common/nomad/src/main/java/org/terracotta/nomad/client/results/MuxAllResultsReceiver.java
+++ b/common/nomad/src/main/java/org/terracotta/nomad/client/results/MuxAllResultsReceiver.java
@@ -21,6 +21,7 @@ import org.terracotta.nomad.messages.DiscoverResponse;
 import java.net.InetSocketAddress;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 public class MuxAllResultsReceiver<T> implements AllResultsReceiver<T> {
@@ -62,6 +63,13 @@ public class MuxAllResultsReceiver<T> implements AllResultsReceiver<T> {
   public void discoverClusterInconsistent(UUID changeUuid, Collection<InetSocketAddress> committedServers, Collection<InetSocketAddress> rolledBackServers) {
     for (AllResultsReceiver<T> receiver : receivers) {
       receiver.discoverClusterInconsistent(changeUuid, committedServers, rolledBackServers);
+    }
+  }
+
+  @Override
+  public void discoverClusterDesynchronized(Map<UUID, Collection<InetSocketAddress>> lastChangeUuids) {
+    for (AllResultsReceiver<T> receiver : receivers) {
+      receiver.discoverClusterDesynchronized(lastChangeUuids);
     }
   }
 

--- a/common/nomad/src/main/java/org/terracotta/nomad/client/status/DiscoveryAllResultsReceiverAdapter.java
+++ b/common/nomad/src/main/java/org/terracotta/nomad/client/status/DiscoveryAllResultsReceiverAdapter.java
@@ -22,6 +22,7 @@ import org.terracotta.nomad.messages.DiscoverResponse;
 
 import java.net.InetSocketAddress;
 import java.util.Collection;
+import java.util.Map;
 import java.util.UUID;
 
 /**
@@ -62,6 +63,11 @@ public class DiscoveryAllResultsReceiverAdapter<T> implements AllResultsReceiver
   @Override
   public void discoverClusterInconsistent(UUID changeUuid, Collection<InetSocketAddress> committedServers, Collection<InetSocketAddress> rolledBackServers) {
     receiver.discoverClusterInconsistent(changeUuid, committedServers, rolledBackServers);
+  }
+
+  @Override
+  public void discoverClusterDesynchronized(Map<UUID, Collection<InetSocketAddress>> lastChangeUuids) {
+    receiver.discoverClusterDesynchronized(lastChangeUuids);
   }
 
   @Override

--- a/common/nomad/src/main/java/org/terracotta/nomad/client/status/MultiDiscoveryResultReceiver.java
+++ b/common/nomad/src/main/java/org/terracotta/nomad/client/status/MultiDiscoveryResultReceiver.java
@@ -20,6 +20,7 @@ import org.terracotta.nomad.messages.DiscoverResponse;
 
 import java.net.InetSocketAddress;
 import java.util.Collection;
+import java.util.Map;
 import java.util.UUID;
 
 /**
@@ -58,6 +59,13 @@ public class MultiDiscoveryResultReceiver<T> implements DiscoverResultsReceiver<
   public void discoverClusterInconsistent(UUID changeUuid, Collection<InetSocketAddress> committedServers, Collection<InetSocketAddress> rolledBackServers) {
     for (DiscoverResultsReceiver<T> receiver : receivers) {
       receiver.discoverClusterInconsistent(changeUuid, committedServers, rolledBackServers);
+    }
+  }
+
+  @Override
+  public void discoverClusterDesynchronized(Map<UUID, Collection<InetSocketAddress>> lastChangeUuids) {
+    for (DiscoverResultsReceiver<T> receiver : receivers) {
+      receiver.discoverClusterDesynchronized(lastChangeUuids);
     }
   }
 

--- a/common/nomad/src/test/java/org/terracotta/nomad/client/ClusterConsistencyCheckerTest.java
+++ b/common/nomad/src/test/java/org/terracotta/nomad/client/ClusterConsistencyCheckerTest.java
@@ -25,6 +25,7 @@ import org.terracotta.nomad.client.results.DiscoverResultsReceiver;
 import java.net.InetSocketAddress;
 import java.util.UUID;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -35,6 +36,10 @@ import static org.terracotta.nomad.server.ChangeRequestState.ROLLED_BACK;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ClusterConsistencyCheckerTest {
+
+  UUID uuid1 = UUID.randomUUID();
+  UUID uuid2 = UUID.randomUUID();
+
   @Mock
   private DiscoverResultsReceiver<String> results;
 
@@ -86,10 +91,22 @@ public class ClusterConsistencyCheckerTest {
 
   @Test
   public void differentUuids() {
-    consistencyChecker.discovered(address1, discovery(COMMITTED));
-    consistencyChecker.discovered(address2, discovery(ROLLED_BACK));
+    consistencyChecker.discovered(address1, discovery(COMMITTED, uuid1));
+    consistencyChecker.discovered(address2, discovery(ROLLED_BACK, uuid2));
 
     consistencyChecker.checkClusterConsistency(results);
+
+    verify(results).discoverClusterDesynchronized(any());
+  }
+
+  @Test
+  public void differentCommittedUuids() {
+    consistencyChecker.discovered(address1, discovery(COMMITTED, UUID.randomUUID()));
+    consistencyChecker.discovered(address2, discovery(COMMITTED, UUID.randomUUID()));
+
+    consistencyChecker.checkClusterConsistency(results);
+
+    verify(results).discoverClusterDesynchronized(any());
   }
 
   @Test

--- a/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/command/DiagnosticCommand.java
+++ b/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/command/DiagnosticCommand.java
@@ -232,6 +232,9 @@ public class DiagnosticCommand extends RemoteCommand {
             + " is committed on " + toString(consistencyAnalyzer.getCommittedNodes())
             + " and rolled back on " + toString(consistencyAnalyzer.getRolledBackNodes());
 
+      case DESYNCHRONIZED:
+        return "Cluster configuration is desynchronized: Different last changes UUIDs found: " + consistencyAnalyzer.getLastChangeUuids().keySet();
+
       case PREPARED:
         return "A new  cluster configuration has been prepared but not yet committed or rolled back on all nodes."
             + " No further configuration change can be done until the 'repair' command is run to finalize the configuration change.";

--- a/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/command/RepairCommand.java
+++ b/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/command/RepairCommand.java
@@ -100,6 +100,11 @@ public class RepairCommand extends RemoteCommand {
             + " and rolled back on " + toString(consistencyAnalyzer.getRolledBackNodes()));
         break;
 
+      case DESYNCHRONIZED:
+        //TODO [DYNAMIC-CONFIG]: TDB-4822 - enhance repair command to force a rollback to a checkpoint ?
+        logger.error("Cluster configuration is desynchronized and cannot be automatically repaired. Nodes are not ending with the same change UUIDs. Details: " + consistencyAnalyzer.getLastChangeUuids());
+        break;
+
       // normal repair cases
       case PREPARED:
       case MAYBE_PREPARED:

--- a/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/nomad/ConsistencyAnalyzer.java
+++ b/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/nomad/ConsistencyAnalyzer.java
@@ -42,6 +42,7 @@ import static org.terracotta.diagnostic.model.LogicalServerState.UNKNOWN;
 import static org.terracotta.diagnostic.model.LogicalServerState.UNREACHABLE;
 import static org.terracotta.dynamic_config.cli.config_tool.nomad.ConsistencyAnalyzer.GlobalState.ACCEPTING;
 import static org.terracotta.dynamic_config.cli.config_tool.nomad.ConsistencyAnalyzer.GlobalState.CONCURRENT_ACCESS;
+import static org.terracotta.dynamic_config.cli.config_tool.nomad.ConsistencyAnalyzer.GlobalState.DESYNCHRONIZED;
 import static org.terracotta.dynamic_config.cli.config_tool.nomad.ConsistencyAnalyzer.GlobalState.DISCOVERY_FAILURE;
 import static org.terracotta.dynamic_config.cli.config_tool.nomad.ConsistencyAnalyzer.GlobalState.INCONSISTENT;
 import static org.terracotta.dynamic_config.cli.config_tool.nomad.ConsistencyAnalyzer.GlobalState.MAYBE_PARTIALLY_COMMITTED;
@@ -66,6 +67,7 @@ public class ConsistencyAnalyzer<T> implements DiscoverResultsReceiver<T> {
     PREPARED,
 
     INCONSISTENT,
+    DESYNCHRONIZED,
     CONCURRENT_ACCESS,
     DISCOVERY_FAILURE,
 
@@ -90,6 +92,9 @@ public class ConsistencyAnalyzer<T> implements DiscoverResultsReceiver<T> {
   private volatile UUID inconsistentChangeUuid;
   private volatile Collection<InetSocketAddress> committedNodes;
   private volatile Collection<InetSocketAddress> rolledBackNodes;
+
+  private volatile boolean discoveredDesynchronizedCluster;
+  private volatile Map<UUID, Collection<InetSocketAddress>> lastChangeUuids;
 
   private volatile InetSocketAddress nodeProcessingOtherClient;
   private volatile String otherClientHost;
@@ -116,6 +121,12 @@ public class ConsistencyAnalyzer<T> implements DiscoverResultsReceiver<T> {
     this.committedNodes = committedNodes;
     this.rolledBackNodes = rolledBackNodes;
     this.discoveredInconsistentCluster = true;
+  }
+
+  @Override
+  public void discoverClusterDesynchronized(Map<UUID, Collection<InetSocketAddress>> lastChangeUuids) {
+    this.discoveredDesynchronizedCluster = true;
+    this.lastChangeUuids = lastChangeUuids;
   }
 
   @Override
@@ -158,6 +169,10 @@ public class ConsistencyAnalyzer<T> implements DiscoverResultsReceiver<T> {
 
   public Collection<InetSocketAddress> getRolledBackNodes() {
     return rolledBackNodes;
+  }
+
+  public Map<UUID, Collection<InetSocketAddress>> getLastChangeUuids() {
+    return lastChangeUuids;
   }
 
   // discoverOtherClient
@@ -256,6 +271,10 @@ public class ConsistencyAnalyzer<T> implements DiscoverResultsReceiver<T> {
       return INCONSISTENT;
     }
 
+    if (discoveredDesynchronizedCluster) {
+      return DESYNCHRONIZED;
+    }
+
     if (discoveredOtherClient) {
       return CONCURRENT_ACCESS;
     }
@@ -300,6 +319,11 @@ public class ConsistencyAnalyzer<T> implements DiscoverResultsReceiver<T> {
     if (uuids > 1 && prepared > 0) {
       // partially prepared change
       return PARTIALLY_PREPARED;
+    }
+
+    if (uuids > 1) {
+      // desynchronized config
+      return DESYNCHRONIZED;
     }
 
     if (uuids == 1 && rolledBack == 0 && committed > 0 && prepared > 0 && (prepared + committed >= nodeCount)) {

--- a/dynamic-config/cli/config-tool/src/test/java/org/terracotta/dynamic_config/cli/config_tool/NomadTestHelper.java
+++ b/dynamic-config/cli/config-tool/src/test/java/org/terracotta/dynamic_config/cli/config_tool/NomadTestHelper.java
@@ -36,6 +36,10 @@ public class NomadTestHelper {
     return discovery(changeState, mutativeMessageCount, UUID.randomUUID());
   }
 
+  public static DiscoverResponse<String> discovery(ChangeRequestState changeState, UUID lastChangeUUID) {
+    return discovery(changeState, 1L, lastChangeUUID);
+  }
+
   public static DiscoverResponse<String> discovery(ChangeRequestState changeState, long mutativeMessageCount, UUID uuid) {
     return new DiscoverResponse<>(
         changeState == PREPARED ? NomadServerMode.PREPARED : NomadServerMode.ACCEPTING,

--- a/dynamic-config/cli/config-tool/src/test/java/org/terracotta/dynamic_config/cli/config_tool/command/ActivateCommandTest.java
+++ b/dynamic-config/cli/config-tool/src/test/java/org/terracotta/dynamic_config/cli/config_tool/command/ActivateCommandTest.java
@@ -36,6 +36,7 @@ import org.terracotta.nomad.server.NomadServer;
 import java.net.InetSocketAddress;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.UUID;
 import java.util.function.IntConsumer;
 import java.util.stream.IntStream;
 
@@ -168,11 +169,13 @@ public class ActivateCommandTest extends BaseTest {
     ActivateCommand command = command()
         .setConfigPropertiesFile(config);
 
+    UUID lastChangeUUID = UUID.randomUUID();
+
     IntStream.of(ports).forEach(rethrow(port -> {
       when(topologyServiceMock("localhost", port).isActivated()).thenReturn(false);
 
       NomadServer<NodeContext> mock = nomadServerMock("localhost", port);
-      doReturn(NomadTestHelper.discovery(COMMITTED)).when(mock).discover();
+      doReturn(NomadTestHelper.discovery(COMMITTED, lastChangeUUID)).when(mock).discover();
       when(mock.prepare(any(PrepareMessage.class))).thenReturn(reject(UNACCEPTABLE, "error", "host", "user"));
       when(mock.rollback(any(RollbackMessage.class))).thenReturn(accept());
     }));
@@ -206,11 +209,13 @@ public class ActivateCommandTest extends BaseTest {
     ActivateCommand command = command()
         .setConfigPropertiesFile(config);
 
+    UUID lastChangeUUID = UUID.randomUUID();
+
     IntStream.of(ports).forEach(rethrow(port -> {
       when(topologyServiceMock("localhost", port).isActivated()).thenReturn(false);
 
       NomadServer<NodeContext> mock = nomadServerMock("localhost", port);
-      doReturn(NomadTestHelper.discovery(COMMITTED)).when(mock).discover();
+      doReturn(NomadTestHelper.discovery(COMMITTED, lastChangeUUID)).when(mock).discover();
       when(mock.prepare(any(PrepareMessage.class))).thenReturn(accept());
       when(mock.commit(any(CommitMessage.class))).thenThrow(new NomadException("an error"));
     }));
@@ -263,13 +268,15 @@ public class ActivateCommandTest extends BaseTest {
   }
 
   private void doRunAndVerify(String clusterName, ActivateCommand command) {
+    UUID lastChangeUUID = UUID.randomUUID();
+
     IntStream.of(ports).forEach(rethrow(port -> {
       TopologyService topologyService = topologyServiceMock("localhost", port);
       NomadServer<NodeContext> mock = nomadServerMock("localhost", port);
       DiagnosticService diagnosticService = diagnosticServiceMock("localhost", port);
 
       when(topologyService.isActivated()).thenReturn(false);
-      doReturn(NomadTestHelper.discovery(COMMITTED)).when(mock).discover();
+      doReturn(NomadTestHelper.discovery(COMMITTED, lastChangeUUID)).when(mock).discover();
       when(mock.prepare(any(PrepareMessage.class))).thenReturn(accept());
       when(mock.commit(any(CommitMessage.class))).thenReturn(accept());
       when(diagnosticService.getLogicalServerState()).thenReturn(PASSIVE);


### PR DESCRIPTION
Fix a bug found by @rahul-mittal when adding a new stripe without syncing the append.log yet: it is possible to trigger a nomad change and it won't fail, even if the append.log history (and last change uuids) differ.

- [X] fail discovery through consistency checker
- [X] update consistency analizer
- [X] support in diagnostic command
- [X] update unit tests
- [X] add system test