### PR TITLE
Cleanup of validate() methods on command classes

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -28,5 +28,27 @@ jobs:
     parameters:
       jobName: Linux_Java_8
       timeoutInMinutes: 180
-      options: -B -Dtest.parallel.forks=1 -Djava.test.version=1.8
+      pool: tc_linux_pool
+      options: -B -Dtest.parallel.forks=6 -Djava.test.version=1.8 -Djava.test.vendor=zulu
+      mavenGoals: 'clean verify'
+  - template: build-templates/maven-common.yml@templates
+    parameters:
+      jobName: Linux_Java_11
+      timeoutInMinutes: 180
+      pool: tc_linux_pool
+      options: -B -Dtest.parallel.forks=6 -Djava.test.version=1.11 -Djava.test.vendor=zulu
+      mavenGoals: 'clean verify'
+  - template: build-templates/maven-common.yml@templates
+    parameters:
+      jobName: Windows_Java_8
+      timeoutInMinutes: 180
+      pool: tc_windows_pool
+      options: -B -Dtest.parallel.forks=4 -Djava.test.version=1.8 -Djava.test.vendor=zulu
+      mavenGoals: 'clean verify'
+  - template: build-templates/maven-common.yml@templates
+    parameters:
+      jobName: Windows_Java_11
+      timeoutInMinutes: 180
+      pool: tc_windows_pool
+      options: -B -Dtest.parallel.forks=4 -Djava.test.version=1.11 -Djava.test.vendor=zulu
       mavenGoals: 'clean verify'

--- a/dynamic-config/cli/cli-support/src/main/java/org/terracotta/dynamic_config/cli/command/JCommanderCommand.java
+++ b/dynamic-config/cli/cli-support/src/main/java/org/terracotta/dynamic_config/cli/command/JCommanderCommand.java
@@ -27,9 +27,10 @@ public abstract class JCommanderCommand implements Runnable {
     return help;
   }
 
-  public void validate() {
-  }
-
   public abstract Command getCommand();
 
+  @Override
+  public void run() {
+    getCommand().run();
+  }
 }

--- a/dynamic-config/cli/cli-support/src/main/java/org/terracotta/dynamic_config/cli/command/LocalMainJCommanderCommand.java
+++ b/dynamic-config/cli/cli-support/src/main/java/org/terracotta/dynamic_config/cli/command/LocalMainJCommanderCommand.java
@@ -30,12 +30,8 @@ public class LocalMainJCommanderCommand extends JCommanderCommand {
   private final LocalConfig underlying = new LocalConfig();
 
   @Override
-  public void validate() {
-    underlying.setVerbose(verbose);
-  }
-
-  @Override
   public void run() {
+    underlying.setVerbose(verbose);
     underlying.run();
   }
 

--- a/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/ConfigTool.java
+++ b/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/ConfigTool.java
@@ -18,12 +18,12 @@ package org.terracotta.dynamic_config.cli.config_tool;
 import com.beust.jcommander.ParameterException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.terracotta.dynamic_config.cli.command.CustomJCommander;
 import org.terracotta.dynamic_config.cli.api.command.Injector;
+import org.terracotta.dynamic_config.cli.api.command.ServiceProvider;
+import org.terracotta.dynamic_config.cli.command.CustomJCommander;
 import org.terracotta.dynamic_config.cli.command.JCommanderCommand;
 import org.terracotta.dynamic_config.cli.command.JCommanderCommandRepository;
 import org.terracotta.dynamic_config.cli.config_tool.command.JCommanderCommandProvider;
-import org.terracotta.dynamic_config.cli.api.command.ServiceProvider;
 import org.terracotta.dynamic_config.cli.config_tool.parsing.RemoteMainJCommanderCommand;
 
 import java.util.Collection;
@@ -68,7 +68,6 @@ public class ConfigTool {
     CustomJCommander jCommander = parseArguments(commandRepository, mainCommand, args);
 
     // Process arguments like '-v'
-    mainCommand.validate();
     mainCommand.run();
 
     // create services
@@ -82,8 +81,6 @@ public class ConfigTool {
       } else {
         LOGGER.debug("Injecting services in specified command");
         Injector.inject(command.getCommand(), services);
-        // validate the real command
-        command.validate();
         // run the real command
         command.run();
         return true;

--- a/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/ActivateJCommanderCommand.java
+++ b/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/ActivateJCommanderCommand.java
@@ -21,10 +21,10 @@ import com.beust.jcommander.Parameters;
 import com.beust.jcommander.converters.PathConverter;
 import org.terracotta.common.struct.Measure;
 import org.terracotta.common.struct.TimeUnit;
+import org.terracotta.dynamic_config.cli.api.command.ActivateCommand;
 import org.terracotta.dynamic_config.cli.api.command.Command;
 import org.terracotta.dynamic_config.cli.command.JCommanderCommand;
 import org.terracotta.dynamic_config.cli.command.Usage;
-import org.terracotta.dynamic_config.cli.api.command.ActivateCommand;
 import org.terracotta.dynamic_config.cli.converter.InetSocketAddressConverter;
 import org.terracotta.dynamic_config.cli.converter.TimeUnitConverter;
 
@@ -59,7 +59,7 @@ public class ActivateJCommanderCommand extends JCommanderCommand {
   private final ActivateCommand underlying = new ActivateCommand();
 
   @Override
-  public void validate() {
+  public void run() {
     // basic validations first
 
     if (!restrictedActivation && node != null && configPropertiesFile != null) {
@@ -80,10 +80,7 @@ public class ActivateJCommanderCommand extends JCommanderCommand {
     underlying.setRestartWaitTime(restartWaitTime);
     underlying.setRestartDelay(restartDelay);
     underlying.setRestrictedActivation(restrictedActivation);
-  }
 
-  @Override
-  public void run() {
     underlying.run();
   }
 

--- a/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/AttachJCommanderCommand.java
+++ b/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/AttachJCommanderCommand.java
@@ -19,11 +19,11 @@ import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
 import org.terracotta.common.struct.Measure;
 import org.terracotta.common.struct.TimeUnit;
+import org.terracotta.dynamic_config.cli.api.command.AttachCommand;
 import org.terracotta.dynamic_config.cli.api.command.Command;
+import org.terracotta.dynamic_config.cli.api.converter.OperationType;
 import org.terracotta.dynamic_config.cli.command.JCommanderCommand;
 import org.terracotta.dynamic_config.cli.command.Usage;
-import org.terracotta.dynamic_config.cli.api.command.AttachCommand;
-import org.terracotta.dynamic_config.cli.api.converter.OperationType;
 import org.terracotta.dynamic_config.cli.converter.InetSocketAddressConverter;
 import org.terracotta.dynamic_config.cli.converter.TimeUnitConverter;
 
@@ -57,7 +57,7 @@ public class AttachJCommanderCommand extends JCommanderCommand {
   private final AttachCommand underlying = new AttachCommand();
 
   @Override
-  public void validate() {
+  public void run() {
     if ((destinationClusterAddress != null && sourceStripeAddress == null) ||
         (destinationClusterAddress == null && sourceStripeAddress != null)) {
       throw new IllegalArgumentException("Both -to-cluster and -stripe must be provided for stripe addition to cluster");
@@ -66,8 +66,7 @@ public class AttachJCommanderCommand extends JCommanderCommand {
         (destinationStripeAddress == null && sourceNodeAddress != null)) {
       throw new IllegalArgumentException("Both -to-stripe and -node must be provided for node addition to cluster");
     }
-    if ((destinationClusterAddress != null || sourceStripeAddress != null) &&
-        (destinationStripeAddress != null || (sourceNodeAddress != null))) {
+    if (destinationClusterAddress != null && destinationStripeAddress != null) {
       throw new IllegalArgumentException("Either you can perform stripe addition to the cluster or node addition to the stripe");
     }
     if (destinationClusterAddress != null) {
@@ -82,10 +81,7 @@ public class AttachJCommanderCommand extends JCommanderCommand {
     underlying.setForce(force);
     underlying.setRestartWaitTime(restartWaitTime);
     underlying.setRestartDelay(restartDelay);
-  }
 
-  @Override
-  public void run() {
     underlying.run();
   }
 

--- a/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/DetachJCommanderCommand.java
+++ b/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/DetachJCommanderCommand.java
@@ -21,10 +21,10 @@ import org.terracotta.common.struct.Measure;
 import org.terracotta.common.struct.TimeUnit;
 import org.terracotta.dynamic_config.api.model.Identifier;
 import org.terracotta.dynamic_config.cli.api.command.Command;
-import org.terracotta.dynamic_config.cli.command.JCommanderCommand;
-import org.terracotta.dynamic_config.cli.command.Usage;
 import org.terracotta.dynamic_config.cli.api.command.DetachCommand;
 import org.terracotta.dynamic_config.cli.api.converter.OperationType;
+import org.terracotta.dynamic_config.cli.command.JCommanderCommand;
+import org.terracotta.dynamic_config.cli.command.Usage;
 import org.terracotta.dynamic_config.cli.converter.IdentifierConverter;
 import org.terracotta.dynamic_config.cli.converter.InetSocketAddressConverter;
 import org.terracotta.dynamic_config.cli.converter.TimeUnitConverter;
@@ -59,7 +59,7 @@ public class DetachJCommanderCommand extends JCommanderCommand {
   private final DetachCommand underlying = new DetachCommand();
 
   @Override
-  public void validate() {
+  public void run() {
     if ((destinationClusterAddress != null && sourceStripeIdentifier == null) ||
         (destinationClusterAddress == null && sourceStripeIdentifier != null)) {
       throw new IllegalArgumentException("Both -from-cluster and -stripe must be provided for stripe detachment from cluster");
@@ -68,8 +68,7 @@ public class DetachJCommanderCommand extends JCommanderCommand {
         (destinationStripeAddress == null && sourceNodeIdentifier != null)) {
       throw new IllegalArgumentException("Both -from-stripe and -node must be provided for node deletion from cluster");
     }
-    if ((destinationClusterAddress != null || sourceStripeIdentifier != null) &&
-        (destinationStripeAddress != null || (sourceNodeIdentifier != null))) {
+    if (destinationClusterAddress != null && destinationStripeAddress != null) {
       throw new IllegalArgumentException("Either you can perform stripe deletion from the cluster or node deletion from the stripe");
     }
     if (destinationClusterAddress != null) {
@@ -84,10 +83,7 @@ public class DetachJCommanderCommand extends JCommanderCommand {
     underlying.setForce(force);
     underlying.setStopWaitTime(stopWaitTime);
     underlying.setStopDelay(stopDelay);
-  }
 
-  @Override
-  public void run() {
     underlying.run();
   }
 

--- a/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/DiagnosticJCommanderCommand.java
+++ b/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/DiagnosticJCommanderCommand.java
@@ -18,9 +18,9 @@ package org.terracotta.dynamic_config.cli.config_tool.parsing;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
 import org.terracotta.dynamic_config.cli.api.command.Command;
+import org.terracotta.dynamic_config.cli.api.command.DiagnosticCommand;
 import org.terracotta.dynamic_config.cli.command.JCommanderCommand;
 import org.terracotta.dynamic_config.cli.command.Usage;
-import org.terracotta.dynamic_config.cli.api.command.DiagnosticCommand;
 import org.terracotta.dynamic_config.cli.converter.InetSocketAddressConverter;
 
 import java.net.InetSocketAddress;
@@ -35,12 +35,9 @@ public class DiagnosticJCommanderCommand extends JCommanderCommand {
   private final DiagnosticCommand underlying = new DiagnosticCommand();
 
   @Override
-  public void validate() {
-    underlying.setNode(node);
-  }
-
-  @Override
   public void run() {
+    underlying.setNode(node);
+
     underlying.run();
   }
 

--- a/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/ExportJCommanderCommand.java
+++ b/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/ExportJCommanderCommand.java
@@ -20,10 +20,10 @@ import com.beust.jcommander.Parameters;
 import com.beust.jcommander.converters.BooleanConverter;
 import com.beust.jcommander.converters.PathConverter;
 import org.terracotta.dynamic_config.cli.api.command.Command;
-import org.terracotta.dynamic_config.cli.command.JCommanderCommand;
-import org.terracotta.dynamic_config.cli.command.Usage;
 import org.terracotta.dynamic_config.cli.api.command.ExportCommand;
 import org.terracotta.dynamic_config.cli.api.converter.OutputFormat;
+import org.terracotta.dynamic_config.cli.command.JCommanderCommand;
+import org.terracotta.dynamic_config.cli.command.Usage;
 import org.terracotta.dynamic_config.cli.converter.FormatConverter;
 import org.terracotta.dynamic_config.cli.converter.InetSocketAddressConverter;
 
@@ -52,16 +52,13 @@ public class ExportJCommanderCommand extends JCommanderCommand {
   private final ExportCommand underlying = new ExportCommand();
 
   @Override
-  public void validate() {
+  public void run() {
     underlying.setNode(node);
     underlying.setOutputFile(outputFile);
     underlying.setIncludeDefaultValues(includeDefaultValues);
     underlying.setWantsRuntimeConfig(wantsRuntimeConfig);
     underlying.setOutputFormat(outputFormat);
-  }
 
-  @Override
-  public void run() {
     underlying.run();
   }
 

--- a/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/GetJCommanderCommand.java
+++ b/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/GetJCommanderCommand.java
@@ -20,9 +20,9 @@ import com.beust.jcommander.Parameters;
 import com.beust.jcommander.converters.BooleanConverter;
 import org.terracotta.dynamic_config.api.model.Configuration;
 import org.terracotta.dynamic_config.cli.api.command.Command;
+import org.terracotta.dynamic_config.cli.api.command.GetCommand;
 import org.terracotta.dynamic_config.cli.command.JCommanderCommand;
 import org.terracotta.dynamic_config.cli.command.Usage;
-import org.terracotta.dynamic_config.cli.api.command.GetCommand;
 import org.terracotta.dynamic_config.cli.converter.ConfigurationConverter;
 import org.terracotta.dynamic_config.cli.converter.InetSocketAddressConverter;
 import org.terracotta.dynamic_config.cli.converter.MultiConfigCommaSplitter;
@@ -46,14 +46,11 @@ public class GetJCommanderCommand extends JCommanderCommand {
   private final GetCommand underlying = new GetCommand();
 
   @Override
-  public void validate() {
+  public void run() {
     underlying.setNode(node);
     underlying.setConfigurations(configurations);
     underlying.setRuntimConfig(wantsRuntimeConfig);
-  }
 
-  @Override
-  public void run() {
     underlying.run();
   }
 

--- a/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/ImportJCommanderCommand.java
+++ b/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/ImportJCommanderCommand.java
@@ -19,9 +19,9 @@ import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
 import com.beust.jcommander.converters.PathConverter;
 import org.terracotta.dynamic_config.cli.api.command.Command;
+import org.terracotta.dynamic_config.cli.api.command.ImportCommand;
 import org.terracotta.dynamic_config.cli.command.JCommanderCommand;
 import org.terracotta.dynamic_config.cli.command.Usage;
-import org.terracotta.dynamic_config.cli.api.command.ImportCommand;
 import org.terracotta.dynamic_config.cli.converter.InetSocketAddressConverter;
 
 import java.net.InetSocketAddress;
@@ -40,13 +40,10 @@ public class ImportJCommanderCommand extends JCommanderCommand {
   private final ImportCommand underlying = new ImportCommand();
 
   @Override
-  public void validate() {
+  public void run() {
     underlying.setNode(node);
     underlying.setConfigPropertiesFile(configFile);
-  }
 
-  @Override
-  public void run() {
     underlying.run();
   }
 

--- a/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/LockConfigJCommanderCommand.java
+++ b/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/LockConfigJCommanderCommand.java
@@ -18,9 +18,9 @@ package org.terracotta.dynamic_config.cli.config_tool.parsing;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
 import org.terracotta.dynamic_config.cli.api.command.Command;
+import org.terracotta.dynamic_config.cli.api.command.LockConfigCommand;
 import org.terracotta.dynamic_config.cli.command.JCommanderCommand;
 import org.terracotta.dynamic_config.cli.command.Usage;
-import org.terracotta.dynamic_config.cli.api.command.LockConfigCommand;
 import org.terracotta.dynamic_config.cli.converter.InetSocketAddressConverter;
 
 import java.net.InetSocketAddress;
@@ -38,13 +38,10 @@ public class LockConfigJCommanderCommand extends JCommanderCommand {
   private final LockConfigCommand underlying = new LockConfigCommand();
 
   @Override
-  public void validate() {
+  public void run() {
     underlying.setNode(node);
     underlying.setLockContext(lockContext);
-  }
 
-  @Override
-  public void run() {
     underlying.run();
   }
 

--- a/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/LogJCommanderCommand.java
+++ b/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/LogJCommanderCommand.java
@@ -18,9 +18,9 @@ package org.terracotta.dynamic_config.cli.config_tool.parsing;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
 import org.terracotta.dynamic_config.cli.api.command.Command;
+import org.terracotta.dynamic_config.cli.api.command.LogCommand;
 import org.terracotta.dynamic_config.cli.command.JCommanderCommand;
 import org.terracotta.dynamic_config.cli.command.Usage;
-import org.terracotta.dynamic_config.cli.api.command.LogCommand;
 import org.terracotta.dynamic_config.cli.converter.InetSocketAddressConverter;
 
 import java.net.InetSocketAddress;
@@ -34,12 +34,9 @@ public class LogJCommanderCommand extends JCommanderCommand {
   private final LogCommand underlying = new LogCommand();
 
   @Override
-  public void validate() {
-    underlying.setNode(node);
-  }
-
-  @Override
   public void run() {
+    underlying.setNode(node);
+
     underlying.run();
   }
 

--- a/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/RemoteMainJCommanderCommand.java
+++ b/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/RemoteMainJCommanderCommand.java
@@ -19,8 +19,8 @@ import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
 import org.terracotta.common.struct.Measure;
 import org.terracotta.common.struct.TimeUnit;
-import org.terracotta.dynamic_config.cli.command.LocalMainJCommanderCommand;
 import org.terracotta.dynamic_config.cli.api.command.RemoteConfig;
+import org.terracotta.dynamic_config.cli.command.LocalMainJCommanderCommand;
 import org.terracotta.dynamic_config.cli.converter.TimeUnitConverter;
 
 @Parameters(commandNames = LocalMainJCommanderCommand.NAME)
@@ -44,7 +44,7 @@ public class RemoteMainJCommanderCommand extends LocalMainJCommanderCommand {
   private final RemoteConfig underlying = new RemoteConfig();
 
   @Override
-  public void validate() {
+  public void run() {
     if (entityOperationTimeout == null) {
       entityOperationTimeout = requestTimeout.multiply(12);
     }
@@ -54,10 +54,7 @@ public class RemoteMainJCommanderCommand extends LocalMainJCommanderCommand {
     underlying.setLockToken(lockToken);
     underlying.setEntityOperationTimeout(entityOperationTimeout);
     underlying.setRequestTimeout(requestTimeout);
-  }
 
-  @Override
-  public void run() {
     underlying.run();
   }
 

--- a/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/RepairJCommanderCommand.java
+++ b/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/RepairJCommanderCommand.java
@@ -18,10 +18,10 @@ package org.terracotta.dynamic_config.cli.config_tool.parsing;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
 import org.terracotta.dynamic_config.cli.api.command.Command;
-import org.terracotta.dynamic_config.cli.command.JCommanderCommand;
-import org.terracotta.dynamic_config.cli.command.Usage;
 import org.terracotta.dynamic_config.cli.api.command.RepairCommand;
 import org.terracotta.dynamic_config.cli.api.converter.RepairAction;
+import org.terracotta.dynamic_config.cli.command.JCommanderCommand;
+import org.terracotta.dynamic_config.cli.command.Usage;
 import org.terracotta.dynamic_config.cli.converter.InetSocketAddressConverter;
 import org.terracotta.dynamic_config.cli.converter.RepairActionConverter;
 
@@ -40,13 +40,10 @@ public class RepairJCommanderCommand extends JCommanderCommand {
   private final RepairCommand underlying = new RepairCommand();
 
   @Override
-  public void validate() {
+  public void run() {
     underlying.setNode(node);
     underlying.setForcedRepairAction(forcedRepairAction);
-  }
 
-  @Override
-  public void run() {
     underlying.run();
   }
 

--- a/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/SetJCommanderCommand.java
+++ b/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/SetJCommanderCommand.java
@@ -19,9 +19,9 @@ import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
 import org.terracotta.dynamic_config.api.model.Configuration;
 import org.terracotta.dynamic_config.cli.api.command.Command;
+import org.terracotta.dynamic_config.cli.api.command.SetCommand;
 import org.terracotta.dynamic_config.cli.command.JCommanderCommand;
 import org.terracotta.dynamic_config.cli.command.Usage;
-import org.terracotta.dynamic_config.cli.api.command.SetCommand;
 import org.terracotta.dynamic_config.cli.converter.ConfigurationConverter;
 import org.terracotta.dynamic_config.cli.converter.InetSocketAddressConverter;
 import org.terracotta.dynamic_config.cli.converter.MultiConfigCommaSplitter;
@@ -42,13 +42,10 @@ public class SetJCommanderCommand extends JCommanderCommand {
   private final SetCommand underlying = new SetCommand();
 
   @Override
-  public void validate() {
+  public void run() {
     underlying.setNode(node);
     underlying.setConfigurations(configurations);
-  }
 
-  @Override
-  public void run() {
     underlying.run();
   }
 

--- a/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/UnlockConfigJCommanderCommand.java
+++ b/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/UnlockConfigJCommanderCommand.java
@@ -18,9 +18,9 @@ package org.terracotta.dynamic_config.cli.config_tool.parsing;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
 import org.terracotta.dynamic_config.cli.api.command.Command;
+import org.terracotta.dynamic_config.cli.api.command.UnlockConfigCommand;
 import org.terracotta.dynamic_config.cli.command.JCommanderCommand;
 import org.terracotta.dynamic_config.cli.command.Usage;
-import org.terracotta.dynamic_config.cli.api.command.UnlockConfigCommand;
 import org.terracotta.dynamic_config.cli.converter.InetSocketAddressConverter;
 
 import java.net.InetSocketAddress;
@@ -35,12 +35,9 @@ public class UnlockConfigJCommanderCommand extends JCommanderCommand {
   private final UnlockConfigCommand underlying = new UnlockConfigCommand();
 
   @Override
-  public void validate() {
-    underlying.setNode(node);
-  }
-
-  @Override
   public void run() {
+    underlying.setNode(node);
+
     underlying.run();
   }
 

--- a/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/UnsetJCommanderCommand.java
+++ b/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/UnsetJCommanderCommand.java
@@ -19,9 +19,9 @@ import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
 import org.terracotta.dynamic_config.api.model.Configuration;
 import org.terracotta.dynamic_config.cli.api.command.Command;
+import org.terracotta.dynamic_config.cli.api.command.UnsetCommand;
 import org.terracotta.dynamic_config.cli.command.JCommanderCommand;
 import org.terracotta.dynamic_config.cli.command.Usage;
-import org.terracotta.dynamic_config.cli.api.command.UnsetCommand;
 import org.terracotta.dynamic_config.cli.converter.ConfigurationConverter;
 import org.terracotta.dynamic_config.cli.converter.InetSocketAddressConverter;
 import org.terracotta.dynamic_config.cli.converter.MultiConfigCommaSplitter;
@@ -42,13 +42,10 @@ public class UnsetJCommanderCommand extends JCommanderCommand {
   private final UnsetCommand underlying = new UnsetCommand();
 
   @Override
-  public void validate() {
+  public void run() {
     underlying.setNode(node);
     underlying.setConfigurations(configurations);
-  }
 
-  @Override
-  public void run() {
     underlying.run();
   }
 

--- a/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/deprecated/DeprecatedActivateJCommanderCommand.java
+++ b/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/deprecated/DeprecatedActivateJCommanderCommand.java
@@ -21,10 +21,10 @@ import com.beust.jcommander.Parameters;
 import com.beust.jcommander.converters.PathConverter;
 import org.terracotta.common.struct.Measure;
 import org.terracotta.common.struct.TimeUnit;
+import org.terracotta.dynamic_config.cli.api.command.ActivateCommand;
 import org.terracotta.dynamic_config.cli.api.command.Command;
 import org.terracotta.dynamic_config.cli.command.DeprecatedUsage;
 import org.terracotta.dynamic_config.cli.command.JCommanderCommand;
-import org.terracotta.dynamic_config.cli.api.command.ActivateCommand;
 import org.terracotta.dynamic_config.cli.converter.InetSocketAddressConverter;
 import org.terracotta.dynamic_config.cli.converter.TimeUnitConverter;
 
@@ -58,7 +58,7 @@ public class DeprecatedActivateJCommanderCommand extends JCommanderCommand {
   private final ActivateCommand underlying = new ActivateCommand();
 
   @Override
-  public void validate() {
+  public void run() {
     // basic validations first
     if (!restrictedActivation && node != null && configPropertiesFile != null) {
       throw new IllegalArgumentException("Either node or config properties file should be specified, not both");
@@ -78,10 +78,7 @@ public class DeprecatedActivateJCommanderCommand extends JCommanderCommand {
     underlying.setRestartWaitTime(restartWaitTime);
     underlying.setRestartDelay(restartDelay);
     underlying.setRestrictedActivation(restrictedActivation);
-  }
 
-  @Override
-  public void run() {
     underlying.run();
   }
 

--- a/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/deprecated/DeprecatedAttachJCommanderCommand.java
+++ b/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/deprecated/DeprecatedAttachJCommanderCommand.java
@@ -19,11 +19,11 @@ import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
 import org.terracotta.common.struct.Measure;
 import org.terracotta.common.struct.TimeUnit;
+import org.terracotta.dynamic_config.cli.api.command.AttachCommand;
 import org.terracotta.dynamic_config.cli.api.command.Command;
+import org.terracotta.dynamic_config.cli.api.converter.OperationType;
 import org.terracotta.dynamic_config.cli.command.DeprecatedUsage;
 import org.terracotta.dynamic_config.cli.command.JCommanderCommand;
-import org.terracotta.dynamic_config.cli.api.command.AttachCommand;
-import org.terracotta.dynamic_config.cli.api.converter.OperationType;
 import org.terracotta.dynamic_config.cli.converter.InetSocketAddressConverter;
 import org.terracotta.dynamic_config.cli.converter.TimeUnitConverter;
 import org.terracotta.dynamic_config.cli.converter.TypeConverter;
@@ -55,17 +55,14 @@ public class DeprecatedAttachJCommanderCommand extends JCommanderCommand {
   private final AttachCommand underlying = new AttachCommand();
 
   @Override
-  public void validate() {
+  public void run() {
     underlying.setOperationType(operationType);
     underlying.setDestinationAddress(destinationAddress);
     underlying.setForce(force);
     underlying.setSourceAddress(sourceAddress);
     underlying.setRestartWaitTime(restartWaitTime);
     underlying.setRestartDelay(restartDelay);
-  }
 
-  @Override
-  public void run() {
     underlying.run();
   }
 

--- a/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/deprecated/DeprecatedDetachJCommanderCommand.java
+++ b/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/deprecated/DeprecatedDetachJCommanderCommand.java
@@ -21,10 +21,10 @@ import org.terracotta.common.struct.Measure;
 import org.terracotta.common.struct.TimeUnit;
 import org.terracotta.dynamic_config.api.model.Identifier;
 import org.terracotta.dynamic_config.cli.api.command.Command;
-import org.terracotta.dynamic_config.cli.command.DeprecatedUsage;
-import org.terracotta.dynamic_config.cli.command.JCommanderCommand;
 import org.terracotta.dynamic_config.cli.api.command.DetachCommand;
 import org.terracotta.dynamic_config.cli.api.converter.OperationType;
+import org.terracotta.dynamic_config.cli.command.DeprecatedUsage;
+import org.terracotta.dynamic_config.cli.command.JCommanderCommand;
 import org.terracotta.dynamic_config.cli.converter.IdentifierConverter;
 import org.terracotta.dynamic_config.cli.converter.InetSocketAddressConverter;
 import org.terracotta.dynamic_config.cli.converter.TimeUnitConverter;
@@ -57,17 +57,14 @@ public class DeprecatedDetachJCommanderCommand extends JCommanderCommand {
   private final DetachCommand underlying = new DetachCommand();
 
   @Override
-  public void validate() {
+  public void run() {
     underlying.setOperationType(operationType);
     underlying.setDestinationAddress(destinationAddress);
     underlying.setForce(force);
     underlying.setSourceIdentifier(sourceIdentifier);
     underlying.setStopWaitTime(stopWaitTime);
     underlying.setStopDelay(stopDelay);
-  }
 
-  @Override
-  public void run() {
     underlying.run();
   }
 

--- a/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/deprecated/DeprecatedDiagnosticJCommanderCommand.java
+++ b/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/deprecated/DeprecatedDiagnosticJCommanderCommand.java
@@ -18,9 +18,9 @@ package org.terracotta.dynamic_config.cli.config_tool.parsing.deprecated;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
 import org.terracotta.dynamic_config.cli.api.command.Command;
+import org.terracotta.dynamic_config.cli.api.command.DiagnosticCommand;
 import org.terracotta.dynamic_config.cli.command.DeprecatedUsage;
 import org.terracotta.dynamic_config.cli.command.JCommanderCommand;
-import org.terracotta.dynamic_config.cli.api.command.DiagnosticCommand;
 import org.terracotta.dynamic_config.cli.converter.InetSocketAddressConverter;
 
 import java.net.InetSocketAddress;
@@ -34,12 +34,9 @@ public class DeprecatedDiagnosticJCommanderCommand extends JCommanderCommand {
   private final DiagnosticCommand underlying = new DiagnosticCommand();
 
   @Override
-  public void validate() {
-    underlying.setNode(node);
-  }
-
-  @Override
   public void run() {
+    underlying.setNode(node);
+
     underlying.run();
   }
 

--- a/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/deprecated/DeprecatedExportJCommanderCommand.java
+++ b/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/deprecated/DeprecatedExportJCommanderCommand.java
@@ -20,10 +20,10 @@ import com.beust.jcommander.Parameters;
 import com.beust.jcommander.converters.BooleanConverter;
 import com.beust.jcommander.converters.PathConverter;
 import org.terracotta.dynamic_config.cli.api.command.Command;
-import org.terracotta.dynamic_config.cli.command.DeprecatedUsage;
-import org.terracotta.dynamic_config.cli.command.JCommanderCommand;
 import org.terracotta.dynamic_config.cli.api.command.ExportCommand;
 import org.terracotta.dynamic_config.cli.api.converter.OutputFormat;
+import org.terracotta.dynamic_config.cli.command.DeprecatedUsage;
+import org.terracotta.dynamic_config.cli.command.JCommanderCommand;
 import org.terracotta.dynamic_config.cli.converter.FormatConverter;
 import org.terracotta.dynamic_config.cli.converter.InetSocketAddressConverter;
 
@@ -52,16 +52,13 @@ public class DeprecatedExportJCommanderCommand extends JCommanderCommand {
   private final ExportCommand underlying = new ExportCommand();
 
   @Override
-  public void validate() {
+  public void run() {
     underlying.setNode(node);
     underlying.setOutputFile(outputFile);
     underlying.setIncludeDefaultValues(includeDefaultValues);
     underlying.setWantsRuntimeConfig(wantsRuntimeConfig);
     underlying.setOutputFormat(outputFormat);
-  }
 
-  @Override
-  public void run() {
     underlying.run();
   }
 

--- a/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/deprecated/DeprecatedGetJCommanderCommand.java
+++ b/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/deprecated/DeprecatedGetJCommanderCommand.java
@@ -20,9 +20,9 @@ import com.beust.jcommander.Parameters;
 import com.beust.jcommander.converters.BooleanConverter;
 import org.terracotta.dynamic_config.api.model.Configuration;
 import org.terracotta.dynamic_config.cli.api.command.Command;
+import org.terracotta.dynamic_config.cli.api.command.GetCommand;
 import org.terracotta.dynamic_config.cli.command.DeprecatedUsage;
 import org.terracotta.dynamic_config.cli.command.JCommanderCommand;
-import org.terracotta.dynamic_config.cli.api.command.GetCommand;
 import org.terracotta.dynamic_config.cli.converter.ConfigurationConverter;
 import org.terracotta.dynamic_config.cli.converter.InetSocketAddressConverter;
 import org.terracotta.dynamic_config.cli.converter.MultiConfigCommaSplitter;
@@ -46,14 +46,11 @@ public class DeprecatedGetJCommanderCommand extends JCommanderCommand {
   private final GetCommand underlying = new GetCommand();
 
   @Override
-  public void validate() {
+  public void run() {
     underlying.setNode(node);
     underlying.setConfigurations(configurations);
     underlying.setRuntimConfig(wantsRuntimeConfig);
-  }
 
-  @Override
-  public void run() {
     underlying.run();
   }
 

--- a/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/deprecated/DeprecatedImportJCommanderCommand.java
+++ b/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/deprecated/DeprecatedImportJCommanderCommand.java
@@ -19,9 +19,9 @@ import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
 import com.beust.jcommander.converters.PathConverter;
 import org.terracotta.dynamic_config.cli.api.command.Command;
+import org.terracotta.dynamic_config.cli.api.command.ImportCommand;
 import org.terracotta.dynamic_config.cli.command.DeprecatedUsage;
 import org.terracotta.dynamic_config.cli.command.JCommanderCommand;
-import org.terracotta.dynamic_config.cli.api.command.ImportCommand;
 import org.terracotta.dynamic_config.cli.converter.InetSocketAddressConverter;
 
 import java.net.InetSocketAddress;
@@ -40,13 +40,10 @@ public class DeprecatedImportJCommanderCommand extends JCommanderCommand {
   private final ImportCommand underlying = new ImportCommand();
 
   @Override
-  public void validate() {
+  public void run() {
     underlying.setNode(node);
     underlying.setConfigPropertiesFile(configFile);
-  }
 
-  @Override
-  public void run() {
     underlying.run();
   }
 

--- a/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/deprecated/DeprecatedLockConfigJCommanderCommand.java
+++ b/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/deprecated/DeprecatedLockConfigJCommanderCommand.java
@@ -18,9 +18,9 @@ package org.terracotta.dynamic_config.cli.config_tool.parsing.deprecated;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
 import org.terracotta.dynamic_config.cli.api.command.Command;
+import org.terracotta.dynamic_config.cli.api.command.LockConfigCommand;
 import org.terracotta.dynamic_config.cli.command.DeprecatedUsage;
 import org.terracotta.dynamic_config.cli.command.JCommanderCommand;
-import org.terracotta.dynamic_config.cli.api.command.LockConfigCommand;
 import org.terracotta.dynamic_config.cli.converter.InetSocketAddressConverter;
 
 import java.net.InetSocketAddress;
@@ -37,13 +37,10 @@ public class DeprecatedLockConfigJCommanderCommand extends JCommanderCommand {
   private final LockConfigCommand underlying = new LockConfigCommand();
 
   @Override
-  public void validate() {
+  public void run() {
     underlying.setNode(node);
     underlying.setLockContext(lockContext);
-  }
 
-  @Override
-  public void run() {
     underlying.run();
   }
 

--- a/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/deprecated/DeprecatedLogJCommanderCommand.java
+++ b/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/deprecated/DeprecatedLogJCommanderCommand.java
@@ -18,9 +18,9 @@ package org.terracotta.dynamic_config.cli.config_tool.parsing.deprecated;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
 import org.terracotta.dynamic_config.cli.api.command.Command;
+import org.terracotta.dynamic_config.cli.api.command.LogCommand;
 import org.terracotta.dynamic_config.cli.command.DeprecatedUsage;
 import org.terracotta.dynamic_config.cli.command.JCommanderCommand;
-import org.terracotta.dynamic_config.cli.api.command.LogCommand;
 import org.terracotta.dynamic_config.cli.converter.InetSocketAddressConverter;
 
 import java.net.InetSocketAddress;
@@ -34,12 +34,9 @@ public class DeprecatedLogJCommanderCommand extends JCommanderCommand {
   private final LogCommand underlying = new LogCommand();
 
   @Override
-  public void validate() {
-    underlying.setNode(node);
-  }
-
-  @Override
   public void run() {
+    underlying.setNode(node);
+
     underlying.run();
   }
 

--- a/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/deprecated/DeprecatedRepairJCommanderCommand.java
+++ b/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/deprecated/DeprecatedRepairJCommanderCommand.java
@@ -18,10 +18,10 @@ package org.terracotta.dynamic_config.cli.config_tool.parsing.deprecated;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
 import org.terracotta.dynamic_config.cli.api.command.Command;
-import org.terracotta.dynamic_config.cli.command.DeprecatedUsage;
-import org.terracotta.dynamic_config.cli.command.JCommanderCommand;
 import org.terracotta.dynamic_config.cli.api.command.RepairCommand;
 import org.terracotta.dynamic_config.cli.api.converter.RepairAction;
+import org.terracotta.dynamic_config.cli.command.DeprecatedUsage;
+import org.terracotta.dynamic_config.cli.command.JCommanderCommand;
 import org.terracotta.dynamic_config.cli.converter.InetSocketAddressConverter;
 import org.terracotta.dynamic_config.cli.converter.RepairActionConverter;
 
@@ -40,13 +40,10 @@ public class DeprecatedRepairJCommanderCommand extends JCommanderCommand {
   private final RepairCommand underlying = new RepairCommand();
 
   @Override
-  public void validate() {
+  public void run() {
     underlying.setNode(node);
     underlying.setForcedRepairAction(forcedRepairAction);
-  }
 
-  @Override
-  public void run() {
     underlying.run();
   }
 

--- a/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/deprecated/DeprecatedSetJCommanderCommand.java
+++ b/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/deprecated/DeprecatedSetJCommanderCommand.java
@@ -19,9 +19,9 @@ import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
 import org.terracotta.dynamic_config.api.model.Configuration;
 import org.terracotta.dynamic_config.cli.api.command.Command;
+import org.terracotta.dynamic_config.cli.api.command.SetCommand;
 import org.terracotta.dynamic_config.cli.command.DeprecatedUsage;
 import org.terracotta.dynamic_config.cli.command.JCommanderCommand;
-import org.terracotta.dynamic_config.cli.api.command.SetCommand;
 import org.terracotta.dynamic_config.cli.converter.ConfigurationConverter;
 import org.terracotta.dynamic_config.cli.converter.InetSocketAddressConverter;
 import org.terracotta.dynamic_config.cli.converter.MultiConfigCommaSplitter;
@@ -42,13 +42,10 @@ public class DeprecatedSetJCommanderCommand extends JCommanderCommand {
   private final SetCommand underlying = new SetCommand();
 
   @Override
-  public void validate() {
+  public void run() {
     underlying.setNode(node);
     underlying.setConfigurations(configurations);
-  }
 
-  @Override
-  public void run() {
     underlying.run();
   }
 

--- a/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/deprecated/DeprecatedUnlockConfigJCommanderCommand.java
+++ b/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/deprecated/DeprecatedUnlockConfigJCommanderCommand.java
@@ -18,9 +18,9 @@ package org.terracotta.dynamic_config.cli.config_tool.parsing.deprecated;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
 import org.terracotta.dynamic_config.cli.api.command.Command;
+import org.terracotta.dynamic_config.cli.api.command.UnlockConfigCommand;
 import org.terracotta.dynamic_config.cli.command.DeprecatedUsage;
 import org.terracotta.dynamic_config.cli.command.JCommanderCommand;
-import org.terracotta.dynamic_config.cli.api.command.UnlockConfigCommand;
 import org.terracotta.dynamic_config.cli.converter.InetSocketAddressConverter;
 
 import java.net.InetSocketAddress;
@@ -35,12 +35,9 @@ public class DeprecatedUnlockConfigJCommanderCommand extends JCommanderCommand {
   private final UnlockConfigCommand underlying = new UnlockConfigCommand();
 
   @Override
-  public void validate() {
-    underlying.setNode(node);
-  }
-
-  @Override
   public void run() {
+    underlying.setNode(node);
+
     underlying.run();
   }
 

--- a/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/deprecated/DeprecatedUnsetJCommanderCommand.java
+++ b/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/deprecated/DeprecatedUnsetJCommanderCommand.java
@@ -19,9 +19,9 @@ import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
 import org.terracotta.dynamic_config.api.model.Configuration;
 import org.terracotta.dynamic_config.cli.api.command.Command;
+import org.terracotta.dynamic_config.cli.api.command.UnsetCommand;
 import org.terracotta.dynamic_config.cli.command.DeprecatedUsage;
 import org.terracotta.dynamic_config.cli.command.JCommanderCommand;
-import org.terracotta.dynamic_config.cli.api.command.UnsetCommand;
 import org.terracotta.dynamic_config.cli.converter.ConfigurationConverter;
 import org.terracotta.dynamic_config.cli.converter.InetSocketAddressConverter;
 import org.terracotta.dynamic_config.cli.converter.MultiConfigCommaSplitter;
@@ -42,13 +42,10 @@ public class DeprecatedUnsetJCommanderCommand extends JCommanderCommand {
   private final UnsetCommand underlying = new UnsetCommand();
 
   @Override
-  public void validate() {
+  public void run() {
     underlying.setNode(node);
     underlying.setConfigurations(configurations);
-  }
 
-  @Override
-  public void run() {
     underlying.run();
   }
 

--- a/dynamic-config/cli/dynamic-config-cli-api/src/main/java/org/terracotta/dynamic_config/cli/api/command/AttachCommand.java
+++ b/dynamic-config/cli/dynamic-config-cli-api/src/main/java/org/terracotta/dynamic_config/cli/api/command/AttachCommand.java
@@ -70,7 +70,7 @@ public class AttachCommand extends TopologyCommand {
   }
 
   @Override
-  public void validate() {
+  protected void validate() {
     super.validate();
 
     source = getEndpoint(sourceAddress);

--- a/dynamic-config/cli/dynamic-config-cli-api/src/main/java/org/terracotta/dynamic_config/cli/api/command/ConfigurationCommand.java
+++ b/dynamic-config/cli/dynamic-config-cli-api/src/main/java/org/terracotta/dynamic_config/cli/api/command/ConfigurationCommand.java
@@ -52,7 +52,7 @@ public abstract class ConfigurationCommand extends RemoteCommand {
     this.configurations = configurations;
   }
 
-  public void validate() {
+  protected void validate() {
     isActivated = isActivated(node);
     clusterState = isActivated ? ACTIVATED : CONFIGURING;
 

--- a/dynamic-config/cli/dynamic-config-cli-api/src/main/java/org/terracotta/dynamic_config/cli/api/command/DetachCommand.java
+++ b/dynamic-config/cli/dynamic-config-cli-api/src/main/java/org/terracotta/dynamic_config/cli/api/command/DetachCommand.java
@@ -66,7 +66,7 @@ public class DetachCommand extends TopologyCommand {
   }
 
   @Override
-  public void validate() {
+  protected void validate() {
     super.validate();
 
     if (destinationCluster.getNodeCount() == 1) {

--- a/dynamic-config/cli/dynamic-config-cli-api/src/main/java/org/terracotta/dynamic_config/cli/api/command/SetCommand.java
+++ b/dynamic-config/cli/dynamic-config-cli-api/src/main/java/org/terracotta/dynamic_config/cli/api/command/SetCommand.java
@@ -33,7 +33,7 @@ public class SetCommand extends ConfigurationMutationCommand {
   }
 
   @Override
-  public void validate() {
+  protected void validate() {
     super.validate();
 
     // we support a list in case the user inputs: set -c license-file=foo/one.xml -c license-file=foo/two.xml

--- a/dynamic-config/cli/dynamic-config-cli-api/src/main/java/org/terracotta/dynamic_config/cli/api/command/TopologyCommand.java
+++ b/dynamic-config/cli/dynamic-config-cli-api/src/main/java/org/terracotta/dynamic_config/cli/api/command/TopologyCommand.java
@@ -21,8 +21,8 @@ import org.terracotta.dynamic_config.api.model.Cluster;
 import org.terracotta.dynamic_config.api.model.Node.Endpoint;
 import org.terracotta.dynamic_config.api.model.nomad.TopologyNomadChange;
 import org.terracotta.dynamic_config.api.service.ClusterValidator;
-import org.terracotta.dynamic_config.cli.api.converter.OperationType;
 import org.terracotta.dynamic_config.cli.api.command.Injector.Inject;
+import org.terracotta.dynamic_config.cli.api.converter.OperationType;
 import org.terracotta.json.ObjectMapperFactory;
 
 import java.io.UncheckedIOException;
@@ -63,7 +63,7 @@ public abstract class TopologyCommand extends RemoteCommand {
     this.force = force;
   }
 
-  public void validate() {
+  protected void validate() {
     destination = getEndpoint(destinationAddress);
 
     // prevent any topology change if a configuration change has been made through Nomad, requiring a restart, but nodes were not restarted yet

--- a/dynamic-config/cli/upgrade-tools/src/main/java/org/terracotta/dynamic_config/cli/upgrade_tools/config_converter/ConfigConverterTool.java
+++ b/dynamic-config/cli/upgrade-tools/src/main/java/org/terracotta/dynamic_config/cli/upgrade_tools/config_converter/ConfigConverterTool.java
@@ -62,7 +62,6 @@ public class ConfigConverterTool {
     CustomJCommander jCommander = parseArguments(commandRepository, args, mainCommand);
 
     // Process arguments like '-v'
-    mainCommand.validate();
     mainCommand.run();
 
     jCommander.getAskedCommand().map(command -> {
@@ -71,9 +70,7 @@ public class ConfigConverterTool {
         jCommander.printUsage();
         return true;
       }
-      // validate the real command
-      command.validate();
-      // run the real command
+      // validate and run the real command
       command.run();
       return true;
     }).orElseGet(() -> {

--- a/dynamic-config/cli/upgrade-tools/src/main/java/org/terracotta/dynamic_config/cli/upgrade_tools/config_converter/parsing/ConvertJCommanderCommand.java
+++ b/dynamic-config/cli/upgrade-tools/src/main/java/org/terracotta/dynamic_config/cli/upgrade_tools/config_converter/parsing/ConvertJCommanderCommand.java
@@ -58,7 +58,7 @@ public class ConvertJCommanderCommand extends JCommanderCommand {
   private final ConvertCommand underlying = new ConvertCommand();
 
   @Override
-  public void validate() {
+  public void run() {
     underlying.setTcConfigFiles(tcConfigFiles);
     underlying.setStripeNames(stripeNames);
     underlying.setLicensePath(licensePath);
@@ -66,10 +66,7 @@ public class ConvertJCommanderCommand extends JCommanderCommand {
     underlying.setNewClusterName(newClusterName);
     underlying.setConversionFormat(conversionFormat);
     underlying.setForce(force);
-  }
 
-  @Override
-  public void run() {
     underlying.run();
   }
 

--- a/dynamic-config/cli/upgrade-tools/src/main/java/org/terracotta/dynamic_config/cli/upgrade_tools/config_converter/parsing/deprecated/DeprecatedConvertJCommanderCommand.java
+++ b/dynamic-config/cli/upgrade-tools/src/main/java/org/terracotta/dynamic_config/cli/upgrade_tools/config_converter/parsing/deprecated/DeprecatedConvertJCommanderCommand.java
@@ -58,7 +58,7 @@ public class DeprecatedConvertJCommanderCommand extends JCommanderCommand {
   private final ConvertCommand underlying = new ConvertCommand();
 
   @Override
-  public void validate() {
+  public void run() {
     underlying.setTcConfigFiles(tcConfigFiles);
     underlying.setStripeNames(stripeNames);
     underlying.setLicensePath(licensePath);
@@ -66,10 +66,7 @@ public class DeprecatedConvertJCommanderCommand extends JCommanderCommand {
     underlying.setNewClusterName(newClusterName);
     underlying.setConversionFormat(conversionFormat);
     underlying.setForce(force);
-  }
 
-  @Override
-  public void run() {
     underlying.run();
   }
 

--- a/dynamic-config/model/src/test/java/org/terracotta/dynamic_config/api/model/ConfigurationTest.java
+++ b/dynamic-config/model/src/test/java/org/terracotta/dynamic_config/api/model/ConfigurationTest.java
@@ -29,6 +29,7 @@ import static org.hamcrest.Matchers.both;
 import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
@@ -149,6 +150,27 @@ public class ConfigurationTest {
         assertThat(defaultValue, is(not(nullValue())));
       }
     });
+  }
+
+  @Test
+  public void test_expand() {
+    List<Configuration> list = Configuration.valueOf("offheap-resources=foo:512MB").expand();
+    assertThat(list, hasSize(1));
+    assertThat(list.get(0).toString(), is(equalTo("offheap-resources.foo=512MB")));
+
+    list = Configuration.valueOf("offheap-resources=foo:512MB,bar:1GB").expand();
+    assertThat(list, hasSize(2));
+    assertThat(list.get(0).toString(), is(equalTo("offheap-resources.foo=512MB")));
+    assertThat(list.get(1).toString(), is(equalTo("offheap-resources.bar=1GB")));
+
+    list = Configuration.valueOf("stripe.1.node.1.data-dirs=foo:a/b").expand();
+    assertThat(list, hasSize(1));
+    assertThat(list.get(0).toString(), is(equalTo("stripe.1.node.1.data-dirs.foo=a/b")));
+
+    list = Configuration.valueOf("stripe.1.node.1.data-dirs=foo:a/b,bar:c/d").expand();
+    assertThat(list, hasSize(2));
+    assertThat(list.get(0).toString(), is(equalTo("stripe.1.node.1.data-dirs.foo=a/b")));
+    assertThat(list.get(1).toString(), is(equalTo("stripe.1.node.1.data-dirs.bar=c/d")));
   }
 
   @Test


### PR DESCRIPTION
- `ConfigurationCommand#validate()` should be protected
- Removed unnecessary `JCommanderCommand#validate()` method