### PR TITLE
Code cleanup and test improvements

### DIFF
--- a/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/service/DynamicConfigServiceImpl.java
+++ b/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/service/DynamicConfigServiceImpl.java
@@ -507,8 +507,13 @@ public class DynamicConfigServiceImpl implements TopologyService, DynamicConfigS
     if (millis < 1_000) {
       throw new IllegalArgumentException("Invalid delay: " + delayInSeconds.getSeconds() + " seconds");
     }
-    LOGGER.info("Node will restart in: {} seconds", delayInSeconds.getSeconds());
     new Thread(getClass().getSimpleName() + "-DelayedRestart") {
+      {
+        {
+          setDaemon(true);
+        }
+      }
+
       @Override
       public void run() {
         try {

--- a/dynamic-config/testing/support/src/main/java/org/terracotta/dynamic_config/test_support/DynamicConfigIT.java
+++ b/dynamic-config/testing/support/src/main/java/org/terracotta/dynamic_config/test_support/DynamicConfigIT.java
@@ -124,7 +124,6 @@ public class DynamicConfigIT {
   private static final Logger LOGGER = LoggerFactory.getLogger(DynamicConfigIT.class);
   private static final Duration DEFAULT_TEST_TIMEOUT = Duration.ofMinutes(2);
   private static final Duration CONN_TIMEOUT = Duration.ofSeconds(30);
-  private static final Duration ASSERT_TIMEOUT = Duration.ofSeconds(90);
 
   protected final TmpDir tmpDir;
   protected final AngelaRule angela;
@@ -246,27 +245,27 @@ public class DynamicConfigIT {
             }
           }
         })
-    .around(new TestWatcher() {
-      @Override
-      protected void succeeded(Description description) {
-        LOGGER.info("[SUCCESS] {}", description);
-      }
+        .around(new TestWatcher() {
+          @Override
+          protected void succeeded(Description description) {
+            LOGGER.info("[SUCCESS] {}", description);
+          }
 
-      @Override
-      protected void failed(Throwable e, Description description) {
-        LOGGER.info("[FAILED] {}", description);
-      }
+          @Override
+          protected void failed(Throwable e, Description description) {
+            LOGGER.info("[FAILED] {}", description);
+          }
 
-      @Override
-      protected void starting(Description description) {
-        LOGGER.info("[STARTING] {}", description);
-      }
+          @Override
+          protected void starting(Description description) {
+            LOGGER.info("[STARTING] {}", description);
+          }
 
-      @Override
-      protected void skipped(AssumptionViolatedException e, Description description) {
-        LOGGER.info("[SKIPPED] {}", description);
-      }
-    });
+          @Override
+          protected void skipped(AssumptionViolatedException e, Description description) {
+            LOGGER.info("[SKIPPED] {}", description);
+          }
+        });
   }
 
   @BeforeClass
@@ -632,11 +631,11 @@ public class DynamicConfigIT {
   // =========================================
 
   protected final void waitUntil(ToolExecutionResult result, Matcher<ToolExecutionResult> matcher) {
-    waitUntil(() -> result, matcher, getAssertTimeout());
+    waitUntil(() -> result, matcher);
   }
 
   protected final void waitUntilServerLogs(TerracottaServer server, String matcher) {
-    assertThat(() -> serverStdOut(server), within(getAssertTimeout()).matches(hasItem(containsString(matcher))));
+    assertThat(() -> serverStdOut(server), within(Duration.ofDays(1)).matches(hasItem(containsString(matcher))));
   }
 
   protected final void assertThatServerLogs(TerracottaServer server, String matcher) {
@@ -656,11 +655,7 @@ public class DynamicConfigIT {
   }
 
   protected final <T> void waitUntil(Supplier<T> callable, Matcher<T> matcher) {
-    waitUntil(callable, matcher, getAssertTimeout());
-  }
-
-  protected final <T> void waitUntil(Supplier<T> callable, Matcher<T> matcher, Duration timeout) {
-    assertThat(callable, within(timeout).matches(matcher));
+    assertThat(callable, within(Duration.ofDays(1)).matches(matcher));
   }
 
   protected final void waitForActive(int stripeId) {
@@ -753,12 +748,8 @@ public class DynamicConfigIT {
     return CONN_TIMEOUT;
   }
 
-  protected Duration getAssertTimeout() {
-    return ASSERT_TIMEOUT;
-  }
-
   protected void setServerDisruptionLinks(Map<Integer, Integer> stripeServer) {
-    stripeServer.forEach((k, v) -> setServerToServerDisruptionLinks(k, v));
+    stripeServer.forEach(this::setServerToServerDisruptionLinks);
   }
 
   protected void setClientServerDisruptionLinks(Map<Integer, Integer> stripeServerNumMap) {

--- a/dynamic-config/testing/support/src/main/java/org/terracotta/dynamic_config/test_support/DynamicConfigIT.java
+++ b/dynamic-config/testing/support/src/main/java/org/terracotta/dynamic_config/test_support/DynamicConfigIT.java
@@ -19,9 +19,11 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.commons.lang3.ArrayUtils;
 import org.hamcrest.Matcher;
 import org.junit.AfterClass;
+import org.junit.AssumptionViolatedException;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.rules.RuleChain;
+import org.junit.rules.TestWatcher;
 import org.junit.runner.Description;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -122,7 +124,7 @@ public class DynamicConfigIT {
   private static final Logger LOGGER = LoggerFactory.getLogger(DynamicConfigIT.class);
   private static final Duration DEFAULT_TEST_TIMEOUT = Duration.ofMinutes(2);
   private static final Duration CONN_TIMEOUT = Duration.ofSeconds(30);
-  private static final Duration ASSERT_TIMEOUT = Duration.ofMinutes(1);
+  private static final Duration ASSERT_TIMEOUT = Duration.ofSeconds(90);
 
   protected final TmpDir tmpDir;
   protected final AngelaRule angela;
@@ -243,7 +245,28 @@ public class DynamicConfigIT {
               }
             }
           }
-        });
+        })
+    .around(new TestWatcher() {
+      @Override
+      protected void succeeded(Description description) {
+        LOGGER.info("[SUCCESS] {}", description);
+      }
+
+      @Override
+      protected void failed(Throwable e, Description description) {
+        LOGGER.info("[FAILED] {}", description);
+      }
+
+      @Override
+      protected void starting(Description description) {
+        LOGGER.info("[STARTING] {}", description);
+      }
+
+      @Override
+      protected void skipped(AssumptionViolatedException e, Description description) {
+        LOGGER.info("[SKIPPED] {}", description);
+      }
+    });
   }
 
   @BeforeClass

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/network_disrupted/AttachInConsistency1x3IT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/network_disrupted/AttachInConsistency1x3IT.java
@@ -50,11 +50,6 @@ public class AttachInConsistency1x3IT extends DynamicConfigIT {
     return FailoverPriority.consistency();
   }
 
-  @Override
-  protected Duration getAssertTimeout() {
-    return Duration.ofMinutes(2);
-  }
-
   @Before
   public void setup() throws Exception {
     startNode(1, 1);

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/network_disrupted/AttachInConsistency1x4IT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/network_disrupted/AttachInConsistency1x4IT.java
@@ -54,11 +54,6 @@ public class AttachInConsistency1x4IT extends DynamicConfigIT {
     return FailoverPriority.consistency();
   }
 
-  @Override
-  protected Duration getAssertTimeout() {
-    return Duration.ofMinutes(2);
-  }
-
   @Before
   public void setup() throws Exception {
     startNode(1, 1);


### PR DESCRIPTION
* Removed assert timeout which was making the test fail instead of timeout, so not thread dump would be taken
* Added test watcher to dump to separate in the logs the start and end of test content