### PR TITLE
TDB-5263 Modified/simplified Settings & Requirements

### DIFF
--- a/dynamic-config/cli/dynamic-config-cli-api/src/main/java/org/terracotta/dynamic_config/cli/api/command/ConfigurationMutationAction.java
+++ b/dynamic-config/cli/dynamic-config-cli-api/src/main/java/org/terracotta/dynamic_config/cli/api/command/ConfigurationMutationAction.java
@@ -36,7 +36,7 @@ import java.util.TreeSet;
 
 import static java.lang.System.lineSeparator;
 import static java.util.stream.Collectors.toList;
-import static org.terracotta.dynamic_config.api.model.Requirement.ALL_NODES_ONLINE;
+import static org.terracotta.dynamic_config.api.model.Requirement.CLUSTER_ONLINE;
 import static org.terracotta.dynamic_config.api.model.Requirement.CLUSTER_RESTART;
 import static org.terracotta.dynamic_config.api.model.Requirement.NODE_RESTART;
 import static org.terracotta.dynamic_config.api.model.Scope.NODE;
@@ -80,6 +80,13 @@ public abstract class ConfigurationMutationAction extends ConfigurationAction {
               }
             });
       }
+    }
+    if (updatedCluster.equals(originalCluster)) {
+      LOGGER.warn(lineSeparator() +
+          "=======================================================================================" + lineSeparator() +
+          "The requested update will not result in any change to the cluster configuration." + lineSeparator() +
+          "=======================================================================================" + lineSeparator());
+      return;
     }
     new ClusterValidator(updatedCluster).validate();
 
@@ -157,6 +164,6 @@ public abstract class ConfigurationMutationAction extends ConfigurationAction {
   }
 
   private boolean requiresAllNodesAlive() {
-    return configurations.stream().map(Configuration::getSetting).anyMatch(setting -> setting.requires(ALL_NODES_ONLINE));
+    return configurations.stream().map(Configuration::getSetting).anyMatch(setting -> setting.requires(CLUSTER_ONLINE));
   }
 }

--- a/dynamic-config/model/src/main/java/org/terracotta/dynamic_config/api/model/Requirement.java
+++ b/dynamic-config/model/src/main/java/org/terracotta/dynamic_config/api/model/Requirement.java
@@ -21,24 +21,22 @@ package org.terracotta.dynamic_config.api.model;
 public enum Requirement {
 
   /**
-   * Setting change needs a restart of all the nodes
+   * Setting change needs a restart of all the nodes.
+   * APPLY TO CLUSTER-WIDE SETTING ONLY
    */
   CLUSTER_RESTART,
 
   /**
-   * Setting change needs a restart of only the impacted nodes
+   * Setting change needs all nodes online (active and passives).
+   * APPLY TO CLUSTER-WIDE SETTING ONLY
+   */
+  CLUSTER_ONLINE,
+
+  /**
+   * Setting change needs a restart of only the impacted nodes.
+   * APPLY TO NODE SETTING ONLY
    */
   NODE_RESTART,
-
-  /**
-   * Setting change needs only active servers to be online plus the targeted objects (which can be nodes, stripes or the cluster)
-   */
-  TARGETS_ONLINE,
-
-  /**
-   * Setting change needs all nodes online (active and passives)
-   */
-  ALL_NODES_ONLINE,
 
   /**
    * A setting that must be eagerly resolved (placeholders) on server-side as soon as possible before any configuration parsing.

--- a/dynamic-config/model/src/main/java/org/terracotta/dynamic_config/api/model/Setting.java
+++ b/dynamic-config/model/src/main/java/org/terracotta/dynamic_config/api/model/Setting.java
@@ -57,14 +57,13 @@ import static org.terracotta.dynamic_config.api.model.Operation.IMPORT;
 import static org.terracotta.dynamic_config.api.model.Operation.SET;
 import static org.terracotta.dynamic_config.api.model.Operation.UNSET;
 import static org.terracotta.dynamic_config.api.model.Permission.Builder.when;
-import static org.terracotta.dynamic_config.api.model.Requirement.ALL_NODES_ONLINE;
+import static org.terracotta.dynamic_config.api.model.Requirement.CLUSTER_ONLINE;
 import static org.terracotta.dynamic_config.api.model.Requirement.CLUSTER_RESTART;
 import static org.terracotta.dynamic_config.api.model.Requirement.CONFIG;
 import static org.terracotta.dynamic_config.api.model.Requirement.HIDDEN;
 import static org.terracotta.dynamic_config.api.model.Requirement.NODE_RESTART;
 import static org.terracotta.dynamic_config.api.model.Requirement.PRESENCE;
 import static org.terracotta.dynamic_config.api.model.Requirement.RESOLVE_EAGERLY;
-import static org.terracotta.dynamic_config.api.model.Requirement.TARGETS_ONLINE;
 import static org.terracotta.dynamic_config.api.model.Scope.CLUSTER;
 import static org.terracotta.dynamic_config.api.model.Scope.NODE;
 import static org.terracotta.dynamic_config.api.model.Scope.STRIPE;
@@ -275,7 +274,7 @@ public enum Setting {
           when(CONFIGURING).allow(IMPORT).atLevel(NODE),
           when(CONFIGURING, ACTIVATED).allow(GET, SET, UNSET).atAnyLevels()
       ),
-      of(TARGETS_ONLINE),
+      EnumSet.noneOf(Requirement.class),
       emptyList(),
       emptyList(),
       (key, value) -> HOST_VALIDATOR.accept(SettingName.NODE_PUBLIC_HOSTNAME, tuple2(key, value))
@@ -291,7 +290,7 @@ public enum Setting {
           when(CONFIGURING).allow(IMPORT).atLevel(NODE),
           when(CONFIGURING, ACTIVATED).allow(GET, SET, UNSET).atAnyLevels()
       ),
-      of(TARGETS_ONLINE),
+      EnumSet.noneOf(Requirement.class),
       emptyList(),
       emptyList(),
       (key, value) -> PORT_VALIDATOR.accept(SettingName.NODE_PUBLIC_PORT, tuple2(key, value))
@@ -361,7 +360,7 @@ public enum Setting {
           when(CONFIGURING).allowAnyOperations().atLevel(CLUSTER),
           when(ACTIVATED).allow(GET, SET).atLevel(CLUSTER)
       ),
-      of(TARGETS_ONLINE),
+      EnumSet.noneOf(Requirement.class),
       emptyList(),
       emptyList(),
       (key, value) -> NAME_VALIDATOR.accept(SettingName.CLUSTER_NAME, tuple2(key, value))
@@ -380,7 +379,7 @@ public enum Setting {
           when(CONFIGURING).allow(IMPORT).atLevel(CLUSTER),
           when(ACTIVATED).allow(SET, UNSET).atLevel(CLUSTER)
       ),
-      of(TARGETS_ONLINE, HIDDEN)
+      of(HIDDEN)
   ),
 
   NODE_CONFIG_DIR(SettingName.NODE_CONFIG_DIR,
@@ -425,7 +424,7 @@ public enum Setting {
           when(CONFIGURING).allow(GET, SET).atAnyLevels(),
           when(ACTIVATED).allow(GET, SET).atAnyLevels()
       ),
-      of(TARGETS_ONLINE, NODE_RESTART, PRESENCE),
+      of(NODE_RESTART, PRESENCE),
       emptyList(),
       emptyList(),
       (key, value) -> PATH_VALIDATOR.accept(SettingName.NODE_LOG_DIR, tuple2(key, value))
@@ -441,7 +440,7 @@ public enum Setting {
           when(CONFIGURING).allow(IMPORT).atLevel(NODE),
           when(CONFIGURING, ACTIVATED).allow(GET, SET, UNSET).atAnyLevels()
       ),
-      of(ALL_NODES_ONLINE),
+      EnumSet.noneOf(Requirement.class),
       emptyList(),
       emptyList(),
       (key, value) -> PATH_VALIDATOR.accept(SettingName.NODE_BACKUP_DIR, tuple2(key, value))
@@ -477,7 +476,7 @@ public enum Setting {
           when(CONFIGURING).allow(IMPORT).atLevel(NODE),
           when(CONFIGURING, ACTIVATED).allow(GET, SET, UNSET).atAnyLevels()
       ),
-      of(TARGETS_ONLINE, CLUSTER_RESTART),
+      of(CLUSTER_RESTART),
       emptyList(),
       emptyList(),
       (key, value) -> PROPS_VALIDATOR.accept(SettingName.TC_PROPERTIES, tuple2(key, value))
@@ -513,7 +512,7 @@ public enum Setting {
           when(CONFIGURING).allow(IMPORT).atLevel(NODE),
           when(CONFIGURING, ACTIVATED).allow(GET, SET, UNSET).atAnyLevels()
       ),
-      of(TARGETS_ONLINE),
+      EnumSet.noneOf(Requirement.class),
       emptyList(),
       emptyList(),
       (key, value) -> LOGGER_LEVEL_VALIDATOR.accept(SettingName.NODE_LOGGER_OVERRIDES, tuple2(key, value))
@@ -529,7 +528,7 @@ public enum Setting {
           when(CONFIGURING).allow(IMPORT).atLevel(CLUSTER),
           when(CONFIGURING, ACTIVATED).allow(GET, SET).atLevel(CLUSTER)
       ),
-      of(TARGETS_ONLINE, PRESENCE),
+      of(PRESENCE),
       emptyList(),
       asList(SECONDS, MINUTES, HOURS),
       (key, value) -> TIME_VALIDATOR.accept(SettingName.CLIENT_RECONNECT_WINDOW, tuple2(key, value))
@@ -545,7 +544,7 @@ public enum Setting {
           when(CONFIGURING).allow(IMPORT).atLevel(CLUSTER),
           when(CONFIGURING, ACTIVATED).allow(GET, SET).atLevel(CLUSTER)
       ),
-      of(ALL_NODES_ONLINE, CLUSTER_RESTART, PRESENCE, CONFIG, RESOLVE_EAGERLY),
+      of(CLUSTER_ONLINE, CLUSTER_RESTART, PRESENCE, CONFIG, RESOLVE_EAGERLY),
       emptyList(),
       emptyList(),
       (key, value) -> DEFAULT_VALIDATOR.andThen((k, v) -> FailoverPriority.valueOf(v.t2)).accept(SettingName.FAILOVER_PRIORITY, tuple2(key, value))
@@ -564,7 +563,7 @@ public enum Setting {
           when(CONFIGURING).allow(IMPORT).atLevel(CLUSTER),
           when(CONFIGURING, ACTIVATED).allow(GET, SET).atLevel(CLUSTER)
       ),
-      of(TARGETS_ONLINE, PRESENCE),
+      of(PRESENCE),
       emptyList(),
       asList(MILLISECONDS, SECONDS, MINUTES, HOURS),
       (key, value) -> TIME_VALIDATOR.accept(SettingName.CLIENT_LEASE_DURATION, tuple2(key, value))
@@ -582,7 +581,7 @@ public enum Setting {
       singletonList(
           when(CONFIGURING, ACTIVATED).allow(SET).atLevel(CLUSTER)
       ),
-      of(TARGETS_ONLINE),
+      EnumSet.noneOf(Requirement.class),
       emptyList(),
       emptyList(),
       (key, value) -> PATH_VALIDATOR.accept(SettingName.LICENSE_FILE, tuple2(key, value))
@@ -601,7 +600,7 @@ public enum Setting {
           when(CONFIGURING).allow(IMPORT).atLevel(NODE),
           when(CONFIGURING, ACTIVATED).allow(GET, SET, UNSET).atAnyLevels()
       ),
-      of(ALL_NODES_ONLINE, CLUSTER_RESTART),
+      of(NODE_RESTART),
       emptyList(),
       emptyList(),
       (key, value) -> PATH_VALIDATOR.accept(SettingName.SECURITY_DIR, tuple2(key, value))
@@ -617,7 +616,7 @@ public enum Setting {
           when(CONFIGURING).allow(IMPORT).atLevel(NODE),
           when(CONFIGURING, ACTIVATED).allow(GET, SET, UNSET).atAnyLevels()
       ),
-      of(ALL_NODES_ONLINE, CLUSTER_RESTART),
+      of(NODE_RESTART),
       emptyList(),
       emptyList(),
       (key, value) -> PATH_VALIDATOR.accept(SettingName.SECURITY_AUDIT_LOG_DIR, tuple2(key, value))
@@ -633,7 +632,7 @@ public enum Setting {
           when(CONFIGURING).allow(IMPORT).atLevel(CLUSTER),
           when(CONFIGURING, ACTIVATED).allow(GET, SET, UNSET).atLevel(CLUSTER)
       ),
-      of(ALL_NODES_ONLINE, CLUSTER_RESTART),
+      of(CLUSTER_ONLINE, CLUSTER_RESTART),
       asList("file", "ldap", "certificate")
   ),
   SECURITY_SSL_TLS(SettingName.SECURITY_SSL_TLS,
@@ -647,7 +646,7 @@ public enum Setting {
           when(CONFIGURING).allow(IMPORT).atLevel(CLUSTER),
           when(CONFIGURING, ACTIVATED).allow(GET, SET, UNSET).atLevel(CLUSTER)
       ),
-      of(ALL_NODES_ONLINE, CLUSTER_RESTART, PRESENCE),
+      of(CLUSTER_ONLINE, CLUSTER_RESTART, PRESENCE),
       asList("true", "false")
   ),
   SECURITY_WHITELIST(SettingName.SECURITY_WHITELIST,
@@ -661,7 +660,7 @@ public enum Setting {
           when(CONFIGURING).allow(IMPORT).atLevel(CLUSTER),
           when(CONFIGURING, ACTIVATED).allow(GET, SET, UNSET).atLevel(CLUSTER)
       ),
-      of(ALL_NODES_ONLINE, CLUSTER_RESTART, PRESENCE),
+      of(CLUSTER_ONLINE, CLUSTER_RESTART, PRESENCE),
       asList("true", "false")
   ),
 
@@ -698,7 +697,7 @@ public enum Setting {
           when(CONFIGURING).allowAnyOperations().atLevel(CLUSTER),
           when(ACTIVATED).allow(GET, SET).atLevel(CLUSTER)
       ),
-      of(TARGETS_ONLINE),
+      EnumSet.noneOf(Requirement.class),
       emptyList(),
       asList(MemoryUnit.values()),
       (key, value) -> OFFHEAP_VALIDATOR.accept(SettingName.OFFHEAP_RESOURCES, tuple2(key, value))
@@ -738,7 +737,7 @@ public enum Setting {
           when(CONFIGURING).allow(GET, SET, UNSET).atAnyLevels(),
           when(ACTIVATED, CONFIGURING).allow(GET, SET).atAnyLevels()
       ),
-      of(ALL_NODES_ONLINE),
+      EnumSet.noneOf(Requirement.class),
       emptyList(),
       emptyList(),
       (key, value) -> DATA_DIRS_VALIDATOR.accept(SettingName.DATA_DIRS, tuple2(key, value))

--- a/dynamic-config/model/src/main/java/org/terracotta/dynamic_config/api/service/ClusterValidator.java
+++ b/dynamic-config/model/src/main/java/org/terracotta/dynamic_config/api/service/ClusterValidator.java
@@ -15,8 +15,6 @@
  */
 package org.terracotta.dynamic_config.api.service;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.terracotta.dynamic_config.api.model.Cluster;
 import org.terracotta.dynamic_config.api.model.FailoverPriority;
 import org.terracotta.dynamic_config.api.model.Node;
@@ -37,10 +35,10 @@ import static java.util.function.Function.identity;
 import static java.util.stream.Collectors.counting;
 import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Collectors.toList;
+import static org.terracotta.dynamic_config.api.model.Setting.SECURITY_AUDIT_LOG_DIR;
 import static org.terracotta.dynamic_config.api.model.Setting.SECURITY_AUTHC;
 import static org.terracotta.dynamic_config.api.model.Setting.SECURITY_SSL_TLS;
 import static org.terracotta.dynamic_config.api.model.Setting.SECURITY_WHITELIST;
-import static org.terracotta.dynamic_config.api.model.Setting.SECURITY_AUDIT_LOG_DIR;
 import static org.terracotta.dynamic_config.api.model.Version.V2;
 
 /**
@@ -49,7 +47,6 @@ import static org.terracotta.dynamic_config.api.model.Version.V2;
  * This class will validate the complete cluster object (inter-field checks and dependency checks).
  */
 public class ClusterValidator {
-  private static final Logger LOGGER = LoggerFactory.getLogger(ClusterValidator.class);
   private final Cluster cluster;
 
   public ClusterValidator(Cluster cluster) {
@@ -236,9 +233,9 @@ public class ClusterValidator {
         .map(Node::getName)
         .collect(toList());
     if (nodesWithBackupDirs.size() != 0 && nodesWithBackupDirs.size() != cluster.getNodeCount()) {
-      throw new MalformedClusterException("Nodes with names: " + nodesWithBackupDirs +
-          " currently have (or will have) backup directories defined, but some nodes in the cluster do not." +
-          " Within a cluster, all nodes must have either a backup directory defined or no backup directory defined.");
+      throw new MalformedClusterException("Nodes: " + nodesWithBackupDirs +
+          " currently have (or will have) backup directories defined, while some nodes in the cluster do not (or will not)." +
+          " Within a cluster, all nodes must have a backup directory defined or no backup directory defined.");
     }
   }
 

--- a/dynamic-config/model/src/test/java/org/terracotta/dynamic_config/api/service/ClusterValidatorTest.java
+++ b/dynamic-config/model/src/test/java/org/terracotta/dynamic_config/api/service/ClusterValidatorTest.java
@@ -26,10 +26,10 @@ import org.terracotta.dynamic_config.api.model.Testing;
 import java.util.Random;
 import java.util.stream.Stream;
 
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertThat;
 import static org.terracotta.common.struct.MemoryUnit.GB;
 import static org.terracotta.common.struct.TimeUnit.SECONDS;
@@ -227,7 +227,7 @@ public class ClusterValidatorTest {
     node1.setBackupDir(RawPath.valueOf("backup"));
 
     assertClusterValidationFails(
-        "Nodes with names: [foo] currently have (or will have) backup directories defined, but some nodes in the cluster do not. Within a cluster, all nodes must have either a backup directory defined or no backup directory defined.",
+        "Nodes: [foo] currently have (or will have) backup directories defined, while some nodes in the cluster do not (or will not). Within a cluster, all nodes must have a backup directory defined or no backup directory defined.",
         newTestCluster(newTestStripe("stripe1").addNodes(node1, node2)));
   }
 
@@ -412,6 +412,7 @@ public class ClusterValidatorTest {
   private void assertClusterValidationFails(String message, Cluster cluster) {
     assertThat(() -> new ClusterValidator(cluster).validate(), is(throwing(instanceOf(MalformedClusterException.class)).andMessage(is(equalTo(message)))));
   }
+
   private void assertClusterValidationFailsContainsMessage(String message, Cluster cluster) {
     assertThat(() -> new ClusterValidator(cluster).validate(), is(throwing(instanceOf(MalformedClusterException.class)).andMessage(is(containsString(message)))));
   }


### PR DESCRIPTION
1. Added support for updating certain settings which do not require that ALL nodes be alive.  The affected settings are: backup-dir, security-dir and auditlog-dir.
2. Changed requirement name from ALL_NODES_ONLINE to CLUSTER_ONLINE.
3. Removed TARGETS_ONLINE altogether as it was not being used anywhere.
3. Removed CLUSTER_ONLINE from backup-dir and data-dirs
4. Removed CLUSTER_RESTART from security-dir and auditlog-dir

Once this PR is merged it will be followed with EE system tests that exercise the above backup-dir and security-related settings.
