### PR TITLE
[BUGFIX] TDB-5174: Fix passive sync bug

### DIFF
--- a/dynamic-config/api/src/main/java/org/terracotta/dynamic_config/api/service/DynamicConfigService.java
+++ b/dynamic-config/api/src/main/java/org/terracotta/dynamic_config/api/service/DynamicConfigService.java
@@ -79,7 +79,6 @@ public interface DynamicConfigService {
 
   /**
    * Reset and sync this node's append log with the provided nomad changes and update the its configurations accordingly.
-   * @param nomadChanges
    */
-  void resetAndSync(NomadChangeInfo[] nomadChanges);
+  void resetAndSync(NomadChangeInfo[] nomadChanges, Cluster cluster);
 }

--- a/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/command/RemoteCommand.java
+++ b/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/command/RemoteCommand.java
@@ -147,7 +147,7 @@ public abstract class RemoteCommand extends Command {
 
     runClusterActivation(newNodes, cluster);
 
-    syncNomadChangesTo(newNodes, getAllNomadChangesFrom(destination));
+    syncNomadChangesTo(newNodes, getAllNomadChangesFrom(destination), cluster);
 
     restartNodes(newNodes, restartDelay, restartWaitTime);
   }
@@ -166,13 +166,13 @@ public abstract class RemoteCommand extends Command {
     }
   }
 
-  private void syncNomadChangesTo(Collection<InetSocketAddress> newNodes, NomadChangeInfo[] nomadChanges) {
+  private void syncNomadChangesTo(Collection<InetSocketAddress> newNodes, NomadChangeInfo[] nomadChanges, Cluster cluster) {
     logger.info("Sync'ing nomad changes to nodes : {}", toString(newNodes));
 
     try (DiagnosticServices diagnosticServices = multiDiagnosticServiceProvider.fetchOnlineDiagnosticServices(newNodes)) {
       dynamicConfigServices(diagnosticServices)
         .map(Tuple2::getT2)
-        .forEach(service -> service.resetAndSync(nomadChanges));
+        .forEach(service -> service.resetAndSync(nomadChanges, cluster));
       logger.info("Nomad changes sync successful");
     }
   }

--- a/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/DynamicConfigConfigurationProvider.java
+++ b/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/DynamicConfigConfigurationProvider.java
@@ -128,7 +128,7 @@ public class DynamicConfigConfigurationProvider implements ConfigurationProvider
           nomadServerManager.getConfiguration().orElse(null),
           nomadServer,
           dynamicConfigService,
-          () -> dynamicConfigService.getLicenseContent().orElse(null));
+          topologyService, () -> dynamicConfigService.getLicenseContent().orElse(null));
 
       // generate the configuration wrapper
       configuration = configurationGeneratorVisitor.generateConfiguration();

--- a/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/sync/Check.java
+++ b/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/sync/Check.java
@@ -15,6 +15,8 @@
  */
 package org.terracotta.dynamic_config.server.configuration.sync;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.terracotta.dynamic_config.api.model.Cluster;
 import org.terracotta.dynamic_config.api.model.nomad.TopologyNomadChange;
 import org.terracotta.nomad.server.ChangeRequestState;
@@ -22,6 +24,7 @@ import org.terracotta.nomad.server.NomadChangeInfo;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.OptionalInt;
 import java.util.function.Supplier;
 
 import static java.lang.Math.min;
@@ -31,6 +34,8 @@ import static org.terracotta.nomad.server.ChangeRequestState.COMMITTED;
  * @author Mathieu Carbou
  */
 class Check {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(Check.class);
 
   static void assertNonEmpty(Collection<?>... collections) {
     for (Collection<?> collection : collections) {
@@ -46,22 +51,33 @@ class Check {
     }
   }
 
-  static int lastIndexOfSameCommittedSourceTopologyChange(List<NomadChangeInfo> sourceNomadChanges, Cluster currentCluster) {
-    // lookup source changes (reverse order) to find the latest change in force that contains the current topology
-    for (int i = sourceNomadChanges.size() - 1; i >= 0; i--) {
-      NomadChangeInfo changeInfo = sourceNomadChanges.get(i);
-      if (changeInfo.getChangeRequestState() == COMMITTED
-          && changeInfo.getNomadChange() instanceof TopologyNomadChange
-          && ((TopologyNomadChange) changeInfo.getNomadChange()).getCluster().equals(currentCluster)) {
-        // we have found the last topology change in the source node matching the topology used to activate the current node
-        return i;
+  static OptionalInt findLastSyncPosition(List<NomadChangeInfo> sourceNomadChanges, Cluster sourceTopology, Cluster currentCluster) {
+    // index until which we need to force a sync
+    // this will try to find a nomad topology change in the active node that matches the topology used to start the passive node
+    // this will cover the case where we need to repair a broken node attachment for example
+    int pos = lastIndexOfSameCommittedSourceTopologyChange(sourceNomadChanges, currentCluster);
+
+    // if not found:
+    // - either there has been some subsequent changes in the active node after the topology change, and the passive node was activated
+    // with the resulting exported topology from active (in this case there is no matching nomad topology change for the passive topology)
+    // - either the passive node has been started with a topology not matching at all the active node, and we must fail
+    if (pos == -1) {
+      if (topologyMatches(sourceTopology, currentCluster)) {
+        // if we have found that the active node last change result matches this passive topology, we are fine and we need to force sync of all the append log entries
+        pos = sourceNomadChanges.size() - 1;
+
+      } else {
+        return OptionalInt.empty();
       }
     }
-    return -1;
+
+    LOGGER.trace("findLastSyncPosition({}, {}): {}", sourceNomadChanges, currentCluster, pos);
+    return OptionalInt.of(pos);
   }
 
   static void requireEquals(List<NomadChangeInfo> nomadChanges, List<NomadChangeInfo> sourceNomadChanges, int from, int count) {
     int to = min(min(from + count, nomadChanges.size()), sourceNomadChanges.size());
+    LOGGER.trace("requireEquals({}, {}, {}, {}, {})", nomadChanges, sourceNomadChanges, count, from, to);
     for (; from < to; from++) {
       NomadChangeInfo nomadChange = nomadChanges.get(from);
       NomadChangeInfo sourceChange = sourceNomadChanges.get(from);
@@ -81,10 +97,36 @@ class Check {
   }
 
   static boolean isNodeNew(List<NomadChangeInfo> nomadChanges) {
-    return nomadChanges.size() == 1;
+    final boolean b = nomadChanges.size() == 1;
+    LOGGER.trace("isNodeNew({}): {}", nomadChanges, b);
+    return b;
   }
 
   static boolean isJointActivation(List<NomadChangeInfo> nomadChanges, List<NomadChangeInfo> sourceNomadChanges) {
-    return nomadChanges.get(0).equals(sourceNomadChanges.get(0));
+    final boolean b = nomadChanges.get(0).equals(sourceNomadChanges.get(0));
+    LOGGER.trace("isJointActivation({}, {}): {}", nomadChanges, sourceNomadChanges, b);
+    return b;
+  }
+
+  private static boolean topologyMatches(Cluster sourceTopology, Cluster currentCluster) {
+    final boolean b = currentCluster.equals(sourceTopology);
+    LOGGER.trace("topologyMatches({}, {}): {}", sourceTopology, currentCluster, b);
+    return b;
+  }
+
+  private static int lastIndexOfSameCommittedSourceTopologyChange(List<NomadChangeInfo> sourceNomadChanges, Cluster currentCluster) {
+    // lookup source changes (reverse order) to find the latest change in force that contains the current topology
+    for (int i = sourceNomadChanges.size() - 1; i >= 0; i--) {
+      NomadChangeInfo changeInfo = sourceNomadChanges.get(i);
+      if (changeInfo.getChangeRequestState() == COMMITTED
+          && changeInfo.getNomadChange() instanceof TopologyNomadChange
+          && ((TopologyNomadChange) changeInfo.getNomadChange()).getCluster().equals(currentCluster)) {
+        // we have found the last topology change in the source node matching the topology used to activate the current node
+        LOGGER.trace("lastIndexOfSameCommittedSourceTopologyChange({}, {}): {}", sourceNomadChanges, currentCluster, i);
+        return i;
+      }
+    }
+    LOGGER.trace("lastIndexOfSameCommittedSourceTopologyChange({}, {}): {}", sourceNomadChanges, currentCluster, -1);
+    return -1;
   }
 }

--- a/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/sync/DynamicConfigSyncData.java
+++ b/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/sync/DynamicConfigSyncData.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.terracotta.dynamic_config.api.model.Cluster;
 import org.terracotta.json.ObjectMapperFactory;
 import org.terracotta.nomad.server.NomadChangeInfo;
 
@@ -34,11 +35,14 @@ public class DynamicConfigSyncData {
 
   private final List<NomadChangeInfo> nomadChanges;
   private final String license;
+  private final Cluster cluster;
 
   @JsonCreator
   public DynamicConfigSyncData(@JsonProperty(value = "nomadChanges", required = true) List<NomadChangeInfo> nomadChanges,
+                               @JsonProperty(value = "cluster", required = true) Cluster cluster,
                                @JsonProperty(value = "license") String license) {
     this.nomadChanges = nomadChanges;
+    this.cluster = cluster;
     this.license = license;
   }
 
@@ -48,6 +52,10 @@ public class DynamicConfigSyncData {
 
   public String getLicense() {
     return license;
+  }
+
+  public Cluster getCluster() {
+    return cluster;
   }
 
   public static class Codec {

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/LockConfigIT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/LockConfigIT.java
@@ -17,29 +17,39 @@ package org.terracotta.dynamic_config.system_tests.activated;
 
 import org.junit.Test;
 import org.terracotta.common.struct.LockContext;
+import org.terracotta.dynamic_config.api.service.Props;
 import org.terracotta.dynamic_config.test_support.ClusterDefinition;
 import org.terracotta.dynamic_config.test_support.DynamicConfigIT;
 
+import java.io.IOException;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
 import static java.util.Arrays.asList;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.is;
+import static org.terracotta.angela.client.support.hamcrest.AngelaMatchers.containsOutput;
 
-@ClusterDefinition(autoActivate = true)
+@ClusterDefinition(nodesPerStripe = 2, autoStart = false)
 public class LockConfigIT extends DynamicConfigIT {
   private final LockContext lockContext =
       new LockContext(UUID.randomUUID().toString(), "platform", "dynamic-scale");
 
   @Test
-  public void testLockUnlock() {
+  public void testLockUnlock() throws Exception {
+    activate();
     lock();
     unlock();
   }
 
   @Test
-  public void testSettingChangesWithoutTokenWhileLocked() {
+  public void testSettingChangesWithoutTokenWhileLocked() throws Exception {
+    activate();
     lock();
 
     assertThat(
@@ -53,10 +63,49 @@ public class LockConfigIT extends DynamicConfigIT {
   }
 
   @Test
-  public void testSettingChangesWithTokenWhileLocked() {
+  public void testSettingChangesWithTokenWhileLocked() throws Exception {
+    activate();
     lock();
 
     invokeWithToken("set", "-s", "localhost:" + getNodePort(), "-c", "offheap-resources.test=123MB");
+  }
+
+  @Test
+  public void testLockCanBeExported() throws Exception {
+    activate();
+    lock();
+    assertThat(
+        invokeConfigTool("export", "-s", "localhost:" + getNodePort()),
+        containsOutput("lock-context=" + lockContext));
+  }
+
+  @Test
+  public void testNodeCanJoinALockedClusterAndAlsoBeLocked() throws IOException {
+    // auto activating a stripe
+    // The goal is to have an activated cluster with inside its topology some "room" to add a node that is not yet created
+    // this situation can happen in case of node failure we need to replace, when auto-activating at startup, etc.
+    Path configurationFile = copyConfigProperty("/config-property-files/1x2.properties");
+    startNode(1, 1, "--auto-activate", "-f", configurationFile.toString(), "-s", "localhost", "-p", String.valueOf(getNodePort(1, 1)), "--config-dir", "node-1-1");
+    waitForActive(1, 1);
+
+    // we lock the configuration
+    // but not all nodes are there
+    lock();
+
+    // we need to repair / or make a node join
+    // we will be able to add it through a restrictive activation
+    // For a node to be able to join a topology, it needs to have EXACTLY the same topology information of the target cluster
+    Path exportedConfigPath = tmpDir.getRoot().resolve("cluster.properties").toAbsolutePath();
+    invokeConfigTool("export", "-s", "localhost:" + getNodePort(1, 1), "-f", exportedConfigPath.toString());
+    //System.out.println(new String(Files.readAllBytes(exportedConfigPath), StandardCharsets.UTF_8));
+    assertThat(Props.toString(Props.load(exportedConfigPath)), Props.load(exportedConfigPath).stringPropertyNames(), hasItem("lock-context"));
+
+    startNode(1, 2);
+    waitForDiagnostic(1, 2);
+
+    assertThat(
+        invokeConfigTool("activate", "-R", "-s", "localhost:" + getNodePort(1, 2), "-f", exportedConfigPath.toString()),
+        allOf(containsOutput("No license installed"), containsOutput("came back up")));
   }
 
   private void lock() {
@@ -75,5 +124,24 @@ public class LockConfigIT extends DynamicConfigIT {
     List<String> newArgs = new ArrayList<>(asList("--lock-token", lockContext.getToken()));
     newArgs.addAll(asList(args));
     invokeConfigTool(newArgs.toArray(new String[0]));
+  }
+
+  private void activate() throws Exception {
+    startNode(1, 1);
+    waitForDiagnostic(1, 1);
+    assertThat(getUpcomingCluster("localhost", getNodePort(1, 1)).getNodeCount(), is(equalTo(1)));
+
+    // start the second node
+    startNode(1, 2);
+    waitForDiagnostic(1, 2);
+    assertThat(getUpcomingCluster("localhost", getNodePort(1, 2)).getNodeCount(), is(equalTo(1)));
+
+    //attach the second node
+    invokeConfigTool("attach", "-d", "localhost:" + getNodePort(1, 1), "-s", "localhost:" + getNodePort(1, 2));
+
+    //Activate cluster
+    activateCluster();
+    waitForActive(1);
+    waitForNPassives(1, 1);
   }
 }

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activation/AutoActivateNewPassive1x2IT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activation/AutoActivateNewPassive1x2IT.java
@@ -15,17 +15,23 @@
  */
 package org.terracotta.dynamic_config.system_tests.activation;
 
+import org.hamcrest.MatcherAssert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.terracotta.angela.client.support.junit.NodeOutputRule;
+import org.terracotta.dynamic_config.api.service.Props;
 import org.terracotta.dynamic_config.test_support.ClusterDefinition;
 import org.terracotta.dynamic_config.test_support.DynamicConfigIT;
 
+import java.io.IOException;
 import java.nio.file.Path;
 
 import static com.tc.util.Assert.fail;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.hasItem;
 import static org.junit.Assert.assertThat;
 import static org.terracotta.angela.client.support.hamcrest.AngelaMatchers.containsLog;
+import static org.terracotta.angela.client.support.hamcrest.AngelaMatchers.containsOutput;
 
 @ClusterDefinition(nodesPerStripe = 2, autoStart = false)
 public class AutoActivateNewPassive1x2IT extends DynamicConfigIT {
@@ -74,5 +80,33 @@ public class AutoActivateNewPassive1x2IT extends DynamicConfigIT {
 
     startNode(1, 2, "--auto-activate", "-f", configurationFile.toString(), "-n", "node-1-2", "--config-dir", "config/stripe1/1-2");
     waitForPassive(1, 2);
+  }
+
+  @Test
+  public void testNodeCanJoinAClusterWithChanges() throws IOException {
+    // auto activating a stripe
+    // The goal is to have an activated cluster with inside its topology some "room" to add a node that is not yet created
+    // this situation can happen in case of node failure we need to replace, when auto-activating at startup, etc.
+    Path configurationFile = copyConfigProperty("/config-property-files/1x2.properties");
+    startNode(1, 1, "--auto-activate", "-f", configurationFile.toString(), "-s", "localhost", "-p", String.valueOf(getNodePort(1, 1)), "--config-dir", "node-1-1");
+    waitForActive(1, 1);
+
+    // trigger some changes
+    invokeConfigTool("set", "-s", "localhost:" + getNodePort(), "-c", "stripe.1.node.1.logger-overrides=org.terracotta:TRACE");
+
+    // let's say we need to repair / or make a node join...
+    // we will be able to add it through a restrictive activation
+    // For a node to be able to join a topology, it needs to have EXACTLY the same topology information of the target cluster
+    Path exportedConfigPath = tmpDir.getRoot().resolve("cluster.properties").toAbsolutePath();
+    invokeConfigTool("export", "-s", "localhost:" + getNodePort(1, 1), "-f", exportedConfigPath.toString());
+    //System.out.println(new String(Files.readAllBytes(exportedConfigPath), StandardCharsets.UTF_8));
+    assertThat(Props.toString(Props.load(exportedConfigPath)), Props.load(exportedConfigPath).stringPropertyNames(), hasItem("stripe.1.node.1.logger-overrides"));
+
+    startNode(1, 2);
+    waitForDiagnostic(1, 2);
+
+    MatcherAssert.assertThat(
+        invokeConfigTool("activate", "-R", "-s", "localhost:" + getNodePort(1, 2), "-f", exportedConfigPath.toString()),
+        allOf(containsOutput("No license installed"), containsOutput("came back up")));
   }
 }


### PR DESCRIPTION
TDB-5174: Fix passive sync bug
 - on startup auto-activation, restricted activation or repair in case the active has some changes after a topology change
 - added IT tests to make sure the lock context is exported and can be re-imported to repair or auto-activate a node