### PR TITLE
✅ 🐛 TDB-5210: Fix DynamicTopologyEntity problems

### DIFF
--- a/dynamic-config/api/src/main/java/org/terracotta/dynamic_config/api/model/nomad/StripeRemovalNomadChange.java
+++ b/dynamic-config/api/src/main/java/org/terracotta/dynamic_config/api/model/nomad/StripeRemovalNomadChange.java
@@ -36,7 +36,7 @@ public class StripeRemovalNomadChange extends StripeNomadChange {
     }
 
     Cluster updated = original.clone();
-    updated.removeStripe(getStripe());
+    updated.removeStripe(getStripe().getUID());
     return updated;
   }
 

--- a/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/command/DetachCommand.java
+++ b/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/command/DetachCommand.java
@@ -152,9 +152,8 @@ public class DetachCommand extends TopologyCommand {
       }
 
       case STRIPE: {
-        Stripe stripe = cluster.getStripe(source.getUID()).get();
         logger.info("Detaching stripe: {} from cluster: {}", source.getName(), destinationCluster.getName());
-        cluster.removeStripe(stripe);
+        cluster.removeStripe(source.getUID());
         break;
       }
 

--- a/dynamic-config/entities/topology-entity/client/src/main/java/org/terracotta/dynamic_config/entity/topology/client/DynamicTopologyEntity.java
+++ b/dynamic-config/entities/topology-entity/client/src/main/java/org/terracotta/dynamic_config/entity/topology/client/DynamicTopologyEntity.java
@@ -89,15 +89,15 @@ public interface DynamicTopologyEntity extends Entity {
   }
 
   interface Listener {
-    default void onNodeRemoval(UID stripeUID, Node removedNode) {}
+    default void onNodeRemoval(Cluster cluster, UID stripeUID, Node removedNode) {}
 
-    default void onNodeAddition(UID stripeUID, Node addedNode) {}
+    default void onNodeAddition(Cluster cluster, UID addedNodeUID) {}
 
-    default void onStripeAddition(Stripe addedStripe) {}
+    default void onStripeAddition(Cluster cluster, UID addedStripeUID) {}
 
-    default void onStripeRemoval(Stripe removedStripe) {}
+    default void onStripeRemoval(Cluster cluster, Stripe removedStripe) {}
 
-    default void onSettingChange(Configuration configuration, Cluster cluster) {}
+    default void onSettingChange(Cluster cluster, Configuration configuration) {}
 
     default void onDisconnected() {}
   }

--- a/dynamic-config/entities/topology-entity/client/src/main/java/org/terracotta/dynamic_config/entity/topology/client/DynamicTopologyEntityImpl.java
+++ b/dynamic-config/entities/topology-entity/client/src/main/java/org/terracotta/dynamic_config/entity/topology/client/DynamicTopologyEntityImpl.java
@@ -62,34 +62,39 @@ class DynamicTopologyEntityImpl implements DynamicTopologyEntity {
     endpoint.setDelegate(new EndpointDelegate<Response>() {
       @Override
       public void handleMessage(Response messageFromServer) {
-        switch (messageFromServer.getType()) {
-          case EVENT_NODE_ADDITION: {
-            List<Object> payload = messageFromServer.getPayload();
-            listener.onNodeAddition((UID) payload.get(0), (Node) payload.get(1));
-            break;
+        try {
+          LOGGER.trace("handleMessage({})", messageFromServer);
+          switch (messageFromServer.getType()) {
+            case EVENT_NODE_ADDITION: {
+              List<Object> payload = messageFromServer.getPayload();
+              listener.onNodeAddition((Cluster) payload.get(0), (UID) payload.get(1));
+              break;
+            }
+            case EVENT_NODE_REMOVAL: {
+              List<Object> payload = messageFromServer.getPayload();
+              listener.onNodeRemoval((Cluster) payload.get(0), (UID) payload.get(1), (Node) payload.get(2));
+              break;
+            }
+            case EVENT_SETTING_CHANGED: {
+              List<Object> payload = messageFromServer.getPayload();
+              listener.onSettingChange((Cluster) payload.get(0), (Configuration) payload.get(1));
+              break;
+            }
+            case EVENT_STRIPE_ADDITION: {
+              List<Object> payload = messageFromServer.getPayload();
+              listener.onStripeAddition((Cluster) payload.get(0), (UID) payload.get(1));
+              break;
+            }
+            case EVENT_STRIPE_REMOVAL: {
+              List<Object> payload = messageFromServer.getPayload();
+              listener.onStripeRemoval((Cluster) payload.get(0), (Stripe) payload.get(1));
+              break;
+            }
+            default:
+              throw new AssertionError(messageFromServer);
           }
-          case EVENT_NODE_REMOVAL: {
-            List<Object> payload = messageFromServer.getPayload();
-            listener.onNodeRemoval((UID) payload.get(0), (Node) payload.get(1));
-            break;
-          }
-          case EVENT_SETTING_CHANGED: {
-            List<Object> payload = messageFromServer.getPayload();
-            listener.onSettingChange((Configuration) payload.get(0), (Cluster) payload.get(1));
-            break;
-          }
-          case EVENT_STRIPE_ADDITION: {
-            List<Object> payload = messageFromServer.getPayload();
-            listener.onStripeAddition((Stripe) payload.get(0));
-            break;
-          }
-          case EVENT_STRIPE_REMOVAL: {
-            List<Object> payload = messageFromServer.getPayload();
-            listener.onStripeRemoval((Stripe) payload.get(0));
-            break;
-          }
-          default:
-            throw new AssertionError(messageFromServer);
+        } catch (RuntimeException e) {
+          LOGGER.error("Error handling message: " + messageFromServer + ": " + e.getMessage(), e);
         }
       }
 

--- a/dynamic-config/entities/topology-entity/common/src/main/java/org/terracotta/dynamic_config/entity/topology/common/Codec.java
+++ b/dynamic-config/entities/topology-entity/common/src/main/java/org/terracotta/dynamic_config/entity/topology/common/Codec.java
@@ -15,6 +15,8 @@
  */
 package org.terracotta.dynamic_config.entity.topology.common;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.terracotta.dynamic_config.api.model.Cluster;
 import org.terracotta.dynamic_config.api.model.Configuration;
 import org.terracotta.dynamic_config.api.model.License;
@@ -59,6 +61,8 @@ import static org.terracotta.runnel.StructBuilder.newStructBuilder;
  */
 public class Codec implements MessageCodec<Message, Response> {
 
+  private static final Logger LOGGER = LoggerFactory.getLogger(Codec.class);
+
   private static final DateTimeFormatter DT_FORMATTER = DateTimeFormatter.ofPattern("yyyy/MM/dd", Locale.ENGLISH);
 
   private final Struct struct = newStructBuilder()
@@ -90,23 +94,35 @@ public class Codec implements MessageCodec<Message, Response> {
       .string(REQ_RUNTIME_CLUSTER.name(), 50)
       .string(REQ_UPCOMING_CLUSTER.name(), 60)
       .struct(EVENT_NODE_ADDITION.name(), 70, newStructBuilder()
-          .string("stripeUID", 10)
-          .string("node", 20)
+          .string("stripeUID", 10) // V1 (deprecated)
+          .string("node", 20)  // V1 (deprecated)
+          .string("nodeUID", 30) // since V2
+          .string("cluster", 40) // since V2
           .build())
       .struct(EVENT_NODE_REMOVAL.name(), 80, newStructBuilder()
           .string("stripeUID", 10)
           .string("node", 20)
+          .string("cluster", 30) // since V2
           .build())
       .struct(EVENT_SETTING_CHANGED.name(), 90, newStructBuilder()
           .string("configuration", 10)
           .string("cluster", 20)
           .build())
-      .string(EVENT_STRIPE_ADDITION.name(), 100)
-      .string(EVENT_STRIPE_REMOVAL.name(), 110)
+      .string(EVENT_STRIPE_ADDITION.name(), 100) // V1 (deprecated)
+      .string(EVENT_STRIPE_REMOVAL.name(), 110) // V1 (deprecated)
+      .struct("EVENT_STRIPE_ADDITION_V2", 120, newStructBuilder()  // since V2
+          .string("stripeUID", 10)
+          .string("cluster", 20)
+          .build())
+      .struct("EVENT_STRIPE_REMOVAL_V2", 130, newStructBuilder()  // since V2
+          .string("stripe", 10)
+          .string("cluster", 20)
+          .build())
       .build();
 
   @Override
   public byte[] encodeMessage(Message message) throws MessageCodecException {
+    LOGGER.trace("encodeMessage({})", message);
     try {
       return struct.encoder()
           .enm("type", message.getType())
@@ -120,7 +136,9 @@ public class Codec implements MessageCodec<Message, Response> {
   @Override
   public Message decodeMessage(byte[] bytes) throws MessageCodecException {
     try {
-      return new Message(struct.decoder(ByteBuffer.wrap(bytes)).<Type>enm("type").get());
+      final Message message = new Message(struct.decoder(ByteBuffer.wrap(bytes)).<Type>enm("type").get());
+      LOGGER.trace("decodeMessage(): {}", message);
+      return message;
     } catch (RuntimeException e) {
       throw new MessageCodecException(e.getMessage(), e);
     }
@@ -128,6 +146,7 @@ public class Codec implements MessageCodec<Message, Response> {
 
   @Override
   public byte[] encodeResponse(Response response) throws MessageCodecException {
+    LOGGER.trace("encodeResponse({})", response);
     try {
       Type type = response.getType();
       StructEncoder<Void> encoder = struct.encoder();
@@ -157,24 +176,57 @@ public class Codec implements MessageCodec<Message, Response> {
           encoder.string(type.name(), encodeCluster(response.getPayload()));
           break;
         }
-        case EVENT_NODE_ADDITION:
+        case EVENT_NODE_ADDITION: {
+          List<Object> oo = response.getPayload();
+          Cluster cluster = (Cluster) oo.get(0);
+          UID addedNodeUID = (UID) oo.get(1);
+          encoder.struct(type.name())
+              .string("stripeUID", cluster.getStripeByNode(addedNodeUID).get().getUID().toString()) // V1 (deprecated)
+              .string("node", encodeNode(cluster.getNode(addedNodeUID).get())) // V1 (deprecated)
+              .string("nodeUID", addedNodeUID.toString()) // since V2
+              .string("cluster", encodeCluster(cluster)); // since V2
+          break;
+        }
         case EVENT_NODE_REMOVAL: {
           List<Object> oo = response.getPayload();
+          Cluster cluster = (Cluster) oo.get(0);
+          UID stripeUID = (UID) oo.get(1);
+          Node node = (Node) oo.get(2);
           encoder.struct(type.name())
-              .string("stripeUID", oo.get(0).toString())
-              .string("node", encodeNode((Node) oo.get(1)));
+              .string("stripeUID", stripeUID.toString())
+              .string("node", encodeNode(node))
+              .string("cluster", encodeCluster(cluster)); // since V2
           break;
         }
         case EVENT_SETTING_CHANGED: {
           List<Object> oo = response.getPayload();
           encoder.struct(type.name())
-              .string("configuration", encodeConfiguration((Configuration) oo.get(0)))
-              .string("cluster", encodeCluster((Cluster) oo.get(1)));
+              .string("configuration", encodeConfiguration((Configuration) oo.get(1)))
+              .string("cluster", encodeCluster((Cluster) oo.get(0)));
           break;
         }
-        case EVENT_STRIPE_ADDITION:
+        case EVENT_STRIPE_ADDITION: {
+          List<Object> oo = response.getPayload();
+          Cluster cluster = (Cluster) oo.get(0);
+          UID stripeUID = (UID) oo.get(1);
+          // V1 (deprecated)
+          encoder.string(type.name(), encodeStripe(cluster.getStripe(stripeUID).get()));
+          // since V2
+          encoder.struct("EVENT_STRIPE_ADDITION_V2")
+              .string("stripeUID", stripeUID.toString())
+              .string("cluster", encodeCluster(cluster));
+          break;
+        }
         case EVENT_STRIPE_REMOVAL: {
-          encoder.string(type.name(), encodeStripe(response.getPayload()));
+          List<Object> oo = response.getPayload();
+          Cluster cluster = (Cluster) oo.get(0);
+          Stripe stripe = (Stripe) oo.get(1);
+          // V1 (deprecated)
+          encoder.string(type.name(), encodeStripe(stripe));
+          // since V2
+          encoder.struct("EVENT_STRIPE_REMOVAL_V2")
+              .string("stripe", encodeStripe(stripe))
+              .string("cluster", encodeCluster(cluster));
           break;
         }
         default:
@@ -182,6 +234,7 @@ public class Codec implements MessageCodec<Message, Response> {
       }
       return encoder.encode().array();
     } catch (RuntimeException e) {
+      LOGGER.error("encodeResponse({}): {}", response, e.getMessage(), e);
       throw new MessageCodecException(e.getMessage(), e);
     }
   }
@@ -191,6 +244,7 @@ public class Codec implements MessageCodec<Message, Response> {
     try {
       StructDecoder<Void> decoder = struct.decoder(ByteBuffer.wrap(bytes));
       Type type = decoder.<Type>enm("type").get();
+      LOGGER.trace("decodeResponse({})", type);
       switch (type) {
         case REQ_LICENSE: {
           StructDecoder<StructDecoder<Void>> payload = decoder.struct(type.name());
@@ -211,26 +265,45 @@ public class Codec implements MessageCodec<Message, Response> {
         case REQ_RUNTIME_CLUSTER:
         case REQ_UPCOMING_CLUSTER:
           return new Response(type, decodeCluster(decoder.string(type.name())));
-        case EVENT_NODE_ADDITION:
-        case EVENT_NODE_REMOVAL: {
+        case EVENT_NODE_ADDITION: {
+          // since V2
           StructDecoder<?> event = decoder.struct(type.name());
-          return new Response(type, asList(
-              UID.valueOf(event.string("stripeUID")),
-              decodeNode(event.string("node"))));
+          UID nodeUID = UID.valueOf(event.string("nodeUID"));
+          Cluster cluster = decodeCluster(event.string("cluster"));
+          return new Response(type, asList(cluster, nodeUID));
+        }
+        case EVENT_NODE_REMOVAL: {
+          // since V2
+          StructDecoder<?> event = decoder.struct(type.name());
+          UID stripeUID = UID.valueOf(event.string("stripeUID"));
+          Node removedNode = decodeNode(event.string("node"));
+          Cluster cluster = decodeCluster(event.string("cluster"));
+          return new Response(type, asList(cluster, stripeUID, removedNode));
         }
         case EVENT_SETTING_CHANGED: {
           StructDecoder<?> event = decoder.struct(type.name());
-          return new Response(type, asList(
-              decodeConfiguration(event.string("configuration")),
-              decodeCluster(event.string("cluster"))));
+          final String configuration = event.string("configuration");
+          final String cluster = event.string("cluster");
+          return new Response(type, asList(decodeCluster(cluster), decodeConfiguration(configuration)));
         }
-        case EVENT_STRIPE_ADDITION:
+        case EVENT_STRIPE_ADDITION: {
+          // since V2
+          StructDecoder<?> event = decoder.struct("EVENT_STRIPE_ADDITION_V2");
+          UID stripeUID = UID.valueOf(event.string("stripeUID"));
+          Cluster cluster = decodeCluster(event.string("cluster"));
+          return new Response(type, asList(cluster, stripeUID));
+        }
         case EVENT_STRIPE_REMOVAL:
-          return new Response(type, decodeStripe(decoder.string(type.name())));
+          // since V2
+          StructDecoder<?> event = decoder.struct("EVENT_STRIPE_REMOVAL_V2");
+          Stripe stripe = decodeStripe(event.string("stripe"));
+          Cluster cluster = decodeCluster(event.string("cluster"));
+          return new Response(type, asList(cluster, stripe));
         default:
           throw new UnsupportedOperationException(type.name());
       }
     } catch (RuntimeException e) {
+      LOGGER.error("decodeResponse(): {}", e.getMessage(), e);
       throw new MessageCodecException(e.getMessage(), e);
     }
   }

--- a/dynamic-config/entities/topology-entity/common/src/test/java/org/terracotta/dynamic_config/entity/topology/common/CodecTest.java
+++ b/dynamic-config/entities/topology-entity/common/src/test/java/org/terracotta/dynamic_config/entity/topology/common/CodecTest.java
@@ -68,13 +68,13 @@ public class CodecTest {
     test(REQ_RUNTIME_CLUSTER, cluster);
     test(REQ_UPCOMING_CLUSTER, cluster);
 
-    test(EVENT_NODE_ADDITION, asList(stripe.getUID(), node));
-    test(EVENT_NODE_REMOVAL, asList(stripe.getUID(), node));
+    test(EVENT_NODE_ADDITION, asList(cluster, node.getUID()));
+    test(EVENT_NODE_REMOVAL, asList(cluster, stripe.getUID(), node));
 
-    test(EVENT_SETTING_CHANGED, asList(Configuration.valueOf("cluster-name=foo"), cluster));
+    test(EVENT_SETTING_CHANGED, asList(cluster, Configuration.valueOf("cluster-name=foo")));
 
-    test(EVENT_STRIPE_ADDITION, stripe);
-    test(EVENT_STRIPE_REMOVAL, stripe);
+    test(EVENT_STRIPE_ADDITION, asList(cluster, stripe.getUID()));
+    test(EVENT_STRIPE_REMOVAL, asList(cluster, stripe));
   }
 
   private static void test(Type type, Object payload) throws MessageCodecException {

--- a/dynamic-config/model/src/main/java/org/terracotta/dynamic_config/api/model/Cluster.java
+++ b/dynamic-config/model/src/main/java/org/terracotta/dynamic_config/api/model/Cluster.java
@@ -320,7 +320,7 @@ public class Cluster implements Cloneable, PropertyHolder {
   }
 
   public Collection<Endpoint> getSimilarEndpoints(Endpoint initiator) {
-    return getNodes().stream().map(node -> node.getSimilarEndpoints(initiator)).collect(toList());
+    return getNodes().stream().map(node -> node.getSimilarEndpoint(initiator)).collect(toList());
   }
 
   public boolean containsNode(UID nodeUID) {

--- a/dynamic-config/model/src/main/java/org/terracotta/dynamic_config/api/model/Cluster.java
+++ b/dynamic-config/model/src/main/java/org/terracotta/dynamic_config/api/model/Cluster.java
@@ -353,6 +353,10 @@ public class Cluster implements Cloneable, PropertyHolder {
     return stripes.remove(stripe);
   }
 
+  public boolean removeStripe(UID stripeUID) {
+    return stripes.removeIf(stripe -> stripe.getUID().equals(stripeUID));
+  }
+
   public boolean removeNode(UID uid) {
     boolean detached = stripes.stream().anyMatch(stripe -> stripe.removeNode(uid));
     if (detached) {

--- a/dynamic-config/model/src/main/java/org/terracotta/dynamic_config/api/model/Node.java
+++ b/dynamic-config/model/src/main/java/org/terracotta/dynamic_config/api/model/Node.java
@@ -391,7 +391,7 @@ public class Node implements Cloneable, PropertyHolder {
     return getPublicEndpoint().orElseGet(this::getInternalEndpoint);
   }
 
-  public Endpoint getSimilarEndpoints(Endpoint initiator) {
+  public Endpoint getSimilarEndpoint(Endpoint initiator) {
     return ADDR_GROUP_INTERNAL.equals(initiator.getGroup()) ?
         getInternalEndpoint() :
         getPublicEndpoint().orElseGet(this::getInternalEndpoint);

--- a/dynamic-config/model/src/main/java/org/terracotta/dynamic_config/api/model/Stripe.java
+++ b/dynamic-config/model/src/main/java/org/terracotta/dynamic_config/api/model/Stripe.java
@@ -138,7 +138,7 @@ public class Stripe implements Cloneable, PropertyHolder {
   }
 
   public Collection<Node.Endpoint> getSimilarEndpoints(Node.Endpoint initiator) {
-    return getNodes().stream().map(node -> node.getSimilarEndpoints(initiator)).collect(toList());
+    return getNodes().stream().map(node -> node.getSimilarEndpoint(initiator)).collect(toList());
   }
 
   @Override

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/AttachStripeIT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/AttachStripeIT.java
@@ -15,12 +15,20 @@
  */
 package org.terracotta.dynamic_config.system_tests.activated;
 
+import com.terracotta.connection.api.TerracottaConnectionService;
 import org.junit.Before;
 import org.junit.Test;
+import org.terracotta.dynamic_config.api.model.Cluster;
+import org.terracotta.dynamic_config.api.model.UID;
+import org.terracotta.dynamic_config.entity.topology.client.DynamicTopologyEntity;
+import org.terracotta.dynamic_config.entity.topology.client.DynamicTopologyEntityFactory;
 import org.terracotta.dynamic_config.test_support.ClusterDefinition;
 import org.terracotta.dynamic_config.test_support.DynamicConfigIT;
 
+import java.net.InetSocketAddress;
 import java.time.Duration;
+import java.util.Collections;
+import java.util.concurrent.CountDownLatch;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
@@ -88,5 +96,38 @@ public class AttachStripeIT extends DynamicConfigIT {
     assertThat(getRuntimeCluster("localhost", getNodePort(1, 2)).getStripe(2).get().getNodeCount(), is(equalTo(2)));
     assertThat(getUpcomingCluster("localhost", getNodePort(2, 1)).getStripe(1).get().getNodeCount(), is(equalTo(2)));
     assertThat(getRuntimeCluster("localhost", getNodePort(2, 2)).getStripe(1).get().getNodeCount(), is(equalTo(2)));
+  }
+
+  @Test
+  public void test_topology_entity_callback_onStripeAddition() throws Exception {
+    startNode(2, 1);
+    waitForDiagnostic(2, 1);
+    startNode(2, 2);
+    waitForDiagnostic(2, 2);
+    invokeConfigTool("attach", "-d", "localhost:" + getNodePort(2, 1), "-s", "localhost:" + getNodePort(2, 2));
+
+    final int activeId = findActive(1).getAsInt();
+
+    try (DynamicTopologyEntity dynamicTopologyEntity = DynamicTopologyEntityFactory.fetch(
+        new TerracottaConnectionService(),
+        Collections.singletonList(InetSocketAddress.createUnresolved("localhost", getNodePort(1, activeId))),
+        "dynamic-config-topology-entity",
+        getConnectionTimeout(),
+        new DynamicTopologyEntity.Settings(),
+        null)) {
+
+      CountDownLatch called = new CountDownLatch(1);
+
+      dynamicTopologyEntity.setListener(new DynamicTopologyEntity.Listener() {
+        @Override
+        public void onStripeAddition(Cluster cluster, UID addedStripeUID) {
+          called.countDown();
+        }
+      });
+
+      invokeConfigTool("attach", "-t", "stripe", "-d", "localhost:" + getNodePort(1, activeId), "-s", "localhost:" + getNodePort(2, 1));
+
+      called.await();
+    }
   }
 }


### PR DESCRIPTION
- the entity development was not complete (but just wired) since there were no use case at that time
- saw this week that it was use quite a lot in ehcache and EE... (❗)
- callbacks were not tested (but just wired) - there were no use case at time
- fixed callback signatures to allow consumers to have access to the updated topology (and correctly lookup the node endpoints)
- added system tests for each callback
- backward compatibility support for existing clients

__The goal of this PR is to allow fix the many places in Ehcache and EE where the addresses should be looked up according to the user input.__

It also allows listeners to now have access to the updated topology