### PR TITLE
Validate DC object names to prevent the use of special words or characters

### DIFF
--- a/dynamic-config/cli/upgrade-tools/src/main/java/org/terracotta/dynamic_config/cli/upgrade_tools/config_converter/xml/NonSubstitutingTCConfigurationParser.java
+++ b/dynamic-config/cli/upgrade-tools/src/main/java/org/terracotta/dynamic_config/cli/upgrade_tools/config_converter/xml/NonSubstitutingTCConfigurationParser.java
@@ -256,8 +256,12 @@ public class NonSubstitutingTCConfigurationParser {
     }
 
     if (server.getName() == null || server.getName().trim().length() == 0) {
+      // host at least will be defined
       int tsaPort = server.getTsaPort().getValue();
-      server.setName(server.getHost() + (tsaPort > 0 ? ":" + tsaPort : ""));
+      // DC does not support : in server name
+      // using '-' as a replacement of ':' when the server name is generated from host/port.
+      // this matched the normalization that is done in data dirs code for folder name
+      server.setName(server.getHost() + (tsaPort > 0 ? "-" + tsaPort : ""));
     }
   }
 

--- a/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/startup/ConfigurationGeneratorVisitor.java
+++ b/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/startup/ConfigurationGeneratorVisitor.java
@@ -241,7 +241,8 @@ public class ConfigurationGeneratorVisitor {
   }
 
   Path getOrDefaultConfigurationDirectory(String configPath) {
-    return pathResolver.resolve(configPath != null ? Paths.get(configPath) : Setting.NODE_CONFIG_DIR.<RawPath>getDefaultValue().toPath());
+    configPath = parameterSubstitutor.substitute(configPath != null ? configPath : Setting.NODE_CONFIG_DIR.<RawPath>getDefaultValue().getValue());
+    return pathResolver.resolve(Paths.get(configPath));
   }
 
   Optional<String> findNodeName(Path configPath, IParameterSubstitutor parameterSubstitutor) {


### PR DESCRIPTION
__Validate DC object names to prevent the use of special words or characters.__

This change is required to be able to control the user input for names that are mostly used at different key purposes like filenames, etc. DC expects the node name to be used inside the config filename, and DC is relying on that to detect which node name to start when a config dir is used. Also, DC config file format and CLI input to change the configuration rely on cluster, stripe and node names to be used as identifiers for the change, which prevents some special characters to be used.

__Notes:__

 - This change will require an XPC
 - This change will highly likely be compatible with existing DC users
 - This change will highly likely be compatible with existing tc-config.xml

__What can happen:__

 - For user having no server name in their XML file: migration is transparent
 - For user having a tc-config.xml with a server name defined with ':' inside, they will have to change ':' to '-'
 - For user having a tc-config.xml with a server name defined with another unsupported character, migration won't be possible.

__Unsupported characters:__

  - Unicode characters: '\u0000', '\u0001', '\u0002', '\u0003', '\u0004', '\u0005', '\u0006', '\u0007', '\u0008', '\u0009', '\n', '\u000B', '\u000C', '\r', '\u000E', '\u000F', '\u0010', '\u0011', '\u0012', '\u0013', '\u0014', '\u0015', '\u0016', '\u0017', '\u0018', '\u0019', '\u001A', '\u001B', '\u001C', '\u001D', '\u001E', '\u001F'
  - Special characters: ':', '/', '\\', '<', '>', '"', '|', '*', '?', ' ', ',', ':', '=', '%', '{', '}'
  - Words: "CON", "PRN", "AUX", "NUL", "COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7", "COM8", "COM9", "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9"
  - Names cannot ends with: ' ', '.'