### PR TITLE
Inline config-tool calls in DC system tests

### DIFF
--- a/dynamic-config/cli/cli-support/src/main/java/org/terracotta/dynamic_config/cli/command/LocalMainCommand.java
+++ b/dynamic-config/cli/cli-support/src/main/java/org/terracotta/dynamic_config/cli/command/LocalMainCommand.java
@@ -32,9 +32,9 @@ public class LocalMainCommand extends Command {
 
   @Override
   public void run() {
-    Logger rootLogger = (Logger) LoggerFactory.getLogger(ROOT_LOGGER_NAME);
-
     if (verbose) {
+      Logger rootLogger = (Logger) LoggerFactory.getLogger(ROOT_LOGGER_NAME);
+
       ConsoleAppender<ILoggingEvent> appender = (ConsoleAppender<ILoggingEvent>) rootLogger.getAppender("STDERR");
       PatternLayoutEncoder ple = new PatternLayoutEncoder();
       ple.setPattern("%d{yyyy-MM-dd HH:mm:ss.SSS} %-5p %c{1}:%L - %msg%n");

--- a/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/command/CommandProvider.java
+++ b/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/command/CommandProvider.java
@@ -17,6 +17,7 @@
 package org.terracotta.dynamic_config.cli.config_tool.command;
 
 import com.tc.util.ManagedServiceLoader;
+import org.terracotta.dynamic_config.cli.api.command.Configuration;
 import org.terracotta.dynamic_config.cli.command.Command;
 import org.terracotta.dynamic_config.cli.config_tool.parsing.RemoteMainCommand;
 
@@ -25,7 +26,7 @@ import java.util.Map;
 
 public interface CommandProvider {
 
-  RemoteMainCommand getMainCommand();
+  RemoteMainCommand getMainCommand(Configuration configuration);
 
   Map<String, Command> getCommands();
 

--- a/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/command/OssCommandProvider.java
+++ b/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/command/OssCommandProvider.java
@@ -15,6 +15,7 @@
  */
 package org.terracotta.dynamic_config.cli.config_tool.command;
 
+import org.terracotta.dynamic_config.cli.api.command.Configuration;
 import org.terracotta.dynamic_config.cli.command.Command;
 import org.terracotta.dynamic_config.cli.config_tool.parsing.ActivateCommand;
 import org.terracotta.dynamic_config.cli.config_tool.parsing.AttachCommand;
@@ -52,8 +53,8 @@ import static java.util.Collections.unmodifiableMap;
 public class OssCommandProvider implements CommandProvider {
 
   @Override
-  public RemoteMainCommand getMainCommand() {
-    return new RemoteMainCommand();
+  public RemoteMainCommand getMainCommand(Configuration configuration) {
+    return new RemoteMainCommand(configuration);
   }
 
   @Override

--- a/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/RemoteMainCommand.java
+++ b/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/RemoteMainCommand.java
@@ -41,10 +41,6 @@ public class RemoteMainCommand extends LocalMainCommand {
 
   private final Configuration configuration;
 
-  public RemoteMainCommand() {
-    this(new Configuration());
-  }
-
   public RemoteMainCommand(Configuration configuration) {
     this.configuration = configuration;
   }

--- a/dynamic-config/cli/dynamic-config-cli-api/src/main/java/org/terracotta/dynamic_config/cli/api/command/Configuration.java
+++ b/dynamic-config/cli/dynamic-config-cli-api/src/main/java/org/terracotta/dynamic_config/cli/api/command/Configuration.java
@@ -17,6 +17,7 @@ package org.terracotta.dynamic_config.cli.api.command;
 
 import org.terracotta.common.struct.Measure;
 import org.terracotta.common.struct.TimeUnit;
+import org.terracotta.dynamic_config.cli.api.output.OutputService;
 
 public class Configuration {
 
@@ -25,6 +26,19 @@ public class Configuration {
   private Measure<TimeUnit> connectionTimeout = Measure.of(10, TimeUnit.SECONDS);
   private String securityRootDirectory;
   private String lockToken;
+  private OutputService outputService;
+
+  public Configuration(OutputService outputService) {
+    this.outputService = outputService;
+  }
+
+  public OutputService getOutputService() {
+    return outputService;
+  }
+
+  public void setOutputService(OutputService outputService) {
+    this.outputService = outputService;
+  }
 
   public void setEntityOperationTimeout(Measure<TimeUnit> entityOperationTimeout) {
     this.entityOperationTimeout = entityOperationTimeout;

--- a/dynamic-config/cli/dynamic-config-cli-api/src/main/java/org/terracotta/dynamic_config/cli/api/command/ExportAction.java
+++ b/dynamic-config/cli/dynamic-config-cli-api/src/main/java/org/terracotta/dynamic_config/cli/api/command/ExportAction.java
@@ -26,11 +26,9 @@ import org.terracotta.dynamic_config.cli.api.converter.OutputFormat;
 import org.terracotta.dynamic_config.cli.api.output.FileOutputService;
 import org.terracotta.json.ObjectMapperFactory;
 
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.io.UncheckedIOException;
-import java.io.UnsupportedEncodingException;
 import java.net.InetSocketAddress;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -97,8 +95,12 @@ public class ExportAction extends RemoteAction {
         throw new UncheckedIOException(e);
       }
     }
-    output.out(out);
-    output.info("Command successful!");
+    try {
+      output.out(out);
+      output.info("Command successful!");
+    } finally {
+      output.close();
+    }
   }
 
   private String buildOutput(Cluster cluster, OutputFormat outputFormat) {

--- a/dynamic-config/cli/dynamic-config-cli-api/src/main/java/org/terracotta/dynamic_config/cli/api/command/OssServiceProvider.java
+++ b/dynamic-config/cli/dynamic-config-cli-api/src/main/java/org/terracotta/dynamic_config/cli/api/command/OssServiceProvider.java
@@ -25,8 +25,8 @@ import org.terracotta.dynamic_config.api.model.UID;
 import org.terracotta.dynamic_config.cli.api.nomad.DefaultNomadManager;
 import org.terracotta.dynamic_config.cli.api.nomad.LockAwareNomadManager;
 import org.terracotta.dynamic_config.cli.api.nomad.NomadManager;
+import org.terracotta.dynamic_config.cli.api.output.ConsoleOutputService;
 import org.terracotta.dynamic_config.cli.api.output.OutputService;
-import org.terracotta.dynamic_config.cli.api.output.StreamOutputService;
 import org.terracotta.dynamic_config.cli.api.restart.RestartService;
 import org.terracotta.dynamic_config.cli.api.stop.StopService;
 import org.terracotta.json.ObjectMapperFactory;
@@ -57,7 +57,7 @@ public class OssServiceProvider implements ServiceProvider {
   }
 
   protected OutputService createOutputService() {
-    return new StreamOutputService();
+    return new ConsoleOutputService();
   }
 
   protected StopService createStopService(Configuration config) {

--- a/dynamic-config/cli/dynamic-config-cli-api/src/main/java/org/terracotta/dynamic_config/cli/api/command/OssServiceProvider.java
+++ b/dynamic-config/cli/dynamic-config-cli-api/src/main/java/org/terracotta/dynamic_config/cli/api/command/OssServiceProvider.java
@@ -25,7 +25,6 @@ import org.terracotta.dynamic_config.api.model.UID;
 import org.terracotta.dynamic_config.cli.api.nomad.DefaultNomadManager;
 import org.terracotta.dynamic_config.cli.api.nomad.LockAwareNomadManager;
 import org.terracotta.dynamic_config.cli.api.nomad.NomadManager;
-import org.terracotta.dynamic_config.cli.api.output.ConsoleOutputService;
 import org.terracotta.dynamic_config.cli.api.output.OutputService;
 import org.terracotta.dynamic_config.cli.api.restart.RestartService;
 import org.terracotta.dynamic_config.cli.api.stop.StopService;
@@ -53,11 +52,12 @@ public class OssServiceProvider implements ServiceProvider {
         createStopService(config),
         createObjectMapperFactory(config),
         createNomadEntityProvider(config),
-        createOutputService());
+        createOutputService(config));
   }
 
-  protected OutputService createOutputService() {
-    return new ConsoleOutputService();
+  protected OutputService createOutputService(Configuration config) {
+    // we could enhance the output service if we want
+    return config.getOutputService();
   }
 
   protected StopService createStopService(Configuration config) {

--- a/dynamic-config/cli/dynamic-config-cli-api/src/main/java/org/terracotta/dynamic_config/cli/api/output/ConsoleOutputService.java
+++ b/dynamic-config/cli/dynamic-config-cli-api/src/main/java/org/terracotta/dynamic_config/cli/api/output/ConsoleOutputService.java
@@ -15,29 +15,19 @@
  */
 package org.terracotta.dynamic_config.cli.api.output;
 
-import java.io.FileNotFoundException;
-import java.io.PrintStream;
-import java.io.UnsupportedEncodingException;
-import java.nio.charset.Charset;
-import java.nio.file.Path;
+public class ConsoleOutputService extends StreamOutputService {
 
-public class FileOutputService extends StreamOutputService {
-
-  private final Path path;
-
-  public FileOutputService(Path path) throws FileNotFoundException, UnsupportedEncodingException {
-    super(new PrintStream(path.toFile(), Charset.defaultCharset().name()), System.err);
-    this.path = path;
+  public ConsoleOutputService() {
+    super(System.out, System.err);
   }
 
   @Override
   public void close() {
-    out.close();
-    // do not close err stream
+    // do not close anything
   }
 
   @Override
   public String toString() {
-    return "file:" + path;
+    return "console";
   }
 }

--- a/dynamic-config/cli/dynamic-config-cli-api/src/main/java/org/terracotta/dynamic_config/cli/api/output/InMemoryOutputService.java
+++ b/dynamic-config/cli/dynamic-config-cli-api/src/main/java/org/terracotta/dynamic_config/cli/api/output/InMemoryOutputService.java
@@ -20,6 +20,7 @@ import org.slf4j.helpers.MessageFormatter;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.StringTokenizer;
 
 public class InMemoryOutputService implements OutputService {
 
@@ -48,6 +49,10 @@ public class InMemoryOutputService implements OutputService {
 
   @Override
   public synchronized void out(String format, Object... args) {
-    lines.add(MessageFormatter.arrayFormat(format, args).getMessage());
+    // Split using both Windows and UNIX line separators
+    StringTokenizer st = new StringTokenizer(MessageFormatter.arrayFormat(format, args).getMessage(), "\n\r");
+    while (st.hasMoreTokens()) {
+      lines.add(st.nextToken());
+    }
   }
 }

--- a/dynamic-config/cli/dynamic-config-cli-api/src/main/java/org/terracotta/dynamic_config/cli/api/output/InMemoryOutputService.java
+++ b/dynamic-config/cli/dynamic-config-cli-api/src/main/java/org/terracotta/dynamic_config/cli/api/output/InMemoryOutputService.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.dynamic_config.cli.api.output;
+
+import org.slf4j.helpers.MessageFormatter;
+
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+
+public class InMemoryOutputService implements OutputService {
+
+  private final List<String> lines;
+
+  public InMemoryOutputService() {
+    this(new LinkedList<>());
+  }
+
+  public InMemoryOutputService(List<String> buffer) {
+    this.lines = buffer;
+  }
+
+  public synchronized void clear() {
+    lines.clear();
+  }
+
+  public synchronized List<String> getOutput() {
+    return new ArrayList<>(lines);
+  }
+
+  @Override
+  public synchronized String toString() {
+    return "memory";
+  }
+
+  @Override
+  public synchronized void out(String format, Object... args) {
+    lines.add(MessageFormatter.arrayFormat(format, args).getMessage());
+  }
+}

--- a/dynamic-config/cli/dynamic-config-cli-api/src/main/java/org/terracotta/dynamic_config/cli/api/output/LoggingOutputService.java
+++ b/dynamic-config/cli/dynamic-config-cli-api/src/main/java/org/terracotta/dynamic_config/cli/api/output/LoggingOutputService.java
@@ -30,4 +30,14 @@ public class LoggingOutputService implements OutputService {
   public void info(String format, Object... args) {
     LOGGER.info(format, args);
   }
+
+  @Override
+  public void warn(String format, Object... args) {
+    LOGGER.warn(format, args);
+  }
+
+  @Override
+  public String toString() {
+    return "logging";
+  }
 }

--- a/dynamic-config/cli/dynamic-config-cli-api/src/main/java/org/terracotta/dynamic_config/cli/api/output/StreamOutputService.java
+++ b/dynamic-config/cli/dynamic-config-cli-api/src/main/java/org/terracotta/dynamic_config/cli/api/output/StreamOutputService.java
@@ -21,24 +21,37 @@ import java.io.PrintStream;
 
 public class StreamOutputService implements OutputService {
 
-  private final PrintStream outStream;
-  private final PrintStream errStream;
+  protected final PrintStream out;
+  protected final PrintStream err;
 
-  public StreamOutputService() {
-    outStream = System.out;
-    errStream = System.err;
+  public StreamOutputService(PrintStream out, PrintStream err) {
+    this.out = out;
+    this.err = err;
   }
 
-  public StreamOutputService(PrintStream outStream, PrintStream errStream) {
-    this.outStream = outStream;
-    this.errStream = errStream;
-  }
-
+  @Override
   public void out(String format, Object... args) {
-    outStream.println(MessageFormatter.arrayFormat(format, args).getMessage());
+    out.println(MessageFormatter.arrayFormat(format, args).getMessage());
   }
 
+  @Override
   public void info(String format, Object... args) {
-    errStream.println(MessageFormatter.arrayFormat(format, args).getMessage());
+    err.println(MessageFormatter.arrayFormat(format, args).getMessage());
+  }
+
+  @Override
+  public void warn(String format, Object... args) {
+    err.println(MessageFormatter.arrayFormat(format, args).getMessage());
+  }
+
+  @Override
+  public void close() {
+    out.close();
+    err.close();
+  }
+
+  @Override
+  public String toString() {
+    return "streaming";
   }
 }

--- a/dynamic-config/cli/dynamic-config-cli-api/src/test/java/org/terracotta/dynamic_config/cli/api/BaseTest.java
+++ b/dynamic-config/cli/dynamic-config-cli-api/src/test/java/org/terracotta/dynamic_config/cli/api/BaseTest.java
@@ -32,8 +32,8 @@ import org.terracotta.dynamic_config.api.service.DynamicConfigService;
 import org.terracotta.dynamic_config.api.service.TopologyService;
 import org.terracotta.dynamic_config.cli.api.nomad.DefaultNomadManager;
 import org.terracotta.dynamic_config.cli.api.nomad.NomadManager;
+import org.terracotta.dynamic_config.cli.api.output.ConsoleOutputService;
 import org.terracotta.dynamic_config.cli.api.output.OutputService;
-import org.terracotta.dynamic_config.cli.api.output.StreamOutputService;
 import org.terracotta.dynamic_config.cli.api.restart.RestartService;
 import org.terracotta.dynamic_config.cli.api.stop.StopService;
 import org.terracotta.json.ObjectMapperFactory;
@@ -118,7 +118,7 @@ public abstract class BaseTest {
     nomadManager = new DefaultNomadManager<>(new NomadEnvironment(), multiDiagnosticServiceProvider, nomadEntityProvider);
     restartService = new RestartService(diagnosticServiceProvider, concurrencySizing);
     stopService = new StopService(diagnosticServiceProvider, concurrencySizing);
-    outputService = new StreamOutputService();
+    outputService = new ConsoleOutputService();
   }
 
   protected DiagnosticService diagnosticServiceMock(String host, int port) {

--- a/dynamic-config/cli/upgrade-tools/src/main/java/org/terracotta/dynamic_config/cli/upgrade_tools/config_converter/ConfigConverterTool.java
+++ b/dynamic-config/cli/upgrade-tools/src/main/java/org/terracotta/dynamic_config/cli/upgrade_tools/config_converter/ConfigConverterTool.java
@@ -19,7 +19,7 @@ import com.beust.jcommander.ParameterException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terracotta.dynamic_config.cli.api.command.Injector;
-import org.terracotta.dynamic_config.cli.api.output.StreamOutputService;
+import org.terracotta.dynamic_config.cli.api.output.ConsoleOutputService;
 import org.terracotta.dynamic_config.cli.command.Command;
 import org.terracotta.dynamic_config.cli.command.CustomJCommander;
 import org.terracotta.dynamic_config.cli.command.LocalMainCommand;
@@ -62,7 +62,7 @@ public class ConfigConverterTool {
         return true;
       }
       // validate and run the real command
-      Injector.inject(command, Collections.singletonList(new StreamOutputService()));
+      Injector.inject(command, Collections.singletonList(new ConsoleOutputService()));
       command.run();
       return true;
     }).orElseGet(() -> {

--- a/dynamic-config/cli/upgrade-tools/src/main/java/org/terracotta/dynamic_config/cli/upgrade_tools/config_converter/ConfigConverterTool.java
+++ b/dynamic-config/cli/upgrade-tools/src/main/java/org/terracotta/dynamic_config/cli/upgrade_tools/config_converter/ConfigConverterTool.java
@@ -20,6 +20,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terracotta.dynamic_config.cli.api.command.Injector;
 import org.terracotta.dynamic_config.cli.api.output.ConsoleOutputService;
+import org.terracotta.dynamic_config.cli.api.output.OutputService;
 import org.terracotta.dynamic_config.cli.command.Command;
 import org.terracotta.dynamic_config.cli.command.CustomJCommander;
 import org.terracotta.dynamic_config.cli.command.LocalMainCommand;
@@ -32,21 +33,17 @@ import java.util.Map;
 public class ConfigConverterTool {
   private static final Logger LOGGER = LoggerFactory.getLogger(ConfigConverterTool.class);
 
-  public static void main(String... args) {
-    try {
-      ConfigConverterTool.start(args);
-    } catch (Exception e) {
-      String message = e.getMessage();
-      if (LOGGER.isDebugEnabled() || (message == null || message.isEmpty())) {
-        LOGGER.error("Error:", e);
-      } else {
-        LOGGER.error("Error: {}", message);
-      }
-      System.exit(1);
-    }
+  private final OutputService outputService;
+
+  public ConfigConverterTool() {
+    this(new ConsoleOutputService());
   }
 
-  public static void start(String... args) {
+  public ConfigConverterTool(OutputService outputService) {
+    this.outputService = outputService;
+  }
+
+  public void run(String... args) {
     LOGGER.debug("Parsing command-line arguments");
     Map<String, Command> commands = Collections.singletonMap("convert", new ConvertCommand());
     Map<String, Command> depCommands = Collections.singletonMap("convert", new DeprecatedConvertCommand());
@@ -62,7 +59,7 @@ public class ConfigConverterTool {
         return true;
       }
       // validate and run the real command
-      Injector.inject(command, Collections.singletonList(new ConsoleOutputService()));
+      Injector.inject(command, Collections.singletonList(outputService));
       command.run();
       return true;
     }).orElseGet(() -> {
@@ -70,6 +67,20 @@ public class ConfigConverterTool {
       jCommander.usage();
       return false;
     });
+  }
+
+  public static void main(String... args) {
+    try {
+      new ConfigConverterTool().run(args);
+    } catch (Exception e) {
+      String message = e.getMessage();
+      if (LOGGER.isDebugEnabled() || (message == null || message.isEmpty())) {
+        LOGGER.error("Error:", e);
+      } else {
+        LOGGER.error("Error: {}", message);
+      }
+      System.exit(1);
+    }
   }
 
   private static CustomJCommander<LocalMainCommand> parseArguments(Map<String, Command> commands, Map<String, Command> deprecatedCommands, String[] args) {

--- a/dynamic-config/cli/upgrade-tools/src/test/java/org/terracotta/dynamic_config/cli/upgrade_tools/config_converter/ConfigConverterTest.java
+++ b/dynamic-config/cli/upgrade-tools/src/test/java/org/terracotta/dynamic_config/cli/upgrade_tools/config_converter/ConfigConverterTest.java
@@ -33,7 +33,7 @@ public class ConfigConverterTest {
   public void test_conversion_fail_cluster_name_missing() {
     exceptionRule.expect(ParameterException.class);
     exceptionRule.expectMessage("Cluster name is required for conversion into a configuration directory");
-    ConfigConverterTool.start("convert",
+    new ConfigConverterTool().run("convert",
         "-c", "src/test/resources/tc-config.xml",
         "-d", tmpDir.getRoot().resolve("generated-configs").toAbsolutePath().toString(),
         "-f");
@@ -43,7 +43,7 @@ public class ConfigConverterTest {
   public void test_conversion_fail_already_existing_dir() {
     exceptionRule.expect(ParameterException.class);
     exceptionRule.expectMessage("Please specify a non-existent directory");
-    ConfigConverterTool.start("convert",
+    new ConfigConverterTool().run("convert",
         "-c", "src/test/resources/tc-config.xml",
         "-n", "my-cluster",
         "-d", tmpDir.getRoot().toAbsolutePath().toString(),

--- a/dynamic-config/testing/support/pom.xml
+++ b/dynamic-config/testing/support/pom.xml
@@ -32,6 +32,11 @@
   <dependencies>
     <dependency>
       <groupId>org.terracotta.dynamic-config.cli</groupId>
+      <artifactId>dynamic-config-cli-config-tool</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.terracotta.dynamic-config.cli</groupId>
       <artifactId>dynamic-config-cli-upgrade-tools</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/ConfigConversionIT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/ConfigConversionIT.java
@@ -58,7 +58,7 @@ public class ConfigConversionIT {
 
   @Test
   public void test_basic_conversion() {
-    ConfigConverterTool.start("convert",
+    new ConfigConverterTool().run("convert",
         "-c", "src/test/resources/conversion/tc-config-1.xml",
         "-n", "my-cluster",
         "-t", "properties",
@@ -89,7 +89,7 @@ public class ConfigConversionIT {
 
   @Test
   public void test_server_defaults() {
-    ConfigConverterTool.start("convert",
+    new ConfigConverterTool().run("convert",
         "-c", "src/test/resources/conversion/tc-config-4.xml",
         "-n", "my-cluster",
         "-t", "properties",
@@ -113,7 +113,7 @@ public class ConfigConversionIT {
 
   @Test
   public void testWithoutOffheap() {
-    ConfigConverterTool.start("convert",
+    new ConfigConverterTool().run("convert",
         "-c", "src/test/resources/conversion/tc-config-3.xml",
         "-n", "my-cluster",
         "-t", "properties",
@@ -130,7 +130,7 @@ public class ConfigConversionIT {
   @Test
   public void test_conversion_fail_due_to_relative_paths_and_not_forcing_conversion() {
     exceptionRule.expect(RuntimeException.class);
-    ConfigConverterTool.start("convert",
+    new ConfigConverterTool().run("convert",
         "-c", "src/test/resources/conversion/tc-config.xml",
         "-n", "my-cluster",
         "-d", tmpDir.getRoot().resolve("generated-configs").toAbsolutePath().toString());
@@ -140,7 +140,7 @@ public class ConfigConversionIT {
   public void test_conversion_no_server_element() {
     exceptionRule.expect(RuntimeException.class);
     exceptionRule.expectMessage("No server specified.");
-    ConfigConverterTool.start("convert",
+    new ConfigConverterTool().run("convert",
         "-c", "src/test/resources/conversion/tc-config-1_no_server_element.xml",
         "-n", "my-cluster",
         "-t", "properties",
@@ -150,7 +150,7 @@ public class ConfigConversionIT {
 
   @Test
   public void testConversionWithPlaceHolders() {
-    ConfigConverterTool.start("convert",
+    new ConfigConverterTool().run("convert",
         "-c", "src/test/resources/conversion/tc-config-1.xml",
         "-n", "my-cluster",
         "-t", "properties",
@@ -165,7 +165,7 @@ public class ConfigConversionIT {
 
   @Test
   public void testConversionWithLeaseMissingInConfig() {
-    ConfigConverterTool.start("convert",
+    new ConfigConverterTool().run("convert",
         "-c", "src/test/resources/conversion/tc-config-1_default_lease_failover_and_reconnect_window.xml",
         "-n", "cluster_default_lease_failover_reconnect_window",
         "-t", "properties",
@@ -180,7 +180,7 @@ public class ConfigConversionIT {
 
   @Test
   public void testConversionWithoutFailoverPriority() {
-    ConfigConverterTool.start("convert",
+    new ConfigConverterTool().run("convert",
         "-c", "src/test/resources/conversion/tc-config-1_default_lease_failover_and_reconnect_window.xml",
         "-n", "cluster_default_lease_failover_reconnect_window",
         "-t", "properties",
@@ -194,7 +194,7 @@ public class ConfigConversionIT {
 
   @Test
   public void testConversionWithoutClientReconnectWindow() {
-    ConfigConverterTool.start("convert",
+    new ConfigConverterTool().run("convert",
         "-c", "src/test/resources/conversion/tc-config-1_default_lease_failover_and_reconnect_window.xml",
         "-n", "cluster_default_lease_failover_reconnect_window",
         "-t", "properties",
@@ -209,7 +209,7 @@ public class ConfigConversionIT {
 
   @Test
   public void testConversionWithLease() {
-    ConfigConverterTool.start("convert",
+    new ConfigConverterTool().run("convert",
         "-c", "src/test/resources/conversion/tc-config-1_lease_failover_and_reconnect_window.xml",
         "-n", "cluster_lease_failover_reconnect_window",
         "-t", "properties",
@@ -223,7 +223,7 @@ public class ConfigConversionIT {
 
   @Test
   public void testConversionWithFailoverPriority() {
-    ConfigConverterTool.start("convert",
+    new ConfigConverterTool().run("convert",
         "-c", "src/test/resources/conversion/tc-config-1_lease_failover_and_reconnect_window.xml",
         "-n", "cluster_lease_failover_reconnect_window",
         "-t", "properties",
@@ -237,7 +237,7 @@ public class ConfigConversionIT {
 
   @Test
   public void testConversionWithClientReconnectWindow() {
-    ConfigConverterTool.start("convert",
+    new ConfigConverterTool().run("convert",
         "-c", "src/test/resources/conversion/tc-config-1_lease_failover_and_reconnect_window.xml",
         "-n", "cluster_lease_failover_reconnect_window",
         "-t", "properties",
@@ -251,7 +251,7 @@ public class ConfigConversionIT {
 
   @Test
   public void testNodePort() {
-    ConfigConverterTool.start("convert",
+    new ConfigConverterTool().run("convert",
         "-c", "src/test/resources/conversion/tc-config-1_default_lease_failover_and_reconnect_window.xml",
         "-n", "cluster-port-bind-address",
         "-t", "properties",
@@ -265,7 +265,7 @@ public class ConfigConversionIT {
 
   @Test
   public void testNodeBindAddress() {
-    ConfigConverterTool.start("convert",
+    new ConfigConverterTool().run("convert",
         "-c", "src/test/resources/conversion/tc-config-1_default_lease_failover_and_reconnect_window.xml",
         "-n", "cluster-port-bind-address",
         "-t", "properties",
@@ -279,7 +279,7 @@ public class ConfigConversionIT {
 
   @Test
   public void testNodeGroupPort() {
-    ConfigConverterTool.start("convert",
+    new ConfigConverterTool().run("convert",
         "-c", "src/test/resources/conversion/tc-config-1_default_lease_failover_and_reconnect_window.xml",
         "-n", "cluster-group-port-group-bind-address",
         "-t", "properties",
@@ -293,7 +293,7 @@ public class ConfigConversionIT {
 
   @Test
   public void testNodeGroupBindAddress() {
-    ConfigConverterTool.start("convert",
+    new ConfigConverterTool().run("convert",
         "-c", "src/test/resources/conversion/tc-config-1_default_lease_failover_and_reconnect_window.xml",
         "-n", "cluster-group-port-group-bind-address",
         "-t", "properties",
@@ -307,7 +307,7 @@ public class ConfigConversionIT {
 
   @Test
   public void testLogDir() {
-    ConfigConverterTool.start("convert",
+    new ConfigConverterTool().run("convert",
         "-c", "src/test/resources/conversion/tc-config-1_default_lease_failover_and_reconnect_window.xml",
         "-n", "cluster-log-dir-tc-prop",
         "-t", "properties",
@@ -321,7 +321,7 @@ public class ConfigConversionIT {
 
   @Test
   public void testTcProperty() {
-    ConfigConverterTool.start("convert",
+    new ConfigConverterTool().run("convert",
         "-c", "src/test/resources/conversion/tc-config-1_default_lease_failover_and_reconnect_window.xml",
         "-n", "cluster-log-dir-tc-prop",
         "-t", "properties",
@@ -336,7 +336,7 @@ public class ConfigConversionIT {
 
   @Test
   public void test_conversion_with_explicit_repository_option() throws Exception {
-    ConfigConverterTool.start("convert",
+    new ConfigConverterTool().run("convert",
         "-c", "src/test/resources/conversion/tc-config.xml",
         "-n", "my-cluster",
         "-t", "directory",
@@ -349,7 +349,7 @@ public class ConfigConversionIT {
 
   @Test
   public void test_conversion_with_repository_option() throws Exception {
-    ConfigConverterTool.start("convert",
+    new ConfigConverterTool().run("convert",
         "-c", "src/test/resources/conversion/tc-config.xml",
         "-n", "my-cluster",
         "-d", tmpDir.getRoot().resolve("generated-configs").toAbsolutePath().toString(),

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/SetCommand1x1IT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/SetCommand1x1IT.java
@@ -106,7 +106,7 @@ public class SetCommand1x1IT extends DynamicConfigIT {
   public void setFailoverPriority_Consistency() {
     assertThat(
         configTool("set", "-s", "localhost:" + getNodePort(), "-c", "failover-priority=consistency:2"),
-        containsOutput("restart of the cluster is required"));
+        containsOutput("Restart required for cluster"));
 
     assertThat(
         configTool("get", "-s", "localhost:" + getNodePort(), "-c", "failover-priority"),
@@ -117,7 +117,7 @@ public class SetCommand1x1IT extends DynamicConfigIT {
   public void setClusterAndNodeRestartRequiringChangesInOneCommand() {
     assertThat(
         configTool("set", "-s", "localhost:" + getNodePort(), "-c", "failover-priority=consistency:2", "-c", "log-dir=new-logs"),
-        allOf(containsOutput("restart of the cluster is required"), not(containsOutput("restart of nodes"))));
+        allOf(containsOutput("Restart required for cluster"), not(containsOutput("Restart required for nodes:"))));
 
     assertThat(
         configTool("get", "-s", "localhost:" + getNodePort(), "-c", "failover-priority", "-c", "log-dir"),
@@ -128,7 +128,7 @@ public class SetCommand1x1IT extends DynamicConfigIT {
   public void setClusterAndNoRestartRequiringChangesInOneCommand() {
     assertThat(
         configTool("set", "-s", "localhost:" + getNodePort(), "-c", "failover-priority=consistency:2", "-c", "cluster-name=new-cluster"),
-        allOf(containsOutput("restart of the cluster is required"), not(containsOutput("restart of nodes"))));
+        allOf(containsOutput("Restart required for cluster"), not(containsOutput("Restart required for nodes:"))));
 
     assertThat(
         configTool("get", "-s", "localhost:" + getNodePort(), "-c", "failover-priority", "-c", "cluster-name"),
@@ -139,7 +139,7 @@ public class SetCommand1x1IT extends DynamicConfigIT {
   public void setNodeAndNoRestartRequiringChangesInOneCommand() {
     assertThat(
         configTool("set", "-s", "localhost:" + getNodePort(), "-c", "log-dir=new-logs", "-c", "cluster-name=new-cluster"),
-        allOf(not(containsOutput("restart of the cluster is required")), containsOutput("restart of nodes")));
+        allOf(not(containsOutput("Restart required for cluster")), containsOutput("Restart required for nodes: ")));
 
     assertThat(
         configTool("get", "-s", "localhost:" + getNodePort(), "-c", "cluster-name", "-c", "log-dir"),

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/diagnostic/Ipv6ConfigIT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/diagnostic/Ipv6ConfigIT.java
@@ -36,11 +36,13 @@ public class Ipv6ConfigIT extends DynamicConfigIT {
 
   @Test
   public void testStartupFromConfigFileAndExportCommand() {
+    Path file = tmpDir.getRoot().resolve("output.json");
+
     Path configurationFile = copyConfigProperty("/config-property-files/single-stripe_multi-node_ipv6.properties");
     startNode(1, 1, "-f", configurationFile.toString(), "-s", "[::1]", "-p", String.valueOf(getNodePort()), "-r", "config/stripe1/node-1-1");
     waitForDiagnostic(1, 1);
 
-    assertThat(configTool("export", "-s", "[::1]:" + getNodePort(), "-f", "output.json", "-t", "json"), is(successful()));
+    assertThat(configTool("export", "-s", "[::1]:" + getNodePort(), "-f", file.toString(), "-t", "json"), is(successful()));
     stopNode(1, 1);
 
     startNode(1, 1, "-f", configurationFile.toString(), "-s", "::1", "-p", String.valueOf(getNodePort()), "-r", "config/stripe1/node-1-1");


### PR DESCRIPTION
**OutputService refactoring:**

- cleanup hierarchy
- introduced `OutputService#close()`
- introduced `OutputService#then(OutputService)`
- introduced `ConsoleOutputService`
- introduced `InMemoryOutputService`

**Fix:** 
- unclosed file output stream when using `FileOutputService`

**ConfigTool and ConfigConverterTool now support the injection of an OutputService**

**DC system tests are now using inline config-tool invocations**