### PR TITLE
Update jCommander to 1.78

### DIFF
--- a/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/DynamicConfigConfigurationProvider.java
+++ b/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/DynamicConfigConfigurationProvider.java
@@ -171,7 +171,7 @@ public class DynamicConfigConfigurationProvider implements ConfigurationProvider
   public String getConfigurationParamsDescription() {
     StringBuilder out = new StringBuilder();
     CustomJCommander jCommander = new CustomJCommander(new Options());
-    jCommander.usage(out);
+    jCommander.getUsageFormatter().usage(out);
     return out.toString();
   }
 

--- a/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/startup/CustomJCommander.java
+++ b/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/startup/CustomJCommander.java
@@ -15,6 +15,7 @@
  */
 package org.terracotta.dynamic_config.server.configuration.startup;
 
+import com.beust.jcommander.DefaultUsageFormatter;
 import com.beust.jcommander.JCommander;
 import com.beust.jcommander.ParameterDescription;
 import com.beust.jcommander.WrappedParameter;
@@ -40,6 +41,7 @@ public class CustomJCommander extends JCommander {
 
   public CustomJCommander(Options object) {
     super(object);
+    setUsageFormatter(new UsageFormatter(this));
 
     // Hacky way to get the specified options, since JCommander doesn't provide this functionality out-of-the-box
     addConverterInstanceFactory((parameter, forType, optionName) -> {
@@ -53,63 +55,73 @@ public class CustomJCommander extends JCommander {
   }
 
   @Override
-  public void usage(StringBuilder out, String indent) {
-    appendOptions(this, out, indent);
-    appendSubstitutionParamsSection(out, indent);
-  }
-
-  @Override
   public Map<String, JCommander> getCommands() {
     // force an ordering of commands by name
     return new TreeMap<>(super.getCommands());
   }
 
-  private void appendSubstitutionParamsSection(StringBuilder out, String indent) {
-    out.append(lineSeparator()).append(indent).append("Allowed substitution parameters:").append(lineSeparator());
-    Map<String, String> allParams = ParameterSubstitutor.getAllParams();
-    allParams.forEach((param, explanation) -> out.append(indent).append("    ").append(param).append("    ").append(explanation).append(lineSeparator()));
-  }
 
-  private void appendOptions(JCommander jCommander, StringBuilder out, String indent) {
-    List<ParameterDescription> sorted = jCommander.getParameters();
-    sorted.sort(Comparator.comparing(ParameterDescription::getLongestName));
-    boolean containsRequiredOption = sorted.stream().anyMatch(pd -> pd.getParameter().required());
-    int maxParamLength = sorted.stream().map(pd -> pd.getNames().length()).max(Integer::compareTo).get();
-    String requiredHint = " (required)";
-    if (containsRequiredOption) {
-      maxParamLength += requiredHint.length();
+  private static class UsageFormatter extends DefaultUsageFormatter {
+    private final JCommander commander;
+
+    private UsageFormatter(JCommander commander) {
+      super(commander);
+      this.commander = commander;
     }
 
-    // Display all the names and descriptions
-    if (sorted.size() > 0) {
-      for (ParameterDescription pd : sorted) {
-        if (pd.getParameter().hidden()) continue;
+    @Override
+    public void usage(StringBuilder out, String indent) {
+      appendOptions(commander, out, indent);
+      appendSubstitutionParamsSection(out, indent);
+    }
 
-        WrappedParameter parameter = pd.getParameter();
-        out.append(indent).append("    ").append(pd.getNames()).append(parameter.required() ? requiredHint : "");
-        out.append(indent).append("    ");
+    private void appendSubstitutionParamsSection(StringBuilder out, String indent) {
+      out.append(lineSeparator()).append(indent).append("Allowed substitution parameters:").append(lineSeparator());
+      Map<String, String> allParams = ParameterSubstitutor.getAllParams();
+      allParams.forEach((param, explanation) -> out.append(indent).append("    ").append(param).append("    ").append(explanation).append(lineSeparator()));
+    }
 
-        int spaces = maxParamLength - pd.getNames().length();
-        if (parameter.required()) {
-          spaces -= requiredHint.length();
-        }
-        for (int i = 0; i < spaces; i++) {
-          out.append(" ");
-        }
-        out.append(pd.getDescription());
-        Optional<Setting> settingOptional = Setting.findSetting(ConsoleParamsUtils.stripDashDash(pd.getLongestName()));
-        if (settingOptional.isPresent()) {
-          Setting setting = settingOptional.get();
-          Optional<String> defaultValue = setting.getDefaultProperty();
+    private void appendOptions(JCommander jCommander, StringBuilder out, String indent) {
+      List<ParameterDescription> sorted = jCommander.getParameters();
+      sorted.sort(Comparator.comparing(ParameterDescription::getLongestName));
+      boolean containsRequiredOption = sorted.stream().anyMatch(pd -> pd.getParameter().required());
+      int maxParamLength = sorted.stream().map(pd -> pd.getNames().length()).max(Integer::compareTo).get();
+      String requiredHint = " (required)";
+      if (containsRequiredOption) {
+        maxParamLength += requiredHint.length();
+      }
 
-          // special handling
-          if (setting == NODE_NAME || setting == STRIPE_NAME) {
-            defaultValue = Optional.of("<randomly-generated>");
+      // Display all the names and descriptions
+      if (sorted.size() > 0) {
+        for (ParameterDescription pd : sorted) {
+          if (pd.getParameter().hidden()) continue;
+
+          WrappedParameter parameter = pd.getParameter();
+          out.append(indent).append("    ").append(pd.getNames()).append(parameter.required() ? requiredHint : "");
+          out.append(indent).append("    ");
+
+          int spaces = maxParamLength - pd.getNames().length();
+          if (parameter.required()) {
+            spaces -= requiredHint.length();
           }
+          for (int i = 0; i < spaces; i++) {
+            out.append(" ");
+          }
+          out.append(pd.getDescription());
+          Optional<Setting> settingOptional = Setting.findSetting(ConsoleParamsUtils.stripDashDash(pd.getLongestName()));
+          if (settingOptional.isPresent()) {
+            Setting setting = settingOptional.get();
+            Optional<String> defaultValue = setting.getDefaultProperty();
 
-          defaultValue.ifPresent(s -> out.append(". Default: ").append(s));
+            // special handling
+            if (setting == NODE_NAME || setting == STRIPE_NAME) {
+              defaultValue = Optional.of("<randomly-generated>");
+            }
+
+            defaultValue.ifPresent(s -> out.append(". Default: ").append(s));
+          }
+          out.append(lineSeparator());
         }
-        out.append(lineSeparator());
       }
     }
   }

--- a/pom.xml
+++ b/pom.xml
@@ -224,7 +224,7 @@
       <dependency>
         <groupId>com.beust</groupId>
         <artifactId>jcommander</artifactId>
-        <version>1.72</version>
+        <version>1.78</version>
       </dependency>
       <dependency>
         <groupId>ch.qos.logback</groupId>


### PR DESCRIPTION
The move from jCommander 1.72 to 1.78 involved movement of usage-related methods from `JCommander` to a new `IUsageFormatter` interface.