### PR TITLE
Use InetSocketAddress#getHostString() instead of InetSocketAddress#getHostName()

### DIFF
--- a/common/inet-support/src/main/java/org/terracotta/inet/InetSocketAddressConverter.java
+++ b/common/inet-support/src/main/java/org/terracotta/inet/InetSocketAddressConverter.java
@@ -95,10 +95,10 @@ public class InetSocketAddressConverter {
   }
 
   public static String toHostPort(InetSocketAddress address) {
-    if (isValidIPv6(address.getHostName(), false)) {
-      return "[" + address.getHostName() + "]" + ":" + address.getPort();
+    if (isValidIPv6(address.getHostString(), false)) {
+      return "[" + address.getHostString() + "]" + ":" + address.getPort();
     } else {
-      return address.getHostName() + ":" + address.getPort();
+      return address.getHostString() + ":" + address.getPort();
     }
   }
 }

--- a/common/inet-support/src/main/java/org/terracotta/inet/InetSocketAddressUtils.java
+++ b/common/inet-support/src/main/java/org/terracotta/inet/InetSocketAddressUtils.java
@@ -27,8 +27,8 @@ public class InetSocketAddressUtils {
   }
 
   public static InetSocketAddress encloseInBracketsIfIpv6(InetSocketAddress address) {
-    if (address != null && isValidIPv6(address.getHostName(), false)) {
-      address = InetSocketAddress.createUnresolved("[" + address.getHostName() + "]", address.getPort());
+    if (address != null && isValidIPv6(address.getHostString(), false)) {
+      address = InetSocketAddress.createUnresolved("[" + address.getHostString() + "]", address.getPort());
     }
     return address;
   }

--- a/management/cluster-topology/src/test/java/org/terracotta/management/model/cluster/ClusterTest.java
+++ b/management/cluster-topology/src/test/java/org/terracotta/management/model/cluster/ClusterTest.java
@@ -173,8 +173,6 @@ public class ClusterTest extends AbstractTest {
 
   @Test
   public void test_add_remove_server_entity() {
-    System.out.println(ClientIdentifier.discoverHostName());
-
     Server server = cluster1.stripeStream().findAny().get().getActiveServer().get();
 
     assertEquals(1, server.getServerEntityCount());

--- a/management/management-model/src/main/java/org/terracotta/management/model/cluster/ClientIdentifier.java
+++ b/management/management-model/src/main/java/org/terracotta/management/model/cluster/ClientIdentifier.java
@@ -15,16 +15,9 @@
  */
 package org.terracotta.management.model.cluster;
 
-import java.io.ByteArrayOutputStream;
-import java.io.InputStream;
 import java.io.Serializable;
 import java.lang.management.ManagementFactory;
-import java.net.InetAddress;
-import java.net.NetworkInterface;
-import java.net.UnknownHostException;
-import java.util.Enumeration;
 import java.util.Objects;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
@@ -121,14 +114,8 @@ public final class ClientIdentifier implements Serializable {
     return new ClientIdentifier(pid, hostAddress, name, uuid);
   }
 
-  public static ClientIdentifier create(String name, String logicalConnectionUid) {
-    try {
-      InetAddress inetAddress = discoverLANAddress();
-      return new ClientIdentifier(discoverPID(), inetAddress.getHostAddress(), name, logicalConnectionUid);
-    } catch (UnknownHostException e) {
-      return new ClientIdentifier(discoverPID(), "127.0.0.1", name, logicalConnectionUid);
-    }
-
+  public static ClientIdentifier create(String hostname, String name, String logicalConnectionUid) {
+    return new ClientIdentifier(discoverPID(), hostname, name, logicalConnectionUid);
   }
 
   public static ClientIdentifier valueOf(String identifier) {
@@ -155,49 +142,6 @@ public final class ClientIdentifier implements Serializable {
     }
   }
 
-  static String discoverHostName() {
-    String hostname = null;
-
-    try {
-      String procname = "hostname";
-      if (System.getProperty("os.name", "").toLowerCase().contains("win")) {
-        procname += ".exe";
-      }
-      Process process = Runtime.getRuntime().exec(procname);
-      if (process.waitFor() == 0) {
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        InputStream in = process.getInputStream();
-        int r;
-        while ((r = in.read()) != -1) {
-          baos.write(r);
-        }
-        in.close();
-        hostname = new String(baos.toByteArray(), "UTF-8");
-      }
-    } catch (Exception e) {
-      // if anything goes wrong, just ignore
-      if (LOGGER.isLoggable(Level.FINEST)) {
-        LOGGER.log(Level.FINEST, "ERR getHostName(): " + e.getMessage(), e);
-      }
-    }
-
-    if (hostname != null) {
-      return hostname;
-    }
-
-    try {
-      InetAddress address = discoverLANAddress();
-      String resolved = address.getCanonicalHostName();
-      if (!address.getHostAddress().equals(resolved)) {
-        // this check is ok, getCanonicalHostName() does return getHostAddress() in case of failure
-        hostname = resolved;
-      }
-    } catch (Exception ignored) {
-    }
-
-    return hostname;
-  }
-
   static long discoverPID() {
     String name = ManagementFactory.getRuntimeMXBean().getName();
     long pid = 0;
@@ -205,79 +149,5 @@ public final class ClientIdentifier implements Serializable {
       pid = pid * 10 + Character.getNumericValue(name.charAt(i));
     }
     return pid;
-  }
-
-  /**
-   * http://stackoverflow.com/questions/9481865/getting-the-ip-address-of-the-current-machine-using-java
-   * <p>
-   * Returns an <code>InetAddress</code> object encapsulating what is most likely the machine's LAN IP address.
-   * <p>
-   * This method is intended for use as a replacement of JDK method <code>InetAddress.getLocalHost</code>, because
-   * that method is ambiguous on Linux systems. Linux systems enumerate the loopback network interface the same
-   * way as regular LAN network interfaces, but the JDK <code>InetAddress.getLocalHost</code> method does not
-   * specify the algorithm used to select the address returned under such circumstances, and will often return the
-   * loopback address, which is not valid for network communication. Details
-   * <a href="http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=4665037">here</a>.
-   * <p>
-   * This method will scan all IP addresses on all network interfaces on the host machine to determine the IP address
-   * most likely to be the machine's LAN address. If the machine has multiple IP addresses, this method will prefer
-   * a site-local IP address (e.g. 192.168.x.x or 10.10.x.x, usually IPv4) if the machine has one (and will return the
-   * first site-local address if the machine has more than one), but if the machine does not hold a site-local
-   * address, this method will return simply the first non-loopback address found (IPv4 or IPv6).
-   * <p>
-   * If this method cannot find a non-loopback address using this selection algorithm, it will fall back to
-   * calling and returning the result of JDK method <code>InetAddress.getLocalHost</code>.
-   * <p>
-   *
-   * @throws UnknownHostException If the LAN address of the machine cannot be found.
-   */
-  static InetAddress discoverLANAddress() throws UnknownHostException {
-    InetAddress inetAddress = InetAddress.getLocalHost();
-    if (!inetAddress.isLoopbackAddress() && inetAddress.isSiteLocalAddress()) {
-      return inetAddress;
-    }
-
-    try {
-      InetAddress candidateAddress = null;
-      // Iterate all NICs (network interface cards)...
-      for (Enumeration<NetworkInterface> ifaces = NetworkInterface.getNetworkInterfaces(); ifaces.hasMoreElements(); ) {
-        NetworkInterface iface = ifaces.nextElement();
-        // Iterate all IP addresses assigned to each card...
-        for (Enumeration<InetAddress> inetAddrs = iface.getInetAddresses(); inetAddrs.hasMoreElements(); ) {
-          InetAddress inetAddr = inetAddrs.nextElement();
-          if (!inetAddr.isLoopbackAddress()) {
-
-            if (inetAddr.isSiteLocalAddress()) {
-              // Found non-loopback site-local address. Return it immediately...
-              return inetAddr;
-            } else if (candidateAddress == null) {
-              // Found non-loopback address, but not necessarily site-local.
-              // Store it as a candidate to be returned if site-local address is not subsequently found...
-              candidateAddress = inetAddr;
-              // Note that we don't repeatedly assign non-loopback non-site-local addresses as candidates,
-              // only the first. For subsequent iterations, candidate will be non-null.
-            }
-          }
-        }
-      }
-      if (candidateAddress != null) {
-        // We did not find a site-local address, but we found some other non-loopback address.
-        // Server might have a non-site-local address assigned to its NIC (or it might be running
-        // IPv6 which deprecates the "site-local" concept).
-        // Return this non-loopback candidate address...
-        return candidateAddress;
-      }
-      // At this point, we did not find a non-loopback address.
-      // Fall back to returning whatever InetAddress.getLocalHost() returns...
-      InetAddress jdkSuppliedAddress = InetAddress.getLocalHost();
-      if (jdkSuppliedAddress == null) {
-        throw new UnknownHostException("The JDK InetAddress.getLocalHost() method unexpectedly returned null.");
-      }
-      return jdkSuppliedAddress;
-    } catch (Exception e) {
-      UnknownHostException unknownHostException = new UnknownHostException("Failed to determine LAN address: " + e);
-      unknownHostException.initCause(e);
-      throw unknownHostException;
-    }
   }
 }

--- a/management/management-model/src/test/java/org/terracotta/management/model/cluster/ClientIdentifierTest.java
+++ b/management/management-model/src/test/java/org/terracotta/management/model/cluster/ClientIdentifierTest.java
@@ -23,7 +23,6 @@ import java.lang.management.ManagementFactory;
 import java.net.UnknownHostException;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
 
 /**
  * @author Mathieu Carbou
@@ -33,15 +32,13 @@ public class ClientIdentifierTest {
 
   @Test
   public void test_identifier() throws UnknownHostException {
-    ClientIdentifier identifier = ClientIdentifier.create("my-app", "uid");
+    ClientIdentifier identifier = ClientIdentifier.create("127.0.0.1", "my-app", "uid");
     System.out.println(identifier);
 
     assertEquals(Long.parseLong(ManagementFactory.getRuntimeMXBean().getName().split("@")[0]), identifier.getPid());
-    assertNotEquals("127.0.0.1", identifier.getHostAddress());
+    assertEquals("127.0.0.1", identifier.getHostAddress());
 
-    assertEquals(ClientIdentifier.create("my-app", "uid"), identifier);
-    assertEquals(ClientIdentifier.create(ClientIdentifier.discoverPID(), ClientIdentifier.discoverLANAddress().getHostAddress(), "my-app", "uid"), identifier);
-    assertEquals(ClientIdentifier.valueOf(ClientIdentifier.discoverPID() + "@" + ClientIdentifier.discoverLANAddress().getHostAddress() + ":my-app:uid"), identifier);
+    assertEquals(ClientIdentifier.create("127.0.0.1", "my-app", "uid"), identifier);
 
     identifier = ClientIdentifier.valueOf("123@127.0.0.1:jetty:app:3");
     assertEquals("123@127.0.0.1:jetty:app:3", identifier.getClientId());


### PR DESCRIPTION
Because:
- getHostName() may trigger a dns call
- we want to keep user input as much as possible and getHostName() could return something different than the user provided value

This code was extracted a while ago from EE to be re-used in DC. This code is also used in EE.
If some places **REALLY** need at one point to use a resolved address, I think this is up to these places to ask for the address to be resolved.