### PR TITLE
Revert "Disallow stripe level topology changes on activated clusters"

### DIFF
--- a/common/test-utilities/src/main/java/org/terracotta/testing/Retry.java
+++ b/common/test-utilities/src/main/java/org/terracotta/testing/Retry.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.testing;
+
+/**
+ * @author Mathieu Carbou
+ */
+public class Retry {
+
+  public static void untilInterrupted(Runnable r) throws InterruptedException {
+    RuntimeException re = null;
+    Error e = null;
+    while (!Thread.currentThread().isInterrupted()) {
+      try {
+        r.run();
+        return;
+      } catch (RuntimeException err) {
+        re = err;
+      } catch (Error err) {
+        e = err;
+      }
+    }
+    if (re != null) {
+      throw re;
+    }
+    if (e != null) {
+      throw e;
+    }
+    throw new InterruptedException();
+  }
+
+}

--- a/dynamic-config/cli/dynamic-config-cli-api/src/main/java/org/terracotta/dynamic_config/cli/api/command/TopologyCommand.java
+++ b/dynamic-config/cli/dynamic-config-cli-api/src/main/java/org/terracotta/dynamic_config/cli/api/command/TopologyCommand.java
@@ -81,17 +81,9 @@ public abstract class TopologyCommand extends RemoteCommand {
       throw new IllegalArgumentException("Wrong destination endpoint: " + destination + ". It does not match any node in destination cluster: " + destinationCluster.toShapeString());
     }
 
-    checkForOperationSupport();
-
     if (destinationClusterActivated) {
       ensureNodesAreEitherActiveOrPassive(destinationOnlineNodes);
       ensureActivesAreAllOnline(destinationCluster, destinationOnlineNodes);
-    }
-  }
-
-  protected void checkForOperationSupport() {
-    if (destinationClusterActivated && OperationType.STRIPE.equals(getOperationType())) {
-      throw new UnsupportedOperationException("Topology modifications of whole stripes on an activated cluster are not supported");
     }
   }
 

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/AttachStripeIT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/AttachStripeIT.java
@@ -17,7 +17,6 @@ package org.terracotta.dynamic_config.system_tests.activated;
 
 import com.terracotta.connection.api.TerracottaConnectionService;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.terracotta.dynamic_config.api.model.Cluster;
 import org.terracotta.dynamic_config.api.model.UID;
@@ -36,7 +35,6 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.terracotta.angela.client.support.hamcrest.AngelaMatchers.successful;
 
-@Ignore("Attaching *any* stripes to an activated cluster is currently unsupported")
 @ClusterDefinition(stripes = 2, nodesPerStripe = 2, autoStart = false)
 public class AttachStripeIT extends DynamicConfigIT {
 

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/DetachCommand2x1IT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/DetachCommand2x1IT.java
@@ -15,7 +15,6 @@
  */
 package org.terracotta.dynamic_config.system_tests.activated;
 
-import org.junit.Ignore;
 import org.junit.Test;
 import org.terracotta.dynamic_config.test_support.ClusterDefinition;
 import org.terracotta.dynamic_config.test_support.DynamicConfigIT;
@@ -27,7 +26,6 @@ import static org.junit.Assert.assertThat;
 /**
  * @author Mathieu Carbou
  */
-@Ignore("Detaching *any* stripes from an activated cluster is currently unsupported")
 @ClusterDefinition(stripes = 2, nodesPerStripe = 1, autoActivate = true)
 public class DetachCommand2x1IT extends DynamicConfigIT {
 

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/DetachStripeIT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/DetachStripeIT.java
@@ -17,7 +17,6 @@ package org.terracotta.dynamic_config.system_tests.activated;
 
 import com.terracotta.connection.api.TerracottaConnectionService;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.terracotta.dynamic_config.api.model.Cluster;
 import org.terracotta.dynamic_config.api.model.Stripe;
@@ -36,7 +35,6 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.terracotta.angela.client.support.hamcrest.AngelaMatchers.successful;
 
-@Ignore("Detaching *any* stripes from an activated cluster is currently unsupported")
 @ClusterDefinition(stripes = 2, nodesPerStripe = 2, autoStart = false)
 public class DetachStripeIT extends DynamicConfigIT {
 


### PR DESCRIPTION
This reverts commit cb743166 to allow container level resizing in OSS (even if mutli-stripe is not usable for now by OSS clients, the capability to add/remove stripes is still coded, supported and tested here), whatever the contraints imposed by security / multi-stripe / one-stripe client after.