### PR TITLE
Fixing the semantic of unset. Unset removes user-defined value:

### DIFF
--- a/dynamic-config/model/src/main/java/org/terracotta/dynamic_config/api/model/Cluster.java
+++ b/dynamic-config/model/src/main/java/org/terracotta/dynamic_config/api/model/Cluster.java
@@ -212,14 +212,8 @@ public class Cluster implements Cloneable, PropertyHolder {
   }
 
   public Cluster unsetOffheapResources() {
-    if (this.offheapResources != null) {
-      setOffheapResources(emptyMap());
-    } else {
-      Map<String, Measure<MemoryUnit>> def = OFFHEAP_RESOURCES.getDefaultValue();
-      if (def != null && !def.isEmpty()) {
-        setOffheapResources(emptyMap());
-      }
-    }
+    Map<String, String> def = OFFHEAP_RESOURCES.getDefaultValue();
+    setOffheapResources(def == null || def.isEmpty() ? null : emptyMap());
     return this;
   }
 

--- a/dynamic-config/model/src/main/java/org/terracotta/dynamic_config/api/model/Configuration.java
+++ b/dynamic-config/model/src/main/java/org/terracotta/dynamic_config/api/model/Configuration.java
@@ -33,11 +33,6 @@ import static java.util.Objects.requireNonNull;
 import static java.util.Optional.empty;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
-import static org.terracotta.dynamic_config.api.model.Operation.GET;
-import static org.terracotta.dynamic_config.api.model.Operation.IMPORT;
-import static org.terracotta.dynamic_config.api.model.Operation.SET;
-import static org.terracotta.dynamic_config.api.model.Operation.UNSET;
-import static org.terracotta.dynamic_config.api.model.Requirement.RESOLVE_EAGERLY;
 import static org.terracotta.dynamic_config.api.model.Scope.CLUSTER;
 import static org.terracotta.dynamic_config.api.model.Scope.NODE;
 import static org.terracotta.dynamic_config.api.model.Scope.STRIPE;
@@ -239,10 +234,10 @@ public class Configuration {
     this.stripeId = stripeId;
     this.nodeId = nodeId;
     this.key = key;
-    this.value = value == null ? "" : value.trim();
+    this.value = value == null ? null : value.trim();
 
     // pre-validate with the real value taken from input
-    preValidate(value);
+    preValidate();
   }
 
   public Scope getLevel() {
@@ -273,7 +268,11 @@ public class Configuration {
     return getValue().isPresent();
   }
 
-  private void preValidate(String rawValue) {
+  public boolean isSet() {
+    return value != null;
+  }
+
+  private void preValidate() {
     if (!setting.isMap() && key != null) {
       throw new IllegalArgumentException("Invalid input: '" + rawInput + "'. Reason: Setting '" + setting + "' is not a map and must not have a key");
     }
@@ -286,75 +285,18 @@ public class Configuration {
     if (!setting.allows(level)) {
       throw new IllegalArgumentException("Invalid input: '" + rawInput + "'. Reason: Setting '" + setting + "' does not allow any operation at " + level + " level");
     }
-    if (rawValue == null) {
-      // equivalent to a get or unset command - we do not know yet, so we cannot pre-validate
-      // byt if the setting is not supporting both get and unset, then fail
-      if (!setting.allows(GET) && !setting.allows(UNSET)) {
-        throw new IllegalArgumentException("Invalid input: '" + rawInput + "'. Reason: Setting '" + setting + "' cannot be read or cleared");
-      }
-    } else if (rawValue.isEmpty()) {
-      // equivalent to an unset or config because no value after equal sign
-      // - cluster-name= (in config file)
-      // - unset backup-dir=
-      // - set backup-dir=
-      if (setting.mustBePresent() || !setting.canBeCleared(level)) {
-        // cannot unset a required value
-        throw new IllegalArgumentException("Invalid input: '" + rawInput + "'. Reason: Setting '" + setting + "' requires a value");
-      }
-    } else {
-      // equivalent to a set because we have a value
-      if (!setting.allows(SET) && !setting.allows(IMPORT)) {
-        throw new IllegalArgumentException("Invalid input: '" + rawInput + "'. Reason: Setting '" + setting + "' cannot be set");
-      } else if (!setting.allows(SET, level) && !setting.allows(IMPORT, level)) {
-        throw new IllegalArgumentException("Invalid input: '" + rawInput + "'. Reason: Setting '" + setting + "' cannot be set at " + level + " level");
-      }
-      // check the value if we have one
-      if (!Substitutor.containsSubstitutionParams(value)) {
-        try {
-          setting.validate(key, value);
-        } catch (RuntimeException e) {
-          throw new IllegalArgumentException("Invalid input: '" + rawInput + "'. Reason: " + e.getMessage(), e);
-        }
-      }
+    try {
+      setting.validate(key, value, level);
+    } catch (RuntimeException e) {
+      throw new IllegalArgumentException("Invalid input: '" + rawInput + "'. Reason: " + e.getMessage(), e);
     }
   }
 
   public void validate(ClusterState clusterState, Operation operation) {
-    if (!clusterState.supports(operation)) {
-      throw new AssertionError("Programmatic mistake: tried to validate operation " + operation + " when " + clusterState);
-    }
-    if (!setting.allows(operation)) {
-      throw new IllegalArgumentException("Invalid input: '" + rawInput + "'. Reason: Setting '" + setting + "' cannot be " + operation);
-    }
-    if (!setting.allows(clusterState, operation)) {
-      throw new IllegalArgumentException("Invalid input: '" + rawInput + "'. Reason: Setting '" + setting + "' cannot be " + operation + " when " + clusterState);
-    }
-    if (!setting.allows(clusterState, operation, level)) {
-      throw new IllegalArgumentException("Invalid input: '" + rawInput + "'. Reason: Setting '" + setting + "' cannot be " + operation + " at " + level + " level when " + clusterState);
-    }
-    switch (operation) {
-      case GET:
-      case UNSET:
-        if (getValue().isPresent()) {
-          throw new IllegalArgumentException("Invalid input: '" + rawInput + "'. Reason: Operation " + operation + " must not have a value");
-        }
-        break;
-      case SET:
-        if (!getValue().isPresent()) {
-          throw new IllegalArgumentException("Invalid input: '" + rawInput + "'. Reason: Operation " + operation + " requires a value");
-        }
-        break;
-      case IMPORT:
-        if (!getValue().isPresent() && setting.mustBePresent()) {
-          throw new IllegalArgumentException("Invalid input: '" + rawInput + "'. Reason: Operation " + operation + " requires a value");
-        }
-        // ensure that properties requiring an eager resolve are resolved
-        if (setting.requires(RESOLVE_EAGERLY) && Substitutor.containsSubstitutionParams(value)) {
-          throw new IllegalArgumentException("Invalid input: '" + rawInput + "'. Placeholders are not allowed");
-        }
-        break;
-      default:
-        throw new AssertionError(operation);
+    try {
+      setting.validate(key, value, level, clusterState, operation);
+    } catch (RuntimeException e) {
+      throw new IllegalArgumentException("Invalid input: '" + rawInput + "'. Reason: " + e.getMessage(), e);
     }
   }
 
@@ -675,21 +617,6 @@ public class Configuration {
     }
 
     throw new IllegalArgumentException("Invalid input: '" + input + "'");
-  }
-
-  public static Configuration valueOf(Setting setting) {
-    String val = setting.getDefaultProperty().orElse("");
-    return new Configuration(setting + "=" + val, setting, CLUSTER, null, null, null, val);
-  }
-
-  public static Configuration valueOf(Setting setting, int stripeId) {
-    String val = setting.getDefaultProperty().orElse("");
-    return new Configuration("stripe." + stripeId + "." + setting + "=" + val, setting, STRIPE, stripeId, null, null, val);
-  }
-
-  public static Configuration valueOf(Setting setting, int stripeId, int nodeId) {
-    String val = setting.getDefaultProperty().orElse("");
-    return new Configuration("stripe." + stripeId + ".node." + nodeId + "." + setting + "=" + val, setting, NODE, stripeId, nodeId, null, val);
   }
 
   private static Optional<Node> getNode(Stripe stripe, int nodeId) {

--- a/dynamic-config/model/src/main/java/org/terracotta/dynamic_config/api/model/Node.java
+++ b/dynamic-config/model/src/main/java/org/terracotta/dynamic_config/api/model/Node.java
@@ -245,14 +245,8 @@ public class Node implements Cloneable, PropertyHolder {
   }
 
   public Node unsetLoggerOverrides() {
-    if (this.loggerOverrides != null) {
-      setLoggerOverrides(emptyMap());
-    } else {
-      Map<String, String> def = NODE_LOGGER_OVERRIDES.getDefaultValue();
-      if (def != null && !def.isEmpty()) {
-        setLoggerOverrides(emptyMap());
-      }
-    }
+    Map<String, String> def = NODE_LOGGER_OVERRIDES.getDefaultValue();
+    setLoggerOverrides(def == null || def.isEmpty() ? null : emptyMap());
     return this;
   }
 
@@ -288,14 +282,8 @@ public class Node implements Cloneable, PropertyHolder {
   }
 
   public Node unsetTcProperties() {
-    if (this.tcProperties != null) {
-      setTcProperties(emptyMap());
-    } else {
-      Map<String, String> def = TC_PROPERTIES.getDefaultValue();
-      if (def != null && !def.isEmpty()) {
-        setTcProperties(emptyMap());
-      }
-    }
+    Map<String, String> def = TC_PROPERTIES.getDefaultValue();
+    setTcProperties(def == null || def.isEmpty() ? null : emptyMap());
     return this;
   }
 
@@ -331,14 +319,8 @@ public class Node implements Cloneable, PropertyHolder {
   }
 
   public Node unsetDataDirs() {
-    if (this.dataDirs != null) {
-      setDataDirs(emptyMap());
-    } else {
-      Map<String, RawPath> def = DATA_DIRS.getDefaultValue();
-      if (def != null && !def.isEmpty()) {
-        setDataDirs(emptyMap());
-      }
-    }
+    Map<String, String> def = DATA_DIRS.getDefaultValue();
+    setDataDirs(def == null || def.isEmpty() ? null : emptyMap());
     return this;
   }
 

--- a/dynamic-config/model/src/test/java/org/terracotta/dynamic_config/api/model/ConfigurationTest.java
+++ b/dynamic-config/model/src/test/java/org/terracotta/dynamic_config/api/model/ConfigurationTest.java
@@ -85,7 +85,7 @@ public class ConfigurationTest {
     Stream.of(NODE_CONFIG_DIR).forEach(setting -> {
       String err = "Invalid input: 'config-dir=%H/terracotta/config'. Reason: Setting 'config-dir' does not allow any operation at cluster level".replace("/", File.separator); // unix/win compat'
       assertThat(
-          () -> Configuration.valueOf(setting),
+          () -> setting(setting),
           is(throwing(instanceOf(IllegalArgumentException.class))
               .andMessage(is(equalTo(err)))));
     });
@@ -93,13 +93,13 @@ public class ConfigurationTest {
     Stream.of(
         LICENSE_FILE
     ).forEach(setting -> assertThat(
-        () -> Configuration.valueOf(setting),
+        () -> setting(setting),
         is(throwing(instanceOf(IllegalArgumentException.class)).andMessage(is(equalTo("Invalid input: '" + setting + "='. Reason: Setting 'license-file' requires a value"))))));
 
     Stream.of(
         FAILOVER_PRIORITY
     ).forEach(setting -> assertThat(
-        () -> Configuration.valueOf(setting),
+        () -> setting(setting),
         is(throwing(instanceOf(IllegalArgumentException.class)).andMessage(is(equalTo("Invalid input: '" + setting + "='. Reason: Setting 'failover-priority' requires a value"))))));
 
     Stream.of(
@@ -107,7 +107,7 @@ public class ConfigurationTest {
         NODE_NAME,
         NODE_PORT
     ).forEach(setting -> assertThat(
-        () -> Configuration.valueOf(setting),
+        () -> setting(setting),
         is(throwing(instanceOf(IllegalArgumentException.class)).andMessage(is(endsWith("Reason: Setting '" + setting + "' cannot be set at cluster level"))))));
 
     Stream.of(
@@ -129,7 +129,7 @@ public class ConfigurationTest {
         SECURITY_WHITELIST,
         TC_PROPERTIES
     ).forEach(setting -> {
-      Configuration configuration = Configuration.valueOf(setting);
+      Configuration configuration = setting(setting);
       String rawInput = configuration.toString();
 
       // verify that we can parse back the generated string
@@ -189,7 +189,7 @@ public class ConfigurationTest {
         SECURITY_WHITELIST
     ).forEach(setting -> assertThat(
         setting.toString(),
-        () -> Configuration.valueOf(setting, 1),
+        () -> setting(setting, 1),
         is(throwing(instanceOf(IllegalArgumentException.class))
             .andMessage(both(
                 startsWith("Invalid input: 'stripe.1." + setting + "="))
@@ -201,7 +201,7 @@ public class ConfigurationTest {
         NODE_NAME,
         NODE_PORT
     ).forEach(setting -> assertThat(
-        () -> Configuration.valueOf(setting, 1),
+        () -> setting(setting, 1),
         is(throwing(instanceOf(IllegalArgumentException.class))
             .andMessage(both(
                 startsWith("Invalid input: 'stripe.1." + setting + "="))
@@ -219,7 +219,7 @@ public class ConfigurationTest {
         SECURITY_DIR,
         TC_PROPERTIES
     ).forEach(setting -> {
-      Configuration configuration = Configuration.valueOf(setting, 1);
+      Configuration configuration = setting(setting, 1);
       String rawInput = configuration.toString();
 
       // verify that we can parse back the generated string
@@ -258,7 +258,7 @@ public class ConfigurationTest {
         SECURITY_WHITELIST
     ).forEach(setting -> assertThat(
         setting.toString(),
-        () -> Configuration.valueOf(setting, 1, 1),
+        () -> setting(setting, 1, 1),
         is(throwing(instanceOf(IllegalArgumentException.class))
             .andMessage(both(
                 startsWith("Invalid input: 'stripe.1.node.1." + setting + "="))
@@ -279,7 +279,7 @@ public class ConfigurationTest {
         SECURITY_DIR,
         TC_PROPERTIES
     ).forEach(setting -> {
-      Configuration configuration = Configuration.valueOf(setting, 1, 1);
+      Configuration configuration = setting(setting, 1, 1);
       String rawInput = configuration.toString();
 
       // verify that we can parse back the generated string
@@ -580,7 +580,8 @@ public class ConfigurationTest {
 
     // metadata-dir
     Stream.of(CONFIGURING, ACTIVATED).forEach(state -> state.filter(GET).forEach(op -> NS.forEach(ns -> allow(state, op, ns + "metadata-dir"))));
-    Stream.of(CONFIGURING, ACTIVATED).forEach(state -> state.filter(UNSET).forEach(op -> NS.forEach(ns -> reject(state, op, ns + "metadata-dir"))));
+    Stream.of(ACTIVATED).forEach(state -> state.filter(UNSET).forEach(op -> NS.forEach(ns -> reject(state, op, ns + "metadata-dir"))));
+    Stream.of(CONFIGURING).forEach(state -> state.filter(UNSET).forEach(op -> NS.forEach(ns -> allow(state, op, ns + "metadata-dir"))));
     Stream.of(CONFIGURING).forEach(state -> state.filter(SET).forEach(op -> NS.forEach(ns -> allow(state, op, ns + "metadata-dir=foo"))));
     Stream.of(CONFIGURING).forEach(state -> state.filter(SET).forEach(op -> NS.forEach(ns -> reject(state, op, ns + "metadata-dir="))));
     Stream.of(ACTIVATED).forEach(state -> state.filter(SET).forEach(op -> NS.forEach(ns -> reject(state, op, ns + "metadata-dir=foo"))));
@@ -615,7 +616,8 @@ public class ConfigurationTest {
         allow(state, op, "stripe.1.node.1." + setting + "=0.0.0.0");
         reject(state, op, "stripe.1.node.1." + setting + "=");
       }));
-      Stream.of(CONFIGURING, ACTIVATED).forEach(state -> state.filter(UNSET).forEach(op -> NS.forEach(ns -> reject(state, op, ns + setting))));
+      Stream.of(CONFIGURING).forEach(state -> state.filter(UNSET).forEach(op -> NS.forEach(ns -> allow(state, op, ns + setting))));
+      Stream.of(ACTIVATED).forEach(state -> state.filter(UNSET).forEach(op -> NS.forEach(ns -> reject(state, op, ns + setting))));
       Stream.of(CONFIGURING).forEach(state -> state.filter(SET).forEach(op -> NS.forEach(ns -> allow(state, op, ns + setting + "=0.0.0.0"))));
       Stream.of(CONFIGURING).forEach(state -> state.filter(SET).forEach(op -> NS.forEach(ns -> reject(state, op, ns + setting + "="))));
       Stream.of(ACTIVATED).forEach(state -> state.filter(SET).forEach(op -> NS.forEach(ns -> reject(state, op, ns + setting + "=0.0.0.0"))));
@@ -629,7 +631,8 @@ public class ConfigurationTest {
         allow(state, op, "stripe.1.node.1." + setting + "=1234");
         reject(state, op, "stripe.1.node.1." + setting + "=");
       }));
-      Stream.of(CONFIGURING, ACTIVATED).forEach(state -> state.filter(UNSET).forEach(op -> NS.forEach(ns -> reject(state, op, ns + setting))));
+      Stream.of(CONFIGURING).forEach(state -> state.filter(UNSET).forEach(op -> NS.forEach(ns -> allow(state, op, ns + setting))));
+      Stream.of(ACTIVATED).forEach(state -> state.filter(UNSET).forEach(op -> NS.forEach(ns -> reject(state, op, ns + setting))));
       Stream.of(CONFIGURING).forEach(state -> state.filter(SET).forEach(op -> NS.forEach(ns -> allow(state, op, ns + setting + "=1234"))));
       Stream.of(CONFIGURING).forEach(state -> state.filter(SET).forEach(op -> NS.forEach(ns -> reject(state, op, ns + setting + "="))));
       Stream.of(ACTIVATED).forEach(state -> state.filter(SET).forEach(op -> NS.forEach(ns -> reject(state, op, ns + setting + "=1234"))));
@@ -709,9 +712,22 @@ public class ConfigurationTest {
       }));
     });
 
-    // client-reconnect-window, client-lease-duration, failover-priority
-    Stream.of("client-reconnect-window", "client-lease-duration", "failover-priority").forEach(setting -> {
+    // failover-priority
+    Stream.of("failover-priority").forEach(setting -> {
       Stream.of(CONFIGURING, ACTIVATED).forEach(state -> state.filter(UNSET).forEach(op -> NS.forEach(ns -> reject(state, op, ns + setting))));
+      Stream.of(CONFIGURING).forEach(state -> state.filter(GET).forEach(op -> {
+        allow(state, op, setting);
+        reject(state, op, "stripe.1." + setting);
+        reject(state, op, "stripe.1.node.1." + setting);
+      }));
+    });
+    // client-reconnect-window, client-lease-duration
+    Stream.of("client-reconnect-window", "client-lease-duration").forEach(setting -> {
+      Stream.of(CONFIGURING, ACTIVATED).forEach(state -> state.filter(UNSET).forEach(op -> {
+        allow(state, op, setting);
+        reject(state, op, "stripe.1." + setting);
+        reject(state, op, "stripe.1.node.1." + setting);
+      }));
       Stream.of(CONFIGURING).forEach(state -> state.filter(GET).forEach(op -> {
         allow(state, op, setting);
         reject(state, op, "stripe.1." + setting);
@@ -752,7 +768,7 @@ public class ConfigurationTest {
 
     // log-dir
     Stream.of(CONFIGURING, ACTIVATED).forEach(state -> state.filter(GET).forEach(op -> NS.forEach(ns -> allow(state, op, ns + "log-dir"))));
-    Stream.of(CONFIGURING, ACTIVATED).forEach(state -> state.filter(UNSET).forEach(op -> NS.forEach(ns -> reject(state, op, ns + "log-dir"))));
+    Stream.of(CONFIGURING, ACTIVATED).forEach(state -> state.filter(UNSET).forEach(op -> NS.forEach(ns -> allow(state, op, ns + "log-dir"))));
     Stream.of(CONFIGURING, ACTIVATED).forEach(state -> state.filter(SET).forEach(op -> NS.forEach(ns -> allow(state, op, ns + "log-dir=foo"))));
     Stream.of(CONFIGURING, ACTIVATED).forEach(state -> state.filter(SET).forEach(op -> NS.forEach(ns -> reject(state, op, ns + "log-dir="))));
     Stream.of(CONFIGURING).forEach(state -> state.filter(IMPORT).forEach(op -> {
@@ -931,8 +947,9 @@ public class ConfigurationTest {
   public void test_unset_maps_with_defaults() {
     Node node = Testing.newTestNode("foo", "localhost");
     assertFalse(node.getDataDirs().isConfigured());
-    Configuration.valueOf("data-dirs").apply(node);
-    assertTrue(node.getDataDirs().isConfigured());
+
+    Configuration.valueOf("data-dirs").apply(node); // unset
+    assertTrue(node.getDataDirs().isConfigured()); // since data-dirs has a default, unset will not bring back the default (dangerous behavior), so data-dirs=""
     assertThat(node.getDataDirs().get(), is(equalTo(emptyMap())));
 
     node = Testing.newTestNode("foo", "localhost")
@@ -942,20 +959,28 @@ public class ConfigurationTest {
     Configuration.valueOf("data-dirs").apply(node);
     assertTrue(node.getDataDirs().isConfigured());
     assertThat(node.getDataDirs().get(), is(equalTo(emptyMap())));
+
+    node = Testing.newTestNode("foo", "localhost");
+    assertThat(node.getDataDirs().orDefault().size(), is(equalTo(1))); // we have a default data dir
+    Configuration.valueOf("data-dirs=").apply(node); // set to empty value specifically to empty the map
+    assertTrue(node.getDataDirs().isConfigured()); // since data-dirs has a default, data-dirs="" now
+    assertThat(node.getDataDirs().get(), is(equalTo(emptyMap())));
   }
 
   @Test
   public void test_unset_maps_without_defaults() {
     Node node = Testing.newTestNode("foo", "localhost");
     assertFalse(node.getTcProperties().isConfigured());
-    Configuration.valueOf("tc-properties").apply(node);
+    Configuration.valueOf("tc-properties").apply(node); // unset
+    assertFalse(node.getTcProperties().isConfigured());
+
+    Configuration.valueOf("tc-properties=").apply(node); // set to empty map
     assertTrue(node.getTcProperties().isConfigured());
 
     node = Testing.newTestNode("foo", "localhost").putTcProperty("second", ".");
-    assertTrue(node.getTcProperties().isConfigured());
-    Configuration.valueOf("tc-properties").apply(node);
-    assertTrue(node.getTcProperties().isConfigured());
-    assertThat(node.getTcProperties().get(), is(equalTo(emptyMap())));
+    assertTrue(node.getTcProperties().isConfigured()); // configured
+    Configuration.valueOf("tc-properties").apply(node); // unset
+    assertFalse(node.getTcProperties().isConfigured()); // not configured anymore since matches default value
   }
 
   @Test
@@ -1075,5 +1100,20 @@ public class ConfigurationTest {
     if (nodeId != null) {
       assertThat(configuration.getNodeId(), is(equalTo(nodeId)));
     }
+  }
+
+  public static Configuration setting(Setting setting) {
+    String val = setting.getDefaultProperty().orElse("");
+    return Configuration.valueOf(setting + "=" + val);
+  }
+
+  public static Configuration setting(Setting setting, int stripeId) {
+    String val = setting.getDefaultProperty().orElse("");
+    return Configuration.valueOf("stripe." + stripeId + "." + setting + "=" + val);
+  }
+
+  public static Configuration setting(Setting setting, int stripeId, int nodeId) {
+    String val = setting.getDefaultProperty().orElse("");
+    return Configuration.valueOf("stripe." + stripeId + ".node." + nodeId + "." + setting + "=" + val);
   }
 }

--- a/dynamic-config/model/src/test/java/org/terracotta/dynamic_config/api/model/SetSettingTest.java
+++ b/dynamic-config/model/src/test/java/org/terracotta/dynamic_config/api/model/SetSettingTest.java
@@ -21,6 +21,7 @@ import org.terracotta.common.struct.Measure;
 import java.nio.file.Paths;
 
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
@@ -36,6 +37,7 @@ import static org.terracotta.dynamic_config.api.model.Setting.OFFHEAP_RESOURCES;
 import static org.terracotta.dynamic_config.api.model.Setting.SECURITY_AUDIT_LOG_DIR;
 import static org.terracotta.dynamic_config.api.model.Setting.SECURITY_DIR;
 import static org.terracotta.dynamic_config.api.model.Setting.TC_PROPERTIES;
+import static org.terracotta.testing.ExceptionMatcher.throwing;
 
 /**
  * only test the necessary setters having some logic
@@ -85,7 +87,9 @@ public class SetSettingTest {
     Node node = Testing.newTestNode("node1", "localhost");
 
     // not throwing - noop
-    LICENSE_FILE.setProperty(node, null);
+    assertThat(
+        () -> LICENSE_FILE.setProperty(node, null),
+        is(throwing(instanceOf(IllegalArgumentException.class)).andMessage(is(equalTo("Setting 'license-file' cannot be read or cleared")))));
     LICENSE_FILE.setProperty(node, "a.xml");
   }
 

--- a/dynamic-config/model/src/test/java/org/terracotta/dynamic_config/api/service/ConfigurationParserTest.java
+++ b/dynamic-config/model/src/test/java/org/terracotta/dynamic_config/api/service/ConfigurationParserTest.java
@@ -132,7 +132,7 @@ public class ConfigurationParserTest {
     assertConfigFail(config(), "No configuration provided");
 
     // placeholder forbidden for hostname
-    assertConfigFail(config("failover-priority=availability", "stripe.1.node.1.hostname=%h"), "Invalid input: 'stripe.1.node.1.hostname=%h'. Placeholders are not allowed");
+    assertConfigFail(config("failover-priority=availability", "stripe.1.node.1.hostname=%h"), "Invalid input: 'stripe.1.node.1.hostname=%h'. Reason: Placeholders are not allowed");
     assertConfigFail(config(
         "failover-priority=availability",
         "stripe.1.stripe-name=<GENERATED>",

--- a/dynamic-config/server/services/src/main/java/org/terracotta/dynamic_config/server/service/handler/ClientReconnectWindowConfigChangeHandler.java
+++ b/dynamic-config/server/services/src/main/java/org/terracotta/dynamic_config/server/service/handler/ClientReconnectWindowConfigChangeHandler.java
@@ -27,14 +27,13 @@ public class ClientReconnectWindowConfigChangeHandler implements ConfigChangeHan
 
   @Override
   public void validate(NodeContext nodeContext, Configuration change) throws InvalidConfigChangeException {
-    if (!change.hasValue()) {
-      throw new InvalidConfigChangeException("Operation not supported");//unset not supported
-    }
-
-    try {
-      Measure.parse(change.getValue().get(), TimeUnit.class);
-    } catch (RuntimeException e) {
-      throw new InvalidConfigChangeException(e.toString(), e);
+    // if the change has no value, this is an unset which rolls back to the default system value
+    if (change.hasValue()) {
+      try {
+        Measure.parse(change.getValue().get(), TimeUnit.class);
+      } catch (RuntimeException e) {
+        throw new InvalidConfigChangeException(e.toString(), e);
+      }
     }
   }
 }

--- a/dynamic-config/server/services/src/main/java/org/terracotta/dynamic_config/server/service/handler/NodeLogDirChangeHandler.java
+++ b/dynamic-config/server/services/src/main/java/org/terracotta/dynamic_config/server/service/handler/NodeLogDirChangeHandler.java
@@ -17,6 +17,8 @@ package org.terracotta.dynamic_config.server.service.handler;
 
 import org.terracotta.dynamic_config.api.model.Configuration;
 import org.terracotta.dynamic_config.api.model.NodeContext;
+import org.terracotta.dynamic_config.api.model.RawPath;
+import org.terracotta.dynamic_config.api.model.Setting;
 import org.terracotta.dynamic_config.api.service.IParameterSubstitutor;
 import org.terracotta.dynamic_config.server.api.ConfigChangeHandler;
 import org.terracotta.dynamic_config.server.api.InvalidConfigChangeException;
@@ -39,7 +41,9 @@ public class NodeLogDirChangeHandler implements ConfigChangeHandler {
   public void validate(NodeContext nodeContext, Configuration change) throws InvalidConfigChangeException {
     String logPath = change.getValue().orElse(null);
     if (logPath == null) {
-      throw new InvalidConfigChangeException("Operation not supported");//unset not supported
+      // unset will rollback to default value
+      RawPath rawPath = Setting.NODE_LOG_DIR.getDefaultValue();
+      logPath = rawPath.getValue();
     }
 
     Path substitutedLogPath = substitute(Paths.get(logPath));

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/UnsetCommand1x2IT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/UnsetCommand1x2IT.java
@@ -40,7 +40,7 @@ public class UnsetCommand1x2IT extends DynamicConfigIT {
         is(successful()));
 
     assertThat(
-        configTool("get", "-s", "localhost:" + getNodePort(), "-c", "public-hostname", "-c", "public-port"),
+        configTool("export", "-s", "localhost:" + getNodePort()),
         allOf(
             containsOutput("stripe.1.node.1.public-hostname=127.0.0.1"),
             containsOutput("stripe.1.node.2.public-hostname=127.0.0.1"),
@@ -57,7 +57,7 @@ public class UnsetCommand1x2IT extends DynamicConfigIT {
         is(successful()));
 
     assertThat(
-        configTool("get", "-s", "localhost:" + getNodePort(), "-c", "public-hostname", "-c", "public-port"),
+        configTool("export", "-s", "localhost:" + getNodePort()),
         allOf(
             not(containsOutput("public-hostname=")),
             not(containsOutput("public-port="))
@@ -71,7 +71,7 @@ public class UnsetCommand1x2IT extends DynamicConfigIT {
         is(successful()));
 
     assertThat(
-        configTool("get", "-s", "localhost:" + getNodePort(), "-c", "public-hostname", "-c", "public-port"),
+        configTool("export", "-s", "localhost:" + getNodePort()),
         allOf(
             containsOutput("stripe.1.node.1.public-hostname=127.0.0.1"),
             containsOutput("stripe.1.node.2.public-hostname=127.0.0.1"),
@@ -86,7 +86,7 @@ public class UnsetCommand1x2IT extends DynamicConfigIT {
         is(successful()));
 
     assertThat(
-        configTool("get", "-s", "localhost:" + getNodePort(), "-c", "public-hostname", "-c", "public-port"),
+        configTool("export", "-s", "localhost:" + getNodePort()),
         allOf(
             not(containsOutput("public-hostname=")),
             not(containsOutput("public-port="))
@@ -99,10 +99,10 @@ public class UnsetCommand1x2IT extends DynamicConfigIT {
         configTool("set", "-s", "localhost:" + getNodePort(), "-c", "tc-properties=foo:1,bar:2"),
         is(successful()));
     assertThat(
-        configTool("get", "-s", "localhost:" + getNodePort(), "-c", "tc-properties"),
+        configTool("export", "-s", "localhost:" + getNodePort()),
         allOf(
-            containsOutput("stripe.1.node.1.tc-properties=bar:2,foo:1"),
-            containsOutput("stripe.1.node.2.tc-properties=bar:2,foo:1")
+            containsOutput("stripe.1.node.1.tc-properties=bar\\:2,foo\\:1"),
+            containsOutput("stripe.1.node.2.tc-properties=bar\\:2,foo\\:1")
         ));
 
     // ===
@@ -112,10 +112,10 @@ public class UnsetCommand1x2IT extends DynamicConfigIT {
         configTool("set", "-s", "localhost:" + getNodePort(), "-c", "tc-properties=foo:2,baz:3"),
         is(successful()));
     assertThat(
-        configTool("get", "-s", "localhost:" + getNodePort(), "-c", "tc-properties"),
+        configTool("export", "-s", "localhost:" + getNodePort()),
         allOf(
-            containsOutput("stripe.1.node.1.tc-properties=bar:2,baz:3,foo:2"),
-            containsOutput("stripe.1.node.2.tc-properties=bar:2,baz:3,foo:2")
+            containsOutput("stripe.1.node.1.tc-properties=bar\\:2,baz\\:3,foo\\:2"),
+            containsOutput("stripe.1.node.2.tc-properties=bar\\:2,baz\\:3,foo\\:2")
         ));
 
     // removing a specific property
@@ -125,10 +125,10 @@ public class UnsetCommand1x2IT extends DynamicConfigIT {
             "-c", "stripe.1.node.2.tc-properties.baz"),
         is(successful()));
     assertThat(
-        configTool("get", "-s", "localhost:" + getNodePort(), "-c", "tc-properties"),
+        configTool("export", "-s", "localhost:" + getNodePort()),
         allOf(
-            containsOutput("stripe.1.node.1.tc-properties=baz:3,foo:2"),
-            containsOutput("stripe.1.node.2.tc-properties=bar:2,foo:2")
+            containsOutput("stripe.1.node.1.tc-properties=baz\\:3,foo\\:2"),
+            containsOutput("stripe.1.node.2.tc-properties=bar\\:2,foo\\:2")
         ));
 
     // global removal of a whole map
@@ -138,10 +138,10 @@ public class UnsetCommand1x2IT extends DynamicConfigIT {
             "-c", "stripe.1.node.2.tc-properties.baz"),
         is(successful()));
     assertThat(
-        configTool("get", "-s", "localhost:" + getNodePort(), "-c", "tc-properties"),
+        configTool("export", "-s", "localhost:" + getNodePort()),
         allOf(
-            containsOutput("stripe.1.node.1.tc-properties="), // this entry is in the output because the user has explicitly set the map to "empty" So it is exported in the config.
-            containsOutput("stripe.1.node.2.tc-properties=bar:2,foo:2")
+            not(containsOutput("stripe.1.node.1.tc-properties=")), // this entry is in the output because the user has explicitly set the map to "empty" So it is exported in the config.
+            containsOutput("stripe.1.node.2.tc-properties=bar\\:2,foo\\:2")
         ));
 
     // global removal on cluster
@@ -149,20 +149,20 @@ public class UnsetCommand1x2IT extends DynamicConfigIT {
         configTool("set", "-s", "localhost:" + getNodePort(), "-c", "stripe.1.node.1.tc-properties=bar:2,foo:1"),
         is(successful()));
     assertThat(
-        configTool("get", "-s", "localhost:" + getNodePort(), "-c", "tc-properties"),
+        configTool("export", "-s", "localhost:" + getNodePort()),
         allOf(
-            containsOutput("stripe.1.node.1.tc-properties=bar:2,foo:1"),
-            containsOutput("stripe.1.node.2.tc-properties=bar:2,foo:2")
+            containsOutput("stripe.1.node.1.tc-properties=bar\\:2,foo\\:1"),
+            containsOutput("stripe.1.node.2.tc-properties=bar\\:2,foo\\:2")
         ));
     assertThat(
         configTool("unset", "-s", "localhost:" + getNodePort(), "-c", "tc-properties"),
         is(successful()));
     assertThat(
-        configTool("get", "-s", "localhost:" + getNodePort(), "-c", "tc-properties"),
+        configTool("export", "-s", "localhost:" + getNodePort()),
         allOf(
             // these entries are in the output because the user has explicitly set the map to "empty" So it is exported in the config.
-            containsOutput("stripe.1.node.1.tc-properties="),
-            containsOutput("stripe.1.node.2.tc-properties=")
+            not(containsOutput("stripe.1.node.1.tc-properties=")),
+            not(containsOutput("stripe.1.node.2.tc-properties="))
         ));
   }
 
@@ -172,10 +172,10 @@ public class UnsetCommand1x2IT extends DynamicConfigIT {
         configTool("set", "-s", "localhost:" + getNodePort(), "-c", "logger-overrides=foo:DEBUG,bar:INFO"),
         is(successful()));
     assertThat(
-        configTool("get", "-s", "localhost:" + getNodePort(), "-c", "logger-overrides"),
+        configTool("export", "-s", "localhost:" + getNodePort()),
         allOf(
-            containsOutput("stripe.1.node.1.logger-overrides=bar:INFO,foo:DEBUG"),
-            containsOutput("stripe.1.node.2.logger-overrides=bar:INFO,foo:DEBUG")
+            containsOutput("stripe.1.node.1.logger-overrides=bar\\:INFO,foo\\:DEBUG"),
+            containsOutput("stripe.1.node.2.logger-overrides=bar\\:INFO,foo\\:DEBUG")
         ));
 
     // ===
@@ -185,10 +185,10 @@ public class UnsetCommand1x2IT extends DynamicConfigIT {
         configTool("set", "-s", "localhost:" + getNodePort(), "-c", "logger-overrides=foo:INFO,baz:WARN"),
         is(successful()));
     assertThat(
-        configTool("get", "-s", "localhost:" + getNodePort(), "-c", "logger-overrides"),
+        configTool("export", "-s", "localhost:" + getNodePort()),
         allOf(
-            containsOutput("stripe.1.node.1.logger-overrides=bar:INFO,baz:WARN,foo:INFO"),
-            containsOutput("stripe.1.node.2.logger-overrides=bar:INFO,baz:WARN,foo:INFO")
+            containsOutput("stripe.1.node.1.logger-overrides=bar\\:INFO,baz\\:WARN,foo\\:INFO"),
+            containsOutput("stripe.1.node.2.logger-overrides=bar\\:INFO,baz\\:WARN,foo\\:INFO")
         ));
 
     // removing a specific property
@@ -198,10 +198,10 @@ public class UnsetCommand1x2IT extends DynamicConfigIT {
             "-c", "stripe.1.node.2.logger-overrides.baz"),
         is(successful()));
     assertThat(
-        configTool("get", "-s", "localhost:" + getNodePort(), "-c", "logger-overrides"),
+        configTool("export", "-s", "localhost:" + getNodePort()),
         allOf(
-            containsOutput("stripe.1.node.1.logger-overrides=baz:WARN,foo:INFO"),
-            containsOutput("stripe.1.node.2.logger-overrides=bar:INFO,foo:INFO")
+            containsOutput("stripe.1.node.1.logger-overrides=baz\\:WARN,foo\\:INFO"),
+            containsOutput("stripe.1.node.2.logger-overrides=bar\\:INFO,foo\\:INFO")
         ));
 
     // global removal of a whole map
@@ -211,10 +211,10 @@ public class UnsetCommand1x2IT extends DynamicConfigIT {
             "-c", "stripe.1.node.2.logger-overrides.baz"),
         is(successful()));
     assertThat(
-        configTool("get", "-s", "localhost:" + getNodePort(), "-c", "logger-overrides"),
+        configTool("export", "-s", "localhost:" + getNodePort()),
         allOf(
-            containsOutput("stripe.1.node.1.logger-overrides="), // this entry is in the output because the user has explicitly set the map to "empty" So it is exported in the config.
-            containsOutput("stripe.1.node.2.logger-overrides=bar:INFO,foo:INFO")
+            not(containsOutput("stripe.1.node.1.logger-overrides=")), // this entry is in the output because the user has explicitly set the map to "empty" So it is exported in the config.
+            containsOutput("stripe.1.node.2.logger-overrides=bar\\:INFO,foo\\:INFO")
         ));
 
     // global removal on cluster
@@ -222,20 +222,20 @@ public class UnsetCommand1x2IT extends DynamicConfigIT {
         configTool("set", "-s", "localhost:" + getNodePort(), "-c", "stripe.1.node.1.logger-overrides=bar:INFO,foo:DEBUG"),
         is(successful()));
     assertThat(
-        configTool("get", "-s", "localhost:" + getNodePort(), "-c", "logger-overrides"),
+        configTool("export", "-s", "localhost:" + getNodePort()),
         allOf(
-            containsOutput("stripe.1.node.1.logger-overrides=bar:INFO,foo:DEBUG"),
-            containsOutput("stripe.1.node.2.logger-overrides=bar:INFO,foo:INFO")
+            containsOutput("stripe.1.node.1.logger-overrides=bar\\:INFO,foo\\:DEBUG"),
+            containsOutput("stripe.1.node.2.logger-overrides=bar\\:INFO,foo\\:INFO")
         ));
     assertThat(
         configTool("unset", "-s", "localhost:" + getNodePort(), "-c", "logger-overrides"),
         is(successful()));
     assertThat(
-        configTool("get", "-s", "localhost:" + getNodePort(), "-c", "logger-overrides"),
+        configTool("export", "-s", "localhost:" + getNodePort()),
         allOf(
             // these entries are in the output because the user has explicitly set the map to "empty" So it is exported in the config.
-            containsOutput("stripe.1.node.1.logger-overrides="),
-            containsOutput("stripe.1.node.2.logger-overrides=")
+            not(containsOutput("stripe.1.node.1.logger-overrides=")),
+            not(containsOutput("stripe.1.node.2.logger-overrides="))
         ));
   }
 
@@ -247,8 +247,8 @@ public class UnsetCommand1x2IT extends DynamicConfigIT {
         configTool("set", "-s", "localhost:" + getNodePort(), "-c", "offheap-resources=boo:64MB,bar:128MB"),
         is(successful()));
     assertThat(
-        configTool("get", "-s", "localhost:" + getNodePort(), "-c", "offheap-resources"),
-        containsOutput("offheap-resources=bar:128MB,boo:64MB,foo:1GB,main:512MB"));
+        configTool("export", "-s", "localhost:" + getNodePort()),
+        containsOutput("offheap-resources=bar\\:128MB,boo\\:64MB,foo\\:1GB,main\\:512MB"));
 
     // ===
     // IMPORTANT: we do not support to globally replace a map by another map, to prevent any mistake from the user
@@ -257,23 +257,139 @@ public class UnsetCommand1x2IT extends DynamicConfigIT {
         configTool("set", "-s", "localhost:" + getNodePort(), "-c", "offheap-resources=boo:128MB,baz:200MB"),
         is(successful()));
     assertThat(
-        configTool("get", "-s", "localhost:" + getNodePort(), "-c", "offheap-resources"),
-        containsOutput("offheap-resources=bar:128MB,baz:200MB,boo:128MB,foo:1GB,main:512MB"));
+        configTool("export", "-s", "localhost:" + getNodePort()),
+        containsOutput("offheap-resources=bar\\:128MB,baz\\:200MB,boo\\:128MB,foo\\:1GB,main\\:512MB"));
 
     // removing a specific property
     assertThat(
         configTool("unset", "-s", "localhost:" + getNodePort(), "-c", "offheap-resources.bar"),
         is(not(successful())));
     assertThat(
-        configTool("get", "-s", "localhost:" + getNodePort(), "-c", "offheap-resources"),
-        containsOutput("offheap-resources=bar:128MB,baz:200MB,boo:128MB,foo:1GB,main:512MB"));
+        configTool("export", "-s", "localhost:" + getNodePort()),
+        containsOutput("offheap-resources=bar\\:128MB,baz\\:200MB,boo\\:128MB,foo\\:1GB,main\\:512MB"));
 
     // global removal of a whole map
     assertThat(
         configTool("unset", "-s", "localhost:" + getNodePort(), "-c", "offheap-resources"),
         is(not(successful())));
     assertThat(
-        configTool("get", "-s", "localhost:" + getNodePort(), "-c", "offheap-resources"),
-        containsOutput("offheap-resources=bar:128MB,baz:200MB,boo:128MB,foo:1GB,main:512MB"));
+        configTool("export", "-s", "localhost:" + getNodePort()),
+        containsOutput("offheap-resources=bar\\:128MB,baz\\:200MB,boo\\:128MB,foo\\:1GB,main\\:512MB"));
   }
+
+  @Test
+  public void unset_node_log_dir() {
+    assertThat(
+        configTool("set", "-s", "localhost:" + getNodePort(),
+            "-c", "stripe.1.node.1.log-dir=a/b",
+            "-c", "stripe.1.node.2.log-dir=c/d"),
+        is(successful()));
+
+    assertThat(
+        configTool("export", "-s", "localhost:" + getNodePort()),
+        allOf(
+            containsOutput("stripe.1.node.1.log-dir=a/b"),
+            containsOutput("stripe.1.node.2.log-dir=c/d")
+        ));
+
+    assertThat(
+        configTool("unset", "-s", "localhost:" + getNodePort(),
+            "-c", "stripe.1.node.1.log-dir",
+            "-c", "stripe.1.node.2.log-dir"),
+        is(successful()));
+
+    assertThat(
+        configTool("export", "-s", "localhost:" + getNodePort()),
+        not(containsOutput("log-dir=")));
+
+    assertThat(
+        configTool("set", "-s", "localhost:" + getNodePort(), "-c", "log-dir=e/f"),
+        is(successful()));
+
+    assertThat(
+        configTool("export", "-s", "localhost:" + getNodePort()),
+        allOf(
+            containsOutput("stripe.1.node.1.log-dir=e/f"),
+            containsOutput("stripe.1.node.2.log-dir=e/f")
+        ));
+
+    assertThat(
+        configTool("unset", "-s", "localhost:" + getNodePort(), "-c", "log-dir"),
+        is(successful()));
+
+    assertThat(
+        configTool("export", "-s", "localhost:" + getNodePort()),
+        not(containsOutput("log-dir=")));
+  }
+
+  @Test
+  public void unset_client_reconnect() {
+    assertThat(
+        configTool("set", "-s", "localhost:" + getNodePort(), "-c", "client-reconnect-window=1s"),
+        is(successful()));
+
+    assertThat(
+        configTool("export", "-s", "localhost:" + getNodePort()),
+        containsOutput("client-reconnect-window=1s"));
+
+    assertThat(
+        configTool("unset", "-s", "localhost:" + getNodePort(), "-c", "client-reconnect-window"),
+        is(successful()));
+
+    assertThat(
+        configTool("export", "-s", "localhost:" + getNodePort()),
+        not(containsOutput("client-reconnect-window=")));
+
+    assertThat(
+        configTool("set", "-s", "localhost:" + getNodePort(), "-c", "client-reconnect-window=120s"),
+        is(successful()));
+
+    assertThat(
+        configTool("export", "-s", "localhost:" + getNodePort()),
+        containsOutput("client-reconnect-window=120s"));
+
+    assertThat(
+        configTool("unset", "-s", "localhost:" + getNodePort(), "-c", "client-reconnect-window"),
+        is(successful()));
+
+    assertThat(
+        configTool("export", "-s", "localhost:" + getNodePort()),
+        not(containsOutput("client-reconnect-window=")));
+  }
+
+  @Test
+  public void unset_client_lease() {
+    assertThat(
+        configTool("set", "-s", "localhost:" + getNodePort(), "-c", "client-lease-duration=1s"),
+        is(successful()));
+
+    assertThat(
+        configTool("export", "-s", "localhost:" + getNodePort()),
+        containsOutput("client-lease-duration=1s"));
+
+    assertThat(
+        configTool("unset", "-s", "localhost:" + getNodePort(), "-c", "client-lease-duration"),
+        is(successful()));
+
+    assertThat(
+        configTool("export", "-s", "localhost:" + getNodePort()),
+        not(containsOutput("client-lease-duration=")));
+
+    assertThat(
+        configTool("set", "-s", "localhost:" + getNodePort(), "-c", "client-lease-duration=150s"),
+        is(successful()));
+
+    assertThat(
+        configTool("export", "-s", "localhost:" + getNodePort()),
+        containsOutput("client-lease-duration=150s"));
+
+    assertThat(
+        configTool("unset", "-s", "localhost:" + getNodePort(), "-c", "client-lease-duration"),
+        is(successful()));
+
+    assertThat(
+        configTool("export", "-s", "localhost:" + getNodePort()),
+        not(containsOutput("client-lease-duration=")));
+  }
+
 }

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/diagnostic/UnsetCommand1x2IT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/diagnostic/UnsetCommand1x2IT.java
@@ -46,7 +46,7 @@ public class UnsetCommand1x2IT extends DynamicConfigIT {
         is(successful()));
 
     assertThat(
-        configTool("get", "-s", "localhost:" + getNodePort(), "-c", "public-hostname", "-c", "public-port"),
+        configTool("export", "-s", "localhost:" + getNodePort()),
         allOf(
             containsOutput("stripe.1.node.1.public-hostname=127.0.0.1"),
             containsOutput("stripe.1.node.2.public-hostname=127.0.0.1"),
@@ -63,7 +63,7 @@ public class UnsetCommand1x2IT extends DynamicConfigIT {
         is(successful()));
 
     assertThat(
-        configTool("get", "-s", "localhost:" + getNodePort(), "-c", "public-hostname", "-c", "public-port"),
+        configTool("export", "-s", "localhost:" + getNodePort()),
         allOf(
             not(containsOutput("public-hostname=")),
             not(containsOutput("public-port="))
@@ -77,7 +77,7 @@ public class UnsetCommand1x2IT extends DynamicConfigIT {
         is(successful()));
 
     assertThat(
-        configTool("get", "-s", "localhost:" + getNodePort(), "-c", "public-hostname", "-c", "public-port"),
+        configTool("export", "-s", "localhost:" + getNodePort()),
         allOf(
             containsOutput("stripe.1.node.1.public-hostname=127.0.0.1"),
             containsOutput("stripe.1.node.2.public-hostname=127.0.0.1"),
@@ -92,7 +92,7 @@ public class UnsetCommand1x2IT extends DynamicConfigIT {
         is(successful()));
 
     assertThat(
-        configTool("get", "-s", "localhost:" + getNodePort(), "-c", "public-hostname", "-c", "public-port"),
+        configTool("export", "-s", "localhost:" + getNodePort()),
         allOf(
             not(containsOutput("public-hostname=")),
             not(containsOutput("public-port="))
@@ -106,7 +106,7 @@ public class UnsetCommand1x2IT extends DynamicConfigIT {
         is(successful()));
 
     assertThat(
-        configTool("get", "-s", "localhost:" + getNodePort(), "-c", "cluster-name"),
+        configTool("export", "-s", "localhost:" + getNodePort()),
         containsOutput("cluster-name=foo"));
 
     assertThat(
@@ -114,7 +114,7 @@ public class UnsetCommand1x2IT extends DynamicConfigIT {
         is(successful()));
 
     assertThat(
-        configTool("get", "-s", "localhost:" + getNodePort(), "-c", "cluster-name"),
+        configTool("export", "-s", "localhost:" + getNodePort()),
         not(containsOutput("cluster-name=")));
   }
 
@@ -127,7 +127,7 @@ public class UnsetCommand1x2IT extends DynamicConfigIT {
         is(successful()));
 
     assertThat(
-        configTool("get", "-s", "localhost:" + getNodePort(), "-c", "backup-dir"),
+        configTool("export", "-s", "localhost:" + getNodePort()),
         allOf(
             containsOutput("stripe.1.node.1.backup-dir=foo"),
             containsOutput("stripe.1.node.2.backup-dir=bar")
@@ -140,7 +140,7 @@ public class UnsetCommand1x2IT extends DynamicConfigIT {
         is(successful()));
 
     assertThat(
-        configTool("get", "-s", "localhost:" + getNodePort(), "-c", "backup-dir"),
+        configTool("export", "-s", "localhost:" + getNodePort()),
         not(containsOutput("backup-dir=")));
 
     assertThat(
@@ -148,7 +148,7 @@ public class UnsetCommand1x2IT extends DynamicConfigIT {
         is(successful()));
 
     assertThat(
-        configTool("get", "-s", "localhost:" + getNodePort(), "-c", "backup-dir"),
+        configTool("export", "-s", "localhost:" + getNodePort()),
         allOf(
             containsOutput("stripe.1.node.1.backup-dir=foo"),
             containsOutput("stripe.1.node.2.backup-dir=foo")
@@ -159,7 +159,7 @@ public class UnsetCommand1x2IT extends DynamicConfigIT {
         is(successful()));
 
     assertThat(
-        configTool("get", "-s", "localhost:" + getNodePort(), "-c", "backup-dir"),
+        configTool("export", "-s", "localhost:" + getNodePort()),
         not(containsOutput("backup-dir=")));
   }
 
@@ -169,10 +169,10 @@ public class UnsetCommand1x2IT extends DynamicConfigIT {
         configTool("set", "-s", "localhost:" + getNodePort(), "-c", "tc-properties=foo:1,bar:2"),
         is(successful()));
     assertThat(
-        configTool("get", "-s", "localhost:" + getNodePort(), "-c", "tc-properties"),
+        configTool("export", "-s", "localhost:" + getNodePort()),
         allOf(
-            containsOutput("stripe.1.node.1.tc-properties=bar:2,foo:1"),
-            containsOutput("stripe.1.node.2.tc-properties=bar:2,foo:1")
+            containsOutput("stripe.1.node.1.tc-properties=bar\\:2,foo\\:1"),
+            containsOutput("stripe.1.node.2.tc-properties=bar\\:2,foo\\:1")
         ));
 
     // ===
@@ -182,10 +182,10 @@ public class UnsetCommand1x2IT extends DynamicConfigIT {
         configTool("set", "-s", "localhost:" + getNodePort(), "-c", "tc-properties=foo:2,baz:3"),
         is(successful()));
     assertThat(
-        configTool("get", "-s", "localhost:" + getNodePort(), "-c", "tc-properties"),
+        configTool("export", "-s", "localhost:" + getNodePort()),
         allOf(
-            containsOutput("stripe.1.node.1.tc-properties=bar:2,baz:3,foo:2"),
-            containsOutput("stripe.1.node.2.tc-properties=bar:2,baz:3,foo:2")
+            containsOutput("stripe.1.node.1.tc-properties=bar\\:2,baz\\:3,foo\\:2"),
+            containsOutput("stripe.1.node.2.tc-properties=bar\\:2,baz\\:3,foo\\:2")
         ));
 
     // removing a specific property
@@ -195,10 +195,10 @@ public class UnsetCommand1x2IT extends DynamicConfigIT {
             "-c", "stripe.1.node.2.tc-properties.baz"),
         is(successful()));
     assertThat(
-        configTool("get", "-s", "localhost:" + getNodePort(), "-c", "tc-properties"),
+        configTool("export", "-s", "localhost:" + getNodePort()),
         allOf(
-            containsOutput("stripe.1.node.1.tc-properties=baz:3,foo:2"),
-            containsOutput("stripe.1.node.2.tc-properties=bar:2,foo:2")
+            containsOutput("stripe.1.node.1.tc-properties=baz\\:3,foo\\:2"),
+            containsOutput("stripe.1.node.2.tc-properties=bar\\:2,foo\\:2")
         ));
 
     // global removal of a whole map
@@ -208,10 +208,10 @@ public class UnsetCommand1x2IT extends DynamicConfigIT {
             "-c", "stripe.1.node.2.tc-properties.baz"),
         is(successful()));
     assertThat(
-        configTool("get", "-s", "localhost:" + getNodePort(), "-c", "tc-properties"),
+        configTool("export", "-s", "localhost:" + getNodePort()),
         allOf(
-            containsOutput("stripe.1.node.1.tc-properties="), // this entry is in the output because the user has explicitly set the map to "empty" So it is exported in the config.
-            containsOutput("stripe.1.node.2.tc-properties=bar:2,foo:2")
+            not(containsOutput("stripe.1.node.1.tc-properties=")), // this entry is in the output because the user has explicitly set the map to "empty" So it is exported in the config.
+            containsOutput("stripe.1.node.2.tc-properties=bar\\:2,foo\\:2")
         ));
 
     // global removal on cluster
@@ -219,20 +219,20 @@ public class UnsetCommand1x2IT extends DynamicConfigIT {
         configTool("set", "-s", "localhost:" + getNodePort(), "-c", "stripe.1.node.1.tc-properties=bar:2,foo:1"),
         is(successful()));
     assertThat(
-        configTool("get", "-s", "localhost:" + getNodePort(), "-c", "tc-properties"),
+        configTool("export", "-s", "localhost:" + getNodePort()),
         allOf(
-            containsOutput("stripe.1.node.1.tc-properties=bar:2,foo:1"),
-            containsOutput("stripe.1.node.2.tc-properties=bar:2,foo:2")
+            containsOutput("stripe.1.node.1.tc-properties=bar\\:2,foo\\:1"),
+            containsOutput("stripe.1.node.2.tc-properties=bar\\:2,foo\\:2")
         ));
     assertThat(
         configTool("unset", "-s", "localhost:" + getNodePort(), "-c", "tc-properties"),
         is(successful()));
     assertThat(
-        configTool("get", "-s", "localhost:" + getNodePort(), "-c", "tc-properties"),
+        configTool("export", "-s", "localhost:" + getNodePort()),
         allOf(
             // these entries are in the output because the user has explicitly set the map to "empty" So it is exported in the config.
-            containsOutput("stripe.1.node.1.tc-properties="),
-            containsOutput("stripe.1.node.2.tc-properties=")
+            not(containsOutput("stripe.1.node.1.tc-properties=")),
+            not(containsOutput("stripe.1.node.2.tc-properties="))
         ));
   }
 
@@ -242,10 +242,10 @@ public class UnsetCommand1x2IT extends DynamicConfigIT {
         configTool("set", "-s", "localhost:" + getNodePort(), "-c", "logger-overrides=foo:DEBUG,bar:INFO"),
         is(successful()));
     assertThat(
-        configTool("get", "-s", "localhost:" + getNodePort(), "-c", "logger-overrides"),
+        configTool("export", "-s", "localhost:" + getNodePort()),
         allOf(
-            containsOutput("stripe.1.node.1.logger-overrides=bar:INFO,foo:DEBUG"),
-            containsOutput("stripe.1.node.2.logger-overrides=bar:INFO,foo:DEBUG")
+            containsOutput("stripe.1.node.1.logger-overrides=bar\\:INFO,foo\\:DEBUG"),
+            containsOutput("stripe.1.node.2.logger-overrides=bar\\:INFO,foo\\:DEBUG")
         ));
 
     // ===
@@ -255,10 +255,10 @@ public class UnsetCommand1x2IT extends DynamicConfigIT {
         configTool("set", "-s", "localhost:" + getNodePort(), "-c", "logger-overrides=foo:INFO,baz:WARN"),
         is(successful()));
     assertThat(
-        configTool("get", "-s", "localhost:" + getNodePort(), "-c", "logger-overrides"),
+        configTool("export", "-s", "localhost:" + getNodePort()),
         allOf(
-            containsOutput("stripe.1.node.1.logger-overrides=bar:INFO,baz:WARN,foo:INFO"),
-            containsOutput("stripe.1.node.2.logger-overrides=bar:INFO,baz:WARN,foo:INFO")
+            containsOutput("stripe.1.node.1.logger-overrides=bar\\:INFO,baz\\:WARN,foo\\:INFO"),
+            containsOutput("stripe.1.node.2.logger-overrides=bar\\:INFO,baz\\:WARN,foo\\:INFO")
         ));
 
     // removing a specific property
@@ -268,10 +268,10 @@ public class UnsetCommand1x2IT extends DynamicConfigIT {
             "-c", "stripe.1.node.2.logger-overrides.baz"),
         is(successful()));
     assertThat(
-        configTool("get", "-s", "localhost:" + getNodePort(), "-c", "logger-overrides"),
+        configTool("export", "-s", "localhost:" + getNodePort()),
         allOf(
-            containsOutput("stripe.1.node.1.logger-overrides=baz:WARN,foo:INFO"),
-            containsOutput("stripe.1.node.2.logger-overrides=bar:INFO,foo:INFO")
+            containsOutput("stripe.1.node.1.logger-overrides=baz\\:WARN,foo\\:INFO"),
+            containsOutput("stripe.1.node.2.logger-overrides=bar\\:INFO,foo\\:INFO")
         ));
 
     // global removal of a whole map
@@ -281,10 +281,10 @@ public class UnsetCommand1x2IT extends DynamicConfigIT {
             "-c", "stripe.1.node.2.logger-overrides.baz"),
         is(successful()));
     assertThat(
-        configTool("get", "-s", "localhost:" + getNodePort(), "-c", "logger-overrides"),
+        configTool("export", "-s", "localhost:" + getNodePort()),
         allOf(
-            containsOutput("stripe.1.node.1.logger-overrides="), // this entry is in the output because the user has explicitly set the map to "empty" So it is exported in the config.
-            containsOutput("stripe.1.node.2.logger-overrides=bar:INFO,foo:INFO")
+            not(containsOutput("stripe.1.node.1.logger-overrides=")), // this entry is in the output because the user has explicitly set the map to "empty" So it is exported in the config.
+            containsOutput("stripe.1.node.2.logger-overrides=bar\\:INFO,foo\\:INFO")
         ));
 
     // global removal on cluster
@@ -292,20 +292,20 @@ public class UnsetCommand1x2IT extends DynamicConfigIT {
         configTool("set", "-s", "localhost:" + getNodePort(), "-c", "stripe.1.node.1.logger-overrides=bar:INFO,foo:DEBUG"),
         is(successful()));
     assertThat(
-        configTool("get", "-s", "localhost:" + getNodePort(), "-c", "logger-overrides"),
+        configTool("export", "-s", "localhost:" + getNodePort()),
         allOf(
-            containsOutput("stripe.1.node.1.logger-overrides=bar:INFO,foo:DEBUG"),
-            containsOutput("stripe.1.node.2.logger-overrides=bar:INFO,foo:INFO")
+            containsOutput("stripe.1.node.1.logger-overrides=bar\\:INFO,foo\\:DEBUG"),
+            containsOutput("stripe.1.node.2.logger-overrides=bar\\:INFO,foo\\:INFO")
         ));
     assertThat(
         configTool("unset", "-s", "localhost:" + getNodePort(), "-c", "logger-overrides"),
         is(successful()));
     assertThat(
-        configTool("get", "-s", "localhost:" + getNodePort(), "-c", "logger-overrides"),
+        configTool("export", "-s", "localhost:" + getNodePort()),
         allOf(
             // these entries are in the output because the user has explicitly set the map to "empty" So it is exported in the config.
-            containsOutput("stripe.1.node.1.logger-overrides="),
-            containsOutput("stripe.1.node.2.logger-overrides=")
+            not(containsOutput("stripe.1.node.1.logger-overrides=")),
+            not(containsOutput("stripe.1.node.2.logger-overrides="))
         ));
   }
 
@@ -315,8 +315,8 @@ public class UnsetCommand1x2IT extends DynamicConfigIT {
         configTool("set", "-s", "localhost:" + getNodePort(), "-c", "offheap-resources=foo:64MB,bar:128MB"),
         is(successful()));
     assertThat(
-        configTool("get", "-s", "localhost:" + getNodePort(), "-c", "offheap-resources"),
-        containsOutput("offheap-resources=bar:128MB,foo:64MB"));
+        configTool("export", "-s", "localhost:" + getNodePort()),
+        containsOutput("offheap-resources=bar\\:128MB,foo\\:64MB,main\\:512MB"));
 
     // ===
     // IMPORTANT: we do not support to globally replace a map by another map, to prevent any mistake from the user
@@ -325,23 +325,23 @@ public class UnsetCommand1x2IT extends DynamicConfigIT {
         configTool("set", "-s", "localhost:" + getNodePort(), "-c", "offheap-resources=foo:128MB,baz:200MB"),
         is(successful()));
     assertThat(
-        configTool("get", "-s", "localhost:" + getNodePort(), "-c", "offheap-resources"),
-        containsOutput("offheap-resources=bar:128MB,baz:200MB,foo:128MB"));
+        configTool("export", "-s", "localhost:" + getNodePort()),
+        containsOutput("offheap-resources=bar\\:128MB,baz\\:200MB,foo\\:128MB,main\\:512MB"));
 
     // removing a specific property
     assertThat(
         configTool("unset", "-s", "localhost:" + getNodePort(), "-c", "offheap-resources.bar"),
         is(successful()));
     assertThat(
-        configTool("get", "-s", "localhost:" + getNodePort(), "-c", "offheap-resources"),
-        containsOutput("offheap-resources=baz:200MB,foo:128MB"));
+        configTool("export", "-s", "localhost:" + getNodePort()),
+        containsOutput("offheap-resources=baz\\:200MB,foo\\:128MB,main\\:512MB"));
 
     // global removal of a whole map
     assertThat(
         configTool("unset", "-s", "localhost:" + getNodePort(), "-c", "offheap-resources"),
         is(successful()));
     assertThat(
-        configTool("get", "-s", "localhost:" + getNodePort(), "-c", "offheap-resources"),
+        configTool("export", "-s", "localhost:" + getNodePort()),
         containsOutput("offheap-resources=")); // this entry is in the output because the user has explicitly set the map to "empty" So it is exported in the config.
   }
 
@@ -351,8 +351,8 @@ public class UnsetCommand1x2IT extends DynamicConfigIT {
         configTool("set", "-s", "localhost:" + getNodePort(), "-c", "data-dirs=foo:a/b,bar:c/d"),
         is(successful()));
     assertThat(
-        configTool("get", "-s", "localhost:" + getNodePort(), "-c", "data-dirs"),
-        containsOutput("data-dirs=bar:c/d,foo:a/b"));
+        configTool("export", "-s", "localhost:" + getNodePort()),
+        containsOutput("data-dirs=bar\\:c/d,foo\\:a/b"));
 
     // ===
     // IMPORTANT: we do not support to globally replace a map by another map, to prevent any mistake from the user
@@ -361,23 +361,274 @@ public class UnsetCommand1x2IT extends DynamicConfigIT {
         configTool("set", "-s", "localhost:" + getNodePort(), "-c", "data-dirs=foo:c/d,baz:e/f"),
         is(successful()));
     assertThat(
-        configTool("get", "-s", "localhost:" + getNodePort(), "-c", "data-dirs"),
-        containsOutput("data-dirs=bar:c/d,baz:e/f,foo:c/d"));
+        configTool("export", "-s", "localhost:" + getNodePort()),
+        containsOutput("data-dirs=bar\\:c/d,baz\\:e/f,foo\\:c/d"));
 
     // removing a specific property
     assertThat(
         configTool("unset", "-s", "localhost:" + getNodePort(), "-c", "data-dirs.bar"),
         is(successful()));
     assertThat(
-        configTool("get", "-s", "localhost:" + getNodePort(), "-c", "data-dirs"),
-        containsOutput("data-dirs=baz:e/f,foo:c/d"));
+        configTool("export", "-s", "localhost:" + getNodePort()),
+        containsOutput("data-dirs=baz\\:e/f,foo\\:c/d"));
 
     // global removal of a whole map
     assertThat(
         configTool("unset", "-s", "localhost:" + getNodePort(), "-c", "data-dirs"),
         is(successful()));
     assertThat(
-        configTool("get", "-s", "localhost:" + getNodePort(), "-c", "data-dirs"),
+        configTool("export", "-s", "localhost:" + getNodePort()),
         containsOutput("data-dirs=")); // this entry is in the output because the user has explicitly set the map to "empty" So it is exported in the config.
   }
+
+  @Test
+  public void unset_node_group_port() {
+    assertThat(
+        configTool("set", "-s", "localhost:" + getNodePort(),
+            "-c", "stripe.1.node.1.group-port=9112",
+            "-c", "stripe.1.node.2.group-port=9113"),
+        is(successful()));
+
+    assertThat(
+        configTool("export", "-s", "localhost:" + getNodePort()),
+        allOf(
+            containsOutput("stripe.1.node.1.group-port=9112"),
+            containsOutput("stripe.1.node.2.group-port=9113")
+        ));
+
+    assertThat(
+        configTool("unset", "-s", "localhost:" + getNodePort(),
+            "-c", "stripe.1.node.1.group-port",
+            "-c", "stripe.1.node.2.group-port"),
+        is(successful()));
+
+    assertThat(
+        configTool("export", "-s", "localhost:" + getNodePort()),
+        not(containsOutput("group-port=")));
+
+    assertThat(
+        configTool("set", "-s", "localhost:" + getNodePort(), "-c", "group-port=9111"),
+        is(successful()));
+
+    assertThat(
+        configTool("export", "-s", "localhost:" + getNodePort()),
+        allOf(
+            containsOutput("stripe.1.node.1.group-port=9111"),
+            containsOutput("stripe.1.node.2.group-port=9111")
+        ));
+
+    assertThat(
+        configTool("unset", "-s", "localhost:" + getNodePort(), "-c", "group-port"),
+        is(successful()));
+
+    assertThat(
+        configTool("export", "-s", "localhost:" + getNodePort()),
+        not(containsOutput("group-port=")));
+  }
+
+  @Test
+  public void unset_node_bind_address() {
+    assertThat(
+        configTool("set", "-s", "localhost:" + getNodePort(),
+            "-c", "stripe.1.node.1.bind-address=127.0.0.1",
+            "-c", "stripe.1.node.2.bind-address=127.0.0.1"),
+        is(successful()));
+
+    assertThat(
+        configTool("export", "-s", "localhost:" + getNodePort()),
+        allOf(
+            containsOutput("stripe.1.node.1.bind-address=127.0.0.1"),
+            containsOutput("stripe.1.node.2.bind-address=127.0.0.1")
+        ));
+
+    assertThat(
+        configTool("unset", "-s", "localhost:" + getNodePort(),
+            "-c", "stripe.1.node.1.bind-address",
+            "-c", "stripe.1.node.2.bind-address"),
+        is(successful()));
+
+    assertThat(
+        configTool("export", "-s", "localhost:" + getNodePort()),
+        not(containsOutput("bind-address=")));
+
+    assertThat(
+        configTool("set", "-s", "localhost:" + getNodePort(), "-c", "bind-address=127.0.0.1"),
+        is(successful()));
+
+    assertThat(
+        configTool("export", "-s", "localhost:" + getNodePort()),
+        allOf(
+            containsOutput("stripe.1.node.1.bind-address=127.0.0.1"),
+            containsOutput("stripe.1.node.2.bind-address=127.0.0.1")
+        ));
+
+    assertThat(
+        configTool("unset", "-s", "localhost:" + getNodePort(), "-c", "bind-address"),
+        is(successful()));
+
+    assertThat(
+        configTool("export", "-s", "localhost:" + getNodePort()),
+        not(containsOutput("bind-address=")));
+  }
+
+  @Test
+  public void unset_node_group_bind_address() {
+    assertThat(
+        configTool("set", "-s", "localhost:" + getNodePort(),
+            "-c", "stripe.1.node.1.group-bind-address=127.0.0.1",
+            "-c", "stripe.1.node.2.group-bind-address=127.0.0.1"),
+        is(successful()));
+
+    assertThat(
+        configTool("export", "-s", "localhost:" + getNodePort()),
+        allOf(
+            containsOutput("stripe.1.node.1.group-bind-address=127.0.0.1"),
+            containsOutput("stripe.1.node.2.group-bind-address=127.0.0.1")
+        ));
+
+    assertThat(
+        configTool("unset", "-s", "localhost:" + getNodePort(),
+            "-c", "stripe.1.node.1.group-bind-address",
+            "-c", "stripe.1.node.2.group-bind-address"),
+        is(successful()));
+
+    assertThat(
+        configTool("export", "-s", "localhost:" + getNodePort()),
+        not(containsOutput("group-bind-address=")));
+
+    assertThat(
+        configTool("set", "-s", "localhost:" + getNodePort(), "-c", "group-bind-address=127.0.0.1"),
+        is(successful()));
+
+    assertThat(
+        configTool("export", "-s", "localhost:" + getNodePort()),
+        allOf(
+            containsOutput("stripe.1.node.1.group-bind-address=127.0.0.1"),
+            containsOutput("stripe.1.node.2.group-bind-address=127.0.0.1")
+        ));
+
+    assertThat(
+        configTool("unset", "-s", "localhost:" + getNodePort(), "-c", "group-bind-address"),
+        is(successful()));
+
+    assertThat(
+        configTool("export", "-s", "localhost:" + getNodePort()),
+        not(containsOutput("group-bind-address=")));
+  }
+
+  @Test
+  public void unset_node_log_dir() {
+    assertThat(
+        configTool("set", "-s", "localhost:" + getNodePort(),
+            "-c", "stripe.1.node.1.log-dir=a/b",
+            "-c", "stripe.1.node.2.log-dir=c/d"),
+        is(successful()));
+
+    assertThat(
+        configTool("export", "-s", "localhost:" + getNodePort()),
+        allOf(
+            containsOutput("stripe.1.node.1.log-dir=a/b"),
+            containsOutput("stripe.1.node.2.log-dir=c/d")
+        ));
+
+    assertThat(
+        configTool("unset", "-s", "localhost:" + getNodePort(),
+            "-c", "stripe.1.node.1.log-dir",
+            "-c", "stripe.1.node.2.log-dir"),
+        is(successful()));
+
+    assertThat(
+        configTool("export", "-s", "localhost:" + getNodePort()),
+        not(containsOutput("log-dir=")));
+
+    assertThat(
+        configTool("set", "-s", "localhost:" + getNodePort(), "-c", "log-dir=e/f"),
+        is(successful()));
+
+    assertThat(
+        configTool("export", "-s", "localhost:" + getNodePort()),
+        allOf(
+            containsOutput("stripe.1.node.1.log-dir=e/f"),
+            containsOutput("stripe.1.node.2.log-dir=e/f")
+        ));
+
+    assertThat(
+        configTool("unset", "-s", "localhost:" + getNodePort(), "-c", "log-dir"),
+        is(successful()));
+
+    assertThat(
+        configTool("export", "-s", "localhost:" + getNodePort()),
+        not(containsOutput("log-dir=")));
+  }
+
+  @Test
+  public void unset_client_reconnect() {
+    assertThat(
+        configTool("set", "-s", "localhost:" + getNodePort(), "-c", "client-reconnect-window=1s"),
+        is(successful()));
+
+    assertThat(
+        configTool("export", "-s", "localhost:" + getNodePort()),
+        containsOutput("client-reconnect-window=1s"));
+
+    assertThat(
+        configTool("unset", "-s", "localhost:" + getNodePort(), "-c", "client-reconnect-window"),
+        is(successful()));
+
+    assertThat(
+        configTool("export", "-s", "localhost:" + getNodePort()),
+        not(containsOutput("client-reconnect-window=")));
+
+    assertThat(
+        configTool("set", "-s", "localhost:" + getNodePort(), "-c", "client-reconnect-window=120s"),
+        is(successful()));
+
+    assertThat(
+        configTool("export", "-s", "localhost:" + getNodePort()),
+        containsOutput("client-reconnect-window=120s"));
+
+    assertThat(
+        configTool("unset", "-s", "localhost:" + getNodePort(), "-c", "client-reconnect-window"),
+        is(successful()));
+
+    assertThat(
+        configTool("export", "-s", "localhost:" + getNodePort()),
+        not(containsOutput("client-reconnect-window=")));
+  }
+
+  @Test
+  public void unset_client_lease() {
+    assertThat(
+        configTool("set", "-s", "localhost:" + getNodePort(), "-c", "client-lease-duration=1s"),
+        is(successful()));
+
+    assertThat(
+        configTool("export", "-s", "localhost:" + getNodePort()),
+        containsOutput("client-lease-duration=1s"));
+
+    assertThat(
+        configTool("unset", "-s", "localhost:" + getNodePort(), "-c", "client-lease-duration"),
+        is(successful()));
+
+    assertThat(
+        configTool("export", "-s", "localhost:" + getNodePort()),
+        not(containsOutput("client-lease-duration=")));
+
+    assertThat(
+        configTool("set", "-s", "localhost:" + getNodePort(), "-c", "client-lease-duration=150s"),
+        is(successful()));
+
+    assertThat(
+        configTool("export", "-s", "localhost:" + getNodePort()),
+        containsOutput("client-lease-duration=150s"));
+
+    assertThat(
+        configTool("unset", "-s", "localhost:" + getNodePort(), "-c", "client-lease-duration"),
+        is(successful()));
+
+    assertThat(
+        configTool("export", "-s", "localhost:" + getNodePort()),
+        not(containsOutput("client-lease-duration=")));
+  }
+
 }


### PR DESCRIPTION
- a null value is for unset or read
- a non empty value is a configuration from CLI or config file (set or import)
- an empty value is when the user adds an empty property in the config file `cluster-name=`

unset will remove the user-defined setting and switch back to the default value, except for maps because we do not want the default values to be brought back.

Examples:

- `set client-reconnect-window=60s` followed by `unset client-reconnect-window` will rollback to the system default value
- `set tc-properties=foo:bar` followed by `unset tc-properties` will reset `tc-properties` to the default value (nothing) and `tc-properties=` won't be added to the exported config
- `set offheap-resources=foo:1GB` followed by `unset offheap-resources` will export `offheap-resources=` in the config file because we do not want the default offheap resource to come back after a global unset
- `cluster-name=` in the config file is valid and is equivalent to not having it