### PR TITLE
New `-auto-restart` option on set/unset commands

### DIFF
--- a/dynamic-config/api/src/main/java/org/terracotta/dynamic_config/api/service/DynamicConfigService.java
+++ b/dynamic-config/api/src/main/java/org/terracotta/dynamic_config/api/service/DynamicConfigService.java
@@ -65,6 +65,21 @@ public interface DynamicConfigService {
   void restart(Duration delay);
 
   /**
+   * Restart this not after the specified delay only if its physical server state is PASSIVE (the node could be blocked or not)
+   *
+   * @param delay initial delay before restart happens
+   */
+  void restartIfPassive(Duration delay);
+
+  /**
+   * Restart this not after the specified delay only if its physical server state is ACTIVE (the node could be blocked,
+   * in a reconnect window, or serving clients)
+   *
+   * @param delay initial delay before restart happens
+   */
+  void restartIfActive(Duration delay);
+
+  /**
    * Stops an activated node.
    * <p>
    * This method will zap and stop the node.

--- a/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/UnsetCommand.java
+++ b/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/UnsetCommand.java
@@ -17,6 +17,8 @@ package org.terracotta.dynamic_config.cli.config_tool.parsing;
 
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
+import org.terracotta.common.struct.Measure;
+import org.terracotta.common.struct.TimeUnit;
 import org.terracotta.dynamic_config.api.model.Configuration;
 import org.terracotta.dynamic_config.cli.api.command.Injector.Inject;
 import org.terracotta.dynamic_config.cli.api.command.UnsetAction;
@@ -25,12 +27,13 @@ import org.terracotta.dynamic_config.cli.command.Usage;
 import org.terracotta.dynamic_config.cli.converter.ConfigurationConverter;
 import org.terracotta.dynamic_config.cli.converter.InetSocketAddressConverter;
 import org.terracotta.dynamic_config.cli.converter.MultiConfigCommaSplitter;
+import org.terracotta.dynamic_config.cli.converter.TimeUnitConverter;
 
 import java.net.InetSocketAddress;
 import java.util.List;
 
 @Parameters(commandDescription = "Unset configuration properties")
-@Usage("-connect-to <hostname[:port]> -setting <[namespace:]property> -setting <[namespace:]property> ...")
+@Usage("-connect-to <hostname[:port]> -setting <[namespace:]property> -setting <[namespace:]property> ... [-auto-restart] [-restart-wait-time <restart-wait-time>] [-restart-delay <restart-delay>]")
 public class UnsetCommand extends Command {
 
   @Parameter(names = {"-connect-to"}, description = "Node to connect to", required = true, converter = InetSocketAddressConverter.class)
@@ -38,6 +41,15 @@ public class UnsetCommand extends Command {
 
   @Parameter(names = {"-setting"}, description = "Configuration properties", splitter = MultiConfigCommaSplitter.class, required = true, converter = ConfigurationConverter.class)
   List<Configuration> configurations;
+
+  @Parameter(names = {"-auto-restart"}, description = "If a change requires some nodes to be restarted, the command will try to restart them if there are at least 2 nodes online per stripe.")
+  boolean autoRestart = false;
+
+  @Parameter(names = {"-restart-wait-time"}, description = "Maximum time to wait for the nodes to restart. Default: 120s", converter = TimeUnitConverter.class)
+  Measure<TimeUnit> restartWaitTime = Measure.of(120, TimeUnit.SECONDS);
+
+  @Parameter(names = {"-restart-delay"}, description = "Delay before the server restarts itself. Default: 2s", converter = TimeUnitConverter.class)
+  Measure<TimeUnit> restartDelay = Measure.of(2, TimeUnit.SECONDS);
 
   @Inject
   public final UnsetAction action;
@@ -54,6 +66,9 @@ public class UnsetCommand extends Command {
   public void run() {
     action.setNode(node);
     action.setConfigurations(configurations);
+    action.setAutoRestart(autoRestart);
+    action.setRestartDelay(restartDelay);
+    action.setRestartWaitTime(restartWaitTime);
 
     action.run();
   }

--- a/dynamic-config/cli/dynamic-config-cli-api/src/main/java/org/terracotta/dynamic_config/cli/api/command/ConfigurationMutationAction.java
+++ b/dynamic-config/cli/dynamic-config-cli-api/src/main/java/org/terracotta/dynamic_config/cli/api/command/ConfigurationMutationAction.java
@@ -17,6 +17,8 @@ package org.terracotta.dynamic_config.cli.api.command;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.terracotta.common.struct.Measure;
+import org.terracotta.common.struct.TimeUnit;
 import org.terracotta.common.struct.Tuple2;
 import org.terracotta.diagnostic.client.connection.DiagnosticServices;
 import org.terracotta.diagnostic.model.LogicalServerState;
@@ -25,19 +27,31 @@ import org.terracotta.dynamic_config.api.model.Configuration;
 import org.terracotta.dynamic_config.api.model.Node.Endpoint;
 import org.terracotta.dynamic_config.api.model.Operation;
 import org.terracotta.dynamic_config.api.model.PropertyHolder;
+import org.terracotta.dynamic_config.api.model.Stripe;
 import org.terracotta.dynamic_config.api.model.UID;
 import org.terracotta.dynamic_config.api.model.nomad.MultiSettingNomadChange;
 import org.terracotta.dynamic_config.api.model.nomad.SettingNomadChange;
 import org.terracotta.dynamic_config.api.service.ClusterValidator;
 
 import java.net.InetSocketAddress;
+import java.time.Duration;
 import java.util.Collection;
+import java.util.EnumSet;
+import java.util.LinkedHashSet;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeSet;
 
 import static java.lang.System.lineSeparator;
+import static java.util.function.Function.identity;
 import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toMap;
+import static java.util.stream.Stream.concat;
+import static org.terracotta.diagnostic.model.LogicalServerState.ACTIVE;
+import static org.terracotta.diagnostic.model.LogicalServerState.ACTIVE_RECONNECTING;
+import static org.terracotta.diagnostic.model.LogicalServerState.PASSIVE;
+import static org.terracotta.diagnostic.model.LogicalServerState.UNREACHABLE;
 import static org.terracotta.dynamic_config.api.model.Requirement.CLUSTER_ONLINE;
 import static org.terracotta.dynamic_config.api.model.Requirement.CLUSTER_RESTART;
 import static org.terracotta.dynamic_config.api.model.Requirement.NODE_RESTART;
@@ -47,8 +61,24 @@ public abstract class ConfigurationMutationAction extends ConfigurationAction {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(ConfigurationMutationAction.class);
 
+  protected boolean autoRestart;
+  protected Measure<TimeUnit> restartWaitTime = Measure.of(120, TimeUnit.SECONDS);
+  protected Measure<TimeUnit> restartDelay = Measure.of(2, TimeUnit.SECONDS);
+
   protected ConfigurationMutationAction(Operation operation) {
     super(operation);
+  }
+
+  public void setAutoRestart(boolean autoRestart) {
+    this.autoRestart = autoRestart;
+  }
+
+  public void setRestartWaitTime(Measure<TimeUnit> restartWaitTime) {
+    this.restartWaitTime = restartWaitTime;
+  }
+
+  public void setRestartDelay(Measure<TimeUnit> restartDelay) {
+    this.restartDelay = restartDelay;
   }
 
   @Override
@@ -136,11 +166,15 @@ public abstract class ConfigurationMutationAction extends ConfigurationAction {
 
       // do we need to restart to apply the changes ?
       if (changes.getChanges().stream().map(SettingNomadChange::getSetting).anyMatch(setting -> setting.requires(CLUSTER_RESTART))) {
-        LOGGER.warn(lineSeparator() +
-            "====================================================================" + lineSeparator() +
-            "IMPORTANT: A restart of the cluster is required to apply the changes" + lineSeparator() +
-            "====================================================================" + lineSeparator());
-        output.out("restart required for cluster");
+        output.out("Restart required for cluster");
+        if(autoRestart) {
+          rollingRestart(updatedCluster, onlineNodes.keySet().stream().collect(toMap(Endpoint::getNodeName, identity())));
+        } else {
+          LOGGER.warn(lineSeparator() +
+              "====================================================================" + lineSeparator() +
+              "IMPORTANT: A manual restart of the cluster is required to apply the changes" + lineSeparator() +
+              "====================================================================" + lineSeparator());
+        }
       } else {
         final long numberOfDifferentSettingsToChange = configurations.stream()
             .map(Configuration::getSetting)
@@ -159,29 +193,36 @@ public abstract class ConfigurationMutationAction extends ConfigurationAction {
           // I.e. set log-dir + backup-dir
           // In that case, we might already have some nodes inside nodesRequiringRestart.
           // But we need to add into this collection the other nodes that are targeted AND could have vetoed a change to be applied at runtime
-          for (Endpoint endpoint : onlineNodes.keySet()) {
+          for (Endpoint endpoint : new LinkedHashSet<>(onlineNodes.keySet())) {
             try {
               if (targetedNodes.contains(endpoint.getNodeName()) && mustBeRestarted(endpoint)) {
                 nodesRequiringRestart.add(endpoint.getNodeName());
               }
             } catch (RuntimeException e) {
               // some nodes might have failed over and not be reachable anymore
-              LOGGER.warn("Node " + endpoint + " is not reachable anymore: {}", e.getMessage(), e);
+              LOGGER.warn("Node: " + endpoint + " is not reachable anymore: {}", e.getMessage(), e);
+              onlineNodes.remove(endpoint);
             }
           }
         }
 
         if (!nodesRequiringRestart.isEmpty()) {
-          LOGGER.warn(lineSeparator() +
-              "=======================================================================================" + lineSeparator() +
-              "IMPORTANT: A restart of nodes: " + toString(nodesRequiringRestart) + " is required to apply the changes" + lineSeparator() +
-              "=======================================================================================" + lineSeparator());
           List<InetSocketAddress> addresses = onlineNodes.keySet()
               .stream()
               .filter(endpoint -> nodesRequiringRestart.contains(endpoint.getNodeName()))
               .map(Endpoint::getAddress)
               .collect(toList());
-          output.out("restart required for nodes: {} ", toString(addresses));
+          output.out("Restart required for nodes: {} ", toString(addresses));
+          if(autoRestart) {
+            rollingRestart(updatedCluster, onlineNodes.keySet().stream()
+                .filter(endpoint -> nodesRequiringRestart.contains(endpoint.getNodeName()))
+                .collect(toMap(Endpoint::getNodeName, identity())));
+          } else {
+            LOGGER.warn(lineSeparator() +
+                "=======================================================================================" + lineSeparator() +
+                "IMPORTANT: A manual restart of nodes: " + toString(nodesRequiringRestart) + " is required to apply the changes" + lineSeparator() +
+                "=======================================================================================" + lineSeparator());
+          }
         }
       }
 
@@ -210,5 +251,84 @@ public abstract class ConfigurationMutationAction extends ConfigurationAction {
 
   private boolean requiresAllNodesAlive() {
     return configurations.stream().map(Configuration::getSetting).anyMatch(setting -> setting.requires(CLUSTER_ONLINE));
+  }
+
+  private void rollingRestart(Cluster cluster, Map<String, Endpoint> onlineNodesToRestart) {
+    // node that we cannot restart
+    Collection<Endpoint> cannotRestart = new LinkedHashSet<>();
+
+    // nodes that we will restart
+    Collection<Endpoint> actives = new LinkedList<>();
+    Collection<Endpoint> others = new LinkedList<>();
+
+    // first try to grasp the shape of the online topology
+    // to determine which nodes can be restarted
+    for (Stripe stripe : cluster.getStripes()) {
+      List<Endpoint> onlineNodesPerStripe = onlineNodesToRestart.values().stream().filter(endpoint -> stripe.containsNode(endpoint.getNodeName())).collect(toList());
+
+      if (onlineNodesPerStripe.isEmpty()) {
+        LOGGER.warn("No node in stripe '{}' seem to be online", stripe.getName());
+
+      } else if (onlineNodesPerStripe.size() == 1) {
+        Endpoint alone = onlineNodesPerStripe.get(0);
+        LOGGER.warn("Unable to restart node: {} in stripe '{}' because this is the only online node", alone, stripe.getName());
+        cannotRestart.add(alone);
+
+      } else {
+        for (Endpoint endpoint : onlineNodesPerStripe) {
+          // get the node state again (we are searching for actives)
+          LogicalServerState state = UNREACHABLE;
+          try {
+            state = getState(endpoint);
+          } catch (RuntimeException e) {
+            LOGGER.warn("Node: {} in stripe '{}' is not reachable anymore: {}", endpoint, stripe.getName(), e.getMessage(), e);
+            cannotRestart.add(endpoint);
+          }
+          if (state.isActive()) {
+            actives.add(endpoint);
+          } else {
+            others.add(endpoint);
+          }
+        }
+      }
+    }
+
+    // Restarting all but active nodes.
+    // We except the nodes to be restarted in either active or passive state.
+    // If not, the restart will throw.
+    // This is required because next step is to restart the remaining nodes...
+    // Which are active so we have to ensure that a passive not will be there to take over the active role
+    LOGGER.info("Restarting non active nodes: {}...", toString(others));
+    restartNodesIfPassives(
+        others,
+        Duration.ofMillis(restartWaitTime.getQuantity(TimeUnit.MILLISECONDS)),
+        Duration.ofMillis(restartDelay.getQuantity(TimeUnit.MILLISECONDS)),
+        EnumSet.of(ACTIVE, ACTIVE_RECONNECTING, PASSIVE));
+
+    // Restarting actives. This will trigger failovers and active will restart as passives.
+    LOGGER.info("Restarting active nodes: {}...", toString(actives));
+    restartNodesIfActives(
+        actives,
+        Duration.ofMillis(restartWaitTime.getQuantity(TimeUnit.MILLISECONDS)),
+        Duration.ofMillis(restartDelay.getQuantity(TimeUnit.MILLISECONDS)),
+        EnumSet.of(ACTIVE, ACTIVE_RECONNECTING, PASSIVE));
+
+    // let's check if some nodes were not restarted because their state has changed from the last time we got their state
+    concat(actives.stream(), others.stream())
+        .filter(endpoint -> {
+          try {
+            return mustBeRestarted(endpoint);
+          } catch (RuntimeException e) {
+            LOGGER.warn("Node: {} is not reachable anymore: {}", e.getMessage(), e);
+            return true;
+          }
+        }).forEach(cannotRestart::add);
+
+    if (!cannotRestart.isEmpty()) {
+      LOGGER.warn(lineSeparator() +
+          "=======================================================================================" + lineSeparator() +
+          "IMPORTANT: A manual restart of nodes: " + toString(cannotRestart) + " will be required to apply the changes" + lineSeparator() +
+          "=======================================================================================" + lineSeparator());
+    }
   }
 }

--- a/dynamic-config/cli/dynamic-config-cli-api/src/main/java/org/terracotta/dynamic_config/cli/api/command/RemoteAction.java
+++ b/dynamic-config/cli/dynamic-config-cli-api/src/main/java/org/terracotta/dynamic_config/cli/api/command/RemoteAction.java
@@ -352,11 +352,33 @@ public abstract class RemoteAction implements Runnable {
 
   protected final void restartNodes(Collection<Endpoint> endpoints, Duration maximumWaitTime, Duration restartDelay, Collection<LogicalServerState> acceptedStates) {
     LOGGER.trace("restartNodes({}, {})", endpoints, maximumWaitTime);
+    RestartProgress progress = restartService.restartNodes(
+        endpoints,
+        restartDelay,
+        acceptedStates);
+    followRestart(progress, endpoints, maximumWaitTime);
+  }
+
+  protected final void restartNodesIfActives(Collection<Endpoint> endpoints, Duration maximumWaitTime, Duration restartDelay, Collection<LogicalServerState> acceptedStates) {
+    LOGGER.trace("restartNodesIfActives({}, {})", endpoints, maximumWaitTime);
+    RestartProgress progress = restartService.restartNodesIfActives(
+        endpoints,
+        restartDelay,
+        acceptedStates);
+    followRestart(progress, endpoints, maximumWaitTime);
+  }
+
+  protected final void restartNodesIfPassives(Collection<Endpoint> endpoints, Duration maximumWaitTime, Duration restartDelay, Collection<LogicalServerState> acceptedStates) {
+    LOGGER.trace("restartNodesIfPassives({}, {})", endpoints, maximumWaitTime);
+    RestartProgress progress = restartService.restartNodesIfPassives(
+        endpoints,
+        restartDelay,
+        acceptedStates);
+    followRestart(progress, endpoints, maximumWaitTime);
+  }
+
+  private void followRestart(RestartProgress progress, Collection<Endpoint> endpoints, Duration maximumWaitTime) {
     try {
-      RestartProgress progress = restartService.restartNodes(
-          endpoints,
-          restartDelay,
-          acceptedStates);
       progress.getErrors().forEach((address, e) -> LOGGER.warn("Unable to ask node: {} to restart: please restart it manually.", address));
       progress.onRestarted((endpoint, state) -> output.info("Node: {} has restarted in state: {}", endpoint, state));
       Map<Endpoint, LogicalServerState> restarted = progress.await(maximumWaitTime);

--- a/dynamic-config/cli/dynamic-config-cli-api/src/main/java/org/terracotta/dynamic_config/cli/api/restart/RestartService.java
+++ b/dynamic-config/cli/dynamic-config-cli-api/src/main/java/org/terracotta/dynamic_config/cli/api/restart/RestartService.java
@@ -64,6 +64,18 @@ public class RestartService {
    * To detect that a node has been restarted, we will wait until the node reaches one of the status given.
    */
   public RestartProgress restartNodes(Collection<Node.Endpoint> endpoints, Duration restartDelay, Collection<LogicalServerState> acceptedStates) {
+    return restartNodes(endpoints, restartDelay, acceptedStates, DynamicConfigService::restart);
+  }
+
+  public RestartProgress restartNodesIfActives(Collection<Node.Endpoint> endpoints, Duration restartDelay, Collection<LogicalServerState> acceptedStates) {
+    return restartNodes(endpoints, restartDelay, acceptedStates, DynamicConfigService::restartIfActive);
+  }
+
+  public RestartProgress restartNodesIfPassives(Collection<Node.Endpoint> endpoints, Duration restartDelay, Collection<LogicalServerState> acceptedStates) {
+    return restartNodes(endpoints, restartDelay, acceptedStates, DynamicConfigService::restartIfPassive);
+  }
+
+  private RestartProgress restartNodes(Collection<Node.Endpoint> endpoints, Duration restartDelay, Collection<LogicalServerState> acceptedStates, BiConsumer<DynamicConfigService, Duration> restart) {
     if (restartDelay.getSeconds() < 1) {
       throw new IllegalArgumentException("Restart delay must be at least 1 second");
     }
@@ -80,7 +92,7 @@ public class RestartService {
     for (Node.Endpoint endpoint : endpoints) {
       // this call should be pretty fast and should not timeout if restart delay is long enough
       try (DiagnosticService diagnosticService = diagnosticServiceProvider.fetchDiagnosticService(endpoint.getAddress())) {
-        diagnosticService.getProxy(DynamicConfigService.class).restart(restartDelay);
+        restart.accept(diagnosticService.getProxy(DynamicConfigService.class), restartDelay);
         restartRequested.add(endpoint);
       } catch (Exception e) {
         // timeout should not occur with a restart delay. Any error is recorded an we won't wait for this node to restart

--- a/dynamic-config/model/src/main/java/org/terracotta/dynamic_config/api/service/ClusterValidator.java
+++ b/dynamic-config/model/src/main/java/org/terracotta/dynamic_config/api/service/ClusterValidator.java
@@ -18,6 +18,7 @@ package org.terracotta.dynamic_config.api.service;
 import org.terracotta.dynamic_config.api.model.Cluster;
 import org.terracotta.dynamic_config.api.model.FailoverPriority;
 import org.terracotta.dynamic_config.api.model.Node;
+import org.terracotta.dynamic_config.api.model.Scope;
 import org.terracotta.dynamic_config.api.model.Setting;
 import org.terracotta.dynamic_config.api.model.Stripe;
 import org.terracotta.dynamic_config.api.model.UID;
@@ -42,7 +43,7 @@ import static org.terracotta.dynamic_config.api.model.Setting.SECURITY_WHITELIST
 import static org.terracotta.dynamic_config.api.model.Version.V2;
 
 /**
- * This class expects all the fields to be first validated by {@link Setting#validate(String)}.
+ * This class expects all the fields to be first validated by {@link Setting#validate(String, String, Scope)}.
  * <p>
  * This class will validate the complete cluster object (inter-field checks and dependency checks).
  */

--- a/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/service/AuditService.java
+++ b/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/service/AuditService.java
@@ -70,6 +70,18 @@ public class AuditService implements DynamicConfigService {
   }
 
   @Override
+  public void restartIfPassive(Duration delay) {
+    server.audit("RestartIfPassive invoked", new Properties());
+    dynamicConfigService.restartIfPassive(delay);
+  }
+
+  @Override
+  public void restartIfActive(Duration delay) {
+    server.audit("RestartIfActive invoked", new Properties());
+    dynamicConfigService.restartIfActive(delay);
+  }
+
+  @Override
   public void stop(Duration delayInSeconds) {
     server.audit("Stop invoked", new Properties());
     dynamicConfigService.stop(delayInSeconds);

--- a/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/service/DynamicConfigServiceImpl.java
+++ b/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/service/DynamicConfigServiceImpl.java
@@ -368,11 +368,29 @@ public class DynamicConfigServiceImpl implements TopologyService, DynamicConfigS
   }
 
   @Override
-  public void restart(Duration delayInSeconds) {
-    LOGGER.info("Will restart node in {} seconds", delayInSeconds.getSeconds());
-    runAfterDelay(delayInSeconds, () -> {
+  public void restart(Duration delay) {
+    LOGGER.info("Will restart node in {} seconds", delay.getSeconds());
+    runAfterDelay(delay, () -> {
       LOGGER.info("Restarting node");
       server.stop(RESTART);
+    });
+  }
+
+  @Override
+  public void restartIfPassive(Duration delay) {
+    LOGGER.info("Will restart node in {} seconds (if passive)", delay.getSeconds());
+    runAfterDelay(delay, () -> {
+      LOGGER.info("Restarting node");
+      server.stopIfPassive(RESTART);
+    });
+  }
+
+  @Override
+  public void restartIfActive(Duration delay) {
+    LOGGER.info("Will restart node in {} seconds (if active)", delay.getSeconds());
+    runAfterDelay(delay, () -> {
+      LOGGER.info("Restarting node");
+      server.stopIfActive(RESTART);
     });
   }
 

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/AttachCommand1x2IT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/AttachCommand1x2IT.java
@@ -116,7 +116,7 @@ public class AttachCommand1x2IT extends DynamicConfigIT {
     // do a change requiring a restart
     assertThat(
         configTool("set", "-s", destination, "-c", "stripe.1.node.1.tc-properties.foo=bar"),
-        containsOutput("IMPORTANT: A restart of nodes:"));
+        containsOutput("Restart required for nodes:"));
 
     // start a second node
     startNode(1, 2);

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/AttachInConsistency1x2IT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/AttachInConsistency1x2IT.java
@@ -88,7 +88,7 @@ public class AttachInConsistency1x2IT extends DynamicConfigIT {
     // do a change requiring a restart
     assertThat(
         configTool("set", "-s", destination, "-c", "stripe.1.node.1.tc-properties.foo=bar"),
-        containsOutput("IMPORTANT: A restart of nodes:"));
+        containsOutput("Restart required for nodes:"));
 
     // start a second node
     startNode(1, 2);

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/DetachCommand1x2IT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/DetachCommand1x2IT.java
@@ -111,7 +111,7 @@ public class DetachCommand1x2IT extends DynamicConfigIT {
     // do a change requiring a restart on the remaining nodes
     assertThat(
         configTool("set", "-s", "localhost:" + getNodePort(1, activeId), "-c", "stripe.1.node." + activeId + ".tc-properties.foo=bar"),
-        containsOutput("IMPORTANT: A restart of nodes:"));
+        containsOutput("Restart required for nodes:"));
 
     stopNode(1, passiveId);
 
@@ -134,7 +134,7 @@ public class DetachCommand1x2IT extends DynamicConfigIT {
     // do a change requiring a restart on the remaining nodes
     assertThat(
         configTool("set", "-s", "localhost:" + getNodePort(1, passiveId), "-c", "stripe.1.node." + passiveId + ".tc-properties.foo=bar"),
-        containsOutput("IMPORTANT: A restart of nodes:"));
+        containsOutput("Restart required for nodes:"));
 
     stopNode(1, passiveId);
 

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/DetachCommand2x1IT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/DetachCommand2x1IT.java
@@ -48,7 +48,7 @@ public class DetachCommand2x1IT extends DynamicConfigIT {
     // do a change requiring a restart on the remaining nodes
     assertThat(
         configTool("set", "-s", "localhost:" + getNodePort(1, 1), "-c", "tc-properties.foo=bar"),
-        containsOutput("IMPORTANT: A restart of nodes:"));
+        containsOutput("Restart required for nodes:"));
 
     assertThat(
         configTool("detach", "-t", "stripe", "-d", "localhost:" + getNodePort(1, 1), "-s", "localhost:" + getNodePort(2, 1)),
@@ -60,7 +60,7 @@ public class DetachCommand2x1IT extends DynamicConfigIT {
     // do a change requiring a restart on the remaining nodes
     assertThat(
         configTool("set", "-s", "localhost:" + getNodePort(2, 1), "-c", "stripe.2.node.1.tc-properties.foo=bar"),
-        containsOutput("IMPORTANT: A restart of nodes:"));
+        containsOutput("Restart required for nodes:"));
 
     assertThat(
         configTool("detach", "-t", "stripe", "-d", "localhost:" + getNodePort(1, 1), "-s", "localhost:" + getNodePort(2, 1)),

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/SetCommand1x1IT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/SetCommand1x1IT.java
@@ -150,7 +150,7 @@ public class SetCommand1x1IT extends DynamicConfigIT {
   public void setNodeLogDir() {
     assertThat(
         configTool("set", "-s", "localhost:" + getNodePort(), "-c", "log-dir=logs/stripe1"),
-        containsOutput("IMPORTANT: A restart of nodes: node-1-1 is required to apply the changes"));
+        containsOutput("Restart required for nodes:"));
 
     assertThat(
         configTool("get", "-s", "localhost:" + getNodePort(), "-c", "log-dir"),
@@ -206,7 +206,7 @@ public class SetCommand1x1IT extends DynamicConfigIT {
   public void testTcProperty() {
     assertThat(
         configTool("set", "-s", "localhost:" + getNodePort(), "-c", "tc-properties.foo=bar"),
-        containsOutput("IMPORTANT: A restart of nodes:"));
+        containsOutput("Restart required for nodes:"));
 
     assertThat(
         configTool("get", "-r", "-s", "localhost:" + getNodePort(), "-c", "tc-properties"),
@@ -244,12 +244,12 @@ public class SetCommand1x1IT extends DynamicConfigIT {
     String clusterName = usingTopologyService(1, 1, topologyService -> topologyService.getUpcomingNodeContext().getCluster().getName());
     assertThat(
         configTool("set", "-s", "localhost:" + getNodePort(), "-c", "cluster-name=new-name"),
-        not(containsOutput("IMPORTANT: A restart of the cluster is required to apply the changes")));
+        not(containsOutput("Restart required for cluster")));
     assertThat(configTool("diagnostic", "-s", "localhost:" + getNodePort(1, 1)),
         allOf(containsOutput("Node restart required: NO"), containsOutput("Node last configuration change details: set cluster-name=new-name")));
 
     assertThat(configTool("set", "-s", "localhost:" + getNodePort(), "-c", "cluster-name=" + clusterName),
-        not(containsOutput("IMPORTANT: A restart of the cluster is required to apply the changes")));
+        not(containsOutput("Restart required for cluster")));
     assertThat(configTool("diagnostic", "-s", "localhost:" + getNodePort(1, 1)),
         allOf(containsOutput("Node restart required: NO"), containsOutput("Node last configuration change details: set cluster-name=" + clusterName)));
   }

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/SetCommand2x3IT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/SetCommand2x3IT.java
@@ -26,9 +26,11 @@ import java.util.stream.Stream;
 import static java.util.function.Predicate.isEqual;
 import static java.util.stream.IntStream.rangeClosed;
 import static java.util.stream.Stream.concat;
+import static org.hamcrest.Matchers.both;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
+import static org.terracotta.angela.client.support.hamcrest.AngelaMatchers.containsOutput;
 import static org.terracotta.angela.client.support.hamcrest.AngelaMatchers.successful;
 
 @ClusterDefinition(stripes = 2, nodesPerStripe = 3, autoActivate = true)
@@ -39,7 +41,7 @@ public class SetCommand2x3IT extends DynamicConfigIT {
   }
 
   @Test
-  public void testAutoRestart() throws InterruptedException {
+  public void testAutoRestart() {
     int passiveId = findPassives(1)[0];
     stopNode(1, passiveId); // simulate a node down
     String exclude = "stripe.1.node." + passiveId + ".tc-properties.foo=bar";
@@ -55,7 +57,7 @@ public class SetCommand2x3IT extends DynamicConfigIT {
             .flatMap(cfg -> Stream.of("-setting", cfg))
     ).toArray(String[]::new);
 
-    assertThat(configTool(cli), is(successful()));
+    assertThat(configTool(cli), both(is(successful())).and(containsOutput("Restart required for nodes:")));
 
     for (int s = 1; s <= 2; s++) {
       for (int n = 1; n <= 3; n++) {

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/SetCommand2x3IT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/SetCommand2x3IT.java
@@ -37,7 +37,7 @@ import static org.terracotta.angela.client.support.hamcrest.AngelaMatchers.succe
 public class SetCommand2x3IT extends DynamicConfigIT {
 
   public SetCommand2x3IT() {
-    super(Duration.ofMinutes(4));
+    super(Duration.ofMinutes(5));
   }
 
   @Test

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/SetCommand2x3IT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/SetCommand2x3IT.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.dynamic_config.system_tests.activated;
+
+import org.junit.Test;
+import org.terracotta.dynamic_config.api.service.TopologyService;
+import org.terracotta.dynamic_config.test_support.ClusterDefinition;
+import org.terracotta.dynamic_config.test_support.DynamicConfigIT;
+
+import java.time.Duration;
+import java.util.stream.Stream;
+
+import static java.util.function.Predicate.isEqual;
+import static java.util.stream.IntStream.rangeClosed;
+import static java.util.stream.Stream.concat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.terracotta.angela.client.support.hamcrest.AngelaMatchers.successful;
+
+@ClusterDefinition(stripes = 2, nodesPerStripe = 3, autoActivate = true)
+public class SetCommand2x3IT extends DynamicConfigIT {
+
+  public SetCommand2x3IT() {
+    super(Duration.ofMinutes(4));
+  }
+
+  @Test
+  public void testAutoRestart() throws InterruptedException {
+    int passiveId = findPassives(1)[0];
+    stopNode(1, passiveId); // simulate a node down
+    String exclude = "stripe.1.node." + passiveId + ".tc-properties.foo=bar";
+
+    String[] cli = concat(
+        Stream.of(
+            "set",
+            "-auto-restart",
+            "-connect-to", "localhost:" + getNodePort(2, 1)),
+        rangeClosed(1, 2).boxed().flatMap(stripeId -> rangeClosed(1, 3)
+            .mapToObj(nodeId -> "stripe." + stripeId + ".node." + nodeId + ".tc-properties.foo=bar"))
+            .filter(isEqual(exclude).negate())
+            .flatMap(cfg -> Stream.of("-setting", cfg))
+    ).toArray(String[]::new);
+
+    assertThat(configTool(cli), is(successful()));
+
+    for (int s = 1; s <= 2; s++) {
+      for (int n = 1; n <= 3; n++) {
+        if (s != 1 && n != passiveId) {
+          assertFalse(usingTopologyService(s, n, TopologyService::mustBeRestarted));
+        }
+      }
+    }
+  }
+}

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/network_disrupted/AttachInConsistency1x3IT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/network_disrupted/AttachInConsistency1x3IT.java
@@ -47,12 +47,17 @@ public class AttachInConsistency1x3IT extends DynamicConfigIT {
   public final NodeOutputRule out = new NodeOutputRule();
 
   public AttachInConsistency1x3IT() {
-    super(Duration.ofSeconds(300));
+    super(Duration.ofMinutes(5));
   }
 
   @Override
   protected FailoverPriority getFailoverPriority() {
     return FailoverPriority.consistency();
+  }
+
+  @Override
+  protected Duration getAssertTimeout() {
+    return Duration.ofMinutes(2);
   }
 
   @Before


### PR DESCRIPTION
New `-auto-restart` option on set/unset commands to automatically execute a rolling restart of the nodes after a setting change. After the rolling restart is done, a verification is done on the nodes to make sure they have restarted.
- Option is not active by default
- Executed only on stripes with 2 nodes or more
- Calling first `stopIfPassive(RESTART)`, then `stopIfActive(RESTART)`
- If some nodes have crashed or not restarted, issue a big warning to the user asking him to manually restart those nodes

Example with a 2x3 cluster with node-1-1 that is down:

```bash
❯  config-tool.sh -t 30s -r 30s set -auto-restart -connect-to localhost:44374 \
    -setting stripe.1.node.2.tc-properties.foo=bar \
    -setting stripe.1.node.3.tc-properties.foo=bar \
    -setting stripe.2.node.1.tc-properties.foo=bar \
    -setting stripe.2.node.2.tc-properties.foo=bar \
    -setting stripe.2.node.3.tc-properties.foo=bar
Connecting to: node-1-1@localhost:13040, node-1-2@localhost:13261, node-1-3@localhost:25358, node-2-1@localhost:44374, node-2-2@localhost:43615, node-2-3@localhost:14684 (this can take time if some nodes are not reachable)
 - node-1-1@localhost:13040 is not reachable
Applying new configuration change(s) to activated cluster: node-1-2@localhost:13261, node-1-3@localhost:25358, node-2-1@localhost:44374, node-2-2@localhost:43615, node-2-3@localhost:14684
Restarting non active nodes: node-1-2@localhost:13261, node-2-1@localhost:44374, node-2-2@localhost:43615...
Node: node-1-2@localhost:13261 has restarted in state: PASSIVE
Node: node-2-1@localhost:44374 has restarted in state: PASSIVE
Node: node-2-2@localhost:43615 has restarted in state: PASSIVE
Restarting active nodes: node-1-3@localhost:25358, node-2-3@localhost:14684...
Node: node-2-3@localhost:14684 has restarted in state: PASSIVE
Node: node-1-3@localhost:25358 has restarted in state: PASSIVE
Command successful!
```