### PR TITLE
Several bug fixes

### DIFF
--- a/common/nomad/src/main/java/org/terracotta/nomad/client/results/LoggingResultReceiver.java
+++ b/common/nomad/src/main/java/org/terracotta/nomad/client/results/LoggingResultReceiver.java
@@ -217,7 +217,7 @@ public class LoggingResultReceiver<T> implements ChangeResultReceiver<T>, Recove
 
   @Override
   public void cannotDecideOverCommitOrRollback() {
-    error("Please run the 'diagnostic' command to diagnose the configuration state and try to run the 'repair' command and force either a commit or rollback.");
+    error("Please run the 'diagnostic' command to diagnose the configuration state and try to run the 'repair' command. Please refer to the troubleshooting guide for more help.");
   }
 
   private void error(String line) {

--- a/dynamic-config/api/src/main/java/org/terracotta/dynamic_config/api/model/nomad/StripeRemovalNomadChange.java
+++ b/dynamic-config/api/src/main/java/org/terracotta/dynamic_config/api/model/nomad/StripeRemovalNomadChange.java
@@ -31,7 +31,7 @@ public class StripeRemovalNomadChange extends StripeNomadChange {
   public Cluster apply(Cluster original) {
     requireNonNull(original);
 
-    if (!original.getStripes().contains(getStripe())) {
+    if (!original.getStripe(getStripe().getUID()).isPresent()) {
       throw new IllegalArgumentException("Stripe : " + getStripe() + " is not in cluster: " + original);
     }
 

--- a/dynamic-config/api/src/main/java/org/terracotta/dynamic_config/api/service/ConfigurationConsistencyAnalyzer.java
+++ b/dynamic-config/api/src/main/java/org/terracotta/dynamic_config/api/service/ConfigurationConsistencyAnalyzer.java
@@ -300,8 +300,8 @@ public class ConfigurationConsistencyAnalyzer implements DiscoverResultsReceiver
       case ONLINE_PREPARED:
         return "A new cluster configuration has been prepared but not yet committed or rolled back on online nodes."
             + " Some nodes are unreachable so we do not know if the last configuration change has been committed or rolled back on them."
-            + " No further configuration change can be done until the 'repair' command is run to finalize the configuration change."
-            + " If the unreachable nodes do not become available again, you might need to use the '-force' option to force a commit or rollback.";
+            + " No further configuration change can be done until the offline nodes are restarted and the 'repair' command is run again"
+            + " to finalize the configuration change. Please refer to the Troubleshooting Guide if needed.";
 
       case PARTIALLY_PREPARED:
         return "A new  cluster configuration has been *partially* prepared (some nodes didn't get the new change)."

--- a/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/AttachCommand.java
+++ b/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/AttachCommand.java
@@ -30,7 +30,7 @@ import org.terracotta.dynamic_config.cli.converter.TimeUnitConverter;
 import java.net.InetSocketAddress;
 
 @Parameters(commandDescription = "Attach a node to a stripe, or a stripe to a cluster")
-@Usage("(-to-cluster <hostname[:port]> -stripe <hostname[:port]> | -to-stripe <hostname[:port]> -node <hostname[:port]>) [-force] [-restart-wait-time <restart-wait-time>] [-restart-delay <restart-delay>]")
+@Usage("(-to-cluster <hostname[:port]> -stripe <hostname[:port]> | -to-stripe <hostname[:port]> -node <hostname[:port]>) [-restart-wait-time <restart-wait-time>] [-restart-delay <restart-delay>]")
 public class AttachCommand extends Command {
 
   @Parameter(names = {"-to-cluster"}, description = "Cluster to attach to", converter = InetSocketAddressConverter.class)
@@ -51,7 +51,7 @@ public class AttachCommand extends Command {
   @Parameter(names = {"-restart-delay"}, description = "Delay before the server restarts itself. Default: 2s", converter = TimeUnitConverter.class)
   protected Measure<TimeUnit> restartDelay = Measure.of(2, TimeUnit.SECONDS);
 
-  @Parameter(names = {"-force"}, description = "Force the operation")
+  @Parameter(names = {"-force"}, description = "Force the operation", hidden = true)
   protected boolean force;
 
   @Inject

--- a/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/DetachCommand.java
+++ b/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/DetachCommand.java
@@ -32,7 +32,7 @@ import org.terracotta.dynamic_config.cli.converter.TimeUnitConverter;
 import java.net.InetSocketAddress;
 
 @Parameters(commandDescription = "Detach a node from a stripe, or a stripe from a cluster")
-@Usage("(-from-cluster <hostname[:port]> -stripe [<hostname[:port]>|uid|name] | -from-stripe <hostname[:port]> -node [<hostname[:port]>|uid|name]) [-force] [-stop-wait-time <stop-wait-time>] [-stop-delay <stop-delay>]")
+@Usage("(-from-cluster <hostname[:port]> -stripe [<hostname[:port]>|uid|name] | -from-stripe <hostname[:port]> -node [<hostname[:port]>|uid|name]) [-stop-wait-time <stop-wait-time>] [-stop-delay <stop-delay>]")
 public class DetachCommand extends Command {
 
   @Parameter(names = {"-from-cluster"}, description = "Cluster to detach from", converter = InetSocketAddressConverter.class)
@@ -53,7 +53,7 @@ public class DetachCommand extends Command {
   @Parameter(names = {"-stop-delay"}, description = "Delay before the server stops itself. Default: 2s", converter = TimeUnitConverter.class)
   protected Measure<TimeUnit> stopDelay = Measure.of(2, TimeUnit.SECONDS);
 
-  @Parameter(names = {"-force"}, description = "Force the operation")
+  @Parameter(names = {"-force"}, description = "Force the operation", hidden = true)
   protected boolean force;
 
   @Inject

--- a/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/GetCommand.java
+++ b/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/GetCommand.java
@@ -31,7 +31,7 @@ import java.net.InetSocketAddress;
 import java.util.List;
 
 @Parameters(commandDescription = "Read configuration properties")
-@Usage("-connect-to <hostname[:port]> [-runtime] -setting <[namespace:]setting>,<[namespace:]setting>...")
+@Usage("-connect-to <hostname[:port]> [-runtime] -setting <[namespace:]setting> -setting <[namespace:]setting> ...")
 public class GetCommand extends Command {
 
   @Parameter(names = {"-connect-to"}, description = "Node to connect to", required = true, converter = InetSocketAddressConverter.class)

--- a/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/RepairCommand.java
+++ b/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/RepairCommand.java
@@ -28,13 +28,13 @@ import org.terracotta.dynamic_config.cli.converter.RepairActionConverter;
 import java.net.InetSocketAddress;
 
 @Parameters(commandDescription = "Repair a cluster configuration")
-@Usage("-connect-to <hostname[:port]> [-force commit|rollback|reset|unlock]")
+@Usage("-connect-to <hostname[:port]>")
 public class RepairCommand extends Command {
 
   @Parameter(names = {"-connect-to"}, description = "Node to connect to", required = true, converter = InetSocketAddressConverter.class)
   InetSocketAddress node;
 
-  @Parameter(names = {"-force"}, description = "Repair action to force: commit, rollback, reset, unlock", converter = RepairActionConverter.class)
+  @Parameter(names = {"-force"}, description = "Repair action to force: commit, rollback, reset, unlock", converter = RepairActionConverter.class, hidden = true)
   RepairMethod forcedRepairMethod;
 
   @Inject

--- a/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/SetCommand.java
+++ b/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/SetCommand.java
@@ -30,7 +30,7 @@ import java.net.InetSocketAddress;
 import java.util.List;
 
 @Parameters(commandDescription = "Set configuration properties")
-@Usage("-connect-to <hostname[:port]> -setting <[namespace:]property=value>,<[namespace:]property=value>...")
+@Usage("-connect-to <hostname[:port]> -setting <[namespace:]property=value> -setting <[namespace:]property=value> ...")
 public class SetCommand extends Command {
 
   @Parameter(names = {"-connect-to"}, description = "Node to connect to", required = true, converter = InetSocketAddressConverter.class)

--- a/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/UnsetCommand.java
+++ b/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/UnsetCommand.java
@@ -30,7 +30,7 @@ import java.net.InetSocketAddress;
 import java.util.List;
 
 @Parameters(commandDescription = "Unset configuration properties")
-@Usage("-connect-to <hostname[:port]> -setting <[namespace:]property>,<[namespace:]property>...")
+@Usage("-connect-to <hostname[:port]> -setting <[namespace:]property> -setting <[namespace:]property> ...")
 public class UnsetCommand extends Command {
 
   @Parameter(names = {"-connect-to"}, description = "Node to connect to", required = true, converter = InetSocketAddressConverter.class)

--- a/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/deprecated/DeprecatedGetCommand.java
+++ b/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/deprecated/DeprecatedGetCommand.java
@@ -31,7 +31,7 @@ import java.net.InetSocketAddress;
 import java.util.List;
 
 @Parameters(commandDescription = "Read configuration properties")
-@Usage("-s <hostname[:port]> [-r] -c <[namespace:]property>,<[namespace:]property>...")
+@Usage("-s <hostname[:port]> [-r] -c <[namespace:]property> -c <[namespace:]property> ...")
 public class DeprecatedGetCommand extends Command {
 
   @Parameter(names = {"-s"}, description = "Node to connect to", required = true, converter = InetSocketAddressConverter.class)

--- a/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/deprecated/DeprecatedSetCommand.java
+++ b/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/deprecated/DeprecatedSetCommand.java
@@ -30,7 +30,7 @@ import java.net.InetSocketAddress;
 import java.util.List;
 
 @Parameters(commandDescription = "Set configuration properties")
-@Usage("-s <hostname[:port]> -c <[namespace:]property=value>,<[namespace:]property=value>...")
+@Usage("-s <hostname[:port]> -c <[namespace:]property=value> -c <[namespace:]property=value> ...")
 public class DeprecatedSetCommand extends Command {
 
   @Parameter(names = {"-s"}, description = "Node to connect to", required = true, converter = InetSocketAddressConverter.class)

--- a/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/deprecated/DeprecatedUnsetCommand.java
+++ b/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/deprecated/DeprecatedUnsetCommand.java
@@ -30,7 +30,7 @@ import java.net.InetSocketAddress;
 import java.util.List;
 
 @Parameters(commandDescription = "Unset configuration properties")
-@Usage("-s <hostname[:port]> -c <[namespace:]property>,<[namespace:]property>...")
+@Usage("-s <hostname[:port]> -c <[namespace:]property> -c <[namespace:]property> ...")
 public class DeprecatedUnsetCommand extends Command {
 
   @Parameter(names = {"-s"}, description = "Node to connect to", required = true, converter = InetSocketAddressConverter.class)

--- a/dynamic-config/cli/dynamic-config-cli-api/src/main/java/org/terracotta/dynamic_config/cli/api/command/AttachAction.java
+++ b/dynamic-config/cli/dynamic-config-cli-api/src/main/java/org/terracotta/dynamic_config/cli/api/command/AttachAction.java
@@ -118,7 +118,7 @@ public class AttachAction extends TopologyAction {
           () -> sourceCluster.getNodeCount() == 1,
           "Source node: " + source + " is part of a stripe containing more than 1 nodes. " +
               "It must be detached first before being attached to a new stripe. " +
-              "You can run the command with the force option to force the attachment, but at the risk of breaking the cluster from where the node is taken.");
+              "Please refer to the Troubleshooting Guide for more help.");
 
       Stripe destinationStripe = destinationCluster.getStripeByNode(destination.getNodeUID()).get();
       FailoverPriority failoverPriority = destinationCluster.getFailoverPriority();
@@ -143,7 +143,7 @@ public class AttachAction extends TopologyAction {
           () -> sourceCluster.getStripeCount() == 1,
           "Source stripe from node: " + source + " is part of a cluster containing more than 1 stripes. " +
               "It must be detached first before being attached to a new cluster. " +
-              "You can run the command with the force option to force the attachment, but at the risk of breaking the cluster from where the node is taken.");
+              "Please refer to the Troubleshooting Guide for more help.");
     }
 
     // make sure nodes to attach are online

--- a/dynamic-config/cli/dynamic-config-cli-api/src/main/java/org/terracotta/dynamic_config/cli/api/command/AttachAction.java
+++ b/dynamic-config/cli/dynamic-config-cli-api/src/main/java/org/terracotta/dynamic_config/cli/api/command/AttachAction.java
@@ -84,6 +84,14 @@ public class AttachAction extends TopologyAction {
       throw new IllegalArgumentException("The destination and the source endpoints must not be the same");
     }
 
+    // we prevent attaching nodes if some nodes must be restarted
+    for (Endpoint endpoint : destinationOnlineNodes.keySet()) {
+      // prevent any topology change if a configuration change has been made through Nomad, requiring a restart, but nodes were not restarted yet
+      validateLogOrFail(
+          () -> !mustBeRestarted(destination),
+          "Impossible to do any topology change. Node: " + endpoint + " is waiting to be restarted to apply some pending changes. Please refer to the Troubleshooting Guide for more help.");
+    }
+
     Collection<Endpoint> destinationPeers = destinationCluster.getSimilarEndpoints(destination);
     if (destinationPeers.contains(source)) {
       throw new IllegalArgumentException("Source node: " + source + " is already part of cluster: " + destinationCluster.toShapeString());

--- a/dynamic-config/cli/dynamic-config-cli-api/src/main/java/org/terracotta/dynamic_config/cli/api/command/ConfigurationMutationAction.java
+++ b/dynamic-config/cli/dynamic-config-cli-api/src/main/java/org/terracotta/dynamic_config/cli/api/command/ConfigurationMutationAction.java
@@ -126,7 +126,7 @@ public abstract class ConfigurationMutationAction extends ConfigurationAction {
       }
 
       ensureActivesAreAllOnline(originalCluster, onlineNodes);
-      output.info("Applying new configuration change(s) to activated cluster: {}", toString(onlineNodes.keySet()));
+      output.info("Applying new configuration change(s) to activated nodes: {}", toString(onlineNodes.keySet()));
       MultiSettingNomadChange changes = getNomadChanges(updatedCluster);
       if (!changes.getChanges().isEmpty()) {
         runConfigurationChange(updatedCluster, onlineNodes, changes);

--- a/dynamic-config/cli/dynamic-config-cli-api/src/main/java/org/terracotta/dynamic_config/cli/api/command/DetachAction.java
+++ b/dynamic-config/cli/dynamic-config-cli-api/src/main/java/org/terracotta/dynamic_config/cli/api/command/DetachAction.java
@@ -138,7 +138,7 @@ public class DetachAction extends TopologyAction {
     if (operationType == NODE) {
       if (!onlineNodesToRemove.isEmpty() && areAllNodesActivated(onlineNodesToRemove)) {
         validateLogOrFail(onlineNodesToRemove::isEmpty, "Nodes to be detached: " + toString(onlineNodesToRemove) + " are online. " +
-            "Safely shutdown the nodes first, or use the force option to reset and stop the target nodes before detaching them");
+            "Nodes must be safely shutdown first. Please refer to the Troubleshooting Guide for more help.");
       }
     }
   }

--- a/dynamic-config/cli/dynamic-config-cli-api/src/main/java/org/terracotta/dynamic_config/cli/api/command/RepairAction.java
+++ b/dynamic-config/cli/dynamic-config-cli-api/src/main/java/org/terracotta/dynamic_config/cli/api/command/RepairAction.java
@@ -39,7 +39,7 @@ import static org.terracotta.nomad.server.ChangeRequestState.ROLLED_BACK;
 public class RepairAction extends RemoteAction {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(RepairAction.class);
-  
+
   private InetSocketAddress node;
   private RepairMethod forcedRepairMethod;
 
@@ -168,7 +168,7 @@ public class RepairAction extends RemoteAction {
         .collect(toMap(Map.Entry::getKey, Map.Entry::getValue));
     RepairMethod wanted = forcedRepairMethod == null ? fallbackRepairMethod : forcedRepairMethod;
     if (wanted == null) {
-      throw new IllegalArgumentException("Please use the '-force' option to specify whether a commit or rollback is wanted.");
+      throw new IllegalArgumentException("Some nodes are offline. Unable to determine what kind of repair to run. Please refer to the Troubleshooting Guide.");
     } else {
       output.info("Repairing configuration by running a " + wanted + "...");
     }

--- a/dynamic-config/cli/dynamic-config-cli-api/src/main/java/org/terracotta/dynamic_config/cli/api/command/TopologyAction.java
+++ b/dynamic-config/cli/dynamic-config-cli-api/src/main/java/org/terracotta/dynamic_config/cli/api/command/TopologyAction.java
@@ -69,13 +69,6 @@ public abstract class TopologyAction extends RemoteAction {
 
   protected void validate() {
     destination = getEndpoint(destinationAddress);
-
-    // prevent any topology change if a configuration change has been made through Nomad, requiring a restart, but nodes were not restarted yet
-    validateLogOrFail(
-        () -> !mustBeRestarted(destination),
-        "Impossible to do any topology change. Cluster at address: " + destination + " is waiting to be restarted to apply some pending changes. " +
-            "Please refer to the Troubleshooting Guide for more help.");
-
     destinationCluster = getUpcomingCluster(destination);
     destinationOnlineNodes = findOnlineRuntimePeers(destination);
     destinationClusterActivated = areAllNodesActivated(destinationOnlineNodes.keySet());

--- a/dynamic-config/cli/dynamic-config-cli-api/src/main/java/org/terracotta/dynamic_config/cli/api/command/TopologyAction.java
+++ b/dynamic-config/cli/dynamic-config-cli-api/src/main/java/org/terracotta/dynamic_config/cli/api/command/TopologyAction.java
@@ -74,8 +74,7 @@ public abstract class TopologyAction extends RemoteAction {
     validateLogOrFail(
         () -> !mustBeRestarted(destination),
         "Impossible to do any topology change. Cluster at address: " + destination + " is waiting to be restarted to apply some pending changes. " +
-            "You can run the command with the force option to force the commit, but at the risk of breaking this cluster configuration consistency. " +
-            "The newly added node will be restarted, but not the existing ones.");
+            "Please refer to the Troubleshooting Guide for more help.");
 
     destinationCluster = getUpcomingCluster(destination);
     destinationOnlineNodes = findOnlineRuntimePeers(destination);

--- a/dynamic-config/cli/upgrade-tools/src/main/java/org/terracotta/dynamic_config/cli/upgrade_tools/config_converter/parsing/ConvertCommand.java
+++ b/dynamic-config/cli/upgrade-tools/src/main/java/org/terracotta/dynamic_config/cli/upgrade_tools/config_converter/parsing/ConvertCommand.java
@@ -52,7 +52,7 @@ public class ConvertCommand extends Command {
   @Parameter(names = {"-format"}, description = "Conversion type (directory|properties). Default: directory", converter = ConversionFormat.FormatConverter.class)
   private ConversionFormat conversionFormat = DIRECTORY;
 
-  @Parameter(names = {"-force"}, description = "Force a config conversion, ignoring warnings, if any. Default: false")
+  @Parameter(names = {"-force"}, description = "Force a config conversion, ignoring warnings, if any")
   private boolean force;
 
   @Inject public final ConvertAction action;

--- a/dynamic-config/model/src/main/java/org/terracotta/dynamic_config/api/model/Setting.java
+++ b/dynamic-config/model/src/main/java/org/terracotta/dynamic_config/api/model/Setting.java
@@ -497,7 +497,7 @@ public enum Setting {
           when(CONFIGURING).allow(IMPORT).atLevel(NODE),
           when(CONFIGURING, ACTIVATED).allow(GET, SET, UNSET).atAnyLevels()
       ),
-      of(CLUSTER_RESTART),
+      of(NODE_RESTART),
       emptyList(),
       emptyList(),
       (key, value) -> PROPS_VALIDATOR.accept(SettingName.TC_PROPERTIES, tuple2(key, value))

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/AttachCommand1x2IT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/AttachCommand1x2IT.java
@@ -116,7 +116,7 @@ public class AttachCommand1x2IT extends DynamicConfigIT {
     // do a change requiring a restart
     assertThat(
         configTool("set", "-s", destination, "-c", "stripe.1.node.1.tc-properties.foo=bar"),
-        containsOutput("IMPORTANT: A restart of the cluster is required to apply the changes"));
+        containsOutput("IMPORTANT: A restart of nodes:"));
 
     // start a second node
     startNode(1, 2);

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/AttachCommand1x2IT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/AttachCommand1x2IT.java
@@ -125,7 +125,7 @@ public class AttachCommand1x2IT extends DynamicConfigIT {
     // try to attach this node to the cluster
     assertThat(
         configTool("attach", "-d", destination, "-s", "localhost:" + getNodePort(1, 2)),
-        containsOutput("is waiting to be restarted to apply some pending changes. You can run the command with the force option to force the commit, but at the risk of breaking this cluster configuration consistency. The newly added node will be restarted, but not the existing ones."));
+        containsOutput("is waiting to be restarted to apply some pending changes. Please refer to the Troubleshooting Guide for more help."));
 
     // try forcing the attach
     assertThat(configTool("attach", "-f", "-d", destination, "-s", "localhost:" + getNodePort(1, 2)), is(successful()));

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/AttachInConsistency1x2IT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/AttachInConsistency1x2IT.java
@@ -88,7 +88,7 @@ public class AttachInConsistency1x2IT extends DynamicConfigIT {
     // do a change requiring a restart
     assertThat(
         configTool("set", "-s", destination, "-c", "stripe.1.node.1.tc-properties.foo=bar"),
-        containsOutput("IMPORTANT: A restart of the cluster is required to apply the changes"));
+        containsOutput("IMPORTANT: A restart of nodes:"));
 
     // start a second node
     startNode(1, 2);

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/ConfigRepoIT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/ConfigRepoIT.java
@@ -39,14 +39,17 @@ public class ConfigRepoIT extends DynamicConfigIT {
     // runtime topology should be the same as upcoming one
     assertThat(getRuntimeCluster("localhost", getNodePort(1, 1)), is(equalTo(getUpcomingCluster("localhost", getNodePort(1, 2)))));
 
-    // trigger a change that requires a restart
+    // trigger a change that requires a restart on a specific node
     assertThat(configTool("set", "-s", "localhost:" + getNodePort(), "-c", "stripe.1.node.1.tc-properties.foo=bar"), is(successful()));
 
     // config repos written on disk should be the same
     assertThat(getUpcomingCluster("localhost", getNodePort(1, 1)), is(equalTo(getUpcomingCluster("localhost", getNodePort(1, 2)))));
-    // runtime topology should be the same
-    assertThat(getRuntimeCluster("localhost", getNodePort(1, 1)), is(equalTo(getRuntimeCluster("localhost", getNodePort(1, 2)))));
-    // runtime topology and upcoming one should be different
-    assertThat(getRuntimeCluster("localhost", getNodePort(1, 1)), is(not(equalTo(getUpcomingCluster("localhost", getNodePort(1, 2))))));
+    // runtime topology should not be the same because node 1 needs a restart
+    assertThat(getRuntimeCluster("localhost", getNodePort(1, 1)), is(not(equalTo(getRuntimeCluster("localhost", getNodePort(1, 2))))));
+
+    // runtime topology and upcoming one should be different on node 1
+    assertThat(getRuntimeCluster("localhost", getNodePort(1, 1)), is(not(equalTo(getUpcomingCluster("localhost", getNodePort(1, 1))))));
+    // runtime topology and upcoming one should be the same on node 2
+    assertThat(getRuntimeCluster("localhost", getNodePort(1, 2)), is(equalTo(getUpcomingCluster("localhost", getNodePort(1, 2)))));
   }
 }

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/DetachCommand1x2IT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/DetachCommand1x2IT.java
@@ -134,7 +134,7 @@ public class DetachCommand1x2IT extends DynamicConfigIT {
     // detaching an online node needs to be forced
     assertThat(
         configTool("detach", "-d", "localhost:" + getNodePort(1, activeId), "-s", "localhost:" + getNodePort(1, passiveId)),
-        containsOutput("Safely shutdown the nodes first"));
+        containsOutput("Nodes must be safely shutdown first. Please refer to the Troubleshooting Guide for more help."));
 
     assertThat(configTool("detach", "-d", "localhost:" + getNodePort(1, activeId), "-s", "localhost:" + getNodePort(1, passiveId), "-f"), is(successful()));
 

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/DetachCommand1x2IT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/DetachCommand1x2IT.java
@@ -108,14 +108,14 @@ public class DetachCommand1x2IT extends DynamicConfigIT {
     final int activeId = findActive(1).getAsInt();
     final int passiveId = findPassives(1)[0];
 
-    // do a change requiring a restart
+    // do a change requiring a restart on the remaining nodes
     assertThat(
-        configTool("set", "-s", "localhost:" + getNodePort(1, activeId), "-c", "stripe.1.node.1.tc-properties.foo=bar"),
-        containsOutput("IMPORTANT: A restart of the cluster is required to apply the changes"));
+        configTool("set", "-s", "localhost:" + getNodePort(1, activeId), "-c", "stripe.1.node." + activeId + ".tc-properties.foo=bar"),
+        containsOutput("IMPORTANT: A restart of nodes:"));
 
     stopNode(1, passiveId);
 
-    // try to detach this node
+    // try to detach the passive node
     assertThat(
         configTool("detach", "-d", "localhost:" + getNodePort(1, activeId), "-s", "localhost:" + getNodePort(1, passiveId)),
         both(not(successful())).and(containsOutput("Impossible to do any topology change")));

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/DetachCommand2x1IT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/DetachCommand2x1IT.java
@@ -21,8 +21,10 @@ import org.terracotta.dynamic_config.test_support.DynamicConfigIT;
 
 import java.time.Duration;
 
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.terracotta.angela.client.support.hamcrest.AngelaMatchers.containsOutput;
+import static org.terracotta.angela.client.support.hamcrest.AngelaMatchers.successful;
 
 /**
  * @author Mathieu Carbou
@@ -39,5 +41,29 @@ public class DetachCommand2x1IT extends DynamicConfigIT {
     assertThat(
         configTool("detach", "-t", "stripe", "-d", "localhost:" + getNodePort(2, 1), "-s", "localhost:" + getNodePort(1, 1)),
         containsOutput("Removing the leading stripe is not allowed"));
+  }
+
+  @Test
+  public void test_detach_stripe_from_activated_cluster_requiring_restart() throws Exception {
+    // do a change requiring a restart on the remaining nodes
+    assertThat(
+        configTool("set", "-s", "localhost:" + getNodePort(1, 1), "-c", "tc-properties.foo=bar"),
+        containsOutput("IMPORTANT: A restart of nodes:"));
+
+    assertThat(
+        configTool("detach", "-t", "stripe", "-d", "localhost:" + getNodePort(1, 1), "-s", "localhost:" + getNodePort(2, 1)),
+        containsOutput("Impossible to do any topology change."));
+  }
+
+  @Test
+  public void test_detach_stripe_requiring_restart_from_activated_cluster() throws Exception {
+    // do a change requiring a restart on the remaining nodes
+    assertThat(
+        configTool("set", "-s", "localhost:" + getNodePort(2, 1), "-c", "stripe.2.node.1.tc-properties.foo=bar"),
+        containsOutput("IMPORTANT: A restart of nodes:"));
+
+    assertThat(
+        configTool("detach", "-t", "stripe", "-d", "localhost:" + getNodePort(1, 1), "-s", "localhost:" + getNodePort(2, 1)),
+        is(successful()));
   }
 }

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/RepairCommand1x2IT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/RepairCommand1x2IT.java
@@ -76,7 +76,7 @@ public class RepairCommand1x2IT extends DynamicConfigIT {
     // cannot automatic repair since 1 node is down
     assertThat(
         configTool("repair", "-s", "localhost:" + getNodePort(1, activeId)),
-        containsOutput("Error: Please use the '-force' option to specify whether a commit or rollback is wanted."));
+        containsOutput("Some nodes are offline. Unable to determine what kind of repair to run. Please refer to the Troubleshooting Guide."));
 
     // forces a repair
     assertThat(

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/SetCommand1x1IT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/SetCommand1x1IT.java
@@ -206,7 +206,7 @@ public class SetCommand1x1IT extends DynamicConfigIT {
   public void testTcProperty() {
     assertThat(
         configTool("set", "-s", "localhost:" + getNodePort(), "-c", "tc-properties.foo=bar"),
-        containsOutput("IMPORTANT: A restart of the cluster is required to apply the changes"));
+        containsOutput("IMPORTANT: A restart of nodes:"));
 
     assertThat(
         configTool("get", "-r", "-s", "localhost:" + getNodePort(), "-c", "tc-properties"),

--- a/dynamic-config/testing/system-tests/src/test/resources/diagnostic-output/diagnostic5.txt
+++ b/dynamic-config/testing/system-tests/src/test/resources/diagnostic-output/diagnostic5.txt
@@ -5,7 +5,7 @@
  - Nodes online, configured and in repair: 0
  - Nodes online, new and being configured: 0
  - Nodes pending restart: 0
- - Configuration state: A new cluster configuration has been prepared but not yet committed or rolled back on online nodes. Some nodes are unreachable so we do not know if the last configuration change has been committed or rolled back on them. No further configuration change can be done until the 'repair' command is run to finalize the configuration change. If the unreachable nodes do not become available again, you might need to use the '-force' option to force a commit or rollback.
+ - Configuration state: A new cluster configuration has been prepared but not yet committed or rolled back on online nodes. Some nodes are unreachable so we do not know if the last configuration change has been committed or rolled back on them. No further configuration change can be done until the offline nodes are restarted and the 'repair' command is run again to finalize the configuration change. Please refer to the Troubleshooting Guide if needed.
 [node
  - Node state: UNREACHABLE
  - Node online, configured and activated: NO


### PR DESCRIPTION
- [X] Hide the `-force` option to the user and refer instead to the Troubleshooting Guide so that he does not mess up the cluster config
- [X] `tc-properties` change should only require the targeted node to restart
- [X] Correctly checking if a node must be restarted to correctly prevent attach/detach actions. Several issues found and fixed, such as detach stripe not working if a departing node had a runtime topology different than upcoming topology, attach/detach was not preventing of some nodes other than the destination had to be restarted
- [X] Fixing command usage to show multiple use of `-setting`