### PR TITLE
TDB-5247: Refactor the old UpgradableNomadServer and NomadChangeInfo to be able to expose the change result hash

### DIFF
--- a/common/nomad/src/main/java/org/terracotta/nomad/client/NomadEndpoint.java
+++ b/common/nomad/src/main/java/org/terracotta/nomad/client/NomadEndpoint.java
@@ -25,6 +25,7 @@ import org.terracotta.nomad.server.NomadException;
 import org.terracotta.nomad.server.NomadServer;
 
 import java.net.InetSocketAddress;
+import java.util.Optional;
 
 import static java.util.Objects.requireNonNull;
 
@@ -68,6 +69,15 @@ public class NomadEndpoint<T> implements NomadServer<T> {
 
   @Override
   public void close() {server.close();}
+
+  @Override
+  public boolean hasIncompleteChange() {return server.hasIncompleteChange();}
+
+  @Override
+  public Optional<T> getCurrentCommittedConfig() throws NomadException {return server.getCurrentCommittedConfig();}
+
+  @Override
+  public void reset() throws NomadException {server.reset();}
 
   @Override
   public String toString() {

--- a/common/nomad/src/main/java/org/terracotta/nomad/json/NomadJsonModule.java
+++ b/common/nomad/src/main/java/org/terracotta/nomad/json/NomadJsonModule.java
@@ -36,11 +36,9 @@ import org.terracotta.nomad.messages.RollbackMessage;
 import org.terracotta.nomad.messages.TakeoverMessage;
 import org.terracotta.nomad.server.ChangeRequest;
 import org.terracotta.nomad.server.ChangeRequestState;
-import org.terracotta.nomad.server.NomadChangeInfo;
 import org.terracotta.nomad.server.NomadServerMode;
 
 import java.time.Instant;
-import java.util.List;
 import java.util.UUID;
 
 import static java.util.Collections.singletonList;
@@ -66,7 +64,6 @@ public class NomadJsonModule extends SimpleModule {
     setMixInAnnotation(TakeoverMessage.class, TakeoverMessageMixin.class);
 
     setMixInAnnotation(ChangeRequest.class, ChangeRequestMixin.class);
-    setMixInAnnotation(NomadChangeInfo.class, NomadChangeInfoMixin.class);
   }
 
   @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.EXTERNAL_PROPERTY, property = "type")
@@ -154,9 +151,8 @@ public class NomadJsonModule extends SimpleModule {
                                  @JsonProperty(value = "lastMutationTimestamp") Instant lastMutationTimestamp,
                                  @JsonProperty(value = "currentVersion", required = true) long currentVersion,
                                  @JsonProperty(value = "highestVersion", required = true) long highestVersion,
-                                 @JsonProperty(value = "latestChange") ChangeDetails<T> latestChange,
-                                 @JsonProperty(value = "checkpoints") List<NomadChangeInfo> checkpoints) {
-      super(mode, mutativeMessageCount, lastMutationHost, lastMutationUser, lastMutationTimestamp, currentVersion, highestVersion, latestChange, checkpoints);
+                                 @JsonProperty(value = "latestChange") ChangeDetails<T> latestChange) {
+      super(mode, mutativeMessageCount, lastMutationHost, lastMutationUser, lastMutationTimestamp, currentVersion, highestVersion, latestChange);
     }
   }
 
@@ -202,19 +198,6 @@ public class NomadJsonModule extends SimpleModule {
     public ChangeRequestMixin(ChangeRequestState state, long version, String prevChangeId, NomadChange change, T changeResult, String creationHost, String creationUser, Instant creationTimestamp) {
       super(state, version, prevChangeId, change, changeResult, creationHost, creationUser, creationTimestamp);
       this.changeResult = changeResult;
-    }
-  }
-
-  public static class NomadChangeInfoMixin extends NomadChangeInfo {
-    @JsonCreator
-    public NomadChangeInfoMixin(@JsonProperty(value = "changeUuid", required = true) UUID changeUuid,
-                                @JsonProperty(value = "nomadChange", required = true) NomadChange nomadChange,
-                                @JsonProperty(value = "changeRequestState", required = true) ChangeRequestState changeRequestState,
-                                @JsonProperty(value = "version", required = true) long version,
-                                @JsonProperty(value = "creationHost", required = true) String creationHost,
-                                @JsonProperty(value = "creationUser", required = true) String creationUser,
-                                @JsonProperty(value = "creationTimestamp", required = true) Instant creationTimestamp) {
-      super(changeUuid, nomadChange, changeRequestState, version, creationHost, creationUser, creationTimestamp);
     }
   }
 }

--- a/common/nomad/src/main/java/org/terracotta/nomad/messages/DiscoverResponse.java
+++ b/common/nomad/src/main/java/org/terracotta/nomad/messages/DiscoverResponse.java
@@ -15,11 +15,9 @@
  */
 package org.terracotta.nomad.messages;
 
-import org.terracotta.nomad.server.NomadChangeInfo;
 import org.terracotta.nomad.server.NomadServerMode;
 
 import java.time.Instant;
-import java.util.List;
 
 import static java.util.Objects.requireNonNull;
 
@@ -32,7 +30,6 @@ public class DiscoverResponse<T> {
   private final long currentVersion;
   private final long highestVersion;
   private final ChangeDetails<T> latestChange;
-  private final List<NomadChangeInfo> checkpoints;
 
   public DiscoverResponse(NomadServerMode mode,
                           long mutativeMessageCount,
@@ -41,8 +38,7 @@ public class DiscoverResponse<T> {
                           Instant lastMutationTimestamp,
                           long currentVersion,
                           long highestVersion,
-                          ChangeDetails<T> latestChange,
-                          List<NomadChangeInfo> checkpoints) {
+                          ChangeDetails<T> latestChange) {
     this.mode = requireNonNull(mode);
     this.mutativeMessageCount = mutativeMessageCount;
     this.lastMutationHost = lastMutationHost;
@@ -51,15 +47,10 @@ public class DiscoverResponse<T> {
     this.currentVersion = currentVersion;
     this.highestVersion = highestVersion;
     this.latestChange = latestChange;
-    this.checkpoints = checkpoints;
   }
 
   public NomadServerMode getMode() {
     return mode;
-  }
-
-  public List<NomadChangeInfo> getCheckpoints() {
-    return checkpoints;
   }
 
   public long getMutativeMessageCount() {

--- a/common/nomad/src/main/java/org/terracotta/nomad/server/NomadServer.java
+++ b/common/nomad/src/main/java/org/terracotta/nomad/server/NomadServer.java
@@ -22,7 +22,13 @@ import org.terracotta.nomad.messages.PrepareMessage;
 import org.terracotta.nomad.messages.RollbackMessage;
 import org.terracotta.nomad.messages.TakeoverMessage;
 
+import java.util.Optional;
+
 public interface NomadServer<T> extends AutoCloseable {
+  boolean hasIncompleteChange();
+
+  Optional<T> getCurrentCommittedConfig() throws NomadException;
+
   DiscoverResponse<T> discover() throws NomadException;
 
   AcceptRejectResponse prepare(PrepareMessage message) throws NomadException;
@@ -32,6 +38,8 @@ public interface NomadServer<T> extends AutoCloseable {
   AcceptRejectResponse rollback(RollbackMessage message) throws NomadException;
 
   AcceptRejectResponse takeover(TakeoverMessage message) throws NomadException;
+
+  void reset() throws NomadException;
 
   @Override
   void close();

--- a/common/nomad/src/main/java/org/terracotta/nomad/server/NomadServerAdapter.java
+++ b/common/nomad/src/main/java/org/terracotta/nomad/server/NomadServerAdapter.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.nomad.server;
+
+import org.terracotta.nomad.messages.AcceptRejectResponse;
+import org.terracotta.nomad.messages.CommitMessage;
+import org.terracotta.nomad.messages.DiscoverResponse;
+import org.terracotta.nomad.messages.PrepareMessage;
+import org.terracotta.nomad.messages.RollbackMessage;
+import org.terracotta.nomad.messages.TakeoverMessage;
+
+import java.util.Optional;
+
+/**
+ * @author Mathieu Carbou
+ */
+public class NomadServerAdapter<T> implements NomadServer<T> {
+
+  protected final NomadServer<T> delegate;
+
+  public NomadServerAdapter(NomadServer<T> delegate) {
+    this.delegate = delegate;
+  }
+
+  @Override
+  public DiscoverResponse<T> discover() throws NomadException {return delegate.discover();}
+
+  @Override
+  public AcceptRejectResponse prepare(PrepareMessage message) throws NomadException {return delegate.prepare(message);}
+
+  @Override
+  public AcceptRejectResponse commit(CommitMessage message) throws NomadException {return delegate.commit(message);}
+
+  @Override
+  public AcceptRejectResponse rollback(RollbackMessage message) throws NomadException {return delegate.rollback(message);}
+
+  @Override
+  public AcceptRejectResponse takeover(TakeoverMessage message) throws NomadException {return delegate.takeover(message);}
+
+  @Override
+  public boolean hasIncompleteChange() {
+    return delegate.hasIncompleteChange();
+  }
+
+  @Override
+  public Optional<T> getCurrentCommittedConfig() throws NomadException {return delegate.getCurrentCommittedConfig();}
+
+  @Override
+  public void reset() throws NomadException {
+    delegate.reset();
+  }
+
+  @Override
+  public void close() {delegate.close();}
+}

--- a/common/nomad/src/test/java/org/terracotta/nomad/NomadIT.java
+++ b/common/nomad/src/test/java/org/terracotta/nomad/NomadIT.java
@@ -28,12 +28,10 @@ import org.terracotta.nomad.client.recovery.RecoveryResultReceiver;
 import org.terracotta.nomad.messages.AcceptRejectResponse;
 import org.terracotta.nomad.messages.CommitMessage;
 import org.terracotta.nomad.messages.DiscoverResponse;
-import org.terracotta.nomad.messages.PrepareMessage;
-import org.terracotta.nomad.messages.RollbackMessage;
-import org.terracotta.nomad.messages.TakeoverMessage;
 import org.terracotta.nomad.server.ChangeApplicator;
 import org.terracotta.nomad.server.NomadException;
 import org.terracotta.nomad.server.NomadServer;
+import org.terracotta.nomad.server.NomadServerAdapter;
 import org.terracotta.nomad.server.NomadServerImpl;
 import org.terracotta.nomad.server.state.MemoryNomadServerState;
 import org.terracotta.nomad.server.state.NomadServerState;
@@ -200,7 +198,7 @@ public class NomadIT {
     SimpleNomadChange change = new SimpleNomadChange("change", "summary");
 
     when(changeApplicator1.tryApply(null, change)).thenReturn(allow("changeResult"));
-    when(changeApplicator2.tryApply(null, change)).thenReturn(reject(null,"fail"));
+    when(changeApplicator2.tryApply(null, change)).thenReturn(reject(null, "fail"));
     when(changeApplicator3.tryApply(null, change)).thenReturn(allow("changeResult"));
 
     client.tryApplyChange(changeResults, change);
@@ -320,12 +318,11 @@ public class NomadIT {
     return interceptionServer;
   }
 
-  private static class InterceptionServer<T> implements NomadServer<T> {
-    private final NomadServer<T> underlying;
+  private static class InterceptionServer<T> extends NomadServerAdapter<T> {
     private volatile boolean allowCommit = true;
 
     public InterceptionServer(NomadServer<T> underlying) {
-      this.underlying = underlying;
+      super(underlying);
     }
 
     public void setAllowCommit(boolean allowCommit) {
@@ -333,37 +330,12 @@ public class NomadIT {
     }
 
     @Override
-    public DiscoverResponse<T> discover() throws NomadException {
-      return underlying.discover();
-    }
-
-    @Override
-    public AcceptRejectResponse prepare(PrepareMessage message) throws NomadException {
-      return underlying.prepare(message);
-    }
-
-    @Override
     public AcceptRejectResponse commit(CommitMessage message) throws NomadException {
       if (allowCommit) {
-        return underlying.commit(message);
+        return delegate.commit(message);
       } else {
         throw new NomadException();
       }
-    }
-
-    @Override
-    public AcceptRejectResponse rollback(RollbackMessage message) throws NomadException {
-      return underlying.rollback(message);
-    }
-
-    @Override
-    public AcceptRejectResponse takeover(TakeoverMessage message) throws NomadException {
-      return underlying.takeover(message);
-    }
-
-    @Override
-    public void close() {
-      underlying.close();
     }
   }
 }

--- a/common/nomad/src/test/java/org/terracotta/nomad/client/NomadTestHelper.java
+++ b/common/nomad/src/test/java/org/terracotta/nomad/client/NomadTestHelper.java
@@ -23,7 +23,6 @@ import org.terracotta.nomad.server.NomadServerMode;
 
 import java.time.Clock;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.UUID;
 
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -66,8 +65,7 @@ public class NomadTestHelper {
             "testCreationHost",
             "testCreationUser",
             Clock.systemDefaultZone().instant()
-        ),
-        Collections.emptyList()
+        )
     );
   }
 }

--- a/dynamic-config/api/src/main/java/org/terracotta/dynamic_config/api/json/DynamicConfigApiJsonModule.java
+++ b/dynamic-config/api/src/main/java/org/terracotta/dynamic_config/api/json/DynamicConfigApiJsonModule.java
@@ -47,11 +47,16 @@ import org.terracotta.dynamic_config.api.model.nomad.SettingNomadChange;
 import org.terracotta.dynamic_config.api.model.nomad.StripeAdditionNomadChange;
 import org.terracotta.dynamic_config.api.model.nomad.StripeRemovalNomadChange;
 import org.terracotta.dynamic_config.api.model.nomad.UnlockConfigNomadChange;
+import org.terracotta.dynamic_config.api.service.NomadChangeInfo;
 import org.terracotta.inet.json.InetJsonModule;
 import org.terracotta.json.TerracottaJsonModule;
+import org.terracotta.nomad.client.change.NomadChange;
 import org.terracotta.nomad.json.NomadJsonModule;
+import org.terracotta.nomad.server.ChangeRequestState;
 
+import java.time.Instant;
 import java.util.List;
+import java.util.UUID;
 
 import static java.util.Arrays.asList;
 
@@ -94,6 +99,7 @@ public class DynamicConfigApiJsonModule extends SimpleModule {
     setMixInAnnotation(FormatUpgradeNomadChange.class, FormatUpgradeNomadChangeMixIn.class);
     setMixInAnnotation(LockConfigNomadChange.class, LockConfigNomadChangeMixIn.class);
     setMixInAnnotation(UnlockConfigNomadChange.class, UnlockConfigNomadChangeMixIn.class);
+    setMixInAnnotation(NomadChangeInfo.class, NomadChangeInfoMixin.class);
   }
 
   @Override
@@ -202,6 +208,19 @@ public class DynamicConfigApiJsonModule extends SimpleModule {
     @JsonCreator
     public UnlockConfigNomadChangeMixIn(@JsonProperty(value = "forced", required = true) boolean forced) {
       super(forced);
+    }
+  }
+
+  public static class NomadChangeInfoMixin extends NomadChangeInfo {
+    @JsonCreator
+    public NomadChangeInfoMixin(@JsonProperty(value = "changeUuid", required = true) UUID changeUuid,
+                                @JsonProperty(value = "nomadChange", required = true) NomadChange nomadChange,
+                                @JsonProperty(value = "changeRequestState", required = true) ChangeRequestState changeRequestState,
+                                @JsonProperty(value = "version", required = true) long version,
+                                @JsonProperty(value = "creationHost", required = true) String creationHost,
+                                @JsonProperty(value = "creationUser", required = true) String creationUser,
+                                @JsonProperty(value = "creationTimestamp", required = true) Instant creationTimestamp) {
+      super(changeUuid, nomadChange, changeRequestState, version, creationHost, creationUser, creationTimestamp);
     }
   }
 }

--- a/dynamic-config/api/src/main/java/org/terracotta/dynamic_config/api/service/ConsistencyAnalyzer.java
+++ b/dynamic-config/api/src/main/java/org/terracotta/dynamic_config/api/service/ConsistencyAnalyzer.java
@@ -21,12 +21,10 @@ import org.terracotta.nomad.client.results.DiscoverResultsReceiver;
 import org.terracotta.nomad.messages.ChangeDetails;
 import org.terracotta.nomad.messages.DiscoverResponse;
 import org.terracotta.nomad.server.ChangeRequestState;
-import org.terracotta.nomad.server.NomadChangeInfo;
 import org.terracotta.nomad.server.NomadServerMode;
 
 import java.net.InetSocketAddress;
 import java.util.Collection;
-import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -38,7 +36,6 @@ import java.util.stream.Collector;
 import static java.util.function.Function.identity;
 import static java.util.stream.Collectors.counting;
 import static java.util.stream.Collectors.groupingBy;
-import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toMap;
 import static org.terracotta.diagnostic.model.LogicalServerState.STARTING;
 import static org.terracotta.diagnostic.model.LogicalServerState.UNKNOWN;
@@ -195,18 +192,6 @@ public class ConsistencyAnalyzer implements DiscoverResultsReceiver<NodeContext>
 
   public boolean hasUnreachableNodes() {
     return getNodeCount() > responses.size();
-  }
-
-  public Optional<NomadChangeInfo> getCheckpoint() {
-    int configuredNodeCount = getOnlineConfiguredNodes();
-    return responses.values()
-        .stream()
-        .flatMap(response -> response.getCheckpoints().stream())
-        .collect(groupingBy(NomadChangeInfo::getChangeUuid, toList())) // Map<UUID, List<NomadChangeInfo>>
-        .entrySet().stream()
-        .filter(e -> e.getValue().size() == configuredNodeCount) // only consider entries having the change UUID on all the nodes
-        .max(Comparator.comparing(e -> e.getValue().get(0).getVersion())) // select the UUID having the maximum version ID
-        .map(e -> e.getValue().get(0));
   }
 
   /**

--- a/dynamic-config/api/src/main/java/org/terracotta/dynamic_config/api/service/DynamicConfigService.java
+++ b/dynamic-config/api/src/main/java/org/terracotta/dynamic_config/api/service/DynamicConfigService.java
@@ -16,7 +16,6 @@
 package org.terracotta.dynamic_config.api.service;
 
 import org.terracotta.dynamic_config.api.model.Cluster;
-import org.terracotta.nomad.server.NomadChangeInfo;
 
 import java.time.Duration;
 import java.util.Optional;

--- a/dynamic-config/api/src/main/java/org/terracotta/dynamic_config/api/service/NomadChangeInfo.java
+++ b/dynamic-config/api/src/main/java/org/terracotta/dynamic_config/api/service/NomadChangeInfo.java
@@ -13,12 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.terracotta.nomad.server;
+package org.terracotta.dynamic_config.api.service;
 
 import org.terracotta.nomad.client.change.NomadChange;
 import org.terracotta.nomad.messages.CommitMessage;
 import org.terracotta.nomad.messages.PrepareMessage;
 import org.terracotta.nomad.messages.RollbackMessage;
+import org.terracotta.nomad.server.ChangeRequestState;
 
 import java.time.Instant;
 import java.util.Objects;

--- a/dynamic-config/api/src/main/java/org/terracotta/dynamic_config/api/service/TopologyService.java
+++ b/dynamic-config/api/src/main/java/org/terracotta/dynamic_config/api/service/TopologyService.java
@@ -18,7 +18,6 @@ package org.terracotta.dynamic_config.api.service;
 import org.terracotta.dynamic_config.api.model.Cluster;
 import org.terracotta.dynamic_config.api.model.License;
 import org.terracotta.dynamic_config.api.model.NodeContext;
-import org.terracotta.nomad.server.NomadChangeInfo;
 
 import java.util.Optional;
 

--- a/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/command/DiagnosticCommand.java
+++ b/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/command/DiagnosticCommand.java
@@ -105,11 +105,6 @@ public class DiagnosticCommand extends RemoteCommand {
     sb.append(" - Configuration state: ")
         .append(meaningOf(consistencyAnalyzer))
         .append(lineSeparator());
-    sb.append(" - Configuration checkpoint found across all online configured nodes (activated or in repair): ")
-        .append(consistencyAnalyzer.getCheckpoint()
-            .map(nci -> "YES (Version: " + nci.getVersion() + ", UUID: " + nci.getChangeUuid() + ", At: " + nci.getCreationTimestamp().atZone(zoneId).toLocalDateTime().format(ISO_8601) + ", Details: " + nci.getNomadChange().getSummary() + ")")
-            .orElse("NO"))
-        .append(lineSeparator());
 
     allNodes.keySet().forEach(endpoint -> {
       // header

--- a/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/command/LogCommand.java
+++ b/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/command/LogCommand.java
@@ -16,8 +16,8 @@
 package org.terracotta.dynamic_config.cli.config_tool.command;
 
 import org.terracotta.diagnostic.client.DiagnosticService;
+import org.terracotta.dynamic_config.api.service.NomadChangeInfo;
 import org.terracotta.dynamic_config.api.service.TopologyService;
-import org.terracotta.nomad.server.NomadChangeInfo;
 
 import java.net.InetSocketAddress;
 import java.time.Clock;

--- a/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/command/RemoteCommand.java
+++ b/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/command/RemoteCommand.java
@@ -36,6 +36,7 @@ import org.terracotta.dynamic_config.api.model.nomad.TopologyNomadChange;
 import org.terracotta.dynamic_config.api.model.nomad.UnlockConfigNomadChange;
 import org.terracotta.dynamic_config.api.service.ConsistencyAnalyzer;
 import org.terracotta.dynamic_config.api.service.DynamicConfigService;
+import org.terracotta.dynamic_config.api.service.NomadChangeInfo;
 import org.terracotta.dynamic_config.api.service.TopologyService;
 import org.terracotta.dynamic_config.cli.command.Command;
 import org.terracotta.dynamic_config.cli.command.Injector.Inject;
@@ -47,7 +48,6 @@ import org.terracotta.dynamic_config.cli.config_tool.stop.StopProgress;
 import org.terracotta.dynamic_config.cli.config_tool.stop.StopService;
 import org.terracotta.nomad.client.results.NomadFailureReceiver;
 import org.terracotta.nomad.server.ChangeRequestState;
-import org.terracotta.nomad.server.NomadChangeInfo;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;

--- a/dynamic-config/cli/config-tool/src/test/java/org/terracotta/dynamic_config/cli/config_tool/NomadTestHelper.java
+++ b/dynamic-config/cli/config-tool/src/test/java/org/terracotta/dynamic_config/cli/config_tool/NomadTestHelper.java
@@ -21,7 +21,6 @@ import org.terracotta.nomad.server.ChangeRequestState;
 import org.terracotta.nomad.server.NomadServerMode;
 
 import java.time.Instant;
-import java.util.Collections;
 import java.util.UUID;
 
 import static org.terracotta.nomad.server.ChangeRequestState.PREPARED;
@@ -58,8 +57,7 @@ public class NomadTestHelper {
             "testCreationHost",
             "testCreationUser",
             Instant.now()
-        ),
-        Collections.emptyList()
+        )
     );
   }
 }

--- a/dynamic-config/cli/upgrade-tools/src/main/java/org/terracotta/dynamic_config/cli/upgrade_tools/config_converter/ConfigRepoProcessor.java
+++ b/dynamic-config/cli/upgrade-tools/src/main/java/org/terracotta/dynamic_config/cli/upgrade_tools/config_converter/ConfigRepoProcessor.java
@@ -24,6 +24,7 @@ import org.terracotta.dynamic_config.api.model.NodeContext;
 import org.terracotta.dynamic_config.api.model.Stripe;
 import org.terracotta.dynamic_config.api.model.nomad.ClusterActivationNomadChange;
 import org.terracotta.dynamic_config.api.service.IParameterSubstitutor;
+import org.terracotta.dynamic_config.server.api.DynamicConfigNomadServer;
 import org.terracotta.dynamic_config.server.configuration.nomad.NomadServerFactory;
 import org.terracotta.dynamic_config.server.configuration.nomad.persistence.ConfigStorageException;
 import org.terracotta.dynamic_config.server.configuration.nomad.persistence.NomadConfigurationManager;
@@ -37,7 +38,6 @@ import org.terracotta.nomad.server.ChangeApplicator;
 import org.terracotta.nomad.server.NomadException;
 import org.terracotta.nomad.server.NomadServer;
 import org.terracotta.nomad.server.PotentialApplicationResult;
-import org.terracotta.nomad.server.UpgradableNomadServer;
 import org.terracotta.persistence.sanskrit.SanskritException;
 
 import java.nio.file.Path;
@@ -98,7 +98,7 @@ public class ConfigRepoProcessor {
     };
 
     try {
-      UpgradableNomadServer<NodeContext> nomadServer = nomadServerFactory.createServer(nomadConfigurationManager, node.getName(), null);
+      DynamicConfigNomadServer nomadServer = nomadServerFactory.createServer(nomadConfigurationManager, node.getName(), null);
       nomadServer.setChangeApplicator(changeApplicator);
       return nomadServer;
     } catch (SanskritException | NomadException | ConfigStorageException e) {

--- a/dynamic-config/entities/management-entity/server/src/main/java/org/terracotta/dynamic_config/entity/management/server/ManagementCommonEntity.java
+++ b/dynamic-config/entities/management-entity/server/src/main/java/org/terracotta/dynamic_config/entity/management/server/ManagementCommonEntity.java
@@ -23,6 +23,7 @@ import org.terracotta.dynamic_config.api.model.NodeContext;
 import org.terracotta.dynamic_config.api.model.Stripe;
 import org.terracotta.dynamic_config.api.model.UID;
 import org.terracotta.dynamic_config.api.model.nomad.SettingNomadChange;
+import org.terracotta.dynamic_config.api.service.NomadChangeInfo;
 import org.terracotta.dynamic_config.api.service.Props;
 import org.terracotta.dynamic_config.api.service.TopologyService;
 import org.terracotta.dynamic_config.server.api.DynamicConfigEventService;
@@ -40,7 +41,6 @@ import org.terracotta.nomad.messages.AcceptRejectResponse;
 import org.terracotta.nomad.messages.CommitMessage;
 import org.terracotta.nomad.messages.PrepareMessage;
 import org.terracotta.nomad.messages.RollbackMessage;
-import org.terracotta.nomad.server.NomadChangeInfo;
 
 import java.net.InetSocketAddress;
 import java.util.Map;

--- a/dynamic-config/entities/nomad-entity/client/src/main/java/org/terracotta/nomad/entity/client/NomadEntity.java
+++ b/dynamic-config/entities/nomad-entity/client/src/main/java/org/terracotta/nomad/entity/client/NomadEntity.java
@@ -27,15 +27,12 @@ import org.terracotta.nomad.server.NomadException;
 import org.terracotta.nomad.server.NomadServer;
 
 import java.time.Duration;
+import java.util.Optional;
 
 /**
  * @author Mathieu Carbou
  */
 public interface NomadEntity<T> extends Entity, NomadServer<T> {
-  @Override
-  default DiscoverResponse<T> discover() {
-    throw new UnsupportedOperationException();
-  }
 
   @Override
   default AcceptRejectResponse prepare(PrepareMessage message) {
@@ -54,6 +51,26 @@ public interface NomadEntity<T> extends Entity, NomadServer<T> {
 
   @Override
   default AcceptRejectResponse takeover(TakeoverMessage message) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  default DiscoverResponse<T> discover() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  default boolean hasIncompleteChange() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  default Optional<T> getCurrentCommittedConfig() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  default void reset() {
     throw new UnsupportedOperationException();
   }
 

--- a/dynamic-config/entities/nomad-entity/server/pom.xml
+++ b/dynamic-config/entities/nomad-entity/server/pom.xml
@@ -36,6 +36,13 @@
       <version>${project.version}</version>
     </dependency>
 
+    <dependency>
+      <groupId>org.terracotta.dynamic-config.server</groupId>
+      <artifactId>dynamic-config-server-api</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
+
     <!-- provided by server -->
     <dependency>
       <groupId>org.terracotta</groupId>

--- a/dynamic-config/entities/nomad-entity/server/src/main/java/org/terracotta/nomad/entity/server/NomadActiveServerEntity.java
+++ b/dynamic-config/entities/nomad-entity/server/src/main/java/org/terracotta/nomad/entity/server/NomadActiveServerEntity.java
@@ -15,6 +15,7 @@
  */
 package org.terracotta.nomad.entity.server;
 
+import org.terracotta.dynamic_config.server.api.DynamicConfigNomadServer;
 import org.terracotta.entity.ActiveInvokeContext;
 import org.terracotta.entity.ActiveServerEntity;
 import org.terracotta.entity.ClientDescriptor;
@@ -25,11 +26,10 @@ import org.terracotta.nomad.entity.common.NomadEntityResponse;
 import org.terracotta.nomad.messages.AcceptRejectResponse;
 import org.terracotta.nomad.messages.MutativeMessage;
 import org.terracotta.nomad.server.NomadException;
-import org.terracotta.nomad.server.UpgradableNomadServer;
 
 
 public class NomadActiveServerEntity<T> extends NomadCommonServerEntity<T> implements ActiveServerEntity<NomadEntityMessage, NomadEntityResponse> {
-  public NomadActiveServerEntity(UpgradableNomadServer<T> nomadServer) {
+  public NomadActiveServerEntity(DynamicConfigNomadServer nomadServer) {
     super(nomadServer);
   }
 

--- a/dynamic-config/entities/nomad-entity/server/src/main/java/org/terracotta/nomad/entity/server/NomadCommonServerEntity.java
+++ b/dynamic-config/entities/nomad-entity/server/src/main/java/org/terracotta/nomad/entity/server/NomadCommonServerEntity.java
@@ -17,6 +17,8 @@ package org.terracotta.nomad.entity.server;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.terracotta.dynamic_config.api.service.NomadChangeInfo;
+import org.terracotta.dynamic_config.server.api.DynamicConfigNomadServer;
 import org.terracotta.entity.CommonServerEntity;
 import org.terracotta.nomad.entity.common.NomadEntityMessage;
 import org.terracotta.nomad.entity.common.NomadEntityResponse;
@@ -27,9 +29,7 @@ import org.terracotta.nomad.messages.PrepareMessage;
 import org.terracotta.nomad.messages.RollbackMessage;
 import org.terracotta.nomad.messages.TakeoverMessage;
 import org.terracotta.nomad.server.ChangeRequestState;
-import org.terracotta.nomad.server.NomadChangeInfo;
 import org.terracotta.nomad.server.NomadException;
-import org.terracotta.nomad.server.UpgradableNomadServer;
 
 import java.util.Optional;
 import java.util.UUID;
@@ -41,9 +41,9 @@ public class NomadCommonServerEntity<T> implements CommonServerEntity<NomadEntit
 
   protected final Logger logger = LoggerFactory.getLogger(getClass());
 
-  private final UpgradableNomadServer<T> nomadServer;
+  private final DynamicConfigNomadServer nomadServer;
 
-  public NomadCommonServerEntity(UpgradableNomadServer<T> nomadServer) {
+  public NomadCommonServerEntity(DynamicConfigNomadServer nomadServer) {
     this.nomadServer = nomadServer;
   }
 
@@ -75,7 +75,7 @@ public class NomadCommonServerEntity<T> implements CommonServerEntity<NomadEntit
 
   private AcceptRejectResponse prepare(PrepareMessage nomadMessage) throws NomadException {
     final UUID uuid = nomadMessage.getChangeUuid();
-    final Optional<NomadChangeInfo> info = nomadServer.getNomadChangeInfo(uuid);
+    final Optional<NomadChangeInfo> info = nomadServer.getNomadChange(uuid);
     if (!info.isPresent()) {
       // the change UUId is not yet in Nomad - first call probably
       return nomadServer.prepare(nomadMessage);
@@ -94,7 +94,7 @@ public class NomadCommonServerEntity<T> implements CommonServerEntity<NomadEntit
 
   private AcceptRejectResponse rollback(RollbackMessage nomadMessage) throws NomadException {
     final UUID uuid = nomadMessage.getChangeUuid();
-    final Optional<NomadChangeInfo> info = nomadServer.getNomadChangeInfo(uuid);
+    final Optional<NomadChangeInfo> info = nomadServer.getNomadChange(uuid);
     if (!info.isPresent()) {
       // oups! we miss an entry!
       return AcceptRejectResponse.reject(BAD, "Change: " + uuid + " is missing", nomadMessage.getMutationHost(), nomadMessage.getMutationUser());
@@ -120,7 +120,7 @@ public class NomadCommonServerEntity<T> implements CommonServerEntity<NomadEntit
 
   private AcceptRejectResponse commit(CommitMessage nomadMessage) throws NomadException {
     final UUID uuid = nomadMessage.getChangeUuid();
-    final Optional<NomadChangeInfo> info = nomadServer.getNomadChangeInfo(uuid);
+    final Optional<NomadChangeInfo> info = nomadServer.getNomadChange(uuid);
     if (!info.isPresent()) {
       // oups! we miss an entry!
       return AcceptRejectResponse.reject(BAD, "Change: " + uuid + " is missing", nomadMessage.getMutationHost(), nomadMessage.getMutationUser());

--- a/dynamic-config/entities/nomad-entity/server/src/main/java/org/terracotta/nomad/entity/server/NomadPassiveServerEntity.java
+++ b/dynamic-config/entities/nomad-entity/server/src/main/java/org/terracotta/nomad/entity/server/NomadPassiveServerEntity.java
@@ -15,6 +15,7 @@
  */
 package org.terracotta.nomad.entity.server;
 
+import org.terracotta.dynamic_config.server.api.DynamicConfigNomadServer;
 import org.terracotta.entity.EntityUserException;
 import org.terracotta.entity.InvokeContext;
 import org.terracotta.entity.PassiveServerEntity;
@@ -24,12 +25,11 @@ import org.terracotta.nomad.entity.common.NomadEntityMessage;
 import org.terracotta.nomad.entity.common.NomadEntityResponse;
 import org.terracotta.nomad.messages.AcceptRejectResponse;
 import org.terracotta.nomad.server.NomadException;
-import org.terracotta.nomad.server.UpgradableNomadServer;
 
 public class NomadPassiveServerEntity<T> extends NomadCommonServerEntity<T> implements PassiveServerEntity<NomadEntityMessage, NomadEntityResponse> {
   private final PlatformService platformService;
 
-  public NomadPassiveServerEntity(UpgradableNomadServer<T> nomadServer, PlatformService platformService) {
+  public NomadPassiveServerEntity(DynamicConfigNomadServer nomadServer, PlatformService platformService) {
     super(nomadServer);
     this.platformService = platformService;
   }

--- a/dynamic-config/entities/nomad-entity/server/src/main/java/org/terracotta/nomad/entity/server/NomadServerEntityService.java
+++ b/dynamic-config/entities/nomad-entity/server/src/main/java/org/terracotta/nomad/entity/server/NomadServerEntityService.java
@@ -16,6 +16,7 @@
 package org.terracotta.nomad.entity.server;
 
 import com.tc.classloader.PermanentEntity;
+import org.terracotta.dynamic_config.server.api.DynamicConfigNomadServer;
 import org.terracotta.entity.BasicServiceConfiguration;
 import org.terracotta.entity.ConcurrencyStrategy;
 import org.terracotta.entity.ConfigurationException;
@@ -30,7 +31,6 @@ import org.terracotta.nomad.entity.common.NomadEntityConstants;
 import org.terracotta.nomad.entity.common.NomadEntityMessage;
 import org.terracotta.nomad.entity.common.NomadEntityResponse;
 import org.terracotta.nomad.entity.common.NomadMessageCodec;
-import org.terracotta.nomad.server.UpgradableNomadServer;
 
 @PermanentEntity(type = NomadEntityConstants.ENTITY_TYPE, name = NomadEntityConstants.ENTITY_NAME)
 public class NomadServerEntityService<T> implements EntityServerService<NomadEntityMessage, NomadEntityResponse> {
@@ -41,7 +41,7 @@ public class NomadServerEntityService<T> implements EntityServerService<NomadEnt
   public NomadActiveServerEntity<T> createActiveEntity(ServiceRegistry registry, byte[] configuration) throws ConfigurationException {
     try {
       @SuppressWarnings("unchecked")
-      UpgradableNomadServer<T> nomadServer = registry.getService(new BasicServiceConfiguration<>(UpgradableNomadServer.class));
+      DynamicConfigNomadServer nomadServer = registry.getService(new BasicServiceConfiguration<>(DynamicConfigNomadServer.class));
       return new NomadActiveServerEntity<>(nomadServer);
     } catch (ServiceException e) {
       throw new ConfigurationException("Could not retrieve service ", e);
@@ -52,7 +52,7 @@ public class NomadServerEntityService<T> implements EntityServerService<NomadEnt
   public NomadPassiveServerEntity<T> createPassiveEntity(ServiceRegistry registry, byte[] configuration) throws ConfigurationException {
     try {
       @SuppressWarnings("unchecked")
-      UpgradableNomadServer<T> nomadServer = registry.getService(new BasicServiceConfiguration<>(UpgradableNomadServer.class));
+      DynamicConfigNomadServer nomadServer = registry.getService(new BasicServiceConfiguration<>(DynamicConfigNomadServer.class));
       PlatformService platformService = registry.getService(new BasicServiceConfiguration<>(PlatformService.class));
       return new NomadPassiveServerEntity<>(nomadServer, platformService);
     } catch (ServiceException e) {

--- a/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/DynamicConfigConfigurationProvider.java
+++ b/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/DynamicConfigConfigurationProvider.java
@@ -21,7 +21,6 @@ import org.slf4j.LoggerFactory;
 import org.terracotta.configuration.ConfigurationProvider;
 import org.terracotta.diagnostic.server.api.DiagnosticServicesHolder;
 import org.terracotta.dynamic_config.api.json.DynamicConfigApiJsonModule;
-import org.terracotta.dynamic_config.api.model.NodeContext;
 import org.terracotta.dynamic_config.api.service.ClusterFactory;
 import org.terracotta.dynamic_config.api.service.DynamicConfigService;
 import org.terracotta.dynamic_config.api.service.IParameterSubstitutor;
@@ -30,6 +29,7 @@ import org.terracotta.dynamic_config.server.api.ConfigChangeHandlerManager;
 import org.terracotta.dynamic_config.server.api.DynamicConfigEventFiring;
 import org.terracotta.dynamic_config.server.api.DynamicConfigEventService;
 import org.terracotta.dynamic_config.server.api.DynamicConfigExtension;
+import org.terracotta.dynamic_config.server.api.DynamicConfigNomadServer;
 import org.terracotta.dynamic_config.server.api.LicenseParserDiscovery;
 import org.terracotta.dynamic_config.server.api.LicenseService;
 import org.terracotta.dynamic_config.server.api.NomadPermissionChangeProcessor;
@@ -53,7 +53,6 @@ import org.terracotta.dynamic_config.server.configuration.sync.Require;
 import org.terracotta.json.ObjectMapperFactory;
 import org.terracotta.nomad.server.NomadException;
 import org.terracotta.nomad.server.NomadServer;
-import org.terracotta.nomad.server.UpgradableNomadServer;
 import org.terracotta.server.Server;
 import org.terracotta.server.ServerEnv;
 import org.terracotta.server.StopAction;
@@ -125,7 +124,7 @@ public class DynamicConfigConfigurationProvider implements ConfigurationProvider
       commandLineProcessor.process();
 
       // retrieve initialized services
-      UpgradableNomadServer<NodeContext> nomadServer = nomadServerManager.getNomadServer();
+      DynamicConfigNomadServer nomadServer = nomadServerManager.getNomadServer();
       DynamicConfigService dynamicConfigService = nomadServerManager.getDynamicConfigService();
       TopologyService topologyService = nomadServerManager.getTopologyService();
       DynamicConfigEventService eventService = nomadServerManager.getEventRegistrationService();
@@ -149,7 +148,7 @@ public class DynamicConfigConfigurationProvider implements ConfigurationProvider
       configuration.registerExtendedConfiguration(DynamicConfigService.class, dynamicConfigService);
       configuration.registerExtendedConfiguration(DynamicConfigEventFiring.class, nomadServerManager.getEventFiringService());
       configuration.registerExtendedConfiguration(NomadServer.class, nomadServer);
-      configuration.registerExtendedConfiguration(UpgradableNomadServer.class, nomadServer);
+      configuration.registerExtendedConfiguration(DynamicConfigNomadServer.class, nomadServer);
       configuration.registerExtendedConfiguration(LicenseService.class, licenseService);
       configuration.registerExtendedConfiguration(PathResolver.class, userDirResolver);
       configuration.registerExtendedConfiguration(NomadRoutingChangeProcessor.class, nomadServerManager.getNomadRoutingChangeProcessor());

--- a/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/service/AuditListener.java
+++ b/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/service/AuditListener.java
@@ -20,11 +20,11 @@ import org.terracotta.dynamic_config.api.model.Node;
 import org.terracotta.dynamic_config.api.model.Stripe;
 import org.terracotta.dynamic_config.api.model.UID;
 import org.terracotta.dynamic_config.api.model.nomad.SettingNomadChange;
+import org.terracotta.dynamic_config.api.service.NomadChangeInfo;
 import org.terracotta.dynamic_config.server.api.DynamicConfigListener;
 import org.terracotta.nomad.messages.AcceptRejectResponse;
 import org.terracotta.nomad.messages.CommitMessage;
 import org.terracotta.nomad.messages.RollbackMessage;
-import org.terracotta.nomad.server.NomadChangeInfo;
 import org.terracotta.server.Server;
 
 import java.util.Properties;

--- a/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/service/AuditService.java
+++ b/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/service/AuditService.java
@@ -17,7 +17,7 @@ package org.terracotta.dynamic_config.server.configuration.service;
 
 import org.terracotta.dynamic_config.api.model.Cluster;
 import org.terracotta.dynamic_config.api.service.DynamicConfigService;
-import org.terracotta.nomad.server.NomadChangeInfo;
+import org.terracotta.dynamic_config.api.service.NomadChangeInfo;
 import org.terracotta.server.Server;
 
 import java.time.Duration;

--- a/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/service/DynamicConfigEventServiceImpl.java
+++ b/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/service/DynamicConfigEventServiceImpl.java
@@ -21,6 +21,7 @@ import org.terracotta.dynamic_config.api.model.NodeContext;
 import org.terracotta.dynamic_config.api.model.Stripe;
 import org.terracotta.dynamic_config.api.model.UID;
 import org.terracotta.dynamic_config.api.model.nomad.SettingNomadChange;
+import org.terracotta.dynamic_config.api.service.NomadChangeInfo;
 import org.terracotta.dynamic_config.server.api.DynamicConfigEventFiring;
 import org.terracotta.dynamic_config.server.api.DynamicConfigEventService;
 import org.terracotta.dynamic_config.server.api.DynamicConfigListener;
@@ -29,7 +30,6 @@ import org.terracotta.nomad.messages.AcceptRejectResponse;
 import org.terracotta.nomad.messages.CommitMessage;
 import org.terracotta.nomad.messages.PrepareMessage;
 import org.terracotta.nomad.messages.RollbackMessage;
-import org.terracotta.nomad.server.NomadChangeInfo;
 
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;

--- a/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/service/DynamicConfigServiceImpl.java
+++ b/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/service/DynamicConfigServiceImpl.java
@@ -33,9 +33,11 @@ import org.terracotta.dynamic_config.api.model.nomad.MultiSettingNomadChange;
 import org.terracotta.dynamic_config.api.model.nomad.SettingNomadChange;
 import org.terracotta.dynamic_config.api.service.ClusterValidator;
 import org.terracotta.dynamic_config.api.service.DynamicConfigService;
+import org.terracotta.dynamic_config.api.service.NomadChangeInfo;
 import org.terracotta.dynamic_config.api.service.Props;
 import org.terracotta.dynamic_config.api.service.TopologyService;
 import org.terracotta.dynamic_config.server.api.DynamicConfigListener;
+import org.terracotta.dynamic_config.server.api.DynamicConfigNomadServer;
 import org.terracotta.dynamic_config.server.api.InvalidLicenseException;
 import org.terracotta.dynamic_config.server.api.LicenseService;
 import org.terracotta.dynamic_config.server.configuration.sync.DynamicConfigNomadSynchronizer;
@@ -48,9 +50,7 @@ import org.terracotta.nomad.messages.CommitMessage;
 import org.terracotta.nomad.messages.DiscoverResponse;
 import org.terracotta.nomad.messages.PrepareMessage;
 import org.terracotta.nomad.messages.RollbackMessage;
-import org.terracotta.nomad.server.NomadChangeInfo;
 import org.terracotta.nomad.server.NomadException;
-import org.terracotta.nomad.server.UpgradableNomadServer;
 import org.terracotta.server.Server;
 
 import java.io.IOException;
@@ -118,7 +118,7 @@ public class DynamicConfigServiceImpl implements TopologyService, DynamicConfigS
 
   @Override
   public void resetAndSync(NomadChangeInfo[] nomadChanges, Cluster cluster) {
-    UpgradableNomadServer<NodeContext> nomadServer = nomadServerManager.getNomadServer();
+    DynamicConfigNomadServer nomadServer = nomadServerManager.getNomadServer();
     DynamicConfigNomadSynchronizer nomadSynchronizer = new DynamicConfigNomadSynchronizer(
         nomadServerManager.getConfiguration().orElse(null), nomadServer);
 

--- a/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/service/NomadServerManager.java
+++ b/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/service/NomadServerManager.java
@@ -34,6 +34,7 @@ import org.terracotta.dynamic_config.api.service.TopologyService;
 import org.terracotta.dynamic_config.server.api.ConfigChangeHandlerManager;
 import org.terracotta.dynamic_config.server.api.DynamicConfigEventFiring;
 import org.terracotta.dynamic_config.server.api.DynamicConfigEventService;
+import org.terracotta.dynamic_config.server.api.DynamicConfigNomadServer;
 import org.terracotta.dynamic_config.server.api.LicenseService;
 import org.terracotta.dynamic_config.server.api.NomadPermissionChangeProcessor;
 import org.terracotta.dynamic_config.server.api.NomadRoutingChangeProcessor;
@@ -57,7 +58,6 @@ import org.terracotta.dynamic_config.server.configuration.service.nomad.processo
 import org.terracotta.dynamic_config.server.configuration.service.nomad.processor.UnlockConfigNomadChangeProcessor;
 import org.terracotta.json.ObjectMapperFactory;
 import org.terracotta.nomad.server.NomadException;
-import org.terracotta.nomad.server.UpgradableNomadServer;
 import org.terracotta.persistence.sanskrit.SanskritException;
 import org.terracotta.server.Server;
 
@@ -82,7 +82,7 @@ public class NomadServerManager {
   private final DefaultNomadRoutingChangeProcessor router = new DefaultNomadRoutingChangeProcessor();
   private final NomadPermissionChangeProcessorImpl nomadPermissionChangeProcessor = new NomadPermissionChangeProcessorImpl();
 
-  private volatile UpgradableNomadServer<NodeContext> nomadServer;
+  private volatile DynamicConfigNomadServer nomadServer;
   private volatile NomadConfigurationManager configurationManager;
   private volatile DynamicConfigService dynamicConfigService;
   private volatile TopologyService topologyService;
@@ -102,7 +102,7 @@ public class NomadServerManager {
     this.server = server;
   }
 
-  public UpgradableNomadServer<NodeContext> getNomadServer() {
+  public DynamicConfigNomadServer getNomadServer() {
     if (nomadServer == null) {
       throw new AssertionError("Not initialized");
     }

--- a/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/sync/Check.java
+++ b/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/sync/Check.java
@@ -19,8 +19,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terracotta.dynamic_config.api.model.Cluster;
 import org.terracotta.dynamic_config.api.model.nomad.TopologyNomadChange;
+import org.terracotta.dynamic_config.api.service.NomadChangeInfo;
 import org.terracotta.nomad.server.ChangeRequestState;
-import org.terracotta.nomad.server.NomadChangeInfo;
 
 import java.util.Collection;
 import java.util.List;

--- a/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/sync/DynamicConfigNomadSynchronizer.java
+++ b/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/sync/DynamicConfigNomadSynchronizer.java
@@ -23,13 +23,13 @@ import org.terracotta.dynamic_config.api.model.nomad.ClusterActivationNomadChang
 import org.terracotta.dynamic_config.api.model.nomad.DynamicConfigNomadChange;
 import org.terracotta.dynamic_config.api.model.nomad.LockAwareDynamicConfigNomadChange;
 import org.terracotta.dynamic_config.api.model.nomad.TopologyNomadChange;
+import org.terracotta.dynamic_config.api.service.NomadChangeInfo;
 import org.terracotta.dynamic_config.api.service.Props;
+import org.terracotta.dynamic_config.server.api.DynamicConfigNomadServer;
 import org.terracotta.nomad.client.change.NomadChange;
 import org.terracotta.nomad.messages.AcceptRejectResponse;
 import org.terracotta.nomad.messages.DiscoverResponse;
-import org.terracotta.nomad.server.NomadChangeInfo;
 import org.terracotta.nomad.server.NomadException;
-import org.terracotta.nomad.server.UpgradableNomadServer;
 
 import java.util.Collection;
 import java.util.HashSet;
@@ -44,9 +44,9 @@ public class DynamicConfigNomadSynchronizer {
   private static final Logger LOGGER = LoggerFactory.getLogger(DynamicConfigNomadSynchronizer.class);
 
   private final NodeContext nodeStartupConfiguration;
-  private final UpgradableNomadServer<NodeContext> nomadServer;
+  private final DynamicConfigNomadServer nomadServer;
 
-  public DynamicConfigNomadSynchronizer(NodeContext nodeStartupConfiguration, UpgradableNomadServer<NodeContext> nomadServer) {
+  public DynamicConfigNomadSynchronizer(NodeContext nodeStartupConfiguration, DynamicConfigNomadServer nomadServer) {
     this.nodeStartupConfiguration = nodeStartupConfiguration;
     this.nomadServer = nomadServer;
   }

--- a/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/sync/DynamicConfigSyncData.java
+++ b/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/sync/DynamicConfigSyncData.java
@@ -20,8 +20,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.terracotta.dynamic_config.api.model.Cluster;
+import org.terracotta.dynamic_config.api.service.NomadChangeInfo;
 import org.terracotta.json.ObjectMapperFactory;
-import org.terracotta.nomad.server.NomadChangeInfo;
 
 import java.io.UncheckedIOException;
 import java.util.List;

--- a/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/sync/DynamicConfigurationPassiveSync.java
+++ b/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/sync/DynamicConfigurationPassiveSync.java
@@ -20,8 +20,8 @@ import org.slf4j.LoggerFactory;
 import org.terracotta.dynamic_config.api.model.NodeContext;
 import org.terracotta.dynamic_config.api.service.DynamicConfigService;
 import org.terracotta.dynamic_config.api.service.TopologyService;
+import org.terracotta.dynamic_config.server.api.DynamicConfigNomadServer;
 import org.terracotta.nomad.server.NomadException;
-import org.terracotta.nomad.server.UpgradableNomadServer;
 
 import java.util.Objects;
 import java.util.Set;
@@ -31,14 +31,14 @@ public class DynamicConfigurationPassiveSync {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(DynamicConfigurationPassiveSync.class);
 
-  private final UpgradableNomadServer<NodeContext> nomadServer;
+  private final DynamicConfigNomadServer nomadServer;
   private final DynamicConfigService dynamicConfigService;
   private final TopologyService topologyService;
   private final Supplier<String> licenseContent;
   private final DynamicConfigNomadSynchronizer nomadSynchronizer;
 
   public DynamicConfigurationPassiveSync(NodeContext nodeStartupConfiguration,
-                                         UpgradableNomadServer<NodeContext> nomadServer,
+                                         DynamicConfigNomadServer nomadServer,
                                          DynamicConfigService dynamicConfigService,
                                          TopologyService topologyService,
                                          Supplier<String> licenseContent) {

--- a/dynamic-config/server/configuration-provider/src/test/java/org/terracotta/dynamic_config/server/configuration/sync/DynamicConfigurationPassiveSyncTest.java
+++ b/dynamic-config/server/configuration-provider/src/test/java/org/terracotta/dynamic_config/server/configuration/sync/DynamicConfigurationPassiveSyncTest.java
@@ -26,16 +26,16 @@ import org.terracotta.dynamic_config.api.model.Testing;
 import org.terracotta.dynamic_config.api.model.nomad.ClusterActivationNomadChange;
 import org.terracotta.dynamic_config.api.model.nomad.SettingNomadChange;
 import org.terracotta.dynamic_config.api.service.DynamicConfigService;
+import org.terracotta.dynamic_config.api.service.NomadChangeInfo;
 import org.terracotta.dynamic_config.api.service.TopologyService;
+import org.terracotta.dynamic_config.server.api.DynamicConfigNomadServer;
 import org.terracotta.json.ObjectMapperFactory;
 import org.terracotta.nomad.messages.AcceptRejectResponse;
 import org.terracotta.nomad.messages.CommitMessage;
 import org.terracotta.nomad.messages.DiscoverResponse;
 import org.terracotta.nomad.messages.PrepareMessage;
 import org.terracotta.nomad.server.ChangeRequestState;
-import org.terracotta.nomad.server.NomadChangeInfo;
 import org.terracotta.nomad.server.NomadException;
-import org.terracotta.nomad.server.UpgradableNomadServer;
 
 import java.time.Instant;
 import java.util.ArrayList;
@@ -91,7 +91,7 @@ public class DynamicConfigurationPassiveSyncTest {
     activeNomadChanges.add(activation);
     activeNomadChanges.add(new NomadChangeInfo(firstChange, createOffheapChange("a", "100"), ChangeRequestState.COMMITTED, 1L, "SYSTEM", "SYSTEM", now));
 
-    UpgradableNomadServer<NodeContext> activeNomadServer = mock(UpgradableNomadServer.class);
+    DynamicConfigNomadServer activeNomadServer = mock(DynamicConfigNomadServer.class);
     DynamicConfigurationPassiveSync activeSyncManager = new DynamicConfigurationPassiveSync(startupTopology, activeNomadServer, mock(DynamicConfigService.class), topologyService, () -> null);
     when(activeNomadServer.getAllNomadChanges()).thenReturn(activeNomadChanges);
     byte[] active = codec.encode(activeSyncManager.getSyncData());
@@ -101,7 +101,7 @@ public class DynamicConfigurationPassiveSyncTest {
     passiveNomadChanges.add(new NomadChangeInfo(firstChange, createOffheapChange("a", "100"), ChangeRequestState.COMMITTED, 1L, "SYSTEM", "SYSTEM", now));
     passiveNomadChanges.add(new NomadChangeInfo(UUID.randomUUID(), createOffheapChange("b", "200"), ChangeRequestState.COMMITTED, 2L, "SYSTEM", "SYSTEM", now));
 
-    UpgradableNomadServer<NodeContext> nomadServer = mock(UpgradableNomadServer.class);
+    DynamicConfigNomadServer nomadServer = mock(DynamicConfigNomadServer.class);
     when(nomadServer.getAllNomadChanges()).thenReturn(passiveNomadChanges);
 
     DynamicConfigurationPassiveSync syncManager = new DynamicConfigurationPassiveSync(startupTopology, nomadServer, mock(DynamicConfigService.class), topologyService, () -> null);
@@ -117,12 +117,12 @@ public class DynamicConfigurationPassiveSyncTest {
     sameChanges.add(activation);
     sameChanges.add(new NomadChangeInfo(UUID.randomUUID(), createOffheapChange("a", "100"), ChangeRequestState.COMMITTED, 1L, "SYSTEM", "SYSTEM", now));
 
-    UpgradableNomadServer<NodeContext> activeNomadServer = mock(UpgradableNomadServer.class);
+    DynamicConfigNomadServer activeNomadServer = mock(DynamicConfigNomadServer.class);
     DynamicConfigurationPassiveSync activeSyncManager = new DynamicConfigurationPassiveSync(startupTopology, activeNomadServer, mock(DynamicConfigService.class), topologyService, () -> "license content");
     when(activeNomadServer.getAllNomadChanges()).thenReturn(sameChanges);
     byte[] active = codec.encode(activeSyncManager.getSyncData());
 
-    UpgradableNomadServer<NodeContext> nomadServer = mock(UpgradableNomadServer.class);
+    DynamicConfigNomadServer nomadServer = mock(DynamicConfigNomadServer.class);
     when(nomadServer.getAllNomadChanges()).thenReturn(sameChanges);
 
     DynamicConfigService dynamicConfigService = mock(DynamicConfigService.class);
@@ -142,7 +142,7 @@ public class DynamicConfigurationPassiveSyncTest {
     activeNomadChanges.add(new NomadChangeInfo(UUID.randomUUID(), createOffheapChange("a", "100"), ChangeRequestState.COMMITTED, 1L, "SYSTEM", "SYSTEM", now));
     activeNomadChanges.add(new NomadChangeInfo(UUID.randomUUID(), createOffheapChange("b", "200"), ChangeRequestState.COMMITTED, 2L, "SYSTEM", "SYSTEM", now));
 
-    UpgradableNomadServer<NodeContext> activeNomadServer = mock(UpgradableNomadServer.class);
+    DynamicConfigNomadServer activeNomadServer = mock(DynamicConfigNomadServer.class);
     DynamicConfigurationPassiveSync activeSyncManager = new DynamicConfigurationPassiveSync(startupTopology, activeNomadServer, mock(DynamicConfigService.class), topologyService, () -> null);
     when(activeNomadServer.getAllNomadChanges()).thenReturn(activeNomadChanges);
     byte[] active = codec.encode(activeSyncManager.getSyncData());
@@ -151,7 +151,7 @@ public class DynamicConfigurationPassiveSyncTest {
     passiveNomadChanges.add(activation);
     passiveNomadChanges.add(new NomadChangeInfo(UUID.randomUUID(), createOffheapChange("a", "100"), ChangeRequestState.COMMITTED, 1L, "SYSTEM", "SYSTEM", now));
 
-    UpgradableNomadServer<NodeContext> nomadServer = mock(UpgradableNomadServer.class);
+    DynamicConfigNomadServer nomadServer = mock(DynamicConfigNomadServer.class);
     when(nomadServer.getAllNomadChanges()).thenReturn(passiveNomadChanges);
 
     DynamicConfigurationPassiveSync syncManager = new DynamicConfigurationPassiveSync(startupTopology, nomadServer, mock(DynamicConfigService.class), topologyService, () -> null);
@@ -169,7 +169,7 @@ public class DynamicConfigurationPassiveSyncTest {
     activeNomadChanges.add(new NomadChangeInfo(firstChange, createOffheapChange("a", "100"), ChangeRequestState.COMMITTED, 1L, "SYSTEM", "SYSTEM", now));
     activeNomadChanges.add(new NomadChangeInfo(UUID.randomUUID(), createOffheapChange("b", "200"), ChangeRequestState.PREPARED, 2L, "SYSTEM", "SYSTEM", now));
 
-    UpgradableNomadServer<NodeContext> activeNomadServer = mock(UpgradableNomadServer.class);
+    DynamicConfigNomadServer activeNomadServer = mock(DynamicConfigNomadServer.class);
     DynamicConfigurationPassiveSync activeSyncManager = new DynamicConfigurationPassiveSync(startupTopology, activeNomadServer, mock(DynamicConfigService.class), topologyService, () -> null);
     when(activeNomadServer.getAllNomadChanges()).thenReturn(activeNomadChanges);
     byte[] active = codec.encode(activeSyncManager.getSyncData());
@@ -178,7 +178,7 @@ public class DynamicConfigurationPassiveSyncTest {
     passiveNomadChanges.add(activation);
     passiveNomadChanges.add(new NomadChangeInfo(firstChange, createOffheapChange("a", "100"), ChangeRequestState.COMMITTED, 1L, "SYSTEM", "SYSTEM", now));
 
-    UpgradableNomadServer<NodeContext> nomadServer = mock(UpgradableNomadServer.class);
+    DynamicConfigNomadServer nomadServer = mock(DynamicConfigNomadServer.class);
     DiscoverResponse<NodeContext> discoverResponse = mock(DiscoverResponse.class);
     AcceptRejectResponse acceptRejectResponse = mock(AcceptRejectResponse.class);
     when(nomadServer.getAllNomadChanges()).thenReturn(passiveNomadChanges);
@@ -201,7 +201,7 @@ public class DynamicConfigurationPassiveSyncTest {
     activeNomadChanges.add(new NomadChangeInfo(firstChange, createOffheapChange("a", "100"), ChangeRequestState.COMMITTED, 1L, "SYSTEM", "SYSTEM", now));
     activeNomadChanges.add(new NomadChangeInfo(UUID.randomUUID(), createOffheapChange("b", "200"), ChangeRequestState.COMMITTED, 2L, "SYSTEM", "SYSTEM", now));
 
-    UpgradableNomadServer<NodeContext> activeNomadServer = mock(UpgradableNomadServer.class);
+    DynamicConfigNomadServer activeNomadServer = mock(DynamicConfigNomadServer.class);
     DynamicConfigurationPassiveSync activeSyncManager = new DynamicConfigurationPassiveSync(startupTopology, activeNomadServer, mock(DynamicConfigService.class), topologyService, () -> null);
     when(activeNomadServer.getAllNomadChanges()).thenReturn(activeNomadChanges);
     byte[] active = codec.encode(activeSyncManager.getSyncData());
@@ -210,7 +210,7 @@ public class DynamicConfigurationPassiveSyncTest {
     passiveNomadChanges.add(activation);
     passiveNomadChanges.add(new NomadChangeInfo(firstChange, createOffheapChange("a", "100"), ChangeRequestState.COMMITTED, 1L, "SYSTEM", "SYSTEM", now));
 
-    UpgradableNomadServer<NodeContext> nomadServer = mock(UpgradableNomadServer.class);
+    DynamicConfigNomadServer nomadServer = mock(DynamicConfigNomadServer.class);
     DiscoverResponse<NodeContext> discoverResponse = mock(DiscoverResponse.class);
     AcceptRejectResponse acceptRejectResponse = mock(AcceptRejectResponse.class);
     when(nomadServer.getAllNomadChanges()).thenReturn(passiveNomadChanges);
@@ -235,7 +235,7 @@ public class DynamicConfigurationPassiveSyncTest {
     activeNomadChanges.add(new NomadChangeInfo(firstChange, createOffheapChange("a", "100"), ChangeRequestState.COMMITTED, 1L, "SYSTEM", "SYSTEM", now));
     activeNomadChanges.add(new NomadChangeInfo(secondChange, createOffheapChange("b", "200"), ChangeRequestState.COMMITTED, 2L, "SYSTEM", "SYSTEM", now));
 
-    UpgradableNomadServer<NodeContext> activeNomadServer = mock(UpgradableNomadServer.class);
+    DynamicConfigNomadServer activeNomadServer = mock(DynamicConfigNomadServer.class);
     DynamicConfigurationPassiveSync activeSyncManager = new DynamicConfigurationPassiveSync(startupTopology, activeNomadServer, mock(DynamicConfigService.class), topologyService, () -> null);
     when(activeNomadServer.getAllNomadChanges()).thenReturn(activeNomadChanges);
     byte[] active = codec.encode(activeSyncManager.getSyncData());
@@ -244,7 +244,7 @@ public class DynamicConfigurationPassiveSyncTest {
     passiveNomadChanges.add(activation);
     passiveNomadChanges.add(new NomadChangeInfo(firstChange, createOffheapChange("a", "100"), ChangeRequestState.COMMITTED, 1L, "SYSTEM", "SYSTEM", now));
     passiveNomadChanges.add(new NomadChangeInfo(secondChange, createOffheapChange("b", "200"), ChangeRequestState.COMMITTED, 2L, "SYSTEM", "SYSTEM", now));
-    UpgradableNomadServer<NodeContext> nomadServer = mock(UpgradableNomadServer.class);
+    DynamicConfigNomadServer nomadServer = mock(DynamicConfigNomadServer.class);
     DiscoverResponse<NodeContext> discoverResponse = mock(DiscoverResponse.class);
     AcceptRejectResponse acceptRejectResponse = mock(AcceptRejectResponse.class);
     when(nomadServer.getAllNomadChanges()).thenReturn(passiveNomadChanges);

--- a/dynamic-config/server/configuration-repository/src/main/java/org/terracotta/dynamic_config/server/configuration/nomad/DynamicConfigNomadServerImpl.java
+++ b/dynamic-config/server/configuration-repository/src/main/java/org/terracotta/dynamic_config/server/configuration/nomad/DynamicConfigNomadServerImpl.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.dynamic_config.server.configuration.nomad;
+
+import org.terracotta.dynamic_config.api.model.NodeContext;
+import org.terracotta.dynamic_config.api.service.NomadChangeInfo;
+import org.terracotta.dynamic_config.server.api.DynamicConfigNomadServer;
+import org.terracotta.dynamic_config.server.configuration.nomad.persistence.DynamicConfigNomadServerState;
+import org.terracotta.nomad.client.change.NomadChange;
+import org.terracotta.nomad.messages.AcceptRejectResponse;
+import org.terracotta.nomad.server.ChangeApplicator;
+import org.terracotta.nomad.server.ChangeRequest;
+import org.terracotta.nomad.server.NomadException;
+import org.terracotta.nomad.server.NomadServerImpl;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.function.BiFunction;
+
+/**
+ * @author Mathieu Carbou
+ */
+public class DynamicConfigNomadServerImpl extends NomadServerImpl<NodeContext> implements DynamicConfigNomadServer {
+  private final DynamicConfigNomadServerState state;
+
+  public DynamicConfigNomadServerImpl(DynamicConfigNomadServerState state, ChangeApplicator<NodeContext> changeApplicator) throws NomadException {
+    super(state, changeApplicator);
+    this.state = state;
+  }
+
+  public DynamicConfigNomadServerImpl(DynamicConfigNomadServerState state) throws NomadException {
+    super(state);
+    this.state = state;
+  }
+
+  @Override
+  public void setChangeApplicator(ChangeApplicator<NodeContext> changeApplicator) {
+    if (getChangeApplicator() != null && changeApplicator != null) {
+      throw new IllegalArgumentException("Variable changeApplicator is already set");
+    }
+    super.setChangeApplicator(changeApplicator);
+  }
+
+  @Override
+  public ChangeApplicator<NodeContext> getChangeApplicator() {
+    return super.getChangeApplicator();
+  }
+
+  @Override
+  public void forceSync(Iterable<NomadChangeInfo> changes, BiFunction<NodeContext, NomadChange, NodeContext> fn) throws NomadException {
+    ChangeApplicator<NodeContext> backup = getChangeApplicator();
+    try {
+      super.setChangeApplicator(ChangeApplicator.allow(fn));
+      for (NomadChangeInfo change : changes) {
+        switch (change.getChangeRequestState()) {
+          case PREPARED: {
+            long mutativeMessageCount = state.getMutativeMessageCount();
+            AcceptRejectResponse response = prepare(change.toPrepareMessage(mutativeMessageCount));
+            if (!response.isAccepted()) {
+              throw new NomadException("Prepare failure. " +
+                  "Reason: " + response + ". " +
+                  "Change:" + change.getNomadChange().getSummary());
+            }
+            break;
+          }
+          case COMMITTED: {
+            long mutativeMessageCount = state.getMutativeMessageCount();
+            AcceptRejectResponse response = prepare(change.toPrepareMessage(mutativeMessageCount));
+            if (!response.isAccepted()) {
+              throw new NomadException("Prepare failure. " +
+                  "Reason: " + response + ". " +
+                  "Change:" + change.getNomadChange().getSummary());
+            }
+            response = commit(change.toCommitMessage(mutativeMessageCount + 1));
+            if (!response.isAccepted()) {
+              throw new NomadException("Unexpected commit failure. " +
+                  "Reason: " + response + ". " +
+                  "Change:" + change.getNomadChange().getSummary());
+            }
+            break;
+          }
+          case ROLLED_BACK: {
+            long mutativeMessageCount = state.getMutativeMessageCount();
+            AcceptRejectResponse response = prepare(change.toPrepareMessage(mutativeMessageCount));
+            if (!response.isAccepted()) {
+              throw new NomadException("Prepare failure. " +
+                  "Reason: " + response + ". " +
+                  "Change:" + change.getNomadChange().getSummary());
+            }
+            response = rollback(change.toRollbackMessage(mutativeMessageCount + 1));
+            if (!response.isAccepted()) {
+              throw new NomadException("Unexpected rollback failure. " +
+                  "Reason: " + response + ". " +
+                  "Change:" + change.getNomadChange().getSummary());
+            }
+            break;
+          }
+          default:
+            throw new AssertionError(change.getChangeRequestState());
+        }
+      }
+    } finally {
+      super.setChangeApplicator(backup);
+    }
+  }
+
+  @Override
+  public Optional<NomadChangeInfo> getNomadChange(UUID changeUuid) throws NomadException {
+    ChangeRequest<NodeContext> changeRequest = state.getChangeRequest(changeUuid);
+    if (changeRequest == null) {
+      return Optional.empty();
+    }
+    return Optional.of(new NomadChangeInfo(
+        changeUuid,
+        changeRequest.getChange(),
+        changeRequest.getState(),
+        changeRequest.getVersion(),
+        changeRequest.getCreationHost(),
+        changeRequest.getCreationUser(),
+        changeRequest.getCreationTimestamp()));
+  }
+
+  @Override
+  public List<NomadChangeInfo> getAllNomadChanges() throws NomadException {
+    LinkedList<NomadChangeInfo> allNomadChanges = new LinkedList<>();
+    UUID changeUuid = state.getLatestChangeUuid();
+    while (changeUuid != null) {
+      ChangeRequest<NodeContext> changeRequest = state.getChangeRequest(changeUuid);
+      allNomadChanges.addFirst(
+          new NomadChangeInfo(
+              changeUuid,
+              changeRequest.getChange(),
+              changeRequest.getState(),
+              changeRequest.getVersion(),
+              changeRequest.getCreationHost(),
+              changeRequest.getCreationUser(),
+              changeRequest.getCreationTimestamp()
+          )
+      );
+      if (changeRequest.getPrevChangeId() != null) {
+        changeUuid = UUID.fromString(changeRequest.getPrevChangeId());
+      } else {
+        changeUuid = null;
+      }
+    }
+    return allNomadChanges;
+  }
+}

--- a/dynamic-config/server/configuration-repository/src/main/java/org/terracotta/dynamic_config/server/configuration/nomad/SingleThreadedNomadServer.java
+++ b/dynamic-config/server/configuration-repository/src/main/java/org/terracotta/dynamic_config/server/configuration/nomad/SingleThreadedNomadServer.java
@@ -13,8 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.terracotta.nomad.server;
+package org.terracotta.dynamic_config.server.configuration.nomad;
 
+import org.terracotta.dynamic_config.api.model.NodeContext;
+import org.terracotta.dynamic_config.api.service.NomadChangeInfo;
+import org.terracotta.dynamic_config.server.api.DynamicConfigNomadServer;
 import org.terracotta.nomad.client.change.NomadChange;
 import org.terracotta.nomad.messages.AcceptRejectResponse;
 import org.terracotta.nomad.messages.CommitMessage;
@@ -22,6 +25,8 @@ import org.terracotta.nomad.messages.DiscoverResponse;
 import org.terracotta.nomad.messages.PrepareMessage;
 import org.terracotta.nomad.messages.RollbackMessage;
 import org.terracotta.nomad.messages.TakeoverMessage;
+import org.terracotta.nomad.server.ChangeApplicator;
+import org.terracotta.nomad.server.NomadException;
 
 import java.util.List;
 import java.util.Optional;
@@ -29,11 +34,11 @@ import java.util.UUID;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.BiFunction;
 
-public class SingleThreadedNomadServer<T> implements UpgradableNomadServer<T> {
-  private final UpgradableNomadServer<T> underlying;
-  private final ReentrantLock lock = new ReentrantLock(true);
+public class SingleThreadedNomadServer implements DynamicConfigNomadServer {
+  private final DynamicConfigNomadServer underlying;
+  protected final ReentrantLock lock = new ReentrantLock(true);
 
-  public SingleThreadedNomadServer(UpgradableNomadServer<T> underlying) {
+  public SingleThreadedNomadServer(DynamicConfigNomadServer underlying) {
     this.underlying = underlying;
   }
 
@@ -42,16 +47,6 @@ public class SingleThreadedNomadServer<T> implements UpgradableNomadServer<T> {
     lock.lock();
     try {
       underlying.reset();
-    } finally {
-      lock.unlock();
-    }
-  }
-
-  @Override
-  public void forceSync(Iterable<NomadChangeInfo> changes, BiFunction<T, NomadChange, T> fn) throws NomadException {
-    lock.lock();
-    try {
-      underlying.forceSync(changes, fn);
     } finally {
       lock.unlock();
     }
@@ -68,7 +63,7 @@ public class SingleThreadedNomadServer<T> implements UpgradableNomadServer<T> {
   }
 
   @Override
-  public DiscoverResponse<T> discover() throws NomadException {
+  public DiscoverResponse<NodeContext> discover() throws NomadException {
     lock.lock();
     try {
       return underlying.discover();
@@ -118,7 +113,37 @@ public class SingleThreadedNomadServer<T> implements UpgradableNomadServer<T> {
   }
 
   @Override
-  public void setChangeApplicator(ChangeApplicator<T> changeApplicator) {
+  public boolean hasIncompleteChange() {
+    lock.lock();
+    try {
+      return underlying.hasIncompleteChange();
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  @Override
+  public Optional<NodeContext> getCurrentCommittedConfig() throws NomadException {
+    lock.lock();
+    try {
+      return underlying.getCurrentCommittedConfig();
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  @Override
+  public void forceSync(Iterable<NomadChangeInfo> changes, BiFunction<NodeContext, NomadChange, NodeContext> fn) throws NomadException {
+    lock.lock();
+    try {
+      underlying.forceSync(changes, fn);
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  @Override
+  public void setChangeApplicator(ChangeApplicator<NodeContext> changeApplicator) {
     lock.lock();
     try {
       underlying.setChangeApplicator(changeApplicator);
@@ -128,20 +153,10 @@ public class SingleThreadedNomadServer<T> implements UpgradableNomadServer<T> {
   }
 
   @Override
-  public ChangeApplicator<T> getChangeApplicator() {
+  public ChangeApplicator<NodeContext> getChangeApplicator() {
     lock.lock();
     try {
       return underlying.getChangeApplicator();
-    } finally {
-      lock.unlock();
-    }
-  }
-
-  @Override
-  public Optional<NomadChangeInfo> getNomadChangeInfo(UUID uuid) throws NomadException {
-    lock.lock();
-    try {
-      return underlying.getNomadChangeInfo(uuid);
     } finally {
       lock.unlock();
     }
@@ -162,26 +177,6 @@ public class SingleThreadedNomadServer<T> implements UpgradableNomadServer<T> {
     lock.lock();
     try {
       return underlying.getNomadChange(uuid);
-    } finally {
-      lock.unlock();
-    }
-  }
-
-  @Override
-  public boolean hasIncompleteChange() {
-    lock.lock();
-    try {
-      return underlying.hasIncompleteChange();
-    } finally {
-      lock.unlock();
-    }
-  }
-
-  @Override
-  public Optional<T> getCurrentCommittedConfig() throws NomadException {
-    lock.lock();
-    try {
-      return underlying.getCurrentCommittedConfig();
     } finally {
       lock.unlock();
     }

--- a/dynamic-config/server/configuration-repository/src/main/java/org/terracotta/dynamic_config/server/configuration/nomad/persistence/DynamicConfigChangeRequest.java
+++ b/dynamic-config/server/configuration-repository/src/main/java/org/terracotta/dynamic_config/server/configuration/nomad/persistence/DynamicConfigChangeRequest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.dynamic_config.server.configuration.nomad.persistence;
+
+import org.terracotta.dynamic_config.api.model.NodeContext;
+import org.terracotta.nomad.client.change.NomadChange;
+import org.terracotta.nomad.server.ChangeRequest;
+import org.terracotta.nomad.server.ChangeRequestState;
+
+import java.time.Instant;
+
+/**
+ * @author Mathieu Carbou
+ */
+public class DynamicConfigChangeRequest extends ChangeRequest<NodeContext> {
+  public DynamicConfigChangeRequest(ChangeRequestState state, long version, String prevChangeId, NomadChange change, NodeContext changeResult, String creationHost, String creationUser, Instant creationTimestamp) {
+    super(state, version, prevChangeId, change, changeResult, creationHost, creationUser, creationTimestamp);
+  }
+}

--- a/dynamic-config/server/configuration-repository/src/main/java/org/terracotta/dynamic_config/server/configuration/nomad/persistence/DynamicConfigNomadServerState.java
+++ b/dynamic-config/server/configuration-repository/src/main/java/org/terracotta/dynamic_config/server/configuration/nomad/persistence/DynamicConfigNomadServerState.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.dynamic_config.server.configuration.nomad.persistence;
+
+import org.terracotta.dynamic_config.api.model.NodeContext;
+import org.terracotta.nomad.server.NomadException;
+import org.terracotta.nomad.server.state.NomadServerState;
+
+import java.util.UUID;
+
+/**
+ * @author Mathieu Carbou
+ */
+public interface DynamicConfigNomadServerState extends NomadServerState<NodeContext> {
+  @Override
+  DynamicConfigChangeRequest getChangeRequest(UUID changeUuid) throws NomadException;
+}

--- a/dynamic-config/server/configuration-repository/src/main/java/org/terracotta/dynamic_config/server/configuration/nomad/persistence/SanskritNomadServerState.java
+++ b/dynamic-config/server/configuration-repository/src/main/java/org/terracotta/dynamic_config/server/configuration/nomad/persistence/SanskritNomadServerState.java
@@ -18,11 +18,9 @@ package org.terracotta.dynamic_config.server.configuration.nomad.persistence;
 import org.terracotta.dynamic_config.api.model.NodeContext;
 import org.terracotta.dynamic_config.api.model.Version;
 import org.terracotta.nomad.client.change.NomadChange;
-import org.terracotta.nomad.server.ChangeRequest;
 import org.terracotta.nomad.server.ChangeRequestState;
 import org.terracotta.nomad.server.NomadException;
 import org.terracotta.nomad.server.NomadServerMode;
-import org.terracotta.nomad.server.state.NomadServerState;
 import org.terracotta.nomad.server.state.NomadStateChange;
 import org.terracotta.persistence.sanskrit.Sanskrit;
 import org.terracotta.persistence.sanskrit.SanskritException;
@@ -51,7 +49,7 @@ import static org.terracotta.dynamic_config.server.configuration.nomad.persisten
 import static org.terracotta.dynamic_config.server.configuration.nomad.persistence.NomadSanskritKeys.MUTATIVE_MESSAGE_COUNT;
 import static org.terracotta.dynamic_config.server.configuration.nomad.persistence.NomadSanskritKeys.PREV_CHANGE_UUID;
 
-public class SanskritNomadServerState implements NomadServerState<NodeContext> {
+public class SanskritNomadServerState implements DynamicConfigNomadServerState {
   private final Sanskrit sanskrit;
   private final ConfigStorage configStorage;
   private final HashComputer hashComputer;
@@ -119,7 +117,7 @@ public class SanskritNomadServerState implements NomadServerState<NodeContext> {
   }
 
   @Override
-  public ChangeRequest<NodeContext> getChangeRequest(UUID changeUuid) throws NomadException {
+  public DynamicConfigChangeRequest getChangeRequest(UUID changeUuid) throws NomadException {
     try {
       String uuidString = changeUuid.toString();
       SanskritObject child = getObject(uuidString);
@@ -151,7 +149,7 @@ public class SanskritNomadServerState implements NomadServerState<NodeContext> {
         throw new NomadException("Bad hash for change: " + changeUuid + ". " + e.getMessage());
       }
 
-      return new ChangeRequest<>(state, version, prevChangeUuid, change, config.getTopology(), creationHost, creationUser, creationTimestamp);
+      return new DynamicConfigChangeRequest(state, version, prevChangeUuid, change, config.getTopology(), creationHost, creationUser, creationTimestamp);
     } catch (ConfigStorageException e) {
       throw new NomadException("Failed to read configuration: " + changeUuid, e);
     }

--- a/dynamic-config/server/configuration-repository/src/test/java/org/terracotta/dynamic_config/server/configuration/nomad/persistence/BackwardCompatibilityTest.java
+++ b/dynamic-config/server/configuration-repository/src/test/java/org/terracotta/dynamic_config/server/configuration/nomad/persistence/BackwardCompatibilityTest.java
@@ -23,10 +23,10 @@ import org.terracotta.dynamic_config.api.model.NodeContext;
 import org.terracotta.dynamic_config.api.model.nomad.DynamicConfigNomadChange;
 import org.terracotta.dynamic_config.api.service.IParameterSubstitutor;
 import org.terracotta.dynamic_config.api.service.Props;
+import org.terracotta.dynamic_config.server.api.DynamicConfigNomadServer;
 import org.terracotta.dynamic_config.server.configuration.nomad.NomadServerFactory;
 import org.terracotta.json.ObjectMapperFactory;
 import org.terracotta.nomad.server.ChangeApplicator;
-import org.terracotta.nomad.server.UpgradableNomadServer;
 import org.terracotta.testing.TmpDir;
 
 import java.io.IOException;
@@ -71,7 +71,7 @@ public class BackwardCompatibilityTest {
     ObjectMapperFactory objectMapperFactory = new ObjectMapperFactory().withModule(new DynamicConfigApiJsonModule());
     NomadServerFactory nomadServerFactory = new NomadServerFactory(objectMapperFactory);
 
-    try (UpgradableNomadServer<NodeContext> nomadServer = nomadServerFactory.createServer(nomadConfigurationManager, "default-node1", null)) {
+    try (DynamicConfigNomadServer nomadServer = nomadServerFactory.createServer(nomadConfigurationManager, "default-node1", null)) {
       nomadServer.setChangeApplicator(ChangeApplicator.allow((nodeContext, change) -> nodeContext.withCluster(((DynamicConfigNomadChange) change).apply(nodeContext.getCluster())).get()));
 
       // upgrade should have been done

--- a/dynamic-config/server/server-api/src/main/java/org/terracotta/dynamic_config/server/api/DynamicConfigEventFiring.java
+++ b/dynamic-config/server/server-api/src/main/java/org/terracotta/dynamic_config/server/api/DynamicConfigEventFiring.java
@@ -21,11 +21,11 @@ import org.terracotta.dynamic_config.api.model.NodeContext;
 import org.terracotta.dynamic_config.api.model.Stripe;
 import org.terracotta.dynamic_config.api.model.UID;
 import org.terracotta.dynamic_config.api.model.nomad.SettingNomadChange;
+import org.terracotta.dynamic_config.api.service.NomadChangeInfo;
 import org.terracotta.nomad.messages.AcceptRejectResponse;
 import org.terracotta.nomad.messages.CommitMessage;
 import org.terracotta.nomad.messages.PrepareMessage;
 import org.terracotta.nomad.messages.RollbackMessage;
-import org.terracotta.nomad.server.NomadChangeInfo;
 
 /**
  * @author Mathieu Carbou

--- a/dynamic-config/server/server-api/src/main/java/org/terracotta/dynamic_config/server/api/DynamicConfigListener.java
+++ b/dynamic-config/server/server-api/src/main/java/org/terracotta/dynamic_config/server/api/DynamicConfigListener.java
@@ -21,12 +21,12 @@ import org.terracotta.dynamic_config.api.model.NodeContext;
 import org.terracotta.dynamic_config.api.model.Stripe;
 import org.terracotta.dynamic_config.api.model.UID;
 import org.terracotta.dynamic_config.api.model.nomad.SettingNomadChange;
+import org.terracotta.dynamic_config.api.service.NomadChangeInfo;
 import org.terracotta.dynamic_config.api.service.TopologyService;
 import org.terracotta.nomad.messages.AcceptRejectResponse;
 import org.terracotta.nomad.messages.CommitMessage;
 import org.terracotta.nomad.messages.PrepareMessage;
 import org.terracotta.nomad.messages.RollbackMessage;
-import org.terracotta.nomad.server.NomadChangeInfo;
 
 /**
  * @author Mathieu Carbou

--- a/dynamic-config/server/server-api/src/main/java/org/terracotta/dynamic_config/server/api/DynamicConfigNomadServer.java
+++ b/dynamic-config/server/server-api/src/main/java/org/terracotta/dynamic_config/server/api/DynamicConfigNomadServer.java
@@ -13,21 +13,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.terracotta.nomad.server;
+package org.terracotta.dynamic_config.server.api;
 
+import org.terracotta.dynamic_config.api.model.NodeContext;
+import org.terracotta.dynamic_config.api.service.NomadChangeInfo;
 import org.terracotta.nomad.client.change.NomadChange;
+import org.terracotta.nomad.server.ChangeApplicator;
+import org.terracotta.nomad.server.NomadException;
+import org.terracotta.nomad.server.NomadServer;
 
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.function.BiFunction;
 
-public interface UpgradableNomadServer<T> extends NomadServer<T> {
-  void setChangeApplicator(ChangeApplicator<T> changeApplicator);
+public interface DynamicConfigNomadServer extends NomadServer<NodeContext> {
+  void setChangeApplicator(ChangeApplicator<NodeContext> changeApplicator);
 
-  ChangeApplicator<T> getChangeApplicator();
-
-  Optional<NomadChangeInfo> getNomadChangeInfo(UUID uuid) throws NomadException;
+  ChangeApplicator<NodeContext> getChangeApplicator();
 
   List<NomadChangeInfo> getAllNomadChanges() throws NomadException;
 
@@ -39,7 +42,7 @@ public interface UpgradableNomadServer<T> extends NomadServer<T> {
    */
   boolean hasIncompleteChange();
 
-  Optional<T> getCurrentCommittedConfig() throws NomadException;
+  Optional<NodeContext> getCurrentCommittedConfig() throws NomadException;
 
   void reset() throws NomadException;
 
@@ -50,5 +53,5 @@ public interface UpgradableNomadServer<T> extends NomadServer<T> {
    * which will return a new configuration from 2 parameters: the change and
    * the previous configuration, which might be null at the beginning.
    */
-  void forceSync(Iterable<NomadChangeInfo> changes, BiFunction<T, NomadChange, T> fn) throws NomadException;
+  void forceSync(Iterable<NomadChangeInfo> changes, BiFunction<NodeContext, NomadChange, NodeContext> fn) throws NomadException;
 }

--- a/dynamic-config/server/server-api/src/main/java/org/terracotta/dynamic_config/server/api/DynamicConfigNomadServerAdapter.java
+++ b/dynamic-config/server/server-api/src/main/java/org/terracotta/dynamic_config/server/api/DynamicConfigNomadServerAdapter.java
@@ -13,8 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.terracotta.nomad.server;
+package org.terracotta.dynamic_config.server.api;
 
+import org.terracotta.dynamic_config.api.model.NodeContext;
+import org.terracotta.dynamic_config.api.service.NomadChangeInfo;
 import org.terracotta.nomad.client.change.NomadChange;
 import org.terracotta.nomad.messages.AcceptRejectResponse;
 import org.terracotta.nomad.messages.CommitMessage;
@@ -22,6 +24,8 @@ import org.terracotta.nomad.messages.DiscoverResponse;
 import org.terracotta.nomad.messages.PrepareMessage;
 import org.terracotta.nomad.messages.RollbackMessage;
 import org.terracotta.nomad.messages.TakeoverMessage;
+import org.terracotta.nomad.server.ChangeApplicator;
+import org.terracotta.nomad.server.NomadException;
 
 import java.util.List;
 import java.util.Optional;
@@ -31,25 +35,20 @@ import java.util.function.BiFunction;
 /**
  * @author Mathieu Carbou
  */
-public class UpgradableNomadServerAdapter<T> implements UpgradableNomadServer<T> {
+public class DynamicConfigNomadServerAdapter implements DynamicConfigNomadServer {
 
-  private final UpgradableNomadServer<T> delegate;
+  private final DynamicConfigNomadServer delegate;
 
-  public UpgradableNomadServerAdapter(UpgradableNomadServer<T> delegate) {
+  public DynamicConfigNomadServerAdapter(DynamicConfigNomadServer delegate) {
     this.delegate = delegate;
   }
 
   @Override
-  public void setChangeApplicator(ChangeApplicator<T> changeApplicator) {delegate.setChangeApplicator(changeApplicator);}
+  public void setChangeApplicator(ChangeApplicator<NodeContext> changeApplicator) {delegate.setChangeApplicator(changeApplicator);}
 
   @Override
-  public ChangeApplicator<T> getChangeApplicator() {
+  public ChangeApplicator<NodeContext> getChangeApplicator() {
     return delegate.getChangeApplicator();
-  }
-
-  @Override
-  public Optional<NomadChangeInfo> getNomadChangeInfo(UUID uuid) throws NomadException {
-    return delegate.getNomadChangeInfo(uuid);
   }
 
   @Override
@@ -59,7 +58,7 @@ public class UpgradableNomadServerAdapter<T> implements UpgradableNomadServer<T>
   public Optional<NomadChangeInfo> getNomadChange(UUID uuid) throws NomadException {return delegate.getNomadChange(uuid);}
 
   @Override
-  public DiscoverResponse<T> discover() throws NomadException {return delegate.discover();}
+  public DiscoverResponse<NodeContext> discover() throws NomadException {return delegate.discover();}
 
   @Override
   public AcceptRejectResponse prepare(PrepareMessage message) throws NomadException {return delegate.prepare(message);}
@@ -79,7 +78,7 @@ public class UpgradableNomadServerAdapter<T> implements UpgradableNomadServer<T>
   }
 
   @Override
-  public Optional<T> getCurrentCommittedConfig() throws NomadException {return delegate.getCurrentCommittedConfig();}
+  public Optional<NodeContext> getCurrentCommittedConfig() throws NomadException {return delegate.getCurrentCommittedConfig();}
 
   @Override
   public void reset() throws NomadException {
@@ -87,7 +86,7 @@ public class UpgradableNomadServerAdapter<T> implements UpgradableNomadServer<T>
   }
 
   @Override
-  public void forceSync(Iterable<NomadChangeInfo> changes, BiFunction<T, NomadChange, T> fn) throws NomadException {
+  public void forceSync(Iterable<NomadChangeInfo> changes, BiFunction<NodeContext, NomadChange, NodeContext> fn) throws NomadException {
     delegate.forceSync(changes, fn);
   }
 

--- a/dynamic-config/server/services/src/main/java/org/terracotta/dynamic_config/server/service/DynamicConfigServiceProvider.java
+++ b/dynamic-config/server/services/src/main/java/org/terracotta/dynamic_config/server/service/DynamicConfigServiceProvider.java
@@ -27,6 +27,7 @@ import org.terracotta.dynamic_config.server.api.ConfigChangeHandler;
 import org.terracotta.dynamic_config.server.api.ConfigChangeHandlerManager;
 import org.terracotta.dynamic_config.server.api.DynamicConfigEventFiring;
 import org.terracotta.dynamic_config.server.api.DynamicConfigEventService;
+import org.terracotta.dynamic_config.server.api.DynamicConfigNomadServer;
 import org.terracotta.dynamic_config.server.api.LicenseService;
 import org.terracotta.dynamic_config.server.api.NomadPermissionChangeProcessor;
 import org.terracotta.dynamic_config.server.api.NomadRoutingChangeProcessor;
@@ -40,7 +41,6 @@ import org.terracotta.entity.ServiceConfiguration;
 import org.terracotta.entity.ServiceProvider;
 import org.terracotta.entity.ServiceProviderConfiguration;
 import org.terracotta.nomad.server.NomadServer;
-import org.terracotta.nomad.server.UpgradableNomadServer;
 import org.terracotta.server.ServerEnv;
 
 import java.util.Arrays;
@@ -128,7 +128,7 @@ public class DynamicConfigServiceProvider implements ServiceProvider {
         DynamicConfigService.class,
         DynamicConfigEventFiring.class,
         NomadServer.class,
-        UpgradableNomadServer.class,
+        DynamicConfigNomadServer.class,
         NomadRoutingChangeProcessor.class,
         NomadPermissionChangeProcessor.class,
         LicenseService.class,

--- a/dynamic-config/testing/support/src/main/java/org/terracotta/dynamic_config/test_support/util/CommitSkippingConfigRepoProcessor.java
+++ b/dynamic-config/testing/support/src/main/java/org/terracotta/dynamic_config/test_support/util/CommitSkippingConfigRepoProcessor.java
@@ -21,12 +21,8 @@ import org.terracotta.dynamic_config.api.model.NodeContext;
 import org.terracotta.dynamic_config.cli.upgrade_tools.config_converter.ConfigRepoProcessor;
 import org.terracotta.nomad.messages.AcceptRejectResponse;
 import org.terracotta.nomad.messages.CommitMessage;
-import org.terracotta.nomad.messages.DiscoverResponse;
-import org.terracotta.nomad.messages.PrepareMessage;
-import org.terracotta.nomad.messages.RollbackMessage;
-import org.terracotta.nomad.messages.TakeoverMessage;
-import org.terracotta.nomad.server.NomadException;
 import org.terracotta.nomad.server.NomadServer;
+import org.terracotta.nomad.server.NomadServerAdapter;
 
 import java.nio.file.Path;
 
@@ -38,36 +34,10 @@ public class CommitSkippingConfigRepoProcessor extends ConfigRepoProcessor {
 
   @Override
   protected NomadServer<NodeContext> getNomadServer(Cluster cluster, Node node) {
-    NomadServer<NodeContext> nomadServer = super.getNomadServer(cluster, node);
-    return new NomadServer<NodeContext>() {
-      @Override
-      public DiscoverResponse<NodeContext> discover() throws NomadException {
-        return nomadServer.discover();
-      }
-
-      @Override
-      public AcceptRejectResponse prepare(PrepareMessage message) throws NomadException {
-        return nomadServer.prepare(message);
-      }
-
+    return new NomadServerAdapter<NodeContext>(super.getNomadServer(cluster, node)) {
       @Override
       public AcceptRejectResponse commit(CommitMessage message) {
         return AcceptRejectResponse.accept();
-      }
-
-      @Override
-      public AcceptRejectResponse rollback(RollbackMessage message) throws NomadException {
-        return nomadServer.rollback(message);
-      }
-
-      @Override
-      public AcceptRejectResponse takeover(TakeoverMessage message) throws NomadException {
-        return nomadServer.takeover(message);
-      }
-
-      @Override
-      public void close() {
-        nomadServer.close();
       }
     };
   }

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/ConfigConversionIT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/ConfigConversionIT.java
@@ -26,18 +26,17 @@ import org.terracotta.common.struct.TimeUnit;
 import org.terracotta.dynamic_config.api.json.DynamicConfigApiJsonModule;
 import org.terracotta.dynamic_config.api.model.Cluster;
 import org.terracotta.dynamic_config.api.model.FailoverPriority;
-import org.terracotta.dynamic_config.api.model.NodeContext;
 import org.terracotta.dynamic_config.api.model.RawPath;
 import org.terracotta.dynamic_config.api.service.ClusterFactory;
 import org.terracotta.dynamic_config.api.service.IParameterSubstitutor;
 import org.terracotta.dynamic_config.api.service.Props;
 import org.terracotta.dynamic_config.cli.upgrade_tools.config_converter.ConfigConverterTool;
+import org.terracotta.dynamic_config.server.api.DynamicConfigNomadServer;
 import org.terracotta.dynamic_config.server.configuration.nomad.NomadServerFactory;
 import org.terracotta.dynamic_config.server.configuration.nomad.persistence.ConfigStorageException;
 import org.terracotta.dynamic_config.server.configuration.nomad.persistence.NomadConfigurationManager;
 import org.terracotta.json.ObjectMapperFactory;
 import org.terracotta.nomad.server.NomadException;
-import org.terracotta.nomad.server.UpgradableNomadServer;
 import org.terracotta.persistence.sanskrit.SanskritException;
 import org.terracotta.testing.TmpDir;
 
@@ -370,7 +369,7 @@ public class ConfigConversionIT {
     ObjectMapperFactory objectMapperFactory = new ObjectMapperFactory().withModule(new DynamicConfigApiJsonModule());
     NomadServerFactory nomadServerFactory = new NomadServerFactory(objectMapperFactory);
 
-    try (UpgradableNomadServer<NodeContext> nomadServer = nomadServerFactory.createServer(nomadConfigurationManager, "testServer0", null)) {
+    try (DynamicConfigNomadServer nomadServer = nomadServerFactory.createServer(nomadConfigurationManager, "testServer0", null)) {
       nomadServer.discover().getLatestChange().getResult();
     }
   }

--- a/dynamic-config/testing/system-tests/src/test/resources/diagnostic-output/diagnostic-when-locked.txt
+++ b/dynamic-config/testing/system-tests/src/test/resources/diagnostic-output/diagnostic-when-locked.txt
@@ -6,7 +6,6 @@ Diagnostic result:
  - Nodes online, configured and in repair: 0
  - Nodes online, new and being configured: 0
  - Configuration state: The cluster configuration is healthy. No changes are possible as config is locked by
- - Configuration checkpoint found across all online configured nodes (activated or in repair): YES (Version: 2, UUID:
  - Node state: ACTIVE
  - Node online, configured and activated: YES
  - Node online, configured and in repair: NO

--- a/dynamic-config/testing/system-tests/src/test/resources/diagnostic-output/diagnostic1.txt
+++ b/dynamic-config/testing/system-tests/src/test/resources/diagnostic-output/diagnostic1.txt
@@ -6,7 +6,6 @@ Diagnostic result:
  - Nodes online, configured and in repair: 0
  - Nodes online, new and being configured: 1
  - Configuration state: The cluster configuration is healthy. New configuration changes are possible.
- - Configuration checkpoint found across all online configured nodes (activated or in repair): NO
  - Node state: STARTING
  - Node online, configured and activated: NO
  - Node online, configured and in repair: NO

--- a/dynamic-config/testing/system-tests/src/test/resources/diagnostic-output/diagnostic2.txt
+++ b/dynamic-config/testing/system-tests/src/test/resources/diagnostic-output/diagnostic2.txt
@@ -6,7 +6,6 @@ Diagnostic result:
  - Nodes online, configured and in repair: 0
  - Nodes online, new and being configured: 0
  - Configuration state: The cluster configuration is healthy. New configuration changes are possible.
- - Configuration checkpoint found across all online configured nodes (activated or in repair): YES (Version: 1, UUID:
  - Node state: ACTIVE
  - Node online, configured and activated: YES
  - Node online, configured and in repair: NO

--- a/dynamic-config/testing/system-tests/src/test/resources/diagnostic-output/diagnostic3.txt
+++ b/dynamic-config/testing/system-tests/src/test/resources/diagnostic-output/diagnostic3.txt
@@ -6,7 +6,6 @@ Diagnostic result:
  - Nodes online, configured and in repair: 1
  - Nodes online, new and being configured: 0
  - Configuration state: The cluster configuration is healthy. New configuration changes are possible.
- - Configuration checkpoint found across all online configured nodes (activated or in repair): YES (Version: 1, UUID:
  - Node state: STARTING
  - Node online, configured and activated: NO
  - Node online, configured and in repair: YES

--- a/dynamic-config/testing/system-tests/src/test/resources/diagnostic-output/diagnostic4.txt
+++ b/dynamic-config/testing/system-tests/src/test/resources/diagnostic-output/diagnostic4.txt
@@ -6,7 +6,6 @@ Diagnostic result:
  - Nodes online, configured and in repair: 0
  - Nodes online, new and being configured: 1
  - Configuration state: The cluster configuration is healthy. New configuration changes are possible.
- - Configuration checkpoint found across all online configured nodes (activated or in repair): YES (Version: 1, UUID:
  - Node state: ACTIVE
  - Node online, configured and activated: YES
  - Node online, configured and in repair: NO

--- a/dynamic-config/testing/system-tests/src/test/resources/diagnostic-output/diagnostic5.txt
+++ b/dynamic-config/testing/system-tests/src/test/resources/diagnostic-output/diagnostic5.txt
@@ -6,7 +6,6 @@
  - Nodes online, new and being configured: 0
  - Nodes pending restart: 0
  - Configuration state: A new  cluster configuration has been prepared but not yet committed or rolled back on all nodes. No further configuration change can be done until the 'repair' command is run to finalize the configuration change.
- - Configuration checkpoint found across all online configured nodes (activated or in repair): YES (Version: 2, UUID:
 [node
  - Node state: UNREACHABLE
  - Node online, configured and activated: NO


### PR DESCRIPTION
- Introduced a DynamicConfigNomadServer interface to hold all the DC related enhancements
- Remove NomadChangeInfo from Nomad module: this class is DC-centric and will hold soon the result hash
- Remove checkpoint information: checkpoints are not possible anymore through UUID since they can differ from node to node

There is no functional code change / added / removed here: just some refactoring to allow for the result hash to be exposed correctly and to decouple the NomadChangeInfo from the core Nomad module.