### PR TITLE
TDB-5164: Fix and review the cluster config outputs

### DIFF
--- a/dynamic-config/model/src/main/java/org/terracotta/dynamic_config/api/model/Setting.java
+++ b/dynamic-config/model/src/main/java/org/terracotta/dynamic_config/api/model/Setting.java
@@ -915,8 +915,8 @@ public enum Setting {
   public static Properties modelToProperties(PropertyHolder o, boolean expanded, boolean includeDefaultValues, boolean includeHiddenSettings) {
     Properties properties = new Properties();
     Stream.of(Setting.values())
-        .filter(setting -> setting.isUserExportable() || (includeHiddenSettings && setting.requires(HIDDEN)))
         .filter(setting -> setting.isScope(o.getScope()))
+        .filter(setting -> setting.isUserExportable() || (includeHiddenSettings && setting.requires(HIDDEN)))
         .forEach(setting -> properties.putAll(setting.toProperties(o, expanded, includeDefaultValues)));
     return properties;
   }

--- a/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/service/DynamicConfigServiceImpl.java
+++ b/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/service/DynamicConfigServiceImpl.java
@@ -31,7 +31,6 @@ import org.terracotta.dynamic_config.api.model.nomad.MultiSettingNomadChange;
 import org.terracotta.dynamic_config.api.model.nomad.SettingNomadChange;
 import org.terracotta.dynamic_config.api.service.ClusterValidator;
 import org.terracotta.dynamic_config.api.service.DynamicConfigService;
-import org.terracotta.dynamic_config.api.service.Props;
 import org.terracotta.dynamic_config.api.service.TopologyService;
 import org.terracotta.dynamic_config.server.api.DynamicConfigListener;
 import org.terracotta.dynamic_config.server.api.InvalidLicenseException;
@@ -253,9 +252,9 @@ public class DynamicConfigServiceImpl implements TopologyService, DynamicConfigS
       }
 
       if (runtimeNodeContext.equals(upcomingNodeContext)) {
-        LOGGER.info("New cluster configuration: {}{}", lineSeparator(), clusterProperties(runtimeNodeContext));
+        LOGGER.info("New cluster configuration: {}{}", lineSeparator(), runtimeNodeContext.getCluster().toProperties(false, false, true));
       } else {
-        LOGGER.info("Pending cluster configuration: {}{}", lineSeparator(), clusterProperties(upcomingNodeContext));
+        LOGGER.info("Pending cluster configuration: {}{}", lineSeparator(), upcomingNodeContext.getCluster().toProperties(false, false, true));
       }
     } else {
       LOGGER.warn("Nomad change {} failed to commit: {}", message.getChangeUuid(), response);
@@ -401,10 +400,6 @@ public class DynamicConfigServiceImpl implements TopologyService, DynamicConfigS
     licenseService.validate(licensePath, cluster);
     LOGGER.debug("License is valid for cluster: {}", cluster.toShapeString());
     return true;
-  }
-
-  private String clusterProperties(NodeContext nodeContext) {
-    return Props.toString(nodeContext.getCluster().toProperties(false, false));
   }
 
   private Map<String, ?> toMap(Object o) {

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/LockConfigIT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/LockConfigIT.java
@@ -17,29 +17,38 @@ package org.terracotta.dynamic_config.system_tests.activated;
 
 import org.junit.Test;
 import org.terracotta.common.struct.LockContext;
+import org.terracotta.dynamic_config.api.service.Props;
 import org.terracotta.dynamic_config.test_support.ClusterDefinition;
 import org.terracotta.dynamic_config.test_support.DynamicConfigIT;
 
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
 import static java.util.Arrays.asList;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.is;
+import static org.terracotta.angela.client.support.hamcrest.AngelaMatchers.containsOutput;
 
-@ClusterDefinition(autoActivate = true)
+@ClusterDefinition(nodesPerStripe = 2, autoStart = false)
 public class LockConfigIT extends DynamicConfigIT {
   private final LockContext lockContext =
       new LockContext(UUID.randomUUID().toString(), "platform", "dynamic-scale");
 
   @Test
-  public void testLockUnlock() {
+  public void testLockUnlock() throws Exception {
+    activate();
     lock();
     unlock();
   }
 
   @Test
-  public void testSettingChangesWithoutTokenWhileLocked() {
+  public void testSettingChangesWithoutTokenWhileLocked() throws Exception {
+    activate();
     lock();
 
     assertThat(
@@ -53,10 +62,49 @@ public class LockConfigIT extends DynamicConfigIT {
   }
 
   @Test
-  public void testSettingChangesWithTokenWhileLocked() {
+  public void testSettingChangesWithTokenWhileLocked() throws Exception {
+    activate();
     lock();
 
     invokeWithToken("set", "-s", "localhost:" + getNodePort(), "-c", "offheap-resources.test=123MB");
+  }
+
+  @Test
+  public void testLockCanBeExported() throws Exception {
+    activate();
+    lock();
+
+    assertThat(
+        invokeConfigTool("export", "-s", "localhost:" + getNodePort()),
+        containsOutput("lock-context=" + lockContext));
+  }
+
+  @Test
+  public void testNodeCanJoinALockedClusterAndAlsoBeLocked() {
+    // auto activating a stripe
+    // The goal is to have an activated cluster with inside its topology some "room" to add a node that is not yet created
+    // this situation can happen in case of node failure we need to replace, when auto-activating at startup, etc.
+    Path configurationFile = copyConfigProperty("/config-property-files/1x2.properties");
+    startNode(1, 1, "--auto-activate", "-f", configurationFile.toString(), "-s", "localhost", "-p", String.valueOf(getNodePort(1, 1)), "--config-dir", "config/stripe1/1-1");
+    waitForActive(1, 1);
+
+    // we lock the configuration
+    // but not all nodes are there
+    lock();
+
+    // we need to repair / or make a node join
+    // we will be able to add it through a restrictive activation
+    // For a node to be able to join a topology, it needs to have EXACTLY the same topology information of the target cluster
+    Path exportedConfigPath = tmpDir.getRoot().resolve("cluster.properties").toAbsolutePath();
+    invokeConfigTool("export", "-s", "localhost:" + getNodePort(1, 1), "-f", exportedConfigPath.toString());
+    assertThat(Props.toString(Props.load(exportedConfigPath)), Props.load(exportedConfigPath).stringPropertyNames(), hasItem("lock-context"));
+
+    startNode(1, 2);
+    waitForDiagnostic(1, 2);
+
+    assertThat(
+        invokeConfigTool("activate", "-R", "-s", "localhost:" + getNodePort(1, 2), "-f", exportedConfigPath.toString()),
+        allOf(containsOutput("No license installed"), containsOutput("came back up")));
   }
 
   private void lock() {
@@ -75,5 +123,24 @@ public class LockConfigIT extends DynamicConfigIT {
     List<String> newArgs = new ArrayList<>(asList("--lock-token", lockContext.getToken()));
     newArgs.addAll(asList(args));
     invokeConfigTool(newArgs.toArray(new String[0]));
+  }
+
+  private void activate() throws Exception {
+    startNode(1, 1);
+    waitForDiagnostic(1, 1);
+    assertThat(getUpcomingCluster("localhost", getNodePort(1, 1)).getNodeCount(), is(equalTo(1)));
+
+    // start the second node
+    startNode(1, 2);
+    waitForDiagnostic(1, 2);
+    assertThat(getUpcomingCluster("localhost", getNodePort(1, 2)).getNodeCount(), is(equalTo(1)));
+
+    //attach the second node
+    invokeConfigTool("attach", "-d", "localhost:" + getNodePort(1, 1), "-s", "localhost:" + getNodePort(1, 2));
+
+    //Activate cluster
+    activateCluster();
+    waitForActive(1);
+    waitForNPassives(1, 1);
   }
 }


### PR DESCRIPTION
```
#User-defined configurations
client-lease-duration=20s
cluster-name=my-cluster
failover-priority=availability
offheap-resources=main\:512MB,second\:1GB
stripe.1.node.1.backup-dir=backup/stripe1
stripe.1.node.1.data-dirs=main\:user-data/main/stripe1
stripe.1.node.1.group-port=34346
stripe.1.node.1.hostname=localhost
stripe.1.node.1.log-dir=logs/stripe1
stripe.1.node.1.metadata-dir=metadata/stripe1
stripe.1.node.1.name=node-1-1
stripe.1.node.1.port=43704
stripe.1.node.2.backup-dir=backup/stripe1
stripe.1.node.2.data-dirs=main\:user-data/main/stripe1
stripe.1.node.2.group-port=16861
stripe.1.node.2.hostname=localhost
stripe.1.node.2.log-dir=logs/stripe1
stripe.1.node.2.metadata-dir=metadata/stripe1
stripe.1.node.2.name=node-1-2
stripe.1.node.2.port=45161
#Hidden system configurations (only for informational, import and repair purposes): please do not alter, get, set, unset them.
lock-context=a4684c73-a96c-46c1-834d-3843014f50af;platform;dynamic-scale
```
