### PR TITLE
Switching to Jackson 2.12.2 released just after 2.12.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
     <galvan.version>1.6.0-pre5</galvan.version>
     <angela.version>3.1.18</angela.version>
     <statistics.version>2.1</statistics.version>
-    <jackson.version>2.12.1</jackson.version>
+    <jackson.version>2.12.2</jackson.version>
     <terracotta-utilities.version>0.0.8</terracotta-utilities.version>
     <test.parallel.forks>6</test.parallel.forks>
   </properties>


### PR DESCRIPTION
2.12.1 has some issues in key features we are using:
- EXTERNAL_PROPERTY and nulls
- #3045: Bug in polymorphic deserialization with @JsonCreator, @JsonAnySetter, JsonTypeInfo.As.EXTERNAL_PROPERTY) => __we ran into this issue previously, I had to do a work around for that - took me 2 days to figure it out__
- etc

See: https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.12.2