### PR TITLE
✅ 🐛 TDB-5208: Introduce ServiceProvider interface in config-tool to allow EE code base to override and provide some more services

### DIFF
--- a/dynamic-config/cli/cli-support/src/main/java/org/terracotta/dynamic_config/cli/command/CommandRepository.java
+++ b/dynamic-config/cli/cli-support/src/main/java/org/terracotta/dynamic_config/cli/command/CommandRepository.java
@@ -39,7 +39,11 @@ public class CommandRepository {
     return commandMap.get(name);
   }
 
-  public void inject(Object... services) {
+  public void inject(Object[] services) {
+    commandMap.values().forEach(command -> Injector.inject(command, services));
+  }
+
+  public void inject(Collection<Object> services) {
     commandMap.values().forEach(command -> Injector.inject(command, services));
   }
 }

--- a/dynamic-config/cli/cli-support/src/main/java/org/terracotta/dynamic_config/cli/command/Injector.java
+++ b/dynamic-config/cli/cli-support/src/main/java/org/terracotta/dynamic_config/cli/command/Injector.java
@@ -19,17 +19,24 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import java.util.Collection;
 import java.util.stream.Stream;
+
+import static java.util.Arrays.asList;
 
 /**
  * @author Mathieu Carbou
  */
 public class Injector {
-  public static <T> T inject(T target, Object... services) {
+  public static <T> T inject(T target, Object[] services) {
+    return inject(target, asList(services));
+  }
+
+  public static <T> T inject(T target, Collection<Object> services) {
     Stream.of(target.getClass().getFields())
         .filter(field -> field.isAnnotationPresent(Inject.class))
         .forEach(field -> {
-          Object found = Stream.of(services)
+          Object found = services.stream()
               .filter(service -> field.getType().isInstance(service))
               .findAny()
               .orElseThrow(() -> new IllegalStateException("No service found to inject into " + field));

--- a/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/command/OssServiceProvider.java
+++ b/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/command/OssServiceProvider.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.dynamic_config.cli.config_tool.command;
+
+import org.terracotta.common.struct.TimeUnit;
+import org.terracotta.diagnostic.client.connection.ConcurrencySizing;
+import org.terracotta.diagnostic.client.connection.ConcurrentDiagnosticServiceProvider;
+import org.terracotta.diagnostic.client.connection.DiagnosticServiceProvider;
+import org.terracotta.dynamic_config.api.json.DynamicConfigApiJsonModule;
+import org.terracotta.dynamic_config.api.model.NodeContext;
+import org.terracotta.dynamic_config.api.model.UID;
+import org.terracotta.dynamic_config.cli.command.RemoteMainCommand;
+import org.terracotta.dynamic_config.cli.config_tool.nomad.DefaultNomadManager;
+import org.terracotta.dynamic_config.cli.config_tool.nomad.LockAwareNomadManager;
+import org.terracotta.dynamic_config.cli.config_tool.nomad.NomadManager;
+import org.terracotta.dynamic_config.cli.config_tool.restart.RestartService;
+import org.terracotta.dynamic_config.cli.config_tool.stop.StopService;
+import org.terracotta.json.ObjectMapperFactory;
+import org.terracotta.nomad.NomadEnvironment;
+import org.terracotta.nomad.entity.client.NomadEntity;
+import org.terracotta.nomad.entity.client.NomadEntityProvider;
+
+import java.time.Duration;
+import java.util.Collection;
+
+import static java.util.Arrays.asList;
+
+/**
+ * @author Mathieu Carbou
+ */
+public class OssServiceProvider implements ServiceProvider {
+  @Override
+  public Collection<Object> createServices(RemoteMainCommand mainCommand) {
+    return asList(
+        createDiagnosticServiceProvider(mainCommand),
+        createMultiDiagnosticServiceProvider(mainCommand),
+        createNomadManager(mainCommand),
+        createRestartService(mainCommand),
+        createStopService(mainCommand),
+        createObjectMapperFactory(mainCommand),
+        createNomadEntityProvider(mainCommand));
+  }
+
+  protected StopService createStopService(RemoteMainCommand mainCommand) {
+    return new StopService(createDiagnosticServiceProvider(mainCommand), getConcurrencySizing(mainCommand));
+  }
+
+  protected RestartService createRestartService(RemoteMainCommand mainCommand) {
+    return new RestartService(createDiagnosticServiceProvider(mainCommand), getConcurrencySizing(mainCommand));
+  }
+
+  protected NomadManager<NodeContext> createNomadManager(RemoteMainCommand mainCommand) {
+    NomadManager<NodeContext> nomadManager = new DefaultNomadManager<>(new NomadEnvironment(), createMultiDiagnosticServiceProvider(mainCommand), createNomadEntityProvider(mainCommand));
+    if (mainCommand.getLockToken() != null) {
+      nomadManager = new LockAwareNomadManager<>(mainCommand.getLockToken(), nomadManager);
+    }
+    return nomadManager;
+  }
+
+  protected NomadEntityProvider createNomadEntityProvider(RemoteMainCommand mainCommand) {
+    return new NomadEntityProvider(
+        "CONFIG-TOOL",
+        getEntityConnectionTimeout(mainCommand),
+        // A long timeout is important here.
+        // We need to block the call and wait for any return.
+        // We cannot timeout shortly otherwise we won't know the outcome of the 2PC Nomad transaction in case of a failover.
+        new NomadEntity.Settings().setRequestTimeout(getEntityOperationTimeout(mainCommand)),
+        mainCommand.getSecurityRootDirectory());
+  }
+
+  protected ConcurrentDiagnosticServiceProvider<UID> createMultiDiagnosticServiceProvider(RemoteMainCommand mainCommand) {
+    return new ConcurrentDiagnosticServiceProvider<>(
+        createDiagnosticServiceProvider(mainCommand),
+        getConnectionTimeout(mainCommand),
+        getConcurrencySizing(mainCommand));
+  }
+
+  protected DiagnosticServiceProvider createDiagnosticServiceProvider(RemoteMainCommand mainCommand) {
+    return new DiagnosticServiceProvider("CONFIG-TOOL",
+        getConnectionTimeout(mainCommand),
+        getRequestTimeout(mainCommand),
+        mainCommand.getSecurityRootDirectory(),
+        createObjectMapperFactory(mainCommand));
+  }
+
+  protected ObjectMapperFactory createObjectMapperFactory(RemoteMainCommand mainCommand) {
+    return new ObjectMapperFactory().withModule(new DynamicConfigApiJsonModule());
+  }
+
+  protected Duration getEntityConnectionTimeout(RemoteMainCommand mainCommand) {
+    return Duration.ofMillis(mainCommand.getEntityConnectionTimeout().getQuantity(TimeUnit.MILLISECONDS));
+  }
+
+  protected Duration getEntityOperationTimeout(RemoteMainCommand mainCommand) {
+    return Duration.ofMillis(mainCommand.getEntityOperationTimeout().getQuantity(TimeUnit.MILLISECONDS));
+  }
+
+  protected Duration getRequestTimeout(RemoteMainCommand mainCommand) {
+    return Duration.ofMillis(mainCommand.getRequestTimeout().getQuantity(TimeUnit.MILLISECONDS));
+  }
+
+  protected Duration getConnectionTimeout(RemoteMainCommand mainCommand) {
+    return Duration.ofMillis(mainCommand.getConnectionTimeout().getQuantity(TimeUnit.MILLISECONDS));
+  }
+
+  protected ConcurrencySizing getConcurrencySizing(RemoteMainCommand mainCommand) {
+    return new ConcurrencySizing();
+  }
+
+}

--- a/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/command/ServiceProvider.java
+++ b/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/command/ServiceProvider.java
@@ -13,22 +13,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.terracotta.dynamic_config.cli.config_tool.command;
 
 import com.tc.util.ManagedServiceLoader;
-import org.terracotta.dynamic_config.cli.command.Command;
+import org.terracotta.dynamic_config.cli.command.RemoteMainCommand;
 
 import java.util.Collection;
-import java.util.Set;
 
-public interface CommandProvider {
-  Set<Command> getCommands();
+public interface ServiceProvider {
+  Collection<Object> createServices(RemoteMainCommand mainCommand);
 
-  static CommandProvider get() {
-    Collection<CommandProvider> services = ManagedServiceLoader.loadServices(CommandProvider.class, CommandProvider.class.getClassLoader());
+  static ServiceProvider get() {
+    Collection<ServiceProvider> services = ManagedServiceLoader.loadServices(ServiceProvider.class, ServiceProvider.class.getClassLoader());
     if (services.size() != 1) {
-      throw new AssertionError("expected exactly one command provider, but found :" + services.size());
+      throw new AssertionError("expected exactly one service provider, but found :" + services.size());
     }
     return services.iterator().next();
   }

--- a/dynamic-config/cli/config-tool/src/main/resources/META-INF/services/org.terracotta.dynamic_config.cli.config_tool.command.ServiceProvider
+++ b/dynamic-config/cli/config-tool/src/main/resources/META-INF/services/org.terracotta.dynamic_config.cli.config_tool.command.ServiceProvider
@@ -1,0 +1,1 @@
+org.terracotta.dynamic_config.cli.config_tool.command.OssServiceProvider

--- a/dynamic-config/cli/config-tool/src/test/java/org/terracotta/dynamic_config/cli/config_tool/command/ActivateCommandTest.java
+++ b/dynamic-config/cli/config-tool/src/test/java/org/terracotta/dynamic_config/cli/config_tool/command/ActivateCommandTest.java
@@ -40,6 +40,7 @@ import java.util.UUID;
 import java.util.function.IntConsumer;
 import java.util.stream.IntStream;
 
+import static java.util.Arrays.asList;
 import static java.util.Objects.requireNonNull;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
@@ -299,8 +300,7 @@ public class ActivateCommandTest extends BaseTest {
 
   private ActivateCommand command() {
     ActivateCommand command = new ActivateCommand();
-    inject(command, diagnosticServiceProvider, multiDiagnosticServiceProvider, nomadManager, restartService,
-        stopService, nomadEntityProvider);
+    inject(command, asList(diagnosticServiceProvider, multiDiagnosticServiceProvider, nomadManager, restartService, stopService, nomadEntityProvider));
     return command;
   }
 

--- a/dynamic-config/cli/config-tool/src/test/java/org/terracotta/dynamic_config/cli/config_tool/command/TopologyCommandTest.java
+++ b/dynamic-config/cli/config-tool/src/test/java/org/terracotta/dynamic_config/cli/config_tool/command/TopologyCommandTest.java
@@ -19,6 +19,7 @@ import org.junit.Test;
 import org.terracotta.dynamic_config.cli.command.Metadata;
 import org.terracotta.dynamic_config.cli.config_tool.BaseTest;
 
+import static java.util.Arrays.asList;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
@@ -38,8 +39,7 @@ public abstract class TopologyCommandTest<C extends TopologyCommand> extends Bas
   }
 
   protected final C newCommand() {
-    return inject(newTopologyCommand(), diagnosticServiceProvider, multiDiagnosticServiceProvider, nomadManager,
-        restartService, stopService, objectMapperFactory, nomadEntityProvider);
+    return inject(newTopologyCommand(), asList(diagnosticServiceProvider, multiDiagnosticServiceProvider, nomadManager, restartService, stopService, objectMapperFactory, nomadEntityProvider));
   }
 
   protected abstract C newTopologyCommand();

--- a/dynamic-config/cli/upgrade-tools/src/main/java/org/terracotta/dynamic_config/cli/upgrade_tools/config_converter/ConfigConverterTool.java
+++ b/dynamic-config/cli/upgrade-tools/src/main/java/org/terracotta/dynamic_config/cli/upgrade_tools/config_converter/ConfigConverterTool.java
@@ -62,9 +62,6 @@ public class ConfigConverterTool {
     // Process arguments like '-v'
     mainCommand.run();
 
-    LOGGER.debug("Injecting services in CommandRepository");
-    commandRepository.inject(); // no service injection yet
-
     jCommander.getAskedCommand().map(command -> {
       // check for help
       if (command.isHelp()) {


### PR DESCRIPTION
This work is required to fix several issues:
- TDB-5209: Inject the EE connection service instead of OSS one to support better security exceptions and error handling
- TDB-5207: Allow to replay some security validations in an overridden EE service