### PR TITLE
Enhancing Junit Timeout rule to support taking thread dumps of all running java processes in case of test failure.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -29,26 +29,26 @@ jobs:
       jobName: Linux_Java_8
       timeoutInMinutes: 180
       pool: tc_linux_pool
-      options: -B -Dtest.parallel.forks=6 -Djava.test.version=1.8 -Djava.test.vendor=zulu
+      options: -B -Dtest.parallel.forks=2 -Djava.test.version=1.8 -Djava.test.vendor=zulu
       mavenGoals: 'clean verify'
   - template: build-templates/maven-common.yml@templates
     parameters:
       jobName: Linux_Java_11
       timeoutInMinutes: 180
       pool: tc_linux_pool
-      options: -B -Dtest.parallel.forks=6 -Djava.test.version=1.11 -Djava.test.vendor=zulu
+      options: -B -Dtest.parallel.forks=2 -Djava.test.version=1.11 -Djava.test.vendor=zulu
       mavenGoals: 'clean verify'
   - template: build-templates/maven-common.yml@templates
     parameters:
       jobName: Windows_Java_8
       timeoutInMinutes: 180
       pool: tc_windows_pool
-      options: -B -Dtest.parallel.forks=4 -Djava.test.version=1.8 -Djava.test.vendor=zulu
+      options: -B -Dtest.parallel.forks=2 -Djava.test.version=1.8 -Djava.test.vendor=zulu
       mavenGoals: 'clean verify'
   - template: build-templates/maven-common.yml@templates
     parameters:
       jobName: Windows_Java_11
       timeoutInMinutes: 180
       pool: tc_windows_pool
-      options: -B -Dtest.parallel.forks=4 -Djava.test.version=1.11 -Djava.test.vendor=zulu
+      options: -B -Dtest.parallel.forks=2 -Djava.test.version=1.11 -Djava.test.vendor=zulu
       mavenGoals: 'clean verify'

--- a/common/test-utilities/pom.xml
+++ b/common/test-utilities/pom.xml
@@ -38,5 +38,11 @@
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/common/test-utilities/src/main/java/org/terracotta/testing/Binary.java
+++ b/common/test-utilities/src/main/java/org/terracotta/testing/Binary.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.testing;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.Duration;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.stream.Stream;
+
+/**
+ * @author Mathieu Carbou
+ */
+public class Binary {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(Binary.class);
+  private static final boolean WIN = System.getProperty("os.name", "").toLowerCase().contains("win");
+
+  public static final Path JPS;
+  public static final Path JSTACK;
+
+  static {
+    JPS = find("jps").orElse(null);
+    JSTACK = find("jstack").orElse(null);
+    if (JPS == null || JSTACK == null) {
+      LOGGER.warn("Unable to find jps or jstack location using java.home ({}) or JAVA_HOME ({}))", System.getProperty("java.home"), System.getenv("JAVA_HOME"));
+    } else {
+      LOGGER.trace("jps: {}", JPS);
+      LOGGER.trace("jstack: {}", JSTACK);
+    }
+  }
+
+  public static Optional<Path> find(String name) {
+    return Stream.of(System.getProperty("java.home"), System.getenv("JAVA_HOME"))
+        .filter(Objects::nonNull)
+        .map(Paths::get)
+        .flatMap(home -> Stream.of(home, home.getParent())) // second entry will be the jdk if home points to a jre
+        .map(home -> home.resolve("bin").resolve(bin(name)))
+        .filter(Files::exists)
+        .findFirst();
+  }
+
+  public static String exec(Path bin, String... params) {
+    String[] cmd = new String[params.length + 1];
+    cmd[0] = bin.toString();
+    System.arraycopy(params, 0, cmd, 1, params.length);
+    try {
+      LOGGER.trace("exec({})", String.join(" ", cmd));
+      Process process = new ProcessBuilder(cmd)
+          .redirectErrorStream(true)
+          .start();
+      process.waitFor();
+      ByteArrayOutputStream out = new ByteArrayOutputStream();
+      try (InputStream is = process.getInputStream()) {
+        int b;
+        while ((b = is.read()) != -1) {
+          out.write(b);
+        }
+      }
+      return out.toString("UTF-8");
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new RuntimeException(e);
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+
+  public static String exec(Duration timeout, Path bin, String... params) throws TimeoutException {
+    String[] cmd = new String[params.length + 1];
+    cmd[0] = bin.toString();
+    System.arraycopy(params, 0, cmd, 1, params.length);
+    try {
+      LOGGER.trace("exec({}, {})", timeout, String.join(" ", cmd));
+      Process process = new ProcessBuilder(cmd)
+          .redirectErrorStream(true)
+          .start();
+      if (!process.waitFor(timeout.toMillis(), TimeUnit.MILLISECONDS)) {
+        process.destroyForcibly();
+        process.waitFor();
+        throw new TimeoutException("Timeout after " + timeout.getSeconds() + " seconds when trying to execute: " + String.join(" ", cmd));
+      }
+      ByteArrayOutputStream out = new ByteArrayOutputStream();
+      try (InputStream is = process.getInputStream()) {
+        int b;
+        while ((b = is.read()) != -1) {
+          out.write(b);
+        }
+      }
+      return out.toString("UTF-8");
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new RuntimeException(e);
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+
+  public static String bin(String name) {
+    return WIN ? name + ".exe" : name;
+  }
+}

--- a/common/test-utilities/src/main/java/org/terracotta/testing/ThreadDump.java
+++ b/common/test-utilities/src/main/java/org/terracotta/testing/ThreadDump.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.testing;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.Optional;
+import java.util.concurrent.TimeoutException;
+import java.util.stream.Stream;
+
+import static java.util.Objects.requireNonNull;
+import static org.terracotta.testing.Binary.JPS;
+import static org.terracotta.testing.Binary.JSTACK;
+import static org.terracotta.testing.Binary.exec;
+
+/**
+ * @author Mathieu Carbou
+ */
+public class ThreadDump {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(ThreadDump.class);
+
+  private final long pid;
+  private final String output;
+
+  private ThreadDump(long pid, String output) {
+    this.pid = pid;
+    this.output = requireNonNull(output);
+  }
+
+  public long getPid() {
+    return pid;
+  }
+
+  public String getOutput() {
+    return output;
+  }
+
+  public void writeTo(Path out) {
+    LOGGER.info("Saving thread dump of PID: {} to: {}", pid, out);
+    try {
+      Files.write(out, output.getBytes(StandardCharsets.UTF_8));
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+
+  public static Stream<ThreadDump> dumpAll() {
+    if (JPS == null) {
+      return Stream.empty();
+    }
+    return Stream.of(exec(JPS, "-q").split("\\r?\\n"))
+        .map(Long::parseLong)
+        .map(ThreadDump::dump)
+        .filter(Optional::isPresent)
+        .map(Optional::get);
+  }
+
+  public static void dumpAll(Path outputDir) {
+    try {
+      Files.createDirectories(outputDir);
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+    dumpAll().parallel().forEach(dump -> dump.writeTo(outputDir.resolve("thread-dump-" + dump.getPid() + ".log")));
+  }
+
+  public static Optional<ThreadDump> dump(long pid) {
+    LOGGER.info("Taking thread dump of PID: {} (timeout: 10 seconds)", pid);
+    try {
+      String output = exec(Duration.ofSeconds(10), JSTACK, "-l", "" + pid);
+      if (output.contains("No such process")) {
+        LOGGER.warn("No such process: {}", pid);
+        return Optional.empty();
+      } else {
+        return Optional.of(new ThreadDump(pid, output));
+      }
+    } catch (TimeoutException e) {
+      return Optional.of(new ThreadDump(pid, e.getMessage()));
+    }
+  }
+
+  public static void dump(long pid, Path out) {
+    dump(pid).ifPresent(dump -> dump.writeTo(out));
+  }
+}

--- a/common/test-utilities/src/main/java/org/terracotta/testing/Timeout.java
+++ b/common/test-utilities/src/main/java/org/terracotta/testing/Timeout.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.testing;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import org.junit.runner.Description;
+import org.junit.runners.model.MultipleFailureException;
+import org.junit.runners.model.Statement;
+import org.junit.runners.model.TestTimedOutException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.nio.file.Path;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Enhanced Junit Timeout rule  which is able to do a thread dump of all running java processes in case of a timeout
+ *
+ * @author Mathieu Carbou
+ */
+@SuppressFBWarnings("NM_SAME_SIMPLE_NAME_AS_SUPERCLASS")
+public class Timeout extends org.junit.rules.Timeout {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(Timeout.class);
+
+  private final Path threadDump;
+
+  public Timeout(Builder builder) {
+    super(builder);
+    this.threadDump = builder.threadDump;
+  }
+
+  @Override
+  public Statement apply(Statement base, Description description) {
+    try {
+      return createFailOnTimeoutStatement(base, description);
+    } catch (final Exception e) {
+      return new Statement() {
+        @Override
+        public void evaluate() {
+          throw new RuntimeException("Invalid parameters for Timeout", e);
+        }
+      };
+    }
+  }
+
+  protected Statement createFailOnTimeoutStatement(Statement statement, Description description) throws Exception {
+    Statement base = super.createFailOnTimeoutStatement(statement);
+    return new Statement() {
+      @Override
+      public void evaluate() throws Throwable {
+        try {
+          base.evaluate();
+        } catch (Throwable throwable) {
+          if (threadDump != null && (throwable instanceof MultipleFailureException || throwable instanceof TestTimedOutException)) {
+            try {
+              executeThreadDump(description);
+            } catch (RuntimeException e) {
+              LOGGER.warn("Error occurred when trying to take thread dumps after timeout of test: " + description, e);
+            }
+          }
+          throw throwable;
+        }
+      }
+    };
+  }
+
+  protected void executeThreadDump(Description description) {
+    Path output = threadDump.resolve(description.getTestClass().getSimpleName()).resolve(description.getMethodName() == null ? "class" : description.getMethodName());
+    LOGGER.info("Taking thread dumps after timeout of test: {} into: {}", description, output);
+    ThreadDump.dumpAll(output);
+  }
+
+  @SuppressFBWarnings("NM_SAME_SIMPLE_NAME_AS_SUPERCLASS")
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder extends org.junit.rules.Timeout.Builder {
+
+    private Path threadDump;
+
+    @Override
+    public Builder withTimeout(long timeout, TimeUnit unit) {
+      super.withTimeout(timeout, unit);
+      return this;
+    }
+
+    @Override
+    public Builder withLookingForStuckThread(boolean enable) {
+      super.withLookingForStuckThread(enable);
+      return this;
+    }
+
+    public Builder withThreadDump(Path outputDir) {
+      this.threadDump = outputDir;
+      return this;
+    }
+
+    @Override
+    public Timeout build() {
+      return new Timeout(this);
+    }
+  }
+}

--- a/common/test-utilities/src/test/java/org/terracotta/testing/BinaryTest.java
+++ b/common/test-utilities/src/test/java/org/terracotta/testing/BinaryTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.testing;
+
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assume.assumeThat;
+
+/**
+ * @author Mathieu Carbou
+ */
+public class BinaryTest {
+  @Test
+  public void find_linux() {
+    assumeThat(System.getProperty("os.name").toLowerCase(), not(containsString("win")));
+
+    assertThat(Binary.bin("java"), is(equalTo("java")));
+    assertThat(Binary.find("java").get().getFileName().toString(), is(equalTo("java"))); // in jre
+    assertThat(Binary.find("jps").get().getFileName().toString(), is(equalTo("jps"))); // in jdk
+  }
+
+  @Test
+  public void find_win() {
+    assumeThat(System.getProperty("os.name").toLowerCase(), containsString("win"));
+
+    assertThat(Binary.bin("java"), is(equalTo("java.exe")));
+    assertThat(Binary.find("java").get().getFileName().toString(), is(equalTo("java.exe"))); // in jre
+    assertThat(Binary.find("jps").get().getFileName().toString(), is(equalTo("jps.exe"))); // in jdk
+  }
+}

--- a/common/test-utilities/src/test/java/org/terracotta/testing/ThreadDumpTest.java
+++ b/common/test-utilities/src/test/java/org/terracotta/testing/ThreadDumpTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.testing;
+
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.concurrent.TimeUnit;
+
+import static java.util.stream.Collectors.toList;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ * @author Mathieu Carbou
+ */
+public class ThreadDumpTest {
+
+  @Rule
+  public TmpDir tmpDir = new TmpDir(Paths.get(System.getProperty("user.dir"), "target"), false);
+
+  @Rule
+  public Timeout timeout = Timeout.builder()
+      .withLookingForStuckThread(true)
+      .withThreadDump(Paths.get(System.getProperty("user.dir")).resolve("target").resolve("thread-dumps"))
+      .withTimeout(20, TimeUnit.SECONDS)
+      .build();
+
+  @Test
+  public void dump_to_map() {
+    assertThat(ThreadDump.dumpAll().parallel().count(), is(greaterThanOrEqualTo(1L)));
+  }
+
+  @Test
+  public void dump_to_folder() throws IOException {
+    ThreadDump.dumpAll(tmpDir.getRoot());
+    assertThat(Files.list(tmpDir.getRoot()).collect(toList()), hasSize(greaterThanOrEqualTo(1)));
+  }
+
+
+  @Ignore
+  @Test
+  public void test_timeout() throws InterruptedException {
+    Thread.sleep(30_000);
+  }
+}

--- a/common/test-utilities/src/test/resources/simplelogger.properties
+++ b/common/test-utilities/src/test/resources/simplelogger.properties
@@ -1,0 +1,1 @@
+org.slf4j.simpleLogger.defaultLogLevel=info

--- a/dynamic-config/cli/dynamic-config-cli-api/src/main/java/org/terracotta/dynamic_config/cli/api/command/AttachAction.java
+++ b/dynamic-config/cli/dynamic-config-cli-api/src/main/java/org/terracotta/dynamic_config/cli/api/command/AttachAction.java
@@ -48,7 +48,7 @@ import static org.terracotta.dynamic_config.cli.api.converter.OperationType.STRI
 public class AttachAction extends TopologyAction {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(AttachAction.class);
-  
+
   protected Measure<TimeUnit> restartWaitTime = Measure.of(120, TimeUnit.SECONDS);
   protected Measure<TimeUnit> restartDelay = Measure.of(2, TimeUnit.SECONDS);
   protected InetSocketAddress sourceAddress;
@@ -249,8 +249,12 @@ public class AttachAction extends TopologyAction {
         "The node/stripe to attach won't be activated and restarted, and their topology will be rolled back to their initial value."
     );
     newOnlineNodes.forEach((endpoint, cluster) -> {
-      output.info("Rollback topology of node: {}", endpoint);
-      setUpcomingCluster(Collections.singletonList(endpoint), cluster);
+      try {
+        output.info("Rollback topology of node: {}", endpoint);
+        setUpcomingCluster(Collections.singletonList(endpoint), cluster);
+      } catch (RuntimeException e) {
+        LOGGER.warn("Unable to rollback configuration on node: {}. Error: {}", endpoint, e.getMessage(), e);
+      }
     });
     throw error;
   }

--- a/dynamic-config/cli/dynamic-config-cli-api/src/main/java/org/terracotta/dynamic_config/cli/api/command/ConfigurationMutationAction.java
+++ b/dynamic-config/cli/dynamic-config-cli-api/src/main/java/org/terracotta/dynamic_config/cli/api/command/ConfigurationMutationAction.java
@@ -158,8 +158,13 @@ public abstract class ConfigurationMutationAction extends ConfigurationAction {
           // In that case, we might already have some nodes inside nodesRequiringRestart.
           // But we need to add into this collection the other nodes that are targeted AND could have vetoed a change to be applied at runtime
           for (Endpoint endpoint : onlineNodes.keySet()) {
-            if (targetedNodes.contains(endpoint.getNodeName()) && mustBeRestarted(endpoint)) {
-              nodesRequiringRestart.add(endpoint.getNodeName());
+            try {
+              if (targetedNodes.contains(endpoint.getNodeName()) && mustBeRestarted(endpoint)) {
+                nodesRequiringRestart.add(endpoint.getNodeName());
+              }
+            } catch (RuntimeException e) {
+              // some nodes might have failed over and not be reachable anymore
+              LOGGER.warn("Node " + endpoint + " is not reachable anymore: {}", e.getMessage(), e);
             }
           }
         }

--- a/dynamic-config/testing/support/src/main/java/org/terracotta/dynamic_config/test_support/DynamicConfigIT.java
+++ b/dynamic-config/testing/support/src/main/java/org/terracotta/dynamic_config/test_support/DynamicConfigIT.java
@@ -19,7 +19,6 @@ import org.apache.commons.lang3.ArrayUtils;
 import org.hamcrest.Matcher;
 import org.junit.Rule;
 import org.junit.rules.RuleChain;
-import org.junit.rules.Timeout;
 import org.junit.runner.Description;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -49,6 +48,7 @@ import org.terracotta.dynamic_config.test_support.util.ConfigurationGenerator;
 import org.terracotta.dynamic_config.test_support.util.PropertyResolver;
 import org.terracotta.json.ObjectMapperFactory;
 import org.terracotta.testing.ExtendedTestRule;
+import org.terracotta.testing.Timeout;
 import org.terracotta.testing.TmpDir;
 
 import java.io.IOException;
@@ -77,6 +77,7 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.stream.IntStream.rangeClosed;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
@@ -135,7 +136,11 @@ public class DynamicConfigIT {
             DynamicConfigIT.this.startNode(stripeId, nodeId);
           }
         })
-        .around(Timeout.millis(testTimeout.toMillis()))
+        .around(Timeout.builder()
+            .withLookingForStuckThread(true)
+            .withThreadDump(Paths.get(System.getProperty("user.dir")).resolve("target").resolve("thread-dumps"))
+            .withTimeout(testTimeout.toMillis(), MILLISECONDS)
+            .build())
         .around(new ExtendedTestRule() {
           @Override
           protected void before(Description description) {
@@ -249,14 +254,14 @@ public class DynamicConfigIT {
 
     boolean addedOptions = false;
     String timeout = Measure.of(getConnectionTimeout().getSeconds(), TimeUnit.SECONDS).toString();
-    if (!configToolOptions.contains("-t")) {
+    if (!configToolOptions.contains("-t") && !configToolOptions.contains("-connection-timeout")) {
       // Add the option if it wasn't already passed in the `cli` parameter as a config tool option
       enhancedCli.add("-t");
       enhancedCli.add(timeout);
       addedOptions = true;
     }
 
-    if (!configToolOptions.contains("-r")) {
+    if (!configToolOptions.contains("-r") && !configToolOptions.contains("-request-timeout")) {
       // Add the option if it wasn't already passed in the `cli` parameter as a config tool option
       enhancedCli.add("-r");
       enhancedCli.add(timeout);
@@ -464,13 +469,6 @@ public class DynamicConfigIT {
 
   protected final void waitForNPassives(int stripeId, int count) {
     waitUntil(() -> findPassives(stripeId).length, is(equalTo(count)));
-  }
-
-  protected void waitForPassiveReplication() throws Exception {
-    // this is ugly, but I do not know how we could otherwise wait until replication message gets processed by the passive server, which is causing a restart
-    // Angela is not able to observe a server restart
-    // This wait time is to ensure the passive server got the replicated message, processes it and restarted itself
-    Thread.sleep(15_000);
   }
 
   protected final Cluster getUpcomingCluster(int stripeId, int nodeId) {

--- a/dynamic-config/testing/support/src/main/java/org/terracotta/dynamic_config/test_support/DynamicConfigIT.java
+++ b/dynamic-config/testing/support/src/main/java/org/terracotta/dynamic_config/test_support/DynamicConfigIT.java
@@ -326,6 +326,7 @@ public class DynamicConfigIT {
         .offheap("main:512MB,foo:1GB")
         .metaData(getNodePath(stripeId, nodeId).append("/metadata").toString())
         .failoverPriority(getFailoverPriority().toString())
+        .clientReconnectWindow("10s") // the default client reconnect window of 2min can cause some tests to timeout
         .clusterName(CLUSTER_NAME);
   }
 

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/ThreadDumpOnTimeoutIT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/ThreadDumpOnTimeoutIT.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.dynamic_config.system_tests;
+
+import org.junit.Ignore;
+import org.junit.Test;
+import org.terracotta.dynamic_config.test_support.ClusterDefinition;
+import org.terracotta.dynamic_config.test_support.DynamicConfigIT;
+
+import java.time.Duration;
+
+@ClusterDefinition(autoActivate = true)
+public class ThreadDumpOnTimeoutIT extends DynamicConfigIT {
+
+  public ThreadDumpOnTimeoutIT() {
+    super(Duration.ofMinutes(30));
+  }
+
+  @Test
+  @Ignore("Un-ignore me to test the thread dump feature when an angela test times out")
+  public void timeout() throws InterruptedException {
+    Thread.sleep(60_000);
+  }
+}

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/DiagnosticCommand1x2IT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/DiagnosticCommand1x2IT.java
@@ -45,7 +45,7 @@ public class DiagnosticCommand1x2IT extends DynamicConfigIT {
     startNode(1, 1);
     waitForDiagnostic(1, 1);
     assertThat(
-        configTool("-v", "diagnostic", "-s", "localhost:" + getNodePort(1, 1)),
+        configTool("diagnostic", "-s", "localhost:" + getNodePort(1, 1)),
         containsLinesInOrderStartingWith(Files.lines(Paths.get(getClass().getResource("/diagnostic-output/diagnostic1.txt").toURI())).collect(toList())));
   }
 

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/SetCommand1x1IT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/SetCommand1x1IT.java
@@ -66,7 +66,7 @@ public class SetCommand1x1IT extends DynamicConfigIT {
   @Test
   public void addOffheapResource_with_decimal_value() {
     assertThat(
-        configTool("-v", "set", "-s", "localhost:" + getNodePort(), "-c", "offheap-resources=main2:1.5MB"),
+        configTool("set", "-s", "localhost:" + getNodePort(), "-c", "offheap-resources=main2:1.5MB"),
         containsOutput("Invalid input: 'offheap-resources.main2=1.5MB'. Reason: offheap-resources.main2 is invalid: Invalid measure: '1.5'. <quantity> must be a positive integer."));
   }
 

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/diagnostic/GetCommand1x1IT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/diagnostic/GetCommand1x1IT.java
@@ -67,7 +67,7 @@ public class GetCommand1x1IT extends DynamicConfigIT {
   public void testNode_getClientReconnectWindow() {
     assertThat(
         configTool("get", "-s", "localhost:" + getNodePort(), "-c", "client-reconnect-window"),
-        containsOutput("client-reconnect-window=120s"));
+        containsOutput("client-reconnect-window=10s"));
   }
 
   @Test

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/network_disrupted/AttachInConsistency1x4IT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/network_disrupted/AttachInConsistency1x4IT.java
@@ -57,6 +57,11 @@ public class AttachInConsistency1x4IT extends DynamicConfigIT {
     return FailoverPriority.consistency();
   }
 
+  @Override
+  protected Duration getAssertTimeout() {
+    return Duration.ofMinutes(2);
+  }
+
   @Before
   public void setup() throws Exception {
     startNode(1, 1);
@@ -164,11 +169,9 @@ public class AttachInConsistency1x4IT extends DynamicConfigIT {
         clientToServerDisruptor.disrupt(Collections.singletonList(active.getServerSymbolicName()));
         String publicHostName = "stripe.1.node.1.public-hostname=localhost";
         String publicPort = "stripe.1.node.1.public-port=" + getNodePort(1, 4);
-        assertThat(configTool("set", "-s", "localhost:" + getNodePort(1, 4), "-c",
-            publicHostName, "-c", publicPort), is(successful()));
+        assertThat(configTool("set", "-s", "localhost:" + getNodePort(1, 4), "-c", publicHostName, "-c", publicPort), is(successful()));
         int publicPassivePort = map.get(passive.getServerSymbolicName());
-        assertThat(configTool("attach", "-d", "localhost:" + publicPassivePort, "-s", "localhost:" + getNodePort(1, 4)),
-            is(successful()));
+        assertThat(configTool("attach", "-d", "localhost:" + publicPassivePort, "-s", "localhost:" + getNodePort(1, 4)), is(successful()));
         clientToServerDisruptor.undisrupt(Collections.singletonList(active.getServerSymbolicName()));
       }
       disruptor.undisrupt();

--- a/dynamic-config/testing/system-tests/src/test/resources/logback-test.xml
+++ b/dynamic-config/testing/system-tests/src/test/resources/logback-test.xml
@@ -26,7 +26,7 @@
     </layout>
   </appender>
 
-  <root level="WARN">
+  <root level="INFO">
     <appender-ref ref="STDOUT"/>
   </root>
 


### PR DESCRIPTION
This behaviour is added to all the DC system tests **only**