### PR TITLE
New Angela version

### DIFF
--- a/dynamic-config/testing/support/src/main/java/org/terracotta/dynamic_config/test_support/DynamicConfigIT.java
+++ b/dynamic-config/testing/support/src/main/java/org/terracotta/dynamic_config/test_support/DynamicConfigIT.java
@@ -67,6 +67,7 @@ import java.nio.file.Paths;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.OptionalInt;
@@ -189,7 +190,11 @@ public class DynamicConfigIT {
   }
 
   protected final void startNode(TerracottaServer node, String... cli) {
-    angela.tsa().start(node, cli);
+    startNode(node, Collections.emptyMap(), cli);
+  }
+
+  protected final void startNode(TerracottaServer node, Map<String, String> env, String... cli) {
+    angela.tsa().start(node, env, cli);
   }
 
   protected final void stopNode(int stripeId, int nodeId) {
@@ -239,6 +244,10 @@ public class DynamicConfigIT {
   }
 
   protected ToolExecutionResult invokeConfigTool(String... cli) {
+    return invokeConfigTool(Collections.emptyMap(), cli);
+  }
+
+  protected ToolExecutionResult invokeConfigTool(Map<String, String> env, String... cli) {
     List<String> enhancedCli = new ArrayList<>(cli.length);
     List<String> configToolOptions = getConfigToolOptions(cli);
 
@@ -265,7 +274,7 @@ public class DynamicConfigIT {
     } else {
       cmd = cli;
     }
-    return angela.configTool().executeCommand(cmd);
+    return angela.configTool().executeCommand(env, cmd);
   }
 
   private List<String> getConfigToolOptions(String[] cli) {

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
     <terracotta-core.version>5.7.1-pre9</terracotta-core.version>
     <tripwire.version>1.0.0</tripwire.version>
     <galvan.version>1.5.0</galvan.version>
-    <angela.version>3.1.7</angela.version>
+    <angela.version>3.1.8</angela.version>
     <statistics.version>2.1</statistics.version>
     <jackson.version>2.10.5</jackson.version>
     <terracotta-utilities.version>0.0.6</terracotta-utilities.version>


### PR DESCRIPTION
Added ability to debug a specific process

Example of usage: the code below will only debug the first config-tool process

```java

  @Test
  public void setUnsetBackupDir() {
    Map<String, String> env = singletonMap("JAVA_OPTS", "-Xms8m -Xmx128m -Djdk.security.allowNonCaAnchor=true -agentlib:jdwp=transport=dt_socket,server=n,address=localhost:5005,suspend=y");

    // set backup dir: we should not have any warning
    assertThat(
        invokeConfigTool(env, "set", "-s", "localhost:" + getNodePort(), "-c", "backup-dir=foo"),
        not(containsOutput("IMPORTANT: A restart of nodes: node-1-1 is required")));

    // ensure we have the value set at runtime
    assertThat(
        invokeConfigTool("get", "-r", "-s", "localhost:" + getNodePort(), "-c", "backup-dir"),
        containsOutput("stripe.1.node.1.backup-dir=foo"));
```