### PR TITLE
Add support for locking/unlocking dynamic config

### DIFF
--- a/common/structures/src/main/java/org/terracotta/common/struct/LockContext.java
+++ b/common/structures/src/main/java/org/terracotta/common/struct/LockContext.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.common.struct;
+
+import java.util.Objects;
+
+public class LockContext {
+  private static final String DELIMITER = ";";
+
+  private final String token;
+  private final String ownerName;
+  private final String ownerTags;
+
+  public LockContext(String token, String ownerName, String ownerTags) {
+    this.token = token;
+    this.ownerName = ownerName;
+    this.ownerTags = ownerTags;
+  }
+
+  public String getToken() {
+    return token;
+  }
+
+  public String getOwnerName() {
+    return ownerName;
+  }
+
+  public String getOwnerTags() {
+    return ownerTags;
+  }
+
+  public static LockContext from(String contextStr) {
+    String[] substrings = contextStr.split(DELIMITER);
+
+    return new LockContext(substrings[0], substrings[1], substrings[2]);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    final LockContext that = (LockContext)o;
+    return Objects.equals(token, that.token) &&
+           Objects.equals(ownerName, that.ownerName) &&
+           Objects.equals(ownerTags, that.ownerTags);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(token, ownerName, ownerTags);
+  }
+
+  public String toString() {
+    return String.format("%s%s%s%s%s", token, DELIMITER, ownerName, DELIMITER, ownerTags);
+  }
+}

--- a/common/structures/src/main/java/org/terracotta/common/struct/json/StructJsonModule.java
+++ b/common/structures/src/main/java/org/terracotta/common/struct/json/StructJsonModule.java
@@ -22,6 +22,8 @@ import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.core.Version;
 import com.fasterxml.jackson.databind.module.SimpleModule;
+
+import org.terracotta.common.struct.LockContext;
 import org.terracotta.common.struct.Measure;
 import org.terracotta.common.struct.MemoryUnit;
 import org.terracotta.common.struct.TimeUnit;
@@ -38,6 +40,16 @@ public class StructJsonModule extends SimpleModule {
   public StructJsonModule() {
     super(StructJsonModule.class.getSimpleName(), new Version(1, 0, 0, null, null, null));
     setMixInAnnotation(Measure.class, MeasureMixin.class);
+    setMixInAnnotation(LockContext.class, LockContextMixin.class);
+  }
+
+  public static abstract class LockContextMixin extends LockContext {
+    @JsonCreator
+    public LockContextMixin(@JsonProperty(value = "token", required = true) String token,
+                            @JsonProperty(value = "ownerName", required = true) String ownerName,
+                            @JsonProperty(value = "ownerTags", required = true) String ownerTags) {
+      super(token, ownerName, ownerTags);
+    }
   }
 
   @SuppressWarnings("unused")

--- a/dynamic-config/api/src/main/java/org/terracotta/dynamic_config/api/json/DynamicConfigApiJsonModule.java
+++ b/dynamic-config/api/src/main/java/org/terracotta/dynamic_config/api/json/DynamicConfigApiJsonModule.java
@@ -33,6 +33,8 @@ import org.terracotta.dynamic_config.api.model.Setting;
 import org.terracotta.dynamic_config.api.model.Stripe;
 import org.terracotta.dynamic_config.api.model.nomad.Applicability;
 import org.terracotta.dynamic_config.api.model.nomad.ClusterActivationNomadChange;
+import org.terracotta.dynamic_config.api.model.nomad.DynamicConfigNomadChange;
+import org.terracotta.dynamic_config.api.model.nomad.LockAwareDynamicConfigNomadChange;
 import org.terracotta.dynamic_config.api.model.nomad.MultiSettingNomadChange;
 import org.terracotta.dynamic_config.api.model.nomad.NodeAdditionNomadChange;
 import org.terracotta.dynamic_config.api.model.nomad.NodeNomadChange;
@@ -66,7 +68,9 @@ public class DynamicConfigApiJsonModule extends SimpleModule {
         new NamedType(NodeRemovalNomadChange.class, "NodeRemovalNomadChange"),
         new NamedType(SettingNomadChange.class, "SettingNomadChange"),
         new NamedType(StripeAdditionNomadChange.class, "StripeAdditionNomadChange"),
-        new NamedType(StripeRemovalNomadChange.class, "StripeRemovalNomadChange"));
+        new NamedType(StripeRemovalNomadChange.class, "StripeRemovalNomadChange"),
+        new NamedType(LockAwareDynamicConfigNomadChange.class, "LockAwareDynamicConfigNomadChange")
+    );
 
     setMixInAnnotation(NodeNomadChange.class, NodeNomadChangeMixin.class);
     setMixInAnnotation(Applicability.class, ApplicabilityMixin.class);
@@ -77,6 +81,7 @@ public class DynamicConfigApiJsonModule extends SimpleModule {
     setMixInAnnotation(SettingNomadChange.class, SettingNomadChangeMixin.class);
     setMixInAnnotation(StripeAdditionNomadChange.class, StripeAdditionNomadChangeMixin.class);
     setMixInAnnotation(StripeRemovalNomadChange.class, StripeRemovalNomadChangeMixin.class);
+    setMixInAnnotation(LockAwareDynamicConfigNomadChange.class, LockAwareDynamicConfigNomadChangeMixIn.class);
   }
 
   @Override
@@ -180,6 +185,14 @@ public class DynamicConfigApiJsonModule extends SimpleModule {
     public StripeRemovalNomadChangeMixin(@JsonProperty(value = "cluster", required = true) Cluster cluster,
                                          @JsonProperty(value = "stripe", required = true) Stripe stripe) {
       super(cluster, stripe);
+    }
+  }
+
+  private static class LockAwareDynamicConfigNomadChangeMixIn extends LockAwareDynamicConfigNomadChange {
+    @JsonCreator
+    public LockAwareDynamicConfigNomadChangeMixIn(@JsonProperty(value = "lockToken", required = true) String lockToken,
+                                                  @JsonProperty(value = "change", required = true) DynamicConfigNomadChange change) {
+      super(lockToken, change);
     }
   }
 }

--- a/dynamic-config/api/src/main/java/org/terracotta/dynamic_config/api/model/nomad/DynamicConfigNomadChange.java
+++ b/dynamic-config/api/src/main/java/org/terracotta/dynamic_config/api/model/nomad/DynamicConfigNomadChange.java
@@ -32,4 +32,8 @@ public interface DynamicConfigNomadChange extends NomadChange {
   Cluster apply(Cluster original);
 
   boolean canApplyAtRuntime(int stripeId, String nodeName);
+
+  default DynamicConfigNomadChange unwrap() {
+    return this;
+  }
 }

--- a/dynamic-config/api/src/main/java/org/terracotta/dynamic_config/api/model/nomad/LockAwareDynamicConfigNomadChange.java
+++ b/dynamic-config/api/src/main/java/org/terracotta/dynamic_config/api/model/nomad/LockAwareDynamicConfigNomadChange.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.dynamic_config.api.model.nomad;
+
+import org.terracotta.dynamic_config.api.model.Cluster;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+public class LockAwareDynamicConfigNomadChange implements DynamicConfigNomadChange {
+  private final String lockToken;
+  private final DynamicConfigNomadChange change;
+
+  public LockAwareDynamicConfigNomadChange(String lockToken, DynamicConfigNomadChange change) {
+    this.lockToken = lockToken;
+    this.change = change;
+  }
+
+  @Override
+  public Cluster apply(Cluster original) {
+    return change.apply(original);
+  }
+
+  @Override
+  public boolean canApplyAtRuntime(int stripeId, String nodeName) {
+    throw new UnsupportedOperationException();
+  }
+
+  @JsonIgnore
+  @Override
+  public String getSummary() {
+    return change.getSummary();
+  }
+
+  public String getLockToken() {
+    return lockToken;
+  }
+
+  public DynamicConfigNomadChange getChange() {
+    return change;
+  }
+
+  @Override
+  public DynamicConfigNomadChange unwrap() {
+    return change;
+  }
+}

--- a/dynamic-config/cli/cli-support/src/main/java/org/terracotta/dynamic_config/cli/command/RemoteMainCommand.java
+++ b/dynamic-config/cli/cli-support/src/main/java/org/terracotta/dynamic_config/cli/command/RemoteMainCommand.java
@@ -44,6 +44,9 @@ public class RemoteMainCommand extends LocalMainCommand {
   @Parameter(names = {"-srd", "--security-root-directory"}, description = "Security root directory")
   private String securityRootDirectory;
 
+  @Parameter(names = {"--lock-token"}, hidden = true, description = "Lock token")
+  private String lockToken;
+
   public Measure<TimeUnit> getRequestTimeout() {
     return requestTimeout;
   }
@@ -62,6 +65,10 @@ public class RemoteMainCommand extends LocalMainCommand {
 
   public String getSecurityRootDirectory() {
     return securityRootDirectory;
+  }
+
+  public String getLockToken() {
+    return lockToken;
   }
 
   @Override

--- a/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/ConfigTool.java
+++ b/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/ConfigTool.java
@@ -39,6 +39,7 @@ import org.terracotta.dynamic_config.cli.config_tool.command.LogCommand;
 import org.terracotta.dynamic_config.cli.config_tool.command.RepairCommand;
 import org.terracotta.dynamic_config.cli.config_tool.command.SetCommand;
 import org.terracotta.dynamic_config.cli.config_tool.command.UnsetCommand;
+import org.terracotta.dynamic_config.cli.config_tool.nomad.LockAwareNomadManager;
 import org.terracotta.dynamic_config.cli.config_tool.nomad.NomadManager;
 import org.terracotta.dynamic_config.cli.config_tool.restart.RestartService;
 import org.terracotta.dynamic_config.cli.config_tool.stop.StopService;
@@ -125,7 +126,12 @@ public class ConfigTool {
         // We cannot timeout shortly otherwise we won't know the outcome of the 2PC Nomad transaction in case of a failover.
         new NomadEntity.Settings().setRequestTimeout(entityOperationTimeout),
         mainCommand.getSecurityRootDirectory());
-    NomadManager<NodeContext> nomadManager = new NomadManager<>(new NomadEnvironment(), multiDiagnosticServiceProvider, nomadEntityProvider);
+    NomadManager<NodeContext> nomadManager;
+    if (mainCommand.getLockToken() != null) {
+      nomadManager = new LockAwareNomadManager<>(new NomadEnvironment(), multiDiagnosticServiceProvider, nomadEntityProvider, mainCommand.getLockToken());
+    } else {
+      nomadManager = new NomadManager<>(new NomadEnvironment(), multiDiagnosticServiceProvider, nomadEntityProvider);
+    }
     RestartService restartService = new RestartService(diagnosticServiceProvider, concurrencySizing);
     StopService stopService = new StopService(diagnosticServiceProvider, concurrencySizing);
 

--- a/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/nomad/LockAwareNomadManager.java
+++ b/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/nomad/LockAwareNomadManager.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.dynamic_config.cli.config_tool.nomad;
+
+import org.terracotta.diagnostic.client.connection.MultiDiagnosticServiceProvider;
+import org.terracotta.dynamic_config.api.model.nomad.DynamicConfigNomadChange;
+import org.terracotta.dynamic_config.api.model.nomad.LockAwareDynamicConfigNomadChange;
+import org.terracotta.nomad.NomadEnvironment;
+import org.terracotta.nomad.entity.client.NomadEntityProvider;
+
+public class LockAwareNomadManager<T> extends NomadManager<T> {
+  private final String lockToken;
+
+  public LockAwareNomadManager(NomadEnvironment environment, MultiDiagnosticServiceProvider multiDiagnosticServiceProvider, NomadEntityProvider nomadEntityProvider, String lockToken) {
+    super(environment, multiDiagnosticServiceProvider, nomadEntityProvider);
+    this.lockToken = lockToken;
+  }
+
+  @Override
+  protected DynamicConfigNomadChange wrapNomadChange(DynamicConfigNomadChange change) {
+    return new LockAwareDynamicConfigNomadChange(lockToken, change);
+  }
+}

--- a/dynamic-config/model/src/main/java/org/terracotta/dynamic_config/api/model/Cluster.java
+++ b/dynamic-config/model/src/main/java/org/terracotta/dynamic_config/api/model/Cluster.java
@@ -16,6 +16,7 @@
 package org.terracotta.dynamic_config.api.model;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import org.terracotta.common.struct.LockContext;
 import org.terracotta.common.struct.Measure;
 import org.terracotta.common.struct.MemoryUnit;
 import org.terracotta.common.struct.TimeUnit;
@@ -56,6 +57,7 @@ public class Cluster implements Cloneable, PropertyHolder {
   private final List<Stripe> stripes;
 
   private String name;
+  private LockContext lockContext;
   private Measure<TimeUnit> clientReconnectWindow;
   private Measure<TimeUnit> clientLeaseDuration;
   private String securityAuthc;
@@ -245,6 +247,7 @@ public class Cluster implements Cloneable, PropertyHolder {
     Cluster that = (Cluster) o;
     return Objects.equals(stripes, that.stripes) &&
         Objects.equals(name, that.name) &&
+        Objects.equals(lockContext, that.lockContext) &&
         Objects.equals(securitySslTls, that.securitySslTls) &&
         Objects.equals(securityWhitelist, that.securityWhitelist) &&
         Objects.equals(securityAuthc, that.securityAuthc) &&
@@ -256,14 +259,17 @@ public class Cluster implements Cloneable, PropertyHolder {
 
   @Override
   public int hashCode() {
-    return Objects.hash(stripes, name, securityAuthc, securitySslTls, securityWhitelist,
-        failoverPriority, clientReconnectWindow, clientLeaseDuration, offheapResources);
+    return Objects.hash(
+        stripes, name, securityAuthc, securitySslTls, securityWhitelist,
+        failoverPriority, clientReconnectWindow, clientLeaseDuration, offheapResources, lockContext
+    );
   }
 
   @Override
   public String toString() {
     return "Cluster{" +
         "name='" + name + '\'' +
+        ", lockContext='" + lockContext + '\'' +
         ", securityAuthc='" + securityAuthc + '\'' +
         ", securitySslTls=" + securitySslTls +
         ", securityWhitelist=" + securityWhitelist +
@@ -303,6 +309,7 @@ public class Cluster implements Cloneable, PropertyHolder {
   public Cluster clone() {
     return new Cluster(stripes.stream().map(Stripe::clone).collect(toList()))
         .setName(name)
+        .setConfigurationLockContext(lockContext)
         .setClientLeaseDuration(clientLeaseDuration)
         .setClientReconnectWindow(clientReconnectWindow)
         .setFailoverPriority(failoverPriority)
@@ -427,6 +434,15 @@ public class Cluster implements Cloneable, PropertyHolder {
 
   public Cluster removeStripes() {
     stripes.clear();
+    return this;
+  }
+
+  public LockContext getConfigurationLockContext() {
+    return lockContext;
+  }
+
+  public Cluster setConfigurationLockContext(LockContext lockContext) {
+    this.lockContext = lockContext;
     return this;
   }
 }

--- a/dynamic-config/model/src/main/java/org/terracotta/dynamic_config/api/model/Setting.java
+++ b/dynamic-config/model/src/main/java/org/terracotta/dynamic_config/api/model/Setting.java
@@ -15,6 +15,7 @@
  */
 package org.terracotta.dynamic_config.api.model;
 
+import org.terracotta.common.struct.LockContext;
 import org.terracotta.common.struct.Measure;
 import org.terracotta.common.struct.MemoryUnit;
 import org.terracotta.common.struct.TimeUnit;
@@ -281,6 +282,23 @@ public enum Setting {
       ),
       of(ALL_NODES_ONLINE)
   ),
+
+  LOCK_CONTEXT(
+      SettingName.LOCK_CONTEXT,
+      false,
+      always(null),
+      CLUSTER,
+      fromCluster(Cluster::getConfigurationLockContext),
+      intoCluster((cluster, context) -> cluster.setConfigurationLockContext(context != null ? LockContext.from(context) : null)),
+      asList(
+          // only allow loading and parsing a property file
+          // do not allow the use of get/set/unset commands when configuring
+          when(CONFIGURING).allow(IMPORT).atLevel(CLUSTER),
+          when(ACTIVATED).allow(SET, UNSET).atLevel(CLUSTER)
+      ),
+      of(ACTIVES_ONLINE, HIDDEN)
+  ),
+
   NODE_CONFIG_DIR(SettingName.NODE_CONFIG_DIR,
       false,
       always(Paths.get("%H", "terracotta", "config")),

--- a/dynamic-config/model/src/main/java/org/terracotta/dynamic_config/api/model/SettingName.java
+++ b/dynamic-config/model/src/main/java/org/terracotta/dynamic_config/api/model/SettingName.java
@@ -49,4 +49,5 @@ public class SettingName {
   public static final String CONFIG_FILE = "config-file";
   public static final String REPAIR_MODE = "repair-mode";
   public static final String AUTO_ACTIVATE = "auto-activate";
+  public static final String LOCK_CONTEXT = "lock-context";
 }

--- a/dynamic-config/model/src/test/java/org/terracotta/dynamic_config/api/service/ConfigurationParserTest.java
+++ b/dynamic-config/model/src/test/java/org/terracotta/dynamic_config/api/service/ConfigurationParserTest.java
@@ -275,6 +275,7 @@ public class ConfigurationParserTest {
             "client-reconnect-window=120s",
             "failover-priority=availability",
             "client-lease-duration=150s",
+            "lock-context=",
             "authc=",
             "ssl-tls=false",
             "whitelist=false",

--- a/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/service/DynamicConfigServiceImpl.java
+++ b/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/service/DynamicConfigServiceImpl.java
@@ -234,7 +234,7 @@ public class DynamicConfigServiceImpl implements TopologyService, DynamicConfigS
       LOGGER.info("Nomad change {} committed: {}", message.getChangeUuid(), dynamicConfigNomadChange.getSummary());
 
       // extract the changes since there can be multiple settings change
-      List<? extends DynamicConfigNomadChange> nomadChanges = MultiSettingNomadChange.extractChanges(dynamicConfigNomadChange);
+      List<? extends DynamicConfigNomadChange> nomadChanges = MultiSettingNomadChange.extractChanges(dynamicConfigNomadChange.unwrap());
 
       // the following code will be executed on all the nodes, regardless of the applicability
       // level to update the config

--- a/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/service/nomad/processor/LockAwareNomadChangeProcessor.java
+++ b/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/service/nomad/processor/LockAwareNomadChangeProcessor.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.dynamic_config.server.configuration.service.nomad.processor;
+
+import org.terracotta.common.struct.LockContext;
+import org.terracotta.dynamic_config.api.model.NodeContext;
+import org.terracotta.dynamic_config.api.model.nomad.DynamicConfigNomadChange;
+import org.terracotta.dynamic_config.api.model.nomad.LockAwareDynamicConfigNomadChange;
+import org.terracotta.dynamic_config.server.api.NomadChangeProcessor;
+import org.terracotta.nomad.server.NomadException;
+
+import static java.lang.String.format;
+
+public class LockAwareNomadChangeProcessor implements NomadChangeProcessor<DynamicConfigNomadChange> {
+  private static final String REJECT_MESSAGE = "changes are not allowed as config is locked by '%s (%s)'";
+
+  private final NomadChangeProcessor<DynamicConfigNomadChange> next;
+
+  public LockAwareNomadChangeProcessor(NomadChangeProcessor<DynamicConfigNomadChange> next) {
+    this.next = next;
+  }
+
+  @Override
+  public void validate(NodeContext baseConfig, DynamicConfigNomadChange change) throws NomadException {
+    throwIfNotAllowed(baseConfig, change);
+
+    next.validate(baseConfig, change.unwrap());
+  }
+
+  private static void throwIfNotAllowed(NodeContext baseConfig, DynamicConfigNomadChange change) throws NomadException {
+    if (baseConfig != null) {
+      LockContext lockContext = baseConfig.getCluster().getConfigurationLockContext();
+      if (change instanceof LockAwareDynamicConfigNomadChange) {
+        if (lockContext != null) {
+          LockAwareDynamicConfigNomadChange lockAwareDynamicConfigNomadChange = (LockAwareDynamicConfigNomadChange)change;
+          String tokenFromClient = lockAwareDynamicConfigNomadChange.getLockToken();
+          if (!lockContext.getToken().equals(tokenFromClient)) {
+            throw new NomadException(format(REJECT_MESSAGE, lockContext.getOwnerName(), lockContext.getOwnerTags()));
+          }
+        }
+      } else {
+        if (lockContext != null) {
+          throw new NomadException(format(REJECT_MESSAGE, lockContext.getOwnerName(), lockContext.getOwnerTags()));
+        }
+      }
+    }
+  }
+
+  @Override
+  public void apply(DynamicConfigNomadChange change) throws NomadException {
+    next.apply(change.unwrap());
+  }
+}

--- a/dynamic-config/server/services/src/main/java/org/terracotta/dynamic_config/server/service/DynamicConfigServiceProvider.java
+++ b/dynamic-config/server/services/src/main/java/org/terracotta/dynamic_config/server/service/DynamicConfigServiceProvider.java
@@ -47,6 +47,7 @@ import java.util.Collection;
 
 import static org.terracotta.dynamic_config.api.model.Setting.CLIENT_RECONNECT_WINDOW;
 import static org.terracotta.dynamic_config.api.model.Setting.CLUSTER_NAME;
+import static org.terracotta.dynamic_config.api.model.Setting.LOCK_CONTEXT;
 import static org.terracotta.dynamic_config.api.model.Setting.FAILOVER_PRIORITY;
 import static org.terracotta.dynamic_config.api.model.Setting.NODE_LOGGER_OVERRIDES;
 import static org.terracotta.dynamic_config.api.model.Setting.NODE_LOG_DIR;
@@ -88,6 +89,9 @@ public class DynamicConfigServiceProvider implements ServiceProvider {
 
     // cluster name
     addToManager(configChangeHandlerManager, accept(), CLUSTER_NAME);
+
+    // lock context
+    addToManager(configChangeHandlerManager, accept(), LOCK_CONTEXT);
 
     // tc-logging
     LoggerOverrideConfigChangeHandler loggerOverrideConfigChangeHandler = new LoggerOverrideConfigChangeHandler(topologyService);

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/LockConfigIT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/LockConfigIT.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.dynamic_config.system_tests.activated;
+
+import org.junit.Test;
+import org.terracotta.common.struct.LockContext;
+import org.terracotta.dynamic_config.test_support.ClusterDefinition;
+import org.terracotta.dynamic_config.test_support.DynamicConfigIT;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import static java.util.Arrays.asList;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@ClusterDefinition(autoActivate = true)
+public class LockConfigIT extends DynamicConfigIT {
+  private final LockContext lockContext =
+      new LockContext(UUID.randomUUID().toString(), "platform", "dynamic-scale");
+
+  @Test
+  public void testLockUnlock() {
+    lock();
+    unlock();
+  }
+
+  @Test
+  public void testSettingChangesWithoutTokenWhileLocked() {
+    lock();
+
+    assertThat(
+        () -> invokeWithoutToken("set", "-s", "localhost:" + getNodePort(), "-c", "offheap-resources.test=123MB"),
+        exceptionMatcher("changes are not allowed as config is locked by 'platform (dynamic-scale)'")
+    );
+
+    unlock();
+
+    invokeWithoutToken("set", "-s", "localhost:" + getNodePort(), "-c", "offheap-resources.test=123MB");
+  }
+
+  @Test
+  public void testSettingChangesWithTokenWhileLocked() {
+    lock();
+
+    invokeWithToken("set", "-s", "localhost:" + getNodePort(), "-c", "offheap-resources.test=123MB");
+  }
+
+  private void lock() {
+    invokeWithoutToken("set", "-s", "localhost:" + getNodePort(), "-c", "lock-context=" + lockContext);
+  }
+
+  private void unlock() {
+    invokeWithToken("unset", "-s", "localhost:" + getNodePort(), "-c", "lock-context");
+  }
+
+  private void invokeWithoutToken(String... args) {
+    invokeConfigTool(args);
+  }
+
+  private void invokeWithToken(String... args) {
+    List<String> newArgs = new ArrayList<>(asList("--lock-token", lockContext.getToken()));
+    newArgs.addAll(asList(args));
+    invokeConfigTool(newArgs.toArray(new String[0]));
+  }
+}


### PR DESCRIPTION
Usage: 

* `lock` - set `lock-context`
* `unlock` - unset `lock-context` with the `lock-token` given in earlier lock invocation

We could provide `lock` and `unlock` commands but its probably easier to use this way given current use cases and this is not user facing.



