### PR TITLE
Bugfix in convert-tool

### DIFF
--- a/dynamic-config/cli/upgrade-tools/src/main/java/org/terracotta/dynamic_config/cli/upgrade_tools/config_converter/command/ConvertAction.java
+++ b/dynamic-config/cli/upgrade-tools/src/main/java/org/terracotta/dynamic_config/cli/upgrade_tools/config_converter/command/ConvertAction.java
@@ -18,6 +18,7 @@ package org.terracotta.dynamic_config.cli.upgrade_tools.config_converter.command
 import com.beust.jcommander.ParameterException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.terracotta.config.data_roots.DataDirsConfig;
 import org.terracotta.dynamic_config.cli.api.command.Injector.Inject;
 import org.terracotta.dynamic_config.cli.api.output.OutputService;
 import org.terracotta.dynamic_config.cli.upgrade_tools.config_converter.ConfigConverter;
@@ -133,7 +134,7 @@ public class ConvertAction implements Runnable {
       output.info("Configuration directories saved under: {}", destinationDir.toAbsolutePath().normalize());
 
     } else if (conversionFormat == PROPERTIES) {
-      ConfigPropertiesProcessor resultProcessor = new ConfigPropertiesProcessor(destinationDir, newClusterName);
+      ConfigPropertiesProcessor resultProcessor = new ConfigPropertiesProcessor(destinationDir, DataDirsConfig.cleanStringForPath(newClusterName));
       ConfigConverter converter = new ConfigConverter(resultProcessor::process, force);
       converter.processInput(newClusterName, stripeNames, tcConfigFiles.toArray(new Path[0]));
       output.info("Configuration properties file saved under: {}", destinationDir.toAbsolutePath().normalize());

--- a/dynamic-config/cli/upgrade-tools/src/main/java/org/terracotta/dynamic_config/cli/upgrade_tools/config_converter/xml/NonSubstitutingTCConfigurationParser.java
+++ b/dynamic-config/cli/upgrade-tools/src/main/java/org/terracotta/dynamic_config/cli/upgrade_tools/config_converter/xml/NonSubstitutingTCConfigurationParser.java
@@ -249,7 +249,7 @@ public class NonSubstitutingTCConfigurationParser {
   private static void initializeNameAndHost(Server server) {
     if (server.getHost() == null || server.getHost().trim().length() == 0) {
       if (server.getName() == null) {
-        server.setHost("%i");
+        throw new IllegalStateException("Conversion process requires at least a server name or host name to be defined");
       } else {
         server.setHost(server.getName());
       }

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/ConfigConversionIT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/ConfigConversionIT.java
@@ -31,6 +31,7 @@ import org.terracotta.dynamic_config.api.service.ClusterFactory;
 import org.terracotta.dynamic_config.api.service.IParameterSubstitutor;
 import org.terracotta.dynamic_config.api.service.Props;
 import org.terracotta.dynamic_config.cli.upgrade_tools.config_converter.ConfigConverterTool;
+import org.terracotta.dynamic_config.cli.upgrade_tools.config_converter.exception.ConfigConversionException;
 import org.terracotta.dynamic_config.server.api.DynamicConfigNomadServer;
 import org.terracotta.dynamic_config.server.configuration.nomad.NomadServerFactory;
 import org.terracotta.dynamic_config.server.configuration.nomad.persistence.ConfigStorageException;
@@ -46,6 +47,7 @@ import java.nio.file.Paths;
 import java.util.Properties;
 
 import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
@@ -125,6 +127,71 @@ public class ConfigConversionIT {
 
     assertTrue(cluster.getOffheapResources().isConfigured());
     assertThat(cluster.getOffheapResources().get().size(), is(0));
+  }
+
+  @Test
+  public void testWithoutHostPort() {
+    new ConfigConverterTool().run("convert",
+        "-c", "src/test/resources/conversion/tc-config-5.xml",
+        "-n", "my:cluster",
+        "-t", "properties",
+        "-d", tmpDir.getRoot().resolve("generated-configs").toAbsolutePath().toString(),
+        "-f");
+    Path config = tmpDir.getRoot().resolve("generated-configs").resolve("my-cluster.properties");
+    assertTrue(Files.exists(config));
+    Cluster cluster = new ClusterFactory().create(config);
+
+    assertEquals("my:cluster", cluster.getName());
+    assertEquals("foo", cluster.getSingleStripe().get().getSingleNode().get().getName());
+    assertEquals("foo", cluster.getSingleStripe().get().getSingleNode().get().getHostname());
+  }
+
+  @Test
+  public void testWithoutServerName() {
+    new ConfigConverterTool().run("convert",
+        "-c", "src/test/resources/conversion/tc-config-6.xml",
+        "-n", "my:cluster",
+        "-t", "properties",
+        "-d", tmpDir.getRoot().resolve("generated-configs").toAbsolutePath().toString(),
+        "-f");
+    Path config = tmpDir.getRoot().resolve("generated-configs").resolve("my-cluster.properties");
+    assertTrue(Files.exists(config));
+    Cluster cluster = new ClusterFactory().create(config);
+
+    assertEquals("my:cluster", cluster.getName());
+    assertEquals("foo:9410", cluster.getSingleStripe().get().getSingleNode().get().getName());
+    assertEquals("foo", cluster.getSingleStripe().get().getSingleNode().get().getHostname());
+  }
+
+  @Test
+  public void testWithoutServerNameSameHost() {
+    new ConfigConverterTool().run("convert",
+        "-c", "src/test/resources/conversion/tc-config-8.xml",
+        "-n", "my:cluster",
+        "-t", "properties",
+        "-d", tmpDir.getRoot().resolve("generated-configs").toAbsolutePath().toString(),
+        "-f");
+    Path config = tmpDir.getRoot().resolve("generated-configs").resolve("my-cluster.properties");
+    assertTrue(Files.exists(config));
+    Cluster cluster = new ClusterFactory().create(config);
+
+    assertEquals("my:cluster", cluster.getName());
+    assertEquals("foo:1234", cluster.getSingleStripe().get().getNodes().get(0).getName());
+    assertEquals("foo", cluster.getSingleStripe().get().getNodes().get(0).getHostname());
+    assertEquals("foo:1235", cluster.getSingleStripe().get().getNodes().get(1).getName());
+    assertEquals("foo", cluster.getSingleStripe().get().getNodes().get(1).getHostname());
+  }
+
+  @Test
+  public void testWithoutServerNameAndHost() {
+    exceptionRule.expect(ConfigConversionException.class);
+    exceptionRule.expectMessage("Unexpected error while migrating the configuration files: Conversion process requires a valid server name or hostname");
+    new ConfigConverterTool().run("convert",
+        "-c", "src/test/resources/conversion/tc-config-7.xml",
+        "-n", "my:cluster",
+        "-t", "properties",
+        "-d", tmpDir.getRoot().resolve("generated-configs").toAbsolutePath().toString(),
+        "-f");
   }
 
   @Test

--- a/dynamic-config/testing/system-tests/src/test/resources/conversion/tc-config-5.xml
+++ b/dynamic-config/testing/system-tests/src/test/resources/conversion/tc-config-5.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+
+    Copyright Terracotta, Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<tc-config xmlns="http://www.terracotta.org/config">
+  <servers>
+    <server name="foo"/>
+  </servers>
+  <failover-priority>
+    <availability/>
+  </failover-priority>
+</tc-config>

--- a/dynamic-config/testing/system-tests/src/test/resources/conversion/tc-config-6.xml
+++ b/dynamic-config/testing/system-tests/src/test/resources/conversion/tc-config-6.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+
+    Copyright Terracotta, Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<tc-config xmlns="http://www.terracotta.org/config">
+  <servers>
+    <server host="foo"/>
+  </servers>
+  <failover-priority>
+    <availability/>
+  </failover-priority>
+</tc-config>

--- a/dynamic-config/testing/system-tests/src/test/resources/conversion/tc-config-7.xml
+++ b/dynamic-config/testing/system-tests/src/test/resources/conversion/tc-config-7.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+
+    Copyright Terracotta, Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<tc-config xmlns="http://www.terracotta.org/config">
+  <servers>
+    <server/>
+  </servers>
+  <failover-priority>
+    <availability/>
+  </failover-priority>
+</tc-config>

--- a/dynamic-config/testing/system-tests/src/test/resources/conversion/tc-config-8.xml
+++ b/dynamic-config/testing/system-tests/src/test/resources/conversion/tc-config-8.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+
+    Copyright Terracotta, Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<tc-config xmlns="http://www.terracotta.org/config">
+  <servers>
+    <server host="foo">
+      <tsa-port>1234</tsa-port>
+    </server>
+    <server host="foo">
+      <tsa-port>1235</tsa-port>
+    </server>
+  </servers>
+  <failover-priority>
+    <availability/>
+  </failover-priority>
+</tc-config>


### PR DESCRIPTION
It was not possible to migrate a tc-config.xml file having servers with no name (server names can be generated from `host:port`) or server with a name composed of host:port