### PR TITLE
[WIP] TDB-5080: Restricting node names to: [a-zA-Z0-9-_.:]+

### DIFF
--- a/dynamic-config/model/src/main/java/org/terracotta/dynamic_config/api/model/Setting.java
+++ b/dynamic-config/model/src/main/java/org/terracotta/dynamic_config/api/model/Setting.java
@@ -74,7 +74,7 @@ import static org.terracotta.dynamic_config.api.model.SettingValidator.DATA_DIRS
 import static org.terracotta.dynamic_config.api.model.SettingValidator.DEFAULT_VALIDATOR;
 import static org.terracotta.dynamic_config.api.model.SettingValidator.HOST_VALIDATOR;
 import static org.terracotta.dynamic_config.api.model.SettingValidator.LOGGER_LEVEL_VALIDATOR;
-import static org.terracotta.dynamic_config.api.model.SettingValidator.NODE_NAME_VALIDATOR;
+import static org.terracotta.dynamic_config.api.model.SettingValidator.NAME_VALIDATOR;
 import static org.terracotta.dynamic_config.api.model.SettingValidator.OFFHEAP_VALIDATOR;
 import static org.terracotta.dynamic_config.api.model.SettingValidator.PATH_VALIDATOR;
 import static org.terracotta.dynamic_config.api.model.SettingValidator.PORT_VALIDATOR;
@@ -157,7 +157,7 @@ public enum Setting {
       of(RESOLVE_EAGERLY, PRESENCE),
       emptyList(),
       emptyList(),
-      (key, value) -> NODE_NAME_VALIDATOR.accept(SettingName.NODE_NAME, tuple2(key, value))
+      (key, value) -> NAME_VALIDATOR.accept(SettingName.NODE_NAME, tuple2(key, value))
   ),
   NODE_HOSTNAME(SettingName.NODE_HOSTNAME,
       false,

--- a/dynamic-config/model/src/test/java/org/terracotta/dynamic_config/api/model/SettingValidatorTest.java
+++ b/dynamic-config/model/src/test/java/org/terracotta/dynamic_config/api/model/SettingValidatorTest.java
@@ -78,6 +78,12 @@ public class SettingValidatorTest {
           is(throwing(instanceOf(IllegalArgumentException.class)).andMessage(is(equalTo(NODE_NAME + " cannot contain substitution parameters")))));
     });
     NODE_NAME.validate("foo");
+    NODE_NAME.validate("-");
+    NODE_NAME.validate("_");
+    NODE_NAME.validate(".");
+    NODE_NAME.validate(":");
+    NODE_NAME.validate("[]");
+    NODE_NAME.validate("]");
   }
 
   @Test

--- a/dynamic-config/model/src/test/java/org/terracotta/dynamic_config/api/service/ClusterFactoryTest.java
+++ b/dynamic-config/model/src/test/java/org/terracotta/dynamic_config/api/service/ClusterFactoryTest.java
@@ -82,7 +82,7 @@ public class ClusterFactoryTest {
     lenient().when(substitutor.substitute("%c")).thenReturn("localhost.home");
     lenient().when(substitutor.substitute("%H")).thenReturn("home");
     lenient().when(substitutor.substitute("foo")).thenReturn("foo");
-    lenient().when(substitutor.substitute(startsWith("node-"))).thenReturn("<GENERATED>");
+    lenient().when(substitutor.substitute(startsWith("node-"))).thenReturn("_GENERATED_");
     lenient().when(substitutor.substitute("9410")).thenReturn("9410");
     lenient().when(substitutor.substitute("")).thenReturn("");
     lenient().when(substitutor.substitute("availability")).thenReturn("availability");
@@ -90,9 +90,9 @@ public class ClusterFactoryTest {
 
   @Test
   public void test_create_cli() {
-    assertCliEquals(cli("failover-priority=availability"), Testing.newTestCluster(new Stripe(Testing.newTestNode("<GENERATED>", "localhost"))));
-    assertCliEquals(cli("failover-priority=availability", "hostname=%c"), Testing.newTestCluster(new Stripe(Testing.newTestNode("<GENERATED>", "localhost.home"))));
-    assertCliEquals(cli("failover-priority=availability", "hostname=foo"), Testing.newTestCluster(new Stripe(Testing.newTestNode("<GENERATED>", "foo"))));
+    assertCliEquals(cli("failover-priority=availability"), Testing.newTestCluster(new Stripe(Testing.newTestNode("_GENERATED_", "localhost"))));
+    assertCliEquals(cli("failover-priority=availability", "hostname=%c"), Testing.newTestCluster(new Stripe(Testing.newTestNode("_GENERATED_", "localhost.home"))));
+    assertCliEquals(cli("failover-priority=availability", "hostname=foo"), Testing.newTestCluster(new Stripe(Testing.newTestNode("_GENERATED_", "foo"))));
   }
 
   @Test
@@ -394,7 +394,7 @@ public class ClusterFactoryTest {
     // this is a hack that will reset to null only the node names that have been generated
     String nodeName = built.getSingleNode().get().getName();
     cluster.getSingleNode()
-        .filter(node -> node.getName().equals("<GENERATED>"))
+        .filter(node -> node.getName().equals("_GENERATED_"))
         .ifPresent(node -> node.setName(nodeName));
 
     assertThat(built, is(equalTo(cluster)));

--- a/dynamic-config/model/src/test/java/org/terracotta/dynamic_config/api/service/ConfigurationParserTest.java
+++ b/dynamic-config/model/src/test/java/org/terracotta/dynamic_config/api/service/ConfigurationParserTest.java
@@ -70,7 +70,7 @@ public class ConfigurationParserTest {
     lenient().when(substitutor.substitute("%c")).thenReturn("localhost.home");
     lenient().when(substitutor.substitute("%H")).thenReturn("home");
     lenient().when(substitutor.substitute("foo")).thenReturn("foo");
-    lenient().when(substitutor.substitute(startsWith("node-"))).thenReturn("<GENERATED>");
+    lenient().when(substitutor.substitute(startsWith("node-"))).thenReturn("_GENERATED_");
     lenient().when(substitutor.substitute("9410")).thenReturn("9410");
     lenient().when(substitutor.substitute("")).thenReturn("");
     lenient().when(substitutor.substitute("availability")).thenReturn("availability");
@@ -81,10 +81,10 @@ public class ConfigurationParserTest {
     // node hostname should be resolved from default value (%h) if not given
     assertCliEquals(
         cli("failover-priority=availability"),
-        Testing.newTestCluster(new Stripe(Testing.newTestNode("<GENERATED>", "localhost")))
+        Testing.newTestCluster(new Stripe(Testing.newTestNode("_GENERATED_", "localhost")))
             .setFailoverPriority(availability()),
         "stripe.1.node.1.hostname=localhost",
-        "stripe.1.node.1.name=<GENERATED>"
+        "stripe.1.node.1.name=_GENERATED_"
     );
     verify(substitutor, times(1)).substitute("%h");
     verify(substitutor, times(1)).substitute(startsWith("node-"));
@@ -97,9 +97,9 @@ public class ConfigurationParserTest {
     // placeholder in node hostname should be resolved eagerly
     assertCliEquals(
         cli("failover-priority=availability", "hostname=%c"),
-        Testing.newTestCluster(new Stripe(Testing.newTestNode("<GENERATED>", "localhost.home")))
+        Testing.newTestCluster(new Stripe(Testing.newTestNode("_GENERATED_", "localhost.home")))
             .setFailoverPriority(availability()),
-        "stripe.1.node.1.name=<GENERATED>"
+        "stripe.1.node.1.name=_GENERATED_"
     );
     verify(substitutor).substitute("%c");
     verify(substitutor, times(1)).substitute(startsWith("node-"));
@@ -112,9 +112,9 @@ public class ConfigurationParserTest {
     // node hostname without placeholder triggers no resolve
     assertCliEquals(
         cli("failover-priority=availability", "hostname=foo"),
-        Testing.newTestCluster(new Stripe(Testing.newTestNode("<GENERATED>", "foo")))
+        Testing.newTestCluster(new Stripe(Testing.newTestNode("_GENERATED_", "foo")))
             .setFailoverPriority(availability()),
-        "stripe.1.node.1.name=<GENERATED>"
+        "stripe.1.node.1.name=_GENERATED_"
     );
     verify(substitutor).substitute("foo");
     verify(substitutor, times(1)).substitute(startsWith("node-"));
@@ -344,11 +344,11 @@ public class ConfigurationParserTest {
     // this is a hack that will reset to null only the node names that have been generated
     String nodeName = built.getSingleNode().get().getName();
     cluster.getSingleNode()
-        .filter(node -> node.getName().equals("<GENERATED>"))
+        .filter(node -> node.getName().equals("_GENERATED_"))
         .ifPresent(node -> node.setName(nodeName));
 
     Configuration[] configurations = Stream.of(addedConfigurations)
-        .map(string -> string.replace("<GENERATED>", nodeName))
+        .map(string -> string.replace("_GENERATED_", nodeName))
         .map(string -> string.replace("/", File.separator)) // unix/win compat'
         .map(Configuration::valueOf)
         .toArray(Configuration[]::new);


### PR DESCRIPTION
  // Notes:
  // - For migration purpose, we need to support having DNS names in names (users used to specify dns names as names)
  // - For migration purpose, we need to support special characters like :.[] because server names were generated from IPv4 / IPv6 addresses,
  // so we could in theory have a generated server name (by the old XML parser) like: [2001:db8:85a3:8d3:1319:8a2e:370:7348]:9410

This PR still needs discussion or to be refined because it blocks other special characters like 💩 