### PR TITLE
Fixing TEST logback level (no runtime code change)

### DIFF
--- a/dynamic-config/testing/system-tests/src/test/resources/logback-test.xml
+++ b/dynamic-config/testing/system-tests/src/test/resources/logback-test.xml
@@ -26,7 +26,7 @@
     </layout>
   </appender>
 
-  <root level="OFF">
+  <root level="WARN">
     <appender-ref ref="STDOUT"/>
   </root>
 


### PR DESCRIPTION
WE HAVE TO SEE WARNINGS AND ERRORS!
Because of that, the stack traces dumped by core in case of a failure in the connection thread (i.e. codec) was hidden!