### PR TITLE
Disallow stripe level topology changes on activated clusters

### DIFF
--- a/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/command/TopologyCommand.java
+++ b/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/command/TopologyCommand.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import org.terracotta.diagnostic.model.LogicalServerState;
 import org.terracotta.dynamic_config.api.model.Cluster;
 import org.terracotta.dynamic_config.api.model.Node.Endpoint;
+import org.terracotta.dynamic_config.api.model.Operation;
 import org.terracotta.dynamic_config.api.model.nomad.TopologyNomadChange;
 import org.terracotta.dynamic_config.api.service.ClusterValidator;
 import org.terracotta.dynamic_config.cli.command.Injector.Inject;
@@ -81,9 +82,17 @@ public abstract class TopologyCommand extends RemoteCommand {
       throw new IllegalArgumentException("Wrong destination endpoint: " + destination + ". It does not match any node in destination cluster: " + destinationCluster.toShapeString());
     }
 
+    checkForOperationSupport();
+
     if (destinationClusterActivated) {
       ensureNodesAreEitherActiveOrPassive(destinationOnlineNodes);
       ensureActivesAreAllOnline(destinationCluster, destinationOnlineNodes);
+    }
+  }
+
+  protected void checkForOperationSupport() {
+    if (destinationClusterActivated && OperationType.STRIPE.equals(getOperationType())) {
+      throw new UnsupportedOperationException("Topology modifications of whole stripes on an activated cluster are not supported");
     }
   }
 

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/AttachStripeIT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/AttachStripeIT.java
@@ -17,6 +17,7 @@ package org.terracotta.dynamic_config.system_tests.activated;
 
 import com.terracotta.connection.api.TerracottaConnectionService;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.terracotta.dynamic_config.api.model.Cluster;
 import org.terracotta.dynamic_config.api.model.UID;
@@ -35,6 +36,7 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.terracotta.angela.client.support.hamcrest.AngelaMatchers.successful;
 
+@Ignore("Attaching *any* stripes to an activated cluster is currently unsupported")
 @ClusterDefinition(stripes = 2, nodesPerStripe = 2, autoStart = false)
 public class AttachStripeIT extends DynamicConfigIT {
 

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/DetachCommand2x1IT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/DetachCommand2x1IT.java
@@ -15,6 +15,7 @@
  */
 package org.terracotta.dynamic_config.system_tests.activated;
 
+import org.junit.Ignore;
 import org.junit.Test;
 import org.terracotta.dynamic_config.test_support.ClusterDefinition;
 import org.terracotta.dynamic_config.test_support.DynamicConfigIT;
@@ -26,6 +27,7 @@ import static org.junit.Assert.assertThat;
 /**
  * @author Mathieu Carbou
  */
+@Ignore("Detaching *any* stripes from an activated cluster is currently unsupported")
 @ClusterDefinition(stripes = 2, nodesPerStripe = 1, autoActivate = true)
 public class DetachCommand2x1IT extends DynamicConfigIT {
 

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/DetachStripeIT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/DetachStripeIT.java
@@ -17,6 +17,7 @@ package org.terracotta.dynamic_config.system_tests.activated;
 
 import com.terracotta.connection.api.TerracottaConnectionService;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.terracotta.dynamic_config.api.model.Cluster;
 import org.terracotta.dynamic_config.api.model.Stripe;
@@ -35,6 +36,7 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.terracotta.angela.client.support.hamcrest.AngelaMatchers.successful;
 
+@Ignore("Detaching *any* stripes from an activated cluster is currently unsupported")
 @ClusterDefinition(stripes = 2, nodesPerStripe = 2, autoStart = false)
 public class DetachStripeIT extends DynamicConfigIT {
 


### PR DESCRIPTION
First attempt at disabling stripe level topology changes without having support for subsequent entity scaling. This is probably the minimally invasive way of doing it. In my mind (right now) there is this kind of approach and there is the 're-engineer the functionality split' approach that would remove all the stripe level activated topology change code out of this repo. The later seems 'more right' to me, but would be crazy disruptive at this point.