### PR TITLE
Support 'unset' and removal of PRESENCE for ssl-tls and whitelist

### DIFF
--- a/dynamic-config/model/src/main/java/org/terracotta/dynamic_config/api/model/Setting.java
+++ b/dynamic-config/model/src/main/java/org/terracotta/dynamic_config/api/model/Setting.java
@@ -84,59 +84,75 @@ import static org.terracotta.dynamic_config.api.model.Version.V2;
 
 /**
  * <pre>
- *  Here is below a summary of all the settings and their permissions, which can be generated with the following code:
+ *  Summary of all settings and their permissions, which can be generated with the following code:
  *
  *  Stream.of(Setting.values()).collect(Collectors.groupingBy(Setting::getPermissions)).entrySet().forEach(System.out::println);
  *
+ *  authc, ssl-tls, whitelist
+ *      Permission: when: [configuring] allow: [import] at levels: [cluster]
+ *      Permission: when: [activated, configuring] allow: [set, unset, get] at levels: [cluster]
+ *
  *  config-dir
- *  No permission
+ *      No Permissions
  *
- *  license-file
- *  Permission: when: [activated, configuring] allow: [set] at levels: [cluster]
- *
- *  metadata-dir
- *    * Permission: when: [configuring] allow: [import] at levels: [node],
- *    * Permission: when: [configuring] allow: [set, get] at levels: [node, stripe, cluster],
- *    * Permission: when: [activated] allow: [get] at levels: [node, stripe, cluster]
- *
- *  hostname, port
- *    * Permission: when: [activated, configuring] allow: [get] at levels: [node, stripe, cluster],
- *    * Permission: when: [configuring] allow: [import] at levels: [node]
- *
- *  group-port, bind-address, group-bind-address
- *    * Permission: when: [activated, configuring] allow: [get] at levels: [node, stripe, cluster],
- *    * Permission: when: [configuring] allow: [set] at levels: [node, stripe, cluster],
- *    * Permission: when: [configuring] allow: [import] at levels: [node]
- *
- *  data-dirs
- *    * Permission: when: [configuring] allow: [import] at levels: [node]
- *    * Permission: when: [configuring] allow: [set, get, unset] at levels: [node, stripe, cluster]
- *    * Permission: when: [activated, configuring] allow: [set, get] at levels: [node, stripe, cluster]
+ *  node-uid, hostname, port
+ *      Permission: when: [activated, configuring] allow: [get] at levels: [cluster, stripe, node]
+ *      Permission: when: [configuring] allow: [import] at levels: [node]
  *
  *  name
- *    * Permission: when: [activated, configuring] allow: [get] at levels: [node, stripe, cluster],
- *    * Permission: when: [configuring] allow: [set, import] at levels: [node]
+ *      Permission: when: [activated, configuring] allow: [get] at levels: [cluster, stripe, node]
+ *      Permission: when: [configuring] allow: [import, set] at levels: [node]
+ *
+ *  client-reconnect-window, failover-priority, client-lease-duration
+ *      Permission: when: [configuring] allow: [import] at levels: [cluster]
+ *      Permission: when: [activated, configuring] allow: [set, get] at levels: [cluster]
  *
  *  public-hostname, public-port, backup-dir, tc-properties, logger-overrides, security-dir, audit-log-dir
- *    * Permission: when: [configuring] allow: [import] at levels: [node],
- *    * Permission: when: [activated, configuring] allow: [set, get, unset] at levels: [node, stripe, cluster]
+ *      Permission: when: [configuring] allow: [import] at levels: [node]
+ *      Permission: when: [activated, configuring] allow: [set, unset, get] at levels: [cluster, stripe, node]
  *
- *  authc
- *    * Permission: when: [configuring] allow: [import] at levels: [cluster],
- *    * Permission: when: [activated, configuring] allow: [set, get, unset] at levels: [cluster]
- *
- *  client-reconnect-window, failover-priority, client-lease-duration, ssl-tls, whitelist
- *    * Permission: when: [configuring] allow: [import] at levels: [cluster],
- *    * Permission: when: [activated, configuring] allow: [set, get] at levels: [cluster]
+ *  stripe-uid
+ *      Permission: when: [activated, configuring] allow: [get] at levels: [cluster, stripe]
+ *      Permission: when: [configuring] allow: [import] at levels: [stripe]
  *
  *  log-dir
- *    * Permission: when: [configuring] allow: [import] at levels: [node],
- *    * Permission: when: [configuring] allow: [set, get] at levels: [node, stripe, cluster],
- *    * Permission: when: [activated] allow: [set, get] at levels: [node, stripe, cluster]
+ *      Permission: when: [configuring] allow: [import] at levels: [node]
+ *      Permission: when: [configuring] allow: [set, get] at levels: [cluster, stripe, node]
+ *      Permission: when: [activated] allow: [set, get] at levels: [cluster, stripe, node]
+ *
+ *  metadata-dir
+ *      Permission: when: [configuring] allow: [import] at levels: [node]
+ *      Permission: when: [configuring] allow: [set, get] at levels: [cluster, stripe, node]
+ *      Permission: when: [activated] allow: [get] at levels: [cluster, stripe, node]
+ *
+ *  lock-context
+ *      Permission: when: [configuring] allow: [import] at levels: [cluster]
+ *      Permission: when: [activated] allow: [set, unset] at levels: [cluster]
+ *
+ *  stripe-name
+ *      Permission: when: [activated, configuring] allow: [get] at levels: [cluster, stripe]
+ *      Permission: when: [configuring] allow: [import, set] at levels: [stripe]
  *
  *  cluster-name, offheap-resources
- *    * Permission: when: [configuring] allow: [set, get, import, unset] at levels: [cluster],
- *    * Permission: when: [activated] allow: [set, get] at levels: [cluster]
+ *      Permission: when: [configuring] allow: [import, set, unset, get] at levels: [cluster]
+ *      Permission: when: [activated] allow: [set, get] at levels: [cluster]
+ *
+ *  cluster-uid
+ *      Permission: when: [activated, configuring] allow: [get] at levels: [cluster]
+ *      Permission: when: [configuring] allow: [import] at levels: [cluster]
+ *
+ *  group-port, bind-address, group-bind-address
+ *      Permission: when: [activated, configuring] allow: [get] at levels: [cluster, stripe, node]
+ *      Permission: when: [configuring] allow: [set] at levels: [cluster, stripe, node]
+ *      Permission: when: [configuring] allow: [import] at levels: [node]
+ *
+ *  license-file
+ *      Permission: when: [activated, configuring] allow: [set] at levels: [cluster]
+ *
+ *  data-dirs
+ *      Permission: when: [configuring] allow: [import] at levels: [node]
+ *      Permission: when: [configuring] allow: [set, unset, get] at levels: [cluster, stripe, node]
+ *      Permission: when: [activated, configuring] allow: [set, get] at levels: [cluster, stripe, node]
  * </pre>
  *
  * @author Mathieu Carbou
@@ -626,10 +642,10 @@ public enum Setting {
       always(false),
       CLUSTER,
       fromCluster(Cluster::getSecuritySslTls),
-      intoCluster((cluster, value) -> cluster.setSecuritySslTls(Boolean.parseBoolean(value))),
+      intoCluster((cluster, value) -> cluster.setSecuritySslTls(value == null ? null : Boolean.parseBoolean(value))),
       asList(
           when(CONFIGURING).allow(IMPORT).atLevel(CLUSTER),
-          when(CONFIGURING, ACTIVATED).allow(GET, SET).atLevel(CLUSTER)
+          when(CONFIGURING, ACTIVATED).allow(GET, SET, UNSET).atLevel(CLUSTER)
       ),
       of(ALL_NODES_ONLINE, CLUSTER_RESTART, PRESENCE),
       asList("true", "false")
@@ -640,10 +656,10 @@ public enum Setting {
       always(false),
       CLUSTER,
       fromCluster(Cluster::getSecurityWhitelist),
-      intoCluster((cluster, value) -> cluster.setSecurityWhitelist(Boolean.parseBoolean(value))),
+      intoCluster((cluster, value) -> cluster.setSecurityWhitelist(value == null ? null : Boolean.parseBoolean(value))),
       asList(
           when(CONFIGURING).allow(IMPORT).atLevel(CLUSTER),
-          when(CONFIGURING, ACTIVATED).allow(GET, SET).atLevel(CLUSTER)
+          when(CONFIGURING, ACTIVATED).allow(GET, SET, UNSET).atLevel(CLUSTER)
       ),
       of(ALL_NODES_ONLINE, CLUSTER_RESTART, PRESENCE),
       asList("true", "false")
@@ -946,7 +962,7 @@ public enum Setting {
     // for most of the settings, "empty" means nullify.
     // but for maps, "empty" means specifically set an empty map and do not use the default values
     if (!isMap() && empty(value)) {
-      // if the setting is not a map, threat any "" like null
+      // if the setting is not a map, treat any "" like null
       value = null;
     }
     validate(key, value);

--- a/dynamic-config/model/src/main/java/org/terracotta/dynamic_config/api/model/SettingValidator.java
+++ b/dynamic-config/model/src/main/java/org/terracotta/dynamic_config/api/model/SettingValidator.java
@@ -48,9 +48,10 @@ class SettingValidator {
     Setting s = Setting.fromName(setting);
     requireNonNull(kv);
     requireNull(s, kv.t1);
-    // prevent null or empty if property is required
+    // prevent null or empty if property is required and unsetting it is not permitted
     // Note: the 0-length string is allowed: it means that the user has specifically asked for a reset
-    if (s.mustBePresent() && (kv.t2 == null || kv.t2.trim().isEmpty())) {
+
+    if (s.mustBePresent() && !s.allows(Operation.UNSET) && (kv.t2 == null || kv.t2.trim().isEmpty())) {
       throw new IllegalArgumentException(s + " cannot be null or empty");
     }
     if (kv.t2 != null && kv.t2.length() > 0 && kv.t2.trim().isEmpty()) {

--- a/dynamic-config/model/src/test/java/org/terracotta/dynamic_config/api/model/SettingValidatorTest.java
+++ b/dynamic-config/model/src/test/java/org/terracotta/dynamic_config/api/model/SettingValidatorTest.java
@@ -225,11 +225,18 @@ public class SettingValidatorTest {
   }
 
   @Test
-  public void test_booleans() {
+  public void test_WHITELIST_SSLTLS() {
     Stream.of(SECURITY_SSL_TLS, SECURITY_WHITELIST).forEach(setting -> {
       validateDefaults(setting);
+      setting.validate(null);
+      setting.validate("");
       setting.validate("true");
       setting.validate("false");
+      setting.validate(null, null);
+      setting.validate(null, "");
+      setting.validate(null, "true");
+      setting.validate(null, "false");
+
       assertThat(
           () -> setting.validate("foo"),
           is(throwing(instanceOf(IllegalArgumentException.class)).andMessage(is(equalTo(setting + " should be one of: [true, false]")))));
@@ -239,9 +246,6 @@ public class SettingValidatorTest {
       assertThat(
           () -> setting.validate("TRUE"),
           is(throwing(instanceOf(IllegalArgumentException.class)).andMessage(is(equalTo(setting + " should be one of: [true, false]")))));
-      assertThat(
-          () -> setting.validate(""),
-          is(throwing(instanceOf(IllegalArgumentException.class)).andMessage(is(equalTo(setting + " cannot be null or empty")))));
     });
   }
 

--- a/dynamic-config/model/src/test/java/org/terracotta/dynamic_config/api/service/ConfigurationParserTest.java
+++ b/dynamic-config/model/src/test/java/org/terracotta/dynamic_config/api/service/ConfigurationParserTest.java
@@ -56,7 +56,7 @@ public class ConfigurationParserTest {
 
   private final List<Configuration> added = new ArrayList<>();
 
-  private Consumer<Configuration> addedListener = configuration -> {
+  private final Consumer<Configuration> addedListener = configuration -> {
     if (configuration.getSetting().toString().endsWith("-uid") || configuration.getValue().get().startsWith("node-") || configuration.getValue().get().startsWith("stripe-")) {
       added.add(Configuration.valueOf(configuration.toString().replace(configuration.getValue().get(), "<GENERATED>")));
     } else {

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/diagnostic/NodeStartupIT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/diagnostic/NodeStartupIT.java
@@ -110,7 +110,7 @@ public class NodeStartupIT extends DynamicConfigIT {
       startNode(1, 1, "--config-file", configurationFile.toString(), "--hostname", "localhost", "--port", port, "--config-dir", "config/stripe1/node-1");
       fail();
     } catch (Exception e) {
-      waitUntil(out.getLog(1, 1), containsLog("security-dir is mandatory for any of the security configuration"));
+      waitUntil(out.getLog(1, 1), containsLog("When no security root directories are configured all other security settings should also be unconfigured (unset)"));
     }
   }
 
@@ -172,7 +172,7 @@ public class NodeStartupIT extends DynamicConfigIT {
       startSingleNode("--audit-log-dir", "audit-dir", "-r", getNodeConfigDir(1, 1).toString());
       fail();
     } catch (Exception e) {
-      waitUntil(out.getLog(1, 1), containsLog("security-dir is mandatory for any of the security configuration"));
+      waitUntil(out.getLog(1, 1), containsLog("When no security root directories are configured audit-log-dir should also be unconfigured (unset)"));
     }
   }
 


### PR DESCRIPTION
- Added UNSET and removed PRESENCE to/from ssl-tls, whitelist
- refactored/enhanced security-related validation messaging
- fixed all unit tests and added new ones.
- ***not certain if removal of PRESENCE warrants a new V3 version - please review.