### PR TITLE
TDB-5261-even-node-warnings-in-logs

### DIFF
--- a/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/command/AttachCommand.java
+++ b/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/command/AttachCommand.java
@@ -41,6 +41,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 
 import static java.lang.System.lineSeparator;
+import static org.terracotta.dynamic_config.api.model.FailoverPriority.Type.CONSISTENCY;
 import static org.terracotta.dynamic_config.api.model.FailoverPriority.consistency;
 import static org.terracotta.dynamic_config.cli.config_tool.converter.OperationType.NODE;
 import static org.terracotta.dynamic_config.cli.config_tool.converter.OperationType.STRIPE;
@@ -118,7 +119,7 @@ public class AttachCommand extends TopologyCommand {
 
       Stripe destinationStripe = destinationCluster.getStripeByNode(destination.getNodeUID()).get();
       FailoverPriority failoverPriority = destinationCluster.getFailoverPriority();
-      if (failoverPriority.equals(consistency())) {
+      if (failoverPriority.getType() == CONSISTENCY) {
         int voterCount = failoverPriority.getVoters();
         int nodeCount = destinationStripe.getNodes().size();
         int sum = voterCount + nodeCount;

--- a/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/command/DetachCommand.java
+++ b/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/command/DetachCommand.java
@@ -40,6 +40,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 
 import static java.lang.System.lineSeparator;
+import static org.terracotta.dynamic_config.api.model.FailoverPriority.Type.CONSISTENCY;
 import static org.terracotta.dynamic_config.api.model.FailoverPriority.consistency;
 import static org.terracotta.dynamic_config.cli.config_tool.converter.OperationType.NODE;
 import static org.terracotta.dynamic_config.cli.config_tool.converter.OperationType.STRIPE;
@@ -92,7 +93,7 @@ public class DetachCommand extends TopologyCommand {
       }
 
       FailoverPriority failoverPriority = destinationCluster.getFailoverPriority();
-      if (failoverPriority.equals(consistency())) {
+      if (failoverPriority.getType() == CONSISTENCY) {
         int voterCount = failoverPriority.getVoters();
         int nodeCount = destinationStripe.getNodes().size();
         int sum = voterCount + nodeCount;

--- a/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/command/ImportCommand.java
+++ b/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/command/ImportCommand.java
@@ -36,6 +36,7 @@ import java.util.Collection;
 import java.util.Collections;
 
 import static java.lang.System.lineSeparator;
+import static org.terracotta.dynamic_config.api.model.FailoverPriority.Type.CONSISTENCY;
 import static org.terracotta.dynamic_config.api.model.FailoverPriority.consistency;
 
 /**
@@ -58,7 +59,7 @@ public class ImportCommand extends RemoteCommand {
   public void validate() {
     cluster = loadCluster();
     FailoverPriority failoverPriority = cluster.getFailoverPriority();
-    if (failoverPriority.equals(consistency())) {
+    if (failoverPriority.getType() == CONSISTENCY) {
       int voterCount = failoverPriority.getVoters();
       for (Stripe stripe : cluster.getStripes()) {
         int nodeCount = stripe.getNodes().size();

--- a/dynamic-config/model/src/main/java/org/terracotta/dynamic_config/api/service/ClusterValidator.java
+++ b/dynamic-config/model/src/main/java/org/terracotta/dynamic_config/api/service/ClusterValidator.java
@@ -171,22 +171,6 @@ public class ClusterValidator {
     if (failoverPriority == null) {
       throw new MalformedClusterException(Setting.FAILOVER_PRIORITY + " setting is missing");
     }
-
-    if (failoverPriority.equals(consistency())) {
-      int voterCount = failoverPriority.getVoters();
-      for (Stripe stripe : cluster.getStripes()) {
-        int nodeCount = stripe.getNodes().size();
-        int sum = voterCount + nodeCount;
-        if (sum % 2 == 0) {
-          LOGGER.warn(lineSeparator() +
-              "===================================================================================================================" + lineSeparator() +
-              "The sum (" + sum + ") of voter count (" + voterCount + ") and number of nodes (" + nodeCount + ") " +
-              "in stripe '" + stripe.getName() + "' is an even number." + lineSeparator() +
-              "An even-numbered configuration is more likely to experience split-brain situations." + lineSeparator() +
-              "===================================================================================================================" + lineSeparator());
-        }
-      }
-    }
   }
 
   private void validateNodeNames() {


### PR DESCRIPTION
-fixing even-node/voter warning in server log to get logged once on startup and for any configuration change (previous behavior was buggy with every cluster validation call resulting in a log entry)
- fixed bug in Attach/Detach/Import commands not recognizing when consistency mode had non-zero voters configured 