### PR TITLE
Validate DC object names to prevent the use of special words or characters 

### DIFF
--- a/dynamic-config/cli/upgrade-tools/src/main/java/org/terracotta/dynamic_config/cli/upgrade_tools/config_converter/ConfigPropertiesProcessor.java
+++ b/dynamic-config/cli/upgrade-tools/src/main/java/org/terracotta/dynamic_config/cli/upgrade_tools/config_converter/ConfigPropertiesProcessor.java
@@ -15,6 +15,7 @@
  */
 package org.terracotta.dynamic_config.cli.upgrade_tools.config_converter;
 
+import org.terracotta.config.data_roots.DataDirsConfig;
 import org.terracotta.dynamic_config.api.model.Cluster;
 import org.terracotta.dynamic_config.api.service.Props;
 
@@ -34,7 +35,7 @@ public class ConfigPropertiesProcessor {
 
   public ConfigPropertiesProcessor(Path outputDir, String fileName) {
     this.outputDir = outputDir;
-    this.fileName = fileName == null ? "cluster" : fileName;
+    this.fileName = fileName == null ? "cluster" : DataDirsConfig.cleanStringForPath(fileName);
   }
 
   public void process(Cluster cluster) {

--- a/dynamic-config/cli/upgrade-tools/src/main/java/org/terracotta/dynamic_config/cli/upgrade_tools/config_converter/xml/NonSubstitutingTCConfigurationParser.java
+++ b/dynamic-config/cli/upgrade-tools/src/main/java/org/terracotta/dynamic_config/cli/upgrade_tools/config_converter/xml/NonSubstitutingTCConfigurationParser.java
@@ -27,6 +27,7 @@ import org.terracotta.config.TCConfigurationParser;
 import org.terracotta.config.TCConfigurationSetupException;
 import org.terracotta.config.TcConfig;
 import org.terracotta.config.TcConfiguration;
+import org.terracotta.config.data_roots.DataDirsConfig;
 import org.terracotta.config.service.ExtendedConfigParser;
 import org.terracotta.config.service.ServiceConfigParser;
 import org.terracotta.entity.ServiceProviderConfiguration;
@@ -249,7 +250,7 @@ public class NonSubstitutingTCConfigurationParser {
   private static void initializeNameAndHost(Server server) {
     if (server.getHost() == null || server.getHost().trim().length() == 0) {
       if (server.getName() == null) {
-        server.setHost("%i");
+        throw new IllegalStateException("Conversion process requires all servers to be named");
       } else {
         server.setHost(server.getName());
       }
@@ -257,7 +258,7 @@ public class NonSubstitutingTCConfigurationParser {
 
     if (server.getName() == null || server.getName().trim().length() == 0) {
       int tsaPort = server.getTsaPort().getValue();
-      server.setName(server.getHost() + (tsaPort > 0 ? ":" + tsaPort : ""));
+      server.setName(DataDirsConfig.cleanStringForPath(server.getHost() + (tsaPort > 0 ? ":" + tsaPort : "")));
     }
   }
 

--- a/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/service/DynamicConfigServiceImpl.java
+++ b/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/service/DynamicConfigServiceImpl.java
@@ -507,8 +507,13 @@ public class DynamicConfigServiceImpl implements TopologyService, DynamicConfigS
     if (millis < 1_000) {
       throw new IllegalArgumentException("Invalid delay: " + delayInSeconds.getSeconds() + " seconds");
     }
-    LOGGER.info("Node will restart in: {} seconds", delayInSeconds.getSeconds());
     new Thread(getClass().getSimpleName() + "-DelayedRestart") {
+      {
+        {
+          setDaemon(true);
+        }
+      }
+
       @Override
       public void run() {
         try {

--- a/dynamic-config/testing/support/src/main/java/org/terracotta/dynamic_config/test_support/DynamicConfigIT.java
+++ b/dynamic-config/testing/support/src/main/java/org/terracotta/dynamic_config/test_support/DynamicConfigIT.java
@@ -19,9 +19,11 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.commons.lang3.ArrayUtils;
 import org.hamcrest.Matcher;
 import org.junit.AfterClass;
+import org.junit.AssumptionViolatedException;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.rules.RuleChain;
+import org.junit.rules.TestWatcher;
 import org.junit.runner.Description;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -243,7 +245,28 @@ public class DynamicConfigIT {
               }
             }
           }
-        });
+        })
+    .around(new TestWatcher() {
+      @Override
+      protected void succeeded(Description description) {
+        LOGGER.info("[SUCCESS] {}", description);
+      }
+
+      @Override
+      protected void failed(Throwable e, Description description) {
+        LOGGER.info("[FAILED] {}", description);
+      }
+
+      @Override
+      protected void starting(Description description) {
+        LOGGER.info("[STARTING] {}", description);
+      }
+
+      @Override
+      protected void skipped(AssumptionViolatedException e, Description description) {
+        LOGGER.info("[SKIPPED] {}", description);
+      }
+    });
   }
 
   @BeforeClass

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/DetachCommand1x2IT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/DetachCommand1x2IT.java
@@ -48,7 +48,7 @@ import static org.terracotta.angela.client.support.hamcrest.AngelaMatchers.succe
 public class DetachCommand1x2IT extends DynamicConfigIT {
 
   public DetachCommand1x2IT() {
-    super(Duration.ofSeconds(180));
+    super(Duration.ofSeconds(240));
   }
 
   @Test

--- a/dynamic-config/testing/system-tests/src/test/resources/conversion/tc-config-5.xml
+++ b/dynamic-config/testing/system-tests/src/test/resources/conversion/tc-config-5.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+
+    Copyright Terracotta, Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<tc-config xmlns="http://www.terracotta.org/config">
+  <servers>
+    <server name="foo"/>
+  </servers>
+  <failover-priority>
+    <availability/>
+  </failover-priority>
+</tc-config>

--- a/dynamic-config/testing/system-tests/src/test/resources/conversion/tc-config-6.xml
+++ b/dynamic-config/testing/system-tests/src/test/resources/conversion/tc-config-6.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+
+    Copyright Terracotta, Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<tc-config xmlns="http://www.terracotta.org/config">
+  <servers>
+    <server host="foo"/>
+  </servers>
+  <failover-priority>
+    <availability/>
+  </failover-priority>
+</tc-config>

--- a/dynamic-config/testing/system-tests/src/test/resources/conversion/tc-config-7.xml
+++ b/dynamic-config/testing/system-tests/src/test/resources/conversion/tc-config-7.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+
+    Copyright Terracotta, Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<tc-config xmlns="http://www.terracotta.org/config">
+  <servers>
+    <server/>
+  </servers>
+  <failover-priority>
+    <availability/>
+  </failover-priority>
+</tc-config>

--- a/dynamic-config/testing/system-tests/src/test/resources/conversion/tc-config-8.xml
+++ b/dynamic-config/testing/system-tests/src/test/resources/conversion/tc-config-8.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+
+    Copyright Terracotta, Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<tc-config xmlns="http://www.terracotta.org/config">
+  <servers>
+    <server host="foo">
+      <tsa-port>1234</tsa-port>
+    </server>
+    <server host="foo">
+      <tsa-port>1235</tsa-port>
+    </server>
+  </servers>
+  <failover-priority>
+    <availability/>
+  </failover-priority>
+</tc-config>


### PR DESCRIPTION
This change is required to be able to control the user input for names that are mostly used at different key purposes like filenames, etc. DC expects the node name to be used inside the config filename, and DC is relying on that to detect which node name to start when a config dir is used. Also, DC config file format and CLI input to change the configuration rely on cluster, stripe and node names to be used as identifiers for the change, which prevents some special characters to be used.

**Notes:**

- This change will require an XPC
- This change will highly likely be compatible with existing DC users
- This change will highly likely be compatible with existing tc-config.xml: their node name will be sanitized and transformed to the same value used when persisting data

**Fix made in this commit:**

- It was not possible to migrate a tc-config.xml file having servers with no name (server names should be generated from `host:port`)