### PR TITLE
Fix the new long option parsing + help format

### DIFF
--- a/dynamic-config/cli/cli-support/src/main/java/org/terracotta/dynamic_config/cli/command/CustomJCommander.java
+++ b/dynamic-config/cli/cli-support/src/main/java/org/terracotta/dynamic_config/cli/command/CustomJCommander.java
@@ -71,7 +71,7 @@ public class CustomJCommander extends JCommander {
     }
   }
 
-  public void printAskedCommmandUsage(String askedCommand) {
+  public void printAskedCommandUsage(String askedCommand) {
     try {
       if (askedCommand.contains("deprecated")) {
         deprecatedUsage = true;

--- a/dynamic-config/cli/cli-support/src/main/java/org/terracotta/dynamic_config/cli/command/CustomJCommander.java
+++ b/dynamic-config/cli/cli-support/src/main/java/org/terracotta/dynamic_config/cli/command/CustomJCommander.java
@@ -22,6 +22,7 @@ import com.beust.jcommander.ParameterDescription;
 import com.beust.jcommander.Parameters;
 import com.beust.jcommander.WrappedParameter;
 import com.beust.jcommander.internal.Lists;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.util.Comparator;
 import java.util.List;
@@ -133,10 +134,10 @@ public class CustomJCommander extends JCommander {
       boolean hasCommands = !commands.isEmpty();
       out.append(indent).append("Usage: ").append(toolName).append(" [options]");
       if (hasCommands) {
-        out.append(indent).append(" [command] [command-options]");
+        out.append(indent).append(" [command] [command options]");
       }
 
-      out.append(lineSeparator());
+      out.append(lineSeparator()).append(lineSeparator());
       appendOptions(commander, out, indent);
       appendDefinitions(out, indent);
       appendCommands(out, indent, commands, hasCommands);
@@ -149,7 +150,7 @@ public class CustomJCommander extends JCommander {
 
     private void appendCommands(StringBuilder out, String indent, Map<String, JCommander> commands, boolean hasCommands) {
       if (hasCommands) {
-        out.append(lineSeparator()).append("Commands:").append(lineSeparator());
+        out.append(lineSeparator()).append("Commands:").append(lineSeparator()).append(lineSeparator());
         for (Map.Entry<String, JCommander> command : commands.entrySet()) {
           String name = command.getKey();
           if (name.endsWith("-deprecated")) {
@@ -159,53 +160,68 @@ public class CustomJCommander extends JCommander {
           Parameters p = arg.getClass().getAnnotation(Parameters.class);
           if (p == null || !p.hidden()) {
             String description = getCommandDescription(name);
-            out.append(indent).append("    ").append(name).append("      ").append(description).append(lineSeparator());
-            appendUsage(commandRepository.getJCommanderCommand(name), out, indent + "    ");
+            out.append(lineSeparator());
+            out.append(indent).append("    ").append(name).append("      ").append(description).append(lineSeparator()).append(lineSeparator());
+            appendUsage(commandRepository.getJCommanderCommand(name), out, indent + "        ");
+            out.append(lineSeparator());
 
             // Options for this command
             JCommander jc = command.getValue();
-            appendOptions(jc, out, "    ");
-            out.append(lineSeparator());
+            appendOptions(jc, out, "        ");
           }
         }
       }
     }
 
     private void appendUsage(JCommanderCommand command, StringBuilder out, String indent) {
-      out.append(indent).append("Usage:").append(lineSeparator());
+      out.append(indent).append("Usage: ");
       String usage = deprecatedUsage ? Metadata.getDeprecatedUsage(command) : Metadata.getUsage(command);
-      out.append(indent).append("    ").append(usage
-          .replace(lineSeparator(), lineSeparator() + "    " + indent)).append(lineSeparator());
+      out.append(usage.replace(lineSeparator(), lineSeparator() + "    " + indent)).append(lineSeparator());
     }
 
     private void appendOptions(JCommander jCommander, StringBuilder out, String indent) {
       // Align the descriptions at the "longestName" column
-      int longestName = 0;
       List<ParameterDescription> sorted = Lists.newArrayList();
+
+      int colSize = "-security-root-directory".length(); // quick hack to get the largest possible option
       for (ParameterDescription pd : jCommander.getParameters()) {
         if (!pd.getParameter().hidden()) {
           sorted.add(pd);
-          int length = pd.getNames().length() + 2;
-          if (length > longestName) {
-            longestName = length;
+          int length = pd.getParameterAnnotation().names()[0].length();
+          if (length > colSize) {
+            colSize = length;
           }
         }
       }
 
-      // Sort the options
-      sorted.sort(Comparator.comparing(ParameterDescription::getLongestName));
-
       // Display all the names and descriptions
       if (sorted.size() > 0) {
-        out.append(indent).append("Options:").append(lineSeparator());
-      }
 
-      for (ParameterDescription pd : sorted) {
-        WrappedParameter parameter = pd.getParameter();
-        out.append(indent).append("    ").append(pd.getNames()).append(parameter.required() ? " (required)" : "").append(lineSeparator());
-        out.append(indent).append("        ").append(pd.getDescription());
-        out.append(lineSeparator());
+        // Sort the options by only considering the first displayed option
+        // which will be the one with 1 dash (i.e. -help).
+        sorted.sort(Comparator.comparing(pd -> pd.getParameterAnnotation().names()[0]));
+
+        out.append(indent).append("Options:").append(lineSeparator());
+
+        for (ParameterDescription pd : sorted) {
+          WrappedParameter parameter = pd.getParameter();
+          out.append(indent)
+              .append("    ")
+              .append(pad(pd.getParameterAnnotation().names()[0], colSize))
+              .append(parameter.required() ? " (required)    " : " (optional)    ")
+              .append(pd.getDescription())
+              .append(lineSeparator());
+        }
       }
     }
+  }
+
+  @SuppressFBWarnings("SBSC_USE_STRINGBUFFER_CONCATENATION")
+  @SuppressWarnings("StringConcatenationInLoop")
+  private String pad(String str, int colSize) {
+    while (str.length() < colSize) {
+      str += " ";
+    }
+    return str;
   }
 }

--- a/dynamic-config/cli/cli-support/src/main/java/org/terracotta/dynamic_config/cli/command/JCommanderCommand.java
+++ b/dynamic-config/cli/cli-support/src/main/java/org/terracotta/dynamic_config/cli/command/JCommanderCommand.java
@@ -19,7 +19,7 @@ import com.beust.jcommander.Parameter;
 
 public abstract class JCommanderCommand implements Runnable {
 
-  @Parameter(names = {"-h", "--help", "-help"}, description = "Help", help = true)
+  @Parameter(names = {"-help", "-h", "--help"}, description = "Help", help = true)
   private boolean help;
 
   public boolean isHelp() {

--- a/dynamic-config/cli/cli-support/src/main/java/org/terracotta/dynamic_config/cli/command/LocalMainCommand.java
+++ b/dynamic-config/cli/cli-support/src/main/java/org/terracotta/dynamic_config/cli/command/LocalMainCommand.java
@@ -30,7 +30,7 @@ import static org.slf4j.Logger.ROOT_LOGGER_NAME;
 public class LocalMainCommand extends JCommanderCommand {
   public static final String NAME = "main";
 
-  @Parameter(names = {"-v", "--verbose"}, description = "Verbose mode. Default: false")
+  @Parameter(names = {"-verbose", "-v", "--verbose"}, description = "Verbose mode. Default: false")
   private boolean verbose = false;
 
   @Override

--- a/dynamic-config/cli/cli-support/src/main/java/org/terracotta/dynamic_config/cli/command/RemoteMainCommand.java
+++ b/dynamic-config/cli/cli-support/src/main/java/org/terracotta/dynamic_config/cli/command/RemoteMainCommand.java
@@ -27,19 +27,19 @@ import org.terracotta.dynamic_config.cli.converter.TimeUnitConverter;
 @Parameters(commandNames = LocalMainCommand.NAME)
 public class RemoteMainCommand extends LocalMainCommand {
 
-  @Parameter(names = {"-er", "--entity-request-timeout"}, hidden = true, description = "Entity operation timeout. Default: 120s", converter = TimeUnitConverter.class)
+  @Parameter(names = {"-entity-request-timeout", "-er", "--entity-request-timeout"}, hidden = true, description = "Entity operation timeout. Default: 120s", converter = TimeUnitConverter.class)
   private Measure<TimeUnit> entityOperationTimeout;
 
-  @Parameter(names = {"-r", "--request-timeout"}, description = "Request timeout. Default: 10s", converter = TimeUnitConverter.class)
+  @Parameter(names = {"-request-timeout", "-r", "--request-timeout"}, description = "Request timeout. Default: 10s", converter = TimeUnitConverter.class)
   private Measure<TimeUnit> requestTimeout = Measure.of(10, TimeUnit.SECONDS);
 
-  @Parameter(names = {"-t", "--connection-timeout"}, description = "Connection timeout. Default: 10s", converter = TimeUnitConverter.class)
+  @Parameter(names = {"-connection-timeout", "-t", "--connection-timeout"}, description = "Connection timeout. Default: 10s", converter = TimeUnitConverter.class)
   private Measure<TimeUnit> connectionTimeout = Measure.of(10, TimeUnit.SECONDS);
 
-  @Parameter(names = {"-srd", "--security-root-directory"}, description = "Security root directory")
+  @Parameter(names = {"-security-root-directory", "-srd", "--security-root-directory"}, description = "Security root directory")
   private String securityRootDirectory;
 
-  @Parameter(names = {"--lock-token"}, hidden = true, description = "Lock token")
+  @Parameter(names = {"-lock-token", "--lock-token"}, hidden = true, description = "Lock token")
   private String lockToken;
 
   public Measure<TimeUnit> getRequestTimeout() {

--- a/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/ConfigTool.java
+++ b/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/ConfigTool.java
@@ -115,7 +115,7 @@ public class ConfigTool {
             jCommander = getCustomJCommander(commandRepository, mainCommand);
             jCommander.parse(args);
           } catch (ParameterException pe) {
-            jCommander.printAskedCommmandUsage(command);
+            jCommander.printAskedCommandUsage(command);
             throw pe;
           }
         }

--- a/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/ConfigTool.java
+++ b/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/ConfigTool.java
@@ -102,22 +102,24 @@ public class ConfigTool {
     } catch (ParameterException e) {
       String command = jCommander.getParsedCommand();
       if (command != null) {
-        if (!command.contains("-deprecated")) {
-          // Fallback to deprecated version
-          try {
-            for (int i = 0; i < args.length; ++i) {
-              if (args[i].equals(command)) {
-                args[i] = args[i].concat("-deprecated");
-                break;
-              }
+        // Fallback to deprecated version
+        try {
+          for (int i = 0; i < args.length; ++i) {
+            if (args[i].equals(command)) {
+              args[i] = args[i].concat("-deprecated");
+              break;
             }
-            // Create New JCommander object to avoid repeated main command error.
-            jCommander = getCustomJCommander(commandRepository, mainCommand);
-            jCommander.parse(args);
-          } catch (ParameterException pe) {
-            jCommander.printAskedCommandUsage(command);
-            throw pe;
           }
+          // Create New JCommander object to avoid repeated main command error.
+          CustomJCommander deprecatedJCommander = getCustomJCommander(commandRepository, mainCommand);
+          deprecatedJCommander.parse(args);
+          // success ?
+          jCommander = deprecatedJCommander;
+        } catch (ParameterException pe) {
+          // error ?
+          // always display help file for new command
+          jCommander.printAskedCommandUsage(command);
+          throw e;
         }
       } else {
         jCommander.printUsage();

--- a/dynamic-config/cli/upgrade-tools/src/main/java/org/terracotta/dynamic_config/cli/upgrade_tools/config_converter/ConfigConverterTool.java
+++ b/dynamic-config/cli/upgrade-tools/src/main/java/org/terracotta/dynamic_config/cli/upgrade_tools/config_converter/ConfigConverterTool.java
@@ -102,7 +102,7 @@ public class ConfigConverterTool {
             jCommander = getCustomJCommander(commandRepository, mainCommand);
             jCommander.parse(args);
           } catch (ParameterException pe) {
-            jCommander.printAskedCommmandUsage(command);
+            jCommander.printAskedCommandUsage(command);
             throw pe;
           }
         }

--- a/dynamic-config/model/src/main/java/org/terracotta/dynamic_config/api/service/ClusterFactory.java
+++ b/dynamic-config/model/src/main/java/org/terracotta/dynamic_config/api/service/ClusterFactory.java
@@ -103,9 +103,9 @@ public class ClusterFactory {
         String.format(
             "%sRead the following parameters: %s%sAdded the following defaults: %s",
             lineSeparator(),
-            toDisplayParams("--", paramValueMap),
+            toDisplayParams("-", paramValueMap),
             lineSeparator(),
-            toDisplayParams("--", defaultsAdded.stream()
+            toDisplayParams("-", defaultsAdded.stream()
                 .filter(configuration -> configuration.getValue().isPresent())
                 .collect(toMap(Configuration::getSetting, cfg -> cfg.getValue().get()))
             )


### PR DESCRIPTION
### Content

- typo fix
- added missing long parameter for global options such as verbose, timeouts, lock token, etc
- fixing alignment for help content
- fixing the error message displayed on parsing error (error message displayed was related to the failed parsing of the deprecated command, but we want instead to display only errors or help related to the new commands)

### Command help

```bash
❯  ./kit/target/platform-kit-5.8-SNAPSHOT/platform-kit-5.8-SNAPSHOT/tools/bin/config-tool.sh set -help
Set configuration properties
Usage: set -connect-to <hostname[:port]> -setting <[namespace:]property=value>,<[namespace:]property=value>...
Options:
    -connect-to              (required)    Node to connect to
    -help                    (optional)    Help
    -setting                 (required)    Configuration properties
```

### Full help

```bash
~/.../terracotta/terracotta-platform ( jcommander {2} U:3 ⊘ )
❯  ./kit/target/platform-kit-5.8-SNAPSHOT/platform-kit-5.8-SNAPSHOT/tools/bin/config-tool.sh -help
Usage: config-tool [options] [command] [command options]

Options:
    -connection-timeout      (optional)    Connection timeout. Default: 10s
    -help                    (optional)    Help
    -request-timeout         (optional)    Request timeout. Default: 10s
    -security-root-directory (optional)    Security root directory
    -verbose                 (optional)    Verbose mode. Default: false

Definitions:
    namespace
        stripe.<stripeId>.node.<nodeId>    to apply a change only on a specific node
        stripe.<stripeId>                  to apply a change only on a specific stripe
        '' (empty namespace)               to apply a change only on all nodes of the cluster

Commands:


    activate      Activate a cluster

        Usage: activate (-connect-to <hostname[:port]> | -config-file <config-file>) [-cluster-name <cluster-name>] [-restrict] [-license-file <license-file>] [-restart-wait-time <restart-wait-time>] [-restart-delay <restart-delay>]

        Options:
            -cluster-name            (optional)    Cluster name
            -config-file             (optional)    Configuration properties file containing nodes to be activated
            -connect-to              (optional)    Node to connect to
            -help                    (optional)    Help
            -license-file            (optional)    License file
            -restart-delay           (optional)    Delay before the server restarts itself. Default: 2s
            -restart-wait-time       (optional)    Maximum time to wait for the nodes to restart. Default: 120s
            -restrict                (optional)    Restrict the activation process to the node only

    attach      Attach a node to a stripe, or a stripe to a cluster

        Usage: attach (-to-cluster <hostname[:port]> -stripe <hostname[:port]> | -to-stripe <hostname[:port]> -node <hostname[:port]>) [-force] [-restart-wait-time <restart-wait-time>] [-restart-delay <restart-delay>]

        Options:
            -force                   (optional)    Force the operation
            -help                    (optional)    Help
            -node                    (optional)    Node to be attached
            -restart-delay           (optional)    Delay before the server restarts itself. Default: 2s
            -restart-wait-time       (optional)    Maximum time to wait for the nodes to restart. Default: 120s
            -stripe                  (optional)    Stripe to be attached
            -to-cluster              (optional)    Cluster to attach to
            -to-stripe               (optional)    Stripe to attach to

    detach      Detach a node from a stripe, or a stripe from a cluster

        Usage: detach(-from-cluster <hostname[:port]> -stripe [<hostname[:port]>|uid|name] | -from-stripe <hostname[:port]> -node [<hostname[:port]>|uid|name]) [-force] [-stop-wait-time <stop-wait-time>] [-stop-delay <stop-delay>]

        Options:
            -force                   (optional)    Force the operation
            -from-cluster            (optional)    Cluster to detach from
            -from-stripe             (optional)    Stripe to detach from
            -help                    (optional)    Help
            -node                    (optional)    Node to be detached
            -stop-delay              (optional)    Delay before the server stops itself. Default: 2s
            -stop-wait-time          (optional)    Maximum time to wait for the nodes to stop. Default: 120s
            -stripe                  (optional)    Source node or stripe (address, name or UID)

    diagnostic      Diagnose a cluster configuration

        Usage: diagnostic -connect-to <hostname[:port]>

        Options:
            -connect-to              (required)    Node to connect to
            -help                    (optional)    Help

    export      Export a cluster configuration

        Usage: export -connect-to <hostname[:port]> [-output-file <config-file>] [-include-defaults] [-runtime]

        Options:
            -connect-to              (required)    Node to connect to
            -help                    (optional)    Help
            -include-defaults        (optional)    Include default values. Default: false
            -output-file             (optional)    Output configuration file
            -runtime                 (optional)    Export the runtime configuration instead of the configuration saved on disk. Default: false

    get      Read configuration properties

        Usage: get -connect-to <hostname[:port]> [-runtime] -setting <[namespace:]setting>,<[namespace:]setting>...

        Options:
            -connect-to              (required)    Node to connect to
            -help                    (optional)    Help
            -runtime                 (optional)    Read the properties from the current runtime configuration instead of reading them from the last configuration saved on disk
            -setting                 (required)    Configuration properties

    import      Import a cluster configuration

        Usage: import -config-file <config-file> [-connect-to <hostname[:port]>]

        Options:
            -config-file             (required)    Config file
            -connect-to              (optional)    Node to connect to
            -help                    (optional)    Help

    log      Log all the configuration changes of a node and their details

        Usage: log -connect-to <hostname[:port]>

        Options:
            -connect-to              (required)    Node to connect to
            -help                    (optional)    Help

    repair      Repair a cluster configuration

        Usage: repair -connect-to <hostname[:port]> [-force commit|rollback|reset|unlock]

        Options:
            -connect-to              (required)    Node to connect to
            -force                   (optional)    Repair action to force: commit, rollback, reset, unlock
            -help                    (optional)    Help

    set      Set configuration properties

        Usage: set -connect-to <hostname[:port]> -setting <[namespace:]property=value>,<[namespace:]property=value>...

        Options:
            -connect-to              (required)    Node to connect to
            -help                    (optional)    Help
            -setting                 (required)    Configuration properties

    unset      Unset configuration properties

        Usage: unset -connect-to <hostname[:port]> -setting <[namespace:]property>,<[namespace:]property>...

        Options:
            -connect-to              (required)    Node to connect to
            -help                    (optional)    Help
            -setting                 (required)    Configuration properties
```