### PR TITLE
[URG] Node addition and removal should call the mBean with the node internal address, not the public address

### DIFF
--- a/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/command/AttachCommand.java
+++ b/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/command/AttachCommand.java
@@ -196,8 +196,10 @@ public class AttachCommand extends TopologyCommand {
     switch (operationType) {
       case NODE:
         activateNodes(newOnlineNodes.keySet(), result, null, restartDelay, restartWaitTime);
+        break;
       case STRIPE:
         activateStripe(newOnlineNodes.keySet(), result, destination, restartDelay, restartWaitTime);
+        break;
       default:
         throw new UnsupportedOperationException(operationType.name());
     }

--- a/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/service/nomad/processor/NodeAdditionNomadChangeProcessor.java
+++ b/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/service/nomad/processor/NodeAdditionNomadChangeProcessor.java
@@ -78,7 +78,7 @@ public class NodeAdditionNomadChangeProcessor implements NomadChangeProcessor<No
       mbeanServer.invoke(
           TOPOLOGY_MBEAN,
           PLATFORM_MBEAN_OPERATION_NAME,
-          new Object[]{change.getNodeAddress().toString()},
+          new Object[]{change.getNode().getInternalAddress().toString()},
           new String[]{String.class.getName()}
       );
 

--- a/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/service/nomad/processor/NodeRemovalNomadChangeProcessor.java
+++ b/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/service/nomad/processor/NodeRemovalNomadChangeProcessor.java
@@ -78,7 +78,7 @@ public class NodeRemovalNomadChangeProcessor implements NomadChangeProcessor<Nod
       mbeanServer.invoke(
           TOPOLOGY_MBEAN,
           PLATFORM_MBEAN_OPERATION_NAME,
-          new Object[]{change.getNodeAddress().toString()},
+          new Object[]{change.getNode().getInternalAddress().toString()},
           new String[]{String.class.getName()}
       );
 


### PR DESCRIPTION
Note: this is not a fix for TDB-5050.

Whatever solution is chosen to fix TDB-5050, we have to use the node internal addresses, not the public ones.