### PR TITLE
[URG] TDB-5164: Broken repair and auto-activation with hidden settings (option 2)

### DIFF
--- a/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/command/ExportCommand.java
+++ b/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/command/ExportCommand.java
@@ -41,7 +41,7 @@ import java.util.Properties;
 import static java.lang.System.lineSeparator;
 
 @Parameters(commandNames = "export", commandDescription = "Export a cluster configuration")
-@Usage("export -s <hostname[:port]> [-f <config-file>] [-i] [-r]")
+@Usage("export -s <hostname[:port]> [-f <config-file>] [-i] [-r][-a]")
 public class ExportCommand extends RemoteCommand {
   @Parameter(names = {"-s"}, required = true, description = "Node to connect to", converter = InetSocketAddressConverter.class)
   private InetSocketAddress node;
@@ -51,6 +51,9 @@ public class ExportCommand extends RemoteCommand {
 
   @Parameter(names = {"-i"}, description = "Include default values. Default: false", converter = BooleanConverter.class)
   private boolean includeDefaultValues;
+
+  @Parameter(names = {"-a"}, description = "Export all configured settings, including system settings. Required to be able to repair or partially activate a node. Default: false", converter = BooleanConverter.class)
+  private boolean includeHiddenSettings;
 
   @Parameter(names = {"-r"}, description = "Export the runtime configuration instead of the configuration saved on disk. Default: false", converter = BooleanConverter.class)
   private boolean wantsRuntimeConfig;
@@ -109,11 +112,11 @@ public class ExportCommand extends RemoteCommand {
           throw new AssertionError(outputFormat);
         }
       case PROPERTIES:
-        Properties nonDefaults = cluster.toProperties(false, false);
+        Properties nonDefaults = cluster.toProperties(false, false, includeHiddenSettings);
         try (StringWriter out = new StringWriter()) {
           Props.store(out, nonDefaults, "Non-default configurations");
           if (includeDefaultValues) {
-            Properties defaults = cluster.toProperties(false, true);
+            Properties defaults = cluster.toProperties(false, true, includeHiddenSettings);
             defaults.keySet().removeAll(nonDefaults.keySet());
             Props.store(out, defaults, "Default configurations");
           }

--- a/dynamic-config/model/src/main/java/org/terracotta/dynamic_config/api/model/Setting.java
+++ b/dynamic-config/model/src/main/java/org/terracotta/dynamic_config/api/model/Setting.java
@@ -915,8 +915,8 @@ public enum Setting {
   public static Properties modelToProperties(PropertyHolder o, boolean expanded, boolean includeDefaultValues, boolean includeHiddenSettings) {
     Properties properties = new Properties();
     Stream.of(Setting.values())
-        .filter(setting -> setting.isUserExportable() || (includeHiddenSettings && setting.requires(HIDDEN)))
         .filter(setting -> setting.isScope(o.getScope()))
+        .filter(setting -> setting.isUserExportable() || (includeHiddenSettings && setting.requires(HIDDEN)))
         .forEach(setting -> properties.putAll(setting.toProperties(o, expanded, includeDefaultValues)));
     return properties;
   }

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/LockConfigIT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/LockConfigIT.java
@@ -17,29 +17,39 @@ package org.terracotta.dynamic_config.system_tests.activated;
 
 import org.junit.Test;
 import org.terracotta.common.struct.LockContext;
+import org.terracotta.dynamic_config.api.service.Props;
 import org.terracotta.dynamic_config.test_support.ClusterDefinition;
 import org.terracotta.dynamic_config.test_support.DynamicConfigIT;
 
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
 import static java.util.Arrays.asList;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.terracotta.angela.client.support.hamcrest.AngelaMatchers.containsOutput;
 
-@ClusterDefinition(autoActivate = true)
+@ClusterDefinition(nodesPerStripe = 2, autoStart = false)
 public class LockConfigIT extends DynamicConfigIT {
   private final LockContext lockContext =
       new LockContext(UUID.randomUUID().toString(), "platform", "dynamic-scale");
 
   @Test
-  public void testLockUnlock() {
+  public void testLockUnlock() throws Exception {
+    activate();
     lock();
     unlock();
   }
 
   @Test
-  public void testSettingChangesWithoutTokenWhileLocked() {
+  public void testSettingChangesWithoutTokenWhileLocked() throws Exception {
+    activate();
     lock();
 
     assertThat(
@@ -53,10 +63,53 @@ public class LockConfigIT extends DynamicConfigIT {
   }
 
   @Test
-  public void testSettingChangesWithTokenWhileLocked() {
+  public void testSettingChangesWithTokenWhileLocked() throws Exception {
+    activate();
     lock();
 
     invokeWithToken("set", "-s", "localhost:" + getNodePort(), "-c", "offheap-resources.test=123MB");
+  }
+
+  @Test
+  public void testLockCanBeExported() throws Exception {
+    activate();
+    lock();
+
+    assertThat(
+        invokeConfigTool("export", "-s", "localhost:" + getNodePort()),
+        not(containsOutput("lock-context=" + lockContext)));
+
+    assertThat(
+        invokeConfigTool("export", "-s", "localhost:" + getNodePort(), "-a"),
+        containsOutput("lock-context=" + lockContext));
+  }
+
+  @Test
+  public void testNodeCanJoinALockedClusterAndAlsoBeLocked() {
+    // auto activating a stripe
+    // The goal is to have an activated cluster with inside its topology some "room" to add a node that is not yet created
+    // this situation can happen in case of node failure we need to replace, when auto-activating at startup, etc.
+    Path configurationFile = copyConfigProperty("/config-property-files/1x2.properties");
+    startNode(1, 1, "--auto-activate", "-f", configurationFile.toString(), "-s", "localhost", "-p", String.valueOf(getNodePort(1, 1)), "--config-dir", "config/stripe1/1-1");
+    waitForActive(1, 1);
+
+    // we lock the configuration
+    // but not all nodes are there
+    lock();
+
+    // we need to repair / or make a node join
+    // we will be able to add it through a restrictive activation
+    // For a node to be able to join a topology, it needs to have EXACTLY the same topology information of the target cluster
+    Path exportedConfigPath = tmpDir.getRoot().resolve("cluster.properties").toAbsolutePath();
+    invokeConfigTool("export", "-s", "localhost:" + getNodePort(1, 1), "-f", exportedConfigPath.toString(), "-a");
+    assertThat(Props.toString(Props.load(exportedConfigPath)), Props.load(exportedConfigPath).stringPropertyNames(), hasItem("lock-context"));
+
+    startNode(1, 2);
+    waitForDiagnostic(1, 2);
+
+    assertThat(
+        invokeConfigTool("activate", "-R", "-s", "localhost:" + getNodePort(1, 2), "-f", exportedConfigPath.toString()),
+        allOf(containsOutput("No license installed"), containsOutput("came back up")));
   }
 
   private void lock() {
@@ -75,5 +128,24 @@ public class LockConfigIT extends DynamicConfigIT {
     List<String> newArgs = new ArrayList<>(asList("--lock-token", lockContext.getToken()));
     newArgs.addAll(asList(args));
     invokeConfigTool(newArgs.toArray(new String[0]));
+  }
+
+  private void activate() throws Exception {
+    startNode(1, 1);
+    waitForDiagnostic(1, 1);
+    assertThat(getUpcomingCluster("localhost", getNodePort(1, 1)).getNodeCount(), is(equalTo(1)));
+
+    // start the second node
+    startNode(1, 2);
+    waitForDiagnostic(1, 2);
+    assertThat(getUpcomingCluster("localhost", getNodePort(1, 2)).getNodeCount(), is(equalTo(1)));
+
+    //attach the second node
+    invokeConfigTool("attach", "-d", "localhost:" + getNodePort(1, 1), "-s", "localhost:" + getNodePort(1, 2));
+
+    //Activate cluster
+    activateCluster();
+    waitForActive(1);
+    waitForNPassives(1, 1);
   }
 }


### PR DESCRIPTION
There is a problem with the fact of hiding some DC settings from the user (like the lock mechanism): it breaks the repair and sync capability.

For a node to be able to join an existing cluster after an automatic activation or after a repair, the node must have EXACTLY the same DC configuration as the destination cluster. This also includes settings like lock, uuids in the future, etc. This is done so that the node car join, identify itself accordingly and also start in the same "state" as other nodes.

To fix this, there were 2 possibilities:

1. Remove the notion of "hidden" settings and ALWAYS export ALL DC settings.
2. Add a `-a` flag to the export command which means: Export all configured DC settings including system/hidden ones

To be able to do a restricted activation, repair or any special the user is required to have a full exported configuration with `-a`.

**Notes:**
- I strongly prefer 1) and let the user see EVERYTHING also because all DC configurations, whether they are internal or not, brings information to the user. But this goes against what has been decided already (which I do not agree BTW because it leads to weird situations and other UX problems).
- 2) is also dangerous to do because if the user forget to use `-a` when exporting, he can mess up the repair and the node won't start, and the user won't have any feedback why.