### PR TITLE
Enhanced error message when attempting secured/unsecured connections

### DIFF
--- a/diagnostic/client/src/main/java/org/terracotta/diagnostic/client/connection/DiagnosticServiceProvider.java
+++ b/diagnostic/client/src/main/java/org/terracotta/diagnostic/client/connection/DiagnosticServiceProvider.java
@@ -52,6 +52,23 @@ public class DiagnosticServiceProvider {
     try {
       return DiagnosticServiceFactory.fetch(address, connectionName, connectTimeout, diagnosticInvokeTimeout, securityRootDirectory, objectMapperFactory);
     } catch (ConnectionException e) {
+      if (e.getMessage().contains("Client was able to establish connection with server but handshake with server failed")) {
+        String warning;
+        if (this.securityRootDirectory == null)
+        {
+          warning = "The client used a non-secure connection to connect with server '" + address.toString() + "'. " +
+                  "The connection was successful but the handshake failed. " +
+                  "This failure can occur if the server was configured to use secured connections. ";
+        }
+        else
+        {
+          warning = "The client used a secure connection to connect with server '" + address.toString() + "'. " +
+                  "The connection was successful but the handshake failed. " +
+                  "This failure can occur if the server was configured to not use secured connections. ";
+        }
+        warning += "Check the client and server logs for more information.";
+        throw new DiagnosticServiceProviderException(new Throwable(warning));
+      }
       throw new DiagnosticServiceProviderException(e);
     }
   }


### PR DESCRIPTION
For TDB-5163:
All Config Tool client->server commands utilize DiagnosticServiceProvider.fetchDiagnosticService
which in turn calls DiagnosticServiceFactory.fetch
which in turn calls ConnectionFactory.connect
which throws the 'handshake failed' exception.  
DiagnosticServiceProvider.fetchDiagnosticService is the first opportunity for the client to catch the exception - hence the change.  Let me know if there is a better place to inject this exception logic.