### PR TITLE
TDB-5079 new config file format for CLI (get, set , unset)

### DIFF
--- a/dynamic-config/cli/cli-support/src/main/java/org/terracotta/dynamic_config/cli/converter/ConfigurationInputConverter.java
+++ b/dynamic-config/cli/cli-support/src/main/java/org/terracotta/dynamic_config/cli/converter/ConfigurationInputConverter.java
@@ -16,14 +16,14 @@
 package org.terracotta.dynamic_config.cli.converter;
 
 import com.beust.jcommander.IStringConverter;
-import org.terracotta.dynamic_config.api.model.Configuration;
+import org.terracotta.dynamic_config.cli.api.command.ConfigurationInput;
 
 /**
  * @author Mathieu Carbou
  */
-public class ConfigurationConverter implements IStringConverter<Configuration> {
+public class ConfigurationInputConverter implements IStringConverter<ConfigurationInput> {
   @Override
-  public Configuration convert(String value) {
-    return Configuration.valueOf(value);
+  public ConfigurationInput convert(String value) {
+    return new ConfigurationInput(value);
   }
 }

--- a/dynamic-config/cli/cli-support/src/main/java/org/terracotta/dynamic_config/cli/converter/FormatGetConverter.java
+++ b/dynamic-config/cli/cli-support/src/main/java/org/terracotta/dynamic_config/cli/converter/FormatGetConverter.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.dynamic_config.cli.converter;
+
+import com.beust.jcommander.converters.EnumConverter;
+import org.terracotta.dynamic_config.cli.api.converter.OutputFormatGet;
+
+public class FormatGetConverter extends EnumConverter<OutputFormatGet> {
+  public FormatGetConverter() {
+    super("-f", OutputFormatGet.class);
+  }
+}
+

--- a/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/GetCommand.java
+++ b/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/GetCommand.java
@@ -18,12 +18,14 @@ package org.terracotta.dynamic_config.cli.config_tool.parsing;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
 import com.beust.jcommander.converters.BooleanConverter;
-import org.terracotta.dynamic_config.api.model.Configuration;
+import org.terracotta.dynamic_config.cli.api.command.ConfigurationInput;
 import org.terracotta.dynamic_config.cli.api.command.GetAction;
 import org.terracotta.dynamic_config.cli.api.command.Injector.Inject;
+import org.terracotta.dynamic_config.cli.api.converter.OutputFormatGet;
 import org.terracotta.dynamic_config.cli.command.Command;
 import org.terracotta.dynamic_config.cli.command.Usage;
-import org.terracotta.dynamic_config.cli.converter.ConfigurationConverter;
+import org.terracotta.dynamic_config.cli.converter.ConfigurationInputConverter;
+import org.terracotta.dynamic_config.cli.converter.FormatGetConverter;
 import org.terracotta.dynamic_config.cli.converter.InetSocketAddressConverter;
 import org.terracotta.dynamic_config.cli.converter.MultiConfigCommaSplitter;
 
@@ -37,11 +39,14 @@ public class GetCommand extends Command {
   @Parameter(names = {"-connect-to"}, description = "Node to connect to", required = true, converter = InetSocketAddressConverter.class)
   InetSocketAddress node;
 
-  @Parameter(names = {"-setting"}, description = "Configuration properties", splitter = MultiConfigCommaSplitter.class, required = true, converter = ConfigurationConverter.class)
-  List<Configuration> configurations;
+  @Parameter(names = {"-setting"}, description = "Configuration properties", splitter = MultiConfigCommaSplitter.class, required = true, converter = ConfigurationInputConverter.class)
+  List<ConfigurationInput> inputs;
 
   @Parameter(names = {"-runtime"}, description = "Read the properties from the current runtime configuration instead of reading them from the last configuration saved on disk", converter = BooleanConverter.class)
   private boolean wantsRuntimeConfig;
+
+  @Parameter(names = {"-outputformat"}, description = "Output Format (name|index). Default: name", converter = FormatGetConverter.class)
+  private OutputFormatGet outputFormat = OutputFormatGet.NAME;
 
   @Inject
   public final GetAction action;
@@ -57,8 +62,9 @@ public class GetCommand extends Command {
   @Override
   public void run() {
     action.setNode(node);
-    action.setConfigurations(configurations);
-    action.setRuntimConfig(wantsRuntimeConfig);
+    action.setConfigurationInputs(inputs);
+    action.setRuntimeConfig(wantsRuntimeConfig);
+    action.setOutputFormat(outputFormat);
 
     action.run();
   }

--- a/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/SetCommand.java
+++ b/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/SetCommand.java
@@ -19,12 +19,12 @@ import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
 import org.terracotta.common.struct.Measure;
 import org.terracotta.common.struct.TimeUnit;
-import org.terracotta.dynamic_config.api.model.Configuration;
+import org.terracotta.dynamic_config.cli.api.command.ConfigurationInput;
 import org.terracotta.dynamic_config.cli.api.command.Injector.Inject;
 import org.terracotta.dynamic_config.cli.api.command.SetAction;
 import org.terracotta.dynamic_config.cli.command.Command;
 import org.terracotta.dynamic_config.cli.command.Usage;
-import org.terracotta.dynamic_config.cli.converter.ConfigurationConverter;
+import org.terracotta.dynamic_config.cli.converter.ConfigurationInputConverter;
 import org.terracotta.dynamic_config.cli.converter.InetSocketAddressConverter;
 import org.terracotta.dynamic_config.cli.converter.MultiConfigCommaSplitter;
 import org.terracotta.dynamic_config.cli.converter.TimeUnitConverter;
@@ -39,8 +39,8 @@ public class SetCommand extends Command {
   @Parameter(names = {"-connect-to"}, description = "Node to connect to", required = true, converter = InetSocketAddressConverter.class)
   InetSocketAddress node;
 
-  @Parameter(names = {"-setting"}, description = "Configuration properties", splitter = MultiConfigCommaSplitter.class, required = true, converter = ConfigurationConverter.class)
-  List<Configuration> configurations;
+  @Parameter(names = {"-setting"}, description = "Configuration properties", splitter = MultiConfigCommaSplitter.class, required = true, converter = ConfigurationInputConverter.class)
+  List<ConfigurationInput> inputs;
 
   @Parameter(names = {"-auto-restart"}, description = "If a change requires some nodes to be restarted, the command will try to restart them if there are at least 2 nodes online per stripe.")
   boolean autoRestart = false;
@@ -65,7 +65,7 @@ public class SetCommand extends Command {
   @Override
   public void run() {
     action.setNode(node);
-    action.setConfigurations(configurations);
+    action.setConfigurationInputs(inputs);
     action.setAutoRestart(autoRestart);
     action.setRestartDelay(restartDelay);
     action.setRestartWaitTime(restartWaitTime);

--- a/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/UnsetCommand.java
+++ b/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/UnsetCommand.java
@@ -19,12 +19,12 @@ import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
 import org.terracotta.common.struct.Measure;
 import org.terracotta.common.struct.TimeUnit;
-import org.terracotta.dynamic_config.api.model.Configuration;
+import org.terracotta.dynamic_config.cli.api.command.ConfigurationInput;
 import org.terracotta.dynamic_config.cli.api.command.Injector.Inject;
 import org.terracotta.dynamic_config.cli.api.command.UnsetAction;
 import org.terracotta.dynamic_config.cli.command.Command;
 import org.terracotta.dynamic_config.cli.command.Usage;
-import org.terracotta.dynamic_config.cli.converter.ConfigurationConverter;
+import org.terracotta.dynamic_config.cli.converter.ConfigurationInputConverter;
 import org.terracotta.dynamic_config.cli.converter.InetSocketAddressConverter;
 import org.terracotta.dynamic_config.cli.converter.MultiConfigCommaSplitter;
 import org.terracotta.dynamic_config.cli.converter.TimeUnitConverter;
@@ -39,8 +39,8 @@ public class UnsetCommand extends Command {
   @Parameter(names = {"-connect-to"}, description = "Node to connect to", required = true, converter = InetSocketAddressConverter.class)
   InetSocketAddress node;
 
-  @Parameter(names = {"-setting"}, description = "Configuration properties", splitter = MultiConfigCommaSplitter.class, required = true, converter = ConfigurationConverter.class)
-  List<Configuration> configurations;
+  @Parameter(names = {"-setting"}, description = "Configuration properties", splitter = MultiConfigCommaSplitter.class, required = true, converter = ConfigurationInputConverter.class)
+  List<ConfigurationInput> inputs;
 
   @Parameter(names = {"-auto-restart"}, description = "If a change requires some nodes to be restarted, the command will try to restart them if there are at least 2 nodes online per stripe.")
   boolean autoRestart = false;
@@ -65,7 +65,7 @@ public class UnsetCommand extends Command {
   @Override
   public void run() {
     action.setNode(node);
-    action.setConfigurations(configurations);
+    action.setConfigurationInputs(inputs);
     action.setAutoRestart(autoRestart);
     action.setRestartDelay(restartDelay);
     action.setRestartWaitTime(restartWaitTime);

--- a/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/deprecated/DeprecatedGetCommand.java
+++ b/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/deprecated/DeprecatedGetCommand.java
@@ -18,12 +18,14 @@ package org.terracotta.dynamic_config.cli.config_tool.parsing.deprecated;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
 import com.beust.jcommander.converters.BooleanConverter;
-import org.terracotta.dynamic_config.api.model.Configuration;
+import org.terracotta.dynamic_config.cli.api.command.ConfigurationInput;
 import org.terracotta.dynamic_config.cli.api.command.GetAction;
 import org.terracotta.dynamic_config.cli.api.command.Injector.Inject;
+import org.terracotta.dynamic_config.cli.api.converter.OutputFormatGet;
 import org.terracotta.dynamic_config.cli.command.Command;
 import org.terracotta.dynamic_config.cli.command.Usage;
-import org.terracotta.dynamic_config.cli.converter.ConfigurationConverter;
+import org.terracotta.dynamic_config.cli.converter.ConfigurationInputConverter;
+import org.terracotta.dynamic_config.cli.converter.FormatGetConverter;
 import org.terracotta.dynamic_config.cli.converter.InetSocketAddressConverter;
 import org.terracotta.dynamic_config.cli.converter.MultiConfigCommaSplitter;
 
@@ -37,11 +39,14 @@ public class DeprecatedGetCommand extends Command {
   @Parameter(names = {"-s"}, description = "Node to connect to", required = true, converter = InetSocketAddressConverter.class)
   InetSocketAddress node;
 
-  @Parameter(names = {"-c"}, description = "Configuration properties", splitter = MultiConfigCommaSplitter.class, required = true, converter = ConfigurationConverter.class)
-  List<Configuration> configurations;
+  @Parameter(names = {"-c"}, description = "Configuration properties", splitter = MultiConfigCommaSplitter.class, required = true, converter = ConfigurationInputConverter.class)
+  List<ConfigurationInput> inputs;
 
   @Parameter(names = {"-r"}, description = "Read the properties from the current runtime configuration instead of reading them from the last configuration saved on disk", converter = BooleanConverter.class)
   private boolean wantsRuntimeConfig;
+
+  @Parameter(names = {"-t"}, description = "Output Format (name|index). Default: name", converter = FormatGetConverter.class)
+  private OutputFormatGet outputFormat = OutputFormatGet.NAME;
 
   @Inject
   public final GetAction action;
@@ -57,8 +62,9 @@ public class DeprecatedGetCommand extends Command {
   @Override
   public void run() {
     action.setNode(node);
-    action.setConfigurations(configurations);
-    action.setRuntimConfig(wantsRuntimeConfig);
+    action.setConfigurationInputs(inputs);
+    action.setRuntimeConfig(wantsRuntimeConfig);
+    action.setOutputFormat(outputFormat);
 
     action.run();
   }

--- a/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/deprecated/DeprecatedSetCommand.java
+++ b/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/deprecated/DeprecatedSetCommand.java
@@ -17,12 +17,12 @@ package org.terracotta.dynamic_config.cli.config_tool.parsing.deprecated;
 
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
-import org.terracotta.dynamic_config.api.model.Configuration;
+import org.terracotta.dynamic_config.cli.api.command.ConfigurationInput;
 import org.terracotta.dynamic_config.cli.api.command.Injector.Inject;
 import org.terracotta.dynamic_config.cli.api.command.SetAction;
 import org.terracotta.dynamic_config.cli.command.Command;
 import org.terracotta.dynamic_config.cli.command.Usage;
-import org.terracotta.dynamic_config.cli.converter.ConfigurationConverter;
+import org.terracotta.dynamic_config.cli.converter.ConfigurationInputConverter;
 import org.terracotta.dynamic_config.cli.converter.InetSocketAddressConverter;
 import org.terracotta.dynamic_config.cli.converter.MultiConfigCommaSplitter;
 
@@ -36,8 +36,8 @@ public class DeprecatedSetCommand extends Command {
   @Parameter(names = {"-s"}, description = "Node to connect to", required = true, converter = InetSocketAddressConverter.class)
   InetSocketAddress node;
 
-  @Parameter(names = {"-c"}, description = "Configuration properties", splitter = MultiConfigCommaSplitter.class, required = true, converter = ConfigurationConverter.class)
-  List<Configuration> configurations;
+  @Parameter(names = {"-c"}, description = "Configuration properties", splitter = MultiConfigCommaSplitter.class, required = true, converter = ConfigurationInputConverter.class)
+  List<ConfigurationInput> inputs;
 
   @Inject
   public final SetAction action;
@@ -53,7 +53,7 @@ public class DeprecatedSetCommand extends Command {
   @Override
   public void run() {
     action.setNode(node);
-    action.setConfigurations(configurations);
+    action.setConfigurationInputs(inputs);
 
     action.run();
   }

--- a/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/deprecated/DeprecatedUnsetCommand.java
+++ b/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/deprecated/DeprecatedUnsetCommand.java
@@ -17,12 +17,12 @@ package org.terracotta.dynamic_config.cli.config_tool.parsing.deprecated;
 
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
-import org.terracotta.dynamic_config.api.model.Configuration;
+import org.terracotta.dynamic_config.cli.api.command.ConfigurationInput;
 import org.terracotta.dynamic_config.cli.api.command.Injector.Inject;
 import org.terracotta.dynamic_config.cli.api.command.UnsetAction;
 import org.terracotta.dynamic_config.cli.command.Command;
 import org.terracotta.dynamic_config.cli.command.Usage;
-import org.terracotta.dynamic_config.cli.converter.ConfigurationConverter;
+import org.terracotta.dynamic_config.cli.converter.ConfigurationInputConverter;
 import org.terracotta.dynamic_config.cli.converter.InetSocketAddressConverter;
 import org.terracotta.dynamic_config.cli.converter.MultiConfigCommaSplitter;
 
@@ -36,8 +36,8 @@ public class DeprecatedUnsetCommand extends Command {
   @Parameter(names = {"-s"}, description = "Node to connect to", required = true, converter = InetSocketAddressConverter.class)
   InetSocketAddress node;
 
-  @Parameter(names = {"-c"}, description = "Configuration properties", splitter = MultiConfigCommaSplitter.class, required = true, converter = ConfigurationConverter.class)
-  List<Configuration> configurations;
+  @Parameter(names = {"-c"}, description = "Configuration properties", splitter = MultiConfigCommaSplitter.class, required = true, converter = ConfigurationInputConverter.class)
+  List<ConfigurationInput> inputs;
 
   @Inject
   public final UnsetAction action;
@@ -53,7 +53,7 @@ public class DeprecatedUnsetCommand extends Command {
   @Override
   public void run() {
     action.setNode(node);
-    action.setConfigurations(configurations);
+    action.setConfigurationInputs(inputs);
 
     action.run();
   }

--- a/dynamic-config/cli/dynamic-config-cli-api/src/main/java/org/terracotta/dynamic_config/cli/api/command/ConfigurationAction.java
+++ b/dynamic-config/cli/dynamic-config-cli-api/src/main/java/org/terracotta/dynamic_config/cli/api/command/ConfigurationAction.java
@@ -15,14 +15,19 @@
  */
 package org.terracotta.dynamic_config.cli.api.command;
 
+import org.terracotta.dynamic_config.api.model.Cluster;
 import org.terracotta.dynamic_config.api.model.ClusterState;
 import org.terracotta.dynamic_config.api.model.Configuration;
 import org.terracotta.dynamic_config.api.model.Operation;
+import org.terracotta.dynamic_config.api.model.Scope;
 import org.terracotta.dynamic_config.api.model.Setting;
 
 import java.net.InetSocketAddress;
+import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 import static java.lang.String.format;
 import static org.terracotta.dynamic_config.api.model.ClusterState.ACTIVATED;
@@ -32,6 +37,7 @@ public abstract class ConfigurationAction extends RemoteAction {
 
   protected InetSocketAddress node;
   protected List<Configuration> configurations;
+  protected List<ConfigurationInput> inputs;
 
   private final EnumSet<Setting> NOT_SUPPORTED_SETTINGS = EnumSet.of(Setting.LOCK_CONTEXT);
 
@@ -48,11 +54,30 @@ public abstract class ConfigurationAction extends RemoteAction {
     this.node = node;
   }
 
-  public void setConfigurations(List<Configuration> configurations) {
-    this.configurations = configurations;
+  public void setConfigurationInputs(List<ConfigurationInput> inputs) {
+    this.inputs = inputs;
   }
 
   protected void validate() {
+
+    Cluster cluster = getRuntimeCluster(node);
+
+    // Convert the CLI inputs to Configurations.
+    // To support lower-scoped settings overriding higher-scoped settings, group the
+    // configurations in Scope-order (cluster-stripe-node).  Since List<> processing occurs in order
+    // this will result in cluster-wide (<setting>=X) entries getting overwritten by stripe-wide
+    // (stripe:<setting>=Y) entries which will be overridden by node-level (node:<setting>=Z)
+    // entries for the same setting.
+
+    Map<Scope, List<Configuration>> m = inputs.stream()
+        .map(input -> input.toConfiguration(cluster))
+        .flatMap(cfg -> cfg.expand().stream())
+        .collect(Collectors.groupingBy(Configuration::getLevel));
+    configurations = new ArrayList<>();
+    configurations.addAll(m.getOrDefault(Scope.CLUSTER, new ArrayList<>()));
+    configurations.addAll(m.getOrDefault(Scope.STRIPE, new ArrayList<>()));
+    configurations.addAll(m.getOrDefault(Scope.NODE, new ArrayList<>()));
+
     isActivated = isActivated(node);
     clusterState = isActivated ? ACTIVATED : CONFIGURING;
 

--- a/dynamic-config/cli/dynamic-config-cli-api/src/main/java/org/terracotta/dynamic_config/cli/api/command/ConfigurationInput.java
+++ b/dynamic-config/cli/dynamic-config-cli-api/src/main/java/org/terracotta/dynamic_config/cli/api/command/ConfigurationInput.java
@@ -1,0 +1,401 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.dynamic_config.cli.api.command;
+
+import org.terracotta.dynamic_config.api.model.Cluster;
+import org.terracotta.dynamic_config.api.model.Configuration;
+import org.terracotta.dynamic_config.api.model.Node;
+import org.terracotta.dynamic_config.api.model.Scope;
+import org.terracotta.dynamic_config.api.model.Setting;
+import org.terracotta.dynamic_config.api.model.Stripe;
+import org.terracotta.dynamic_config.api.model.UID;
+import org.terracotta.dynamic_config.api.service.ClusterValidator;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.BiConsumer;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+import static org.terracotta.dynamic_config.api.model.Scope.NODE;
+import static org.terracotta.dynamic_config.api.model.Scope.STRIPE;
+
+public class ConfigurationInput {
+
+  private static final Map<Pattern, BiConsumer<ConfigurationInput, Matcher>> CFG_STRIPE_PATTERNS = new LinkedHashMap<>();
+  private static final Map<Pattern, BiConsumer<ConfigurationInput, Matcher>> CFG_NODE_PATTERNS = new LinkedHashMap<>();
+  private static final Map<Pattern, BiConsumer<ConfigurationInput, Matcher>> CFG_STRIPE_OR_NODE_PATTERNS = new LinkedHashMap<>();
+
+  private static final String CFG_STRIPE_SEP = "stripe:";
+  private static final String CFG_NODE_SEP = "node:";
+  // match all chars for stripe/node names except 'forbidden' chars (see FORBIDDEN_FILE_CHARS and FORBIDDEN_DC_CHARS in ClusterValidator)
+  private static final String CFG_GRP_NAME = "([^:/\\\\<>\"|*? ,=%{}]+):";
+  private static final String SEP = "\\.";
+  private static final String GRP_SETTING = "([a-z\\-]+)";
+  private static final String GRP_KEY = "([^=:]+)";
+  private static final String ASSIGN = "=";
+  private static final String GRP_VALUE = "([^=]+)";
+
+  static {
+    // stripe:<name>:<setting>.<key>
+    CFG_STRIPE_PATTERNS.put(Pattern.compile("^" + CFG_STRIPE_SEP + CFG_GRP_NAME + GRP_SETTING + SEP + GRP_KEY + "$"), (input, matcher) -> input.update(
+        Setting.fromName(matcher.group(2)),
+        STRIPE,
+        matcher.group(1),
+        matcher.group(3),
+        null));
+    // stripe:<name>:<setting>
+    CFG_STRIPE_PATTERNS.put(Pattern.compile("^" + CFG_STRIPE_SEP + CFG_GRP_NAME + GRP_SETTING + "$"), (input, matcher) -> input.update(
+        Setting.fromName(matcher.group(2)),
+        STRIPE,
+        matcher.group(1),
+        null,
+        null));
+    // stripe:<name>:<setting>.<key>=
+    CFG_STRIPE_PATTERNS.put(Pattern.compile("^" + CFG_STRIPE_SEP + CFG_GRP_NAME + GRP_SETTING + SEP + GRP_KEY + ASSIGN + "$"), (input, matcher) -> input.update(
+        Setting.fromName(matcher.group(2)),
+        STRIPE,
+        matcher.group(1),
+        matcher.group(3),
+        ""));
+    // stripe:<name>:<setting>=
+    CFG_STRIPE_PATTERNS.put(Pattern.compile("^" + CFG_STRIPE_SEP + CFG_GRP_NAME + GRP_SETTING + ASSIGN + "$"), (input, matcher) -> input.update(
+        Setting.fromName(matcher.group(2)),
+        STRIPE,
+        matcher.group(1),
+        null,
+        ""));
+    // stripe:<name>:<setting>.<key>=<value>
+    CFG_STRIPE_PATTERNS.put(Pattern.compile("^" + CFG_STRIPE_SEP + CFG_GRP_NAME + GRP_SETTING + SEP + GRP_KEY + ASSIGN + GRP_VALUE + "$"), (input, matcher) -> input.update(
+        Setting.fromName(matcher.group(2)),
+        STRIPE,
+        matcher.group(1),
+        matcher.group(3),
+        matcher.group(4)));
+    // stripe:<name>:<setting>=<value>
+    CFG_STRIPE_PATTERNS.put(Pattern.compile("^" + CFG_STRIPE_SEP + CFG_GRP_NAME + GRP_SETTING + ASSIGN + GRP_VALUE + "$"), (input, matcher) -> input.update(
+        Setting.fromName(matcher.group(2)),
+        STRIPE,
+        matcher.group(1),
+        null,
+        matcher.group(3)));
+    // node:<name>:<setting>.<key>=<value>
+    CFG_NODE_PATTERNS.put(Pattern.compile("^" + CFG_NODE_SEP + CFG_GRP_NAME + GRP_SETTING + SEP + GRP_KEY + ASSIGN + GRP_VALUE + "$"), (input, matcher) -> input.update(
+        Setting.fromName(matcher.group(2)),
+        NODE,
+        matcher.group(1),
+        matcher.group(3),
+        matcher.group(4)));
+    // node:<name>:<setting>=<value>
+    CFG_NODE_PATTERNS.put(Pattern.compile("^" + CFG_NODE_SEP + CFG_GRP_NAME + GRP_SETTING + ASSIGN + GRP_VALUE + "$"), (input, matcher) -> input.update(
+        Setting.fromName(matcher.group(2)),
+        NODE,
+        matcher.group(1),
+        null,
+        matcher.group(3)));
+    // node:<name>:<setting>.<key>=
+    CFG_NODE_PATTERNS.put(Pattern.compile("^" + CFG_NODE_SEP + CFG_GRP_NAME + GRP_SETTING + SEP + GRP_KEY + ASSIGN + "$"), (input, matcher) -> input.update(
+        Setting.fromName(matcher.group(2)),
+        NODE,
+        matcher.group(1),
+        matcher.group(3),
+        ""));
+    // node:<name>:<setting>=
+    CFG_NODE_PATTERNS.put(Pattern.compile("^" + CFG_NODE_SEP + CFG_GRP_NAME + GRP_SETTING + ASSIGN + "$"), (input, matcher) -> input.update(
+        Setting.fromName(matcher.group(2)),
+        NODE,
+        matcher.group(1),
+        null,
+        ""));
+    // node:<name>:<setting>.<key>
+    CFG_NODE_PATTERNS.put(Pattern.compile("^" + CFG_NODE_SEP + CFG_GRP_NAME + GRP_SETTING + SEP + GRP_KEY + "$"), (input, matcher) -> input.update(
+        Setting.fromName(matcher.group(2)),
+        NODE,
+        matcher.group(1),
+        matcher.group(3),
+        null));
+    // node:<name>:<setting>
+    CFG_NODE_PATTERNS.put(Pattern.compile("^" + CFG_NODE_SEP + CFG_GRP_NAME + GRP_SETTING + "$"), (input, matcher) -> input.update(
+        Setting.fromName(matcher.group(2)),
+        NODE,
+        matcher.group(1),
+        null,
+        null));
+    // <name>:<setting>.<key>=<value>
+    CFG_STRIPE_OR_NODE_PATTERNS.put(Pattern.compile("^" + CFG_GRP_NAME + GRP_SETTING + SEP + GRP_KEY + ASSIGN + GRP_VALUE + "$"), (input, matcher) -> input.update(
+        Setting.fromName(matcher.group(2)),
+        null,
+        matcher.group(1),
+        matcher.group(3),
+        matcher.group(4)));
+    // <name>:<setting>=<value>
+    CFG_STRIPE_OR_NODE_PATTERNS.put(Pattern.compile("^" + CFG_GRP_NAME + GRP_SETTING + ASSIGN + GRP_VALUE + "$"), (input, matcher) -> input.update(
+        Setting.fromName(matcher.group(2)),
+        null,
+        matcher.group(1),
+        null,
+        matcher.group(3)));
+    // <name>:<setting>.<key>=
+    CFG_STRIPE_OR_NODE_PATTERNS.put(Pattern.compile("^" + CFG_GRP_NAME + GRP_SETTING + SEP + GRP_KEY + ASSIGN + "$"), (input, matcher) -> input.update(
+        Setting.fromName(matcher.group(2)),
+        null,
+        matcher.group(1),
+        matcher.group(3),
+        ""));
+    // <name>:<setting>=
+    CFG_STRIPE_OR_NODE_PATTERNS.put(Pattern.compile("^" + CFG_GRP_NAME + GRP_SETTING + ASSIGN + "$"), (input, matcher) -> input.update(
+        Setting.fromName(matcher.group(2)),
+        null,
+        matcher.group(1),
+        null,
+        ""));
+    // <name>:<setting>.<key>
+    CFG_STRIPE_OR_NODE_PATTERNS.put(Pattern.compile("^" + CFG_GRP_NAME + GRP_SETTING + SEP + GRP_KEY + "$"), (input, matcher) -> input.update(
+        Setting.fromName(matcher.group(2)),
+        null,
+        matcher.group(1),
+        matcher.group(3),
+        null));
+    // <name>:<setting>
+    CFG_STRIPE_OR_NODE_PATTERNS.put(Pattern.compile("^" + CFG_GRP_NAME + GRP_SETTING + "$"), (input, matcher) -> input.update(
+        Setting.fromName(matcher.group(2)),
+        null,
+        matcher.group(1),
+        null,
+        null));
+  }
+
+  private final String cliInput;
+  private String stripeOrNodeName= null;
+  private Setting setting= null;
+  private Scope level= null;
+  private String key= null;
+  private String value= null;
+
+  /***
+   * Every CLI get, set and unset -setting is instantiated through here.
+   * If the setting is based on the name-based syntax then this class handles all functionality.
+   * If the setting is based on the index-based syntax then the Configuration class is
+   * called upon (to satisfy subsequent requests).
+   */
+  public ConfigurationInput(String cliInput) {
+    requireNonNull(cliInput);
+    this.cliInput = cliInput.trim();
+    if (parseAsNamedProperty()) {
+      // the remainder of this class's members have been updated at this point
+      validate();
+    }
+  }
+
+  /***
+   * If this CLI -setting instance uses the name-based syntax, then these properties are
+   * updated based on the static matcher patterns.
+   */
+  private void update(Setting setting, Scope level, String name, String key, String value) {
+    this.setting = requireNonNull(setting);
+    this.stripeOrNodeName = requireNonNull(name);
+    this.level = level; // can be null (user may not have specified 'stripe:' or 'node:' qualifier)
+    this.key = key;
+    this.value = value == null ? null : value.trim();
+  }
+
+  private Boolean parseAsNamedProperty() {
+
+    // Scan the input and determine if it is a name-based namespace property.
+    // If it is and there are fundamental syntax errors, then throw.  If it's determined the configuration
+    // is not named-based then return false and let Configuration() process it.
+
+    // Name-based namespace properties are of the form:
+    // [[stripe|node :]<stripe_or_node_name>:]<setting>=<value>
+
+    String scope = "";
+    String setting;
+    String[] s = cliInput.split("=")[0].split(":");
+    if (s.length == 3) {
+      // This is most likely a named-based formatted setting
+      // Therefore, format must be stripe|node:<stripe_or_node_name>:<setting>
+      // All we can validate at this point is the 'scope' identifier (we can't validate the stripe/node name yet)
+      scope = s[0];
+      if (!scope.equals("stripe") && !scope.equals("node")) {
+        throw new IllegalArgumentException ("Scope '" + scope + ":' specified in property '" + cliInput + "' is invalid. Scope must be one of 'stripe:' or 'node:'");
+      }
+      // assume s[1] is a valid stripe or node name - can only validate later on
+      setting = s[2];
+    } else if (s.length == 2) {
+      // format MUST be <stripe_or_node_name>:<setting>
+      // assume s[0] is a valid stripe or node name - can only validate later on
+      setting = s[1];
+    } else {
+      // Could be a cluster-wide setting or an index-based setting or a mis-configured setting.
+      return false;
+    }
+    //throw for unrecognized setting name
+    int idx = setting.indexOf(".");
+    Setting.fromName(setting.substring(0, idx == -1 ? setting.length() : idx));
+
+    if (scope.equals("node")) {
+      for (Map.Entry<Pattern, BiConsumer<ConfigurationInput, Matcher>> entry : CFG_NODE_PATTERNS.entrySet()) {
+        Matcher matcher = entry.getKey().matcher(cliInput);
+        if (matcher.matches()) {
+          entry.getValue().accept(this, matcher); // calls update()
+          return true;
+        }
+      }
+    }
+    if (scope.equals("stripe")) {
+      for (Map.Entry<Pattern, BiConsumer<ConfigurationInput, Matcher>> entry : CFG_STRIPE_PATTERNS.entrySet()) {
+        Matcher matcher = entry.getKey().matcher(cliInput);
+        if (matcher.matches()) {
+          entry.getValue().accept(this, matcher); // calls update()
+          return true;
+        }
+      }
+    }
+    // no scope has been defined (can be stripe or node)
+    for (Map.Entry<Pattern, BiConsumer<ConfigurationInput, Matcher>> entry : CFG_STRIPE_OR_NODE_PATTERNS.entrySet()) {
+      Matcher matcher = entry.getKey().matcher(cliInput);
+      if (matcher.matches()) {
+        entry.getValue().accept(this, matcher); // calls update()
+        return true;
+      }
+    }
+    throw new IllegalArgumentException("Invalid input: '" + cliInput + "'");
+  }
+
+  private void validate() {
+    String scope;
+    if (level == STRIPE) {
+      scope = "stripe";
+    } else if (level == NODE) {
+      scope = "node";
+    } else {
+      scope = "stripe or node";
+    }
+    ClusterValidator.validateName(stripeOrNodeName, scope);
+
+    if (!setting.isMap() && key != null) {
+      throw new IllegalArgumentException("Invalid input: '" + cliInput + "'. Reason: Setting '" + setting + "' is not a map and must not have a key");
+    }
+    if (level != null) {
+      if (!setting.allows(level)) {
+        throw new IllegalArgumentException("Invalid input: '" + cliInput + "'. Reason: Setting '" + setting + "' does not allow any operation at " + level + " level");
+      }
+      try {
+        setting.validate(key, value, level);
+      } catch (RuntimeException e) {
+        throw new IllegalArgumentException("Invalid input: '" + cliInput + "'. Reason: " + e.getMessage(), e);
+      }
+    }
+  }
+
+  /***
+   * If this ConfigurationInput is derived from a name-based syntax setting, then deduce the correct
+   * stripeId, nodeId and/or scope values based on the supplied cluster and return a Configuration
+   * instance derived from that.  Else, pass the work off to Configuration.valueIf() directly.
+   */
+  public Configuration toConfiguration(Cluster cluster) {
+    Configuration config = valueOf(cluster);
+    if (config == null){
+      config = Configuration.valueOf(cliInput);
+    }
+    return config;
+  }
+
+  public boolean isNamedProperty() {
+    // The 'hook' that determines if this ConfigurationInput instance was entered at the command line
+    // using the name-based syntax, is if the 'stripeOrNodeName' property has been set.
+    // If no stripe or node name has been specified, then this is an index-based syntax setting and
+    // the Configuration class handles things.
+
+    return stripeOrNodeName != null && !stripeOrNodeName.isEmpty();
+  }
+
+  private Configuration valueOf(Cluster cluster) {
+
+    if (!isNamedProperty()) {
+      // This ConfigurationInput instance was created from an index-based namespace cli input.
+      // The Configuration class handles that.
+      return null;
+    }
+
+    Optional<Node> node = cluster.getNodeByName(stripeOrNodeName);
+    Optional<Stripe> stripe = cluster.getStripeByName(stripeOrNodeName);
+
+    if (level == null) {
+      // user did not specify the scope - only <node_or_stripe_name>:<setting>
+      if (node.isPresent() && stripe.isPresent()) {
+        throw new IllegalArgumentException(format("Name '%s' in setting '%s' is both a stripe name and node name. " +
+            "It must be qualified with either 'stripe:' or 'node:'", stripeOrNodeName, cliInput));
+      }
+    } else {
+      if (level.equals(Scope.STRIPE) && !stripe.isPresent()) {
+        throw new IllegalArgumentException(format("Name '%s' in setting '%s' is not a recognized stripe.", stripeOrNodeName, cliInput));
+      }
+      if (level.equals(Scope.NODE) && !node.isPresent()) {
+        throw new IllegalArgumentException(format("Name '%s' in setting '%s' is not a recognized node.", stripeOrNodeName, cliInput));
+      }
+    }
+    if (!stripe.isPresent() && !node.isPresent()) {
+      throw new IllegalArgumentException(format("Name '%s' in setting '%s' is not a recognized stripe or node.", stripeOrNodeName, cliInput));
+    }
+
+    // Update the stripeId and/or nodeId based on the scope level
+
+    if (level == null) {
+      level = stripe.isPresent() ? Scope.STRIPE : Scope.NODE;
+    }
+    int stripeId;
+    Integer nodeId = null;
+    if (level.equals(Scope.STRIPE)) {
+      stripeId = cluster.getStripeId(stripe.get().getUID()).getAsInt();
+    } else {
+      UID nodeUid = node.get().getUID();
+      stripeId = cluster.getStripeIdByNode(nodeUid).getAsInt();
+      nodeId = cluster.getNodeId(nodeUid).getAsInt();
+    }
+    return new Configuration(cliInput, setting, level, stripeId, nodeId, key, value);
+  }
+
+  /***
+   * Extract the Setting embedded in the CLI input. First try parsing it as a 'named-based'
+   * syntax and then as an 'index-based' syntax (if needed).
+   * @param cliInput setting value entered at the command line
+   */
+  public static Setting getSetting(String cliInput) {
+    ConfigurationInput c = new ConfigurationInput(cliInput);
+    if (c.isNamedProperty()) {
+      return c.setting;
+    } else {
+      return Configuration.valueOf(c.cliInput).getSetting();
+    }
+  }
+  /***
+   * Extract the Key (it if exists) for the CLI input. First try parsing it as a 'named-based'
+   * syntax and then as an 'index-based' syntax (if needed).
+   * @param cliInput setting value entered at the command line
+   */
+  public static String getKey(String cliInput) {
+    ConfigurationInput c = new ConfigurationInput(cliInput);
+    if (c.isNamedProperty()) {
+      return c.key;
+    } else {
+      return Configuration.valueOf(c.cliInput).getKey();
+    }
+  }
+}

--- a/dynamic-config/cli/dynamic-config-cli-api/src/main/java/org/terracotta/dynamic_config/cli/api/command/ConfigurationMutationAction.java
+++ b/dynamic-config/cli/dynamic-config-cli-api/src/main/java/org/terracotta/dynamic_config/cli/api/command/ConfigurationMutationAction.java
@@ -118,9 +118,11 @@ public abstract class ConfigurationMutationAction extends ConfigurationAction {
           });
     }
     if (updatedCluster.equals(originalCluster)) {
+      String message = "The requested update will not result in any change to the cluster configuration.";
+      output.out(message);
       LOGGER.warn(lineSeparator() +
           "=======================================================================================" + lineSeparator() +
-          "The requested update will not result in any change to the cluster configuration." + lineSeparator() +
+          message + lineSeparator() +
           "=======================================================================================" + lineSeparator());
       return;
     }

--- a/dynamic-config/cli/dynamic-config-cli-api/src/main/java/org/terracotta/dynamic_config/cli/api/converter/OutputFormatGet.java
+++ b/dynamic-config/cli/dynamic-config-cli-api/src/main/java/org/terracotta/dynamic_config/cli/api/converter/OutputFormatGet.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.dynamic_config.cli.api.converter;
+
+public enum OutputFormatGet {
+  NAME,
+  INDEX;
+}

--- a/dynamic-config/model/src/main/java/org/terracotta/dynamic_config/api/model/Cluster.java
+++ b/dynamic-config/model/src/main/java/org/terracotta/dynamic_config/api/model/Cluster.java
@@ -377,6 +377,10 @@ public class Cluster implements Cloneable, PropertyHolder {
     return getStripes().stream().filter(s -> s.getUID().equals(stripeUID)).findAny();
   }
 
+  public Optional<Stripe> getStripeByName(String name) {
+    return getStripes().stream().filter(s -> s.getName().equals(name)).findAny();
+  }
+
   public Optional<Stripe> getStripe(int stripeId) {
     if (stripeId < 1) {
       throw new IllegalArgumentException("Invalid stripe ID: " + stripeId);
@@ -385,6 +389,16 @@ public class Cluster implements Cloneable, PropertyHolder {
       return Optional.empty();
     }
     return Optional.of(stripes.get(stripeId - 1));
+  }
+
+  public OptionalInt getNodeId(UID nodeUID) {
+    List<Node> nodes = stripes.stream()
+        .filter(s -> s.containsNode(nodeUID))
+        .findAny().get().getNodes();
+    return IntStream.range(0, nodes.size())
+        .filter(idx -> nodes.get(idx).getUID().equals(nodeUID))
+        .map(idx -> idx + 1)
+        .findAny();
   }
 
   public OptionalInt getStripeId(UID stripeUID) {

--- a/dynamic-config/model/src/main/java/org/terracotta/dynamic_config/api/model/Configuration.java
+++ b/dynamic-config/model/src/main/java/org/terracotta/dynamic_config/api/model/Configuration.java
@@ -227,7 +227,7 @@ public class Configuration {
   private final String key;
   private final String value;
 
-  private Configuration(String rawInput, Setting setting, Scope level, Integer stripeId, Integer nodeId, String key, String value) {
+  public Configuration(String rawInput, Setting setting, Scope level, Integer stripeId, Integer nodeId, String key, String value) {
     this.rawInput = requireNonNull(rawInput);
     this.setting = requireNonNull(setting);
     this.level = requireNonNull(level);

--- a/dynamic-config/model/src/main/java/org/terracotta/dynamic_config/api/model/Setting.java
+++ b/dynamic-config/model/src/main/java/org/terracotta/dynamic_config/api/model/Setting.java
@@ -1029,14 +1029,12 @@ public enum Setting {
         }
         break;
       case SET:
-        requireNonNull(value);
-        if (value.isEmpty()) {
+        if (value == null || value.isEmpty()) {
           throw new IllegalArgumentException("Operation " + operation + " requires a value");
         }
         break;
       case IMPORT:
-        requireNonNull(value);
-        if (value.isEmpty() && mustBePresent()) {
+        if ((value == null || value.isEmpty()) && mustBePresent()) {
           throw new IllegalArgumentException("Operation " + operation + " requires a value");
         }
         // ensure that properties requiring an eager resolve are resolved

--- a/dynamic-config/model/src/main/java/org/terracotta/dynamic_config/api/service/ClusterValidator.java
+++ b/dynamic-config/model/src/main/java/org/terracotta/dynamic_config/api/service/ClusterValidator.java
@@ -100,39 +100,39 @@ public class ClusterValidator {
 
   private void validateNames() {
     Stream.concat(Stream.of(cluster), cluster.descendants())
-        .filter(o -> o.getName() != null) // empty names will be validated elsewhere
-        .forEach(o -> {
-          String name = o.getName();
-          // emptiness
-          if (name.isEmpty()) {
-            throw new MalformedClusterException("Empty " + o.getScope().toString().toLowerCase() + " name");
-          }
-          // invalid chars
-          {
-            Character invalid = IntStream.range(0, name.length())
-                .mapToObj(name::charAt)
-                .filter(c -> binarySearch(FORBIDDEN_CTRL_CHARS, c) >= 0 || binarySearch(FORBIDDEN_FILE_CHARS, c) >= 0 || binarySearch(FORBIDDEN_DC_CHARS, c) >= 0)
-                .findFirst()
-                .orElse(null);
-            if (invalid != null) {
-              throw new MalformedClusterException("Invalid character in " + o.getScope().toString().toLowerCase() + " name: '" + invalid + "'");
-            }
-          }
-          // invalid ending characters
-          {
-            char last = name.charAt(name.length() - 1);
-            if (binarySearch(FORBIDDEN_ENDING_CHARS, last) >= 0) {
-              throw new MalformedClusterException("Invalid ending character in " + o.getScope().toString().toLowerCase() + " name: '" + last + "'");
-            }
-          }
-          // invalid filenames
-          {
-            String noExt = name.lastIndexOf(".") == -1 ? name : name.substring(0, name.lastIndexOf("."));
-            if (binarySearch(FORBIDDEN_NAMES_NO_EXT, noExt) >= 0) {
-              throw new MalformedClusterException("Invalid name for " + o.getScope().toString().toLowerCase() + ": '" + noExt + "' is a reserved word");
-            }
-          }
-        });
+      .filter(o -> o.getName() != null) // empty names will be validated elsewhere
+      .forEach(o -> validateName(o.getName(), o.getScope().toString().toLowerCase()));
+  }
+
+  public static void validateName(String name, String scope) {
+    if (name.isEmpty()) {
+      throw new MalformedClusterException("Empty " + scope.toString().toLowerCase() + " name");
+    }
+    // invalid chars
+    {
+      Character invalid = IntStream.range(0, name.length())
+          .mapToObj(name::charAt)
+          .filter(c -> binarySearch(FORBIDDEN_CTRL_CHARS, c) >= 0 || binarySearch(FORBIDDEN_FILE_CHARS, c) >= 0 || binarySearch(FORBIDDEN_DC_CHARS, c) >= 0)
+          .findFirst()
+          .orElse(null);
+      if (invalid != null) {
+        throw new MalformedClusterException("Invalid character in " + scope + " name: '" + invalid + "'");
+      }
+    }
+    // invalid ending characters
+    {
+      char last = name.charAt(name.length() - 1);
+      if (binarySearch(FORBIDDEN_ENDING_CHARS, last) >= 0) {
+        throw new MalformedClusterException("Invalid ending character in " + scope + " name: '" + last + "'");
+      }
+    }
+    // invalid filenames
+    {
+      String noExt = name.lastIndexOf(".") == -1 ? name : name.substring(0, name.lastIndexOf("."));
+      if (binarySearch(FORBIDDEN_NAMES_NO_EXT, noExt) >= 0) {
+        throw new MalformedClusterException("Invalid name for " + scope + ": '" + noExt + "' is a reserved word");
+      }
+    }
   }
 
   private void validateUIDs() {

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/SetCommand1x1IT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/SetCommand1x1IT.java
@@ -120,7 +120,7 @@ public class SetCommand1x1IT extends DynamicConfigIT {
         allOf(containsOutput("Restart required for cluster"), not(containsOutput("Restart required for nodes:"))));
 
     assertThat(
-        configTool("get", "-s", "localhost:" + getNodePort(), "-c", "failover-priority", "-c", "log-dir"),
+        configTool("get", "-s", "localhost:" + getNodePort(), "-c", "failover-priority", "-c", "log-dir", "-t", "index"),
         allOf(containsOutput("failover-priority=consistency:2"), containsOutput("stripe.1.node.1.log-dir=new-logs")));
   }
 
@@ -142,7 +142,7 @@ public class SetCommand1x1IT extends DynamicConfigIT {
         allOf(not(containsOutput("Restart required for cluster")), containsOutput("Restart required for nodes: ")));
 
     assertThat(
-        configTool("get", "-s", "localhost:" + getNodePort(), "-c", "cluster-name", "-c", "log-dir"),
+        configTool("get", "-s", "localhost:" + getNodePort(), "-c", "cluster-name", "-c", "log-dir", "-t", "index"),
         allOf(containsOutput("cluster-name=new-cluster"), containsOutput("stripe.1.node.1.log-dir=new-logs")));
   }
 
@@ -153,7 +153,7 @@ public class SetCommand1x1IT extends DynamicConfigIT {
         containsOutput("Restart required for nodes:"));
 
     assertThat(
-        configTool("get", "-s", "localhost:" + getNodePort(), "-c", "log-dir"),
+        configTool("get", "-s", "localhost:" + getNodePort(), "-c", "log-dir", "-t", "index"),
         containsOutput("stripe.1.node.1.log-dir=logs/stripe1"));
 
     // Restart node and verify that the change has taken effect
@@ -161,7 +161,7 @@ public class SetCommand1x1IT extends DynamicConfigIT {
     startNode(1, 1);
 
     assertThat(
-        configTool("get", "-s", "localhost:" + getNodePort(), "-r", "-c", "log-dir"),
+        configTool("get", "-s", "localhost:" + getNodePort(), "-r", "-c", "log-dir", "-t", "index"),
         containsOutput("stripe.1.node.1.log-dir=logs/stripe1"));
   }
 
@@ -265,7 +265,7 @@ public class SetCommand1x1IT extends DynamicConfigIT {
     assertThat(configTool("set", "-s", "localhost:" + publicPort, "-c", "stripe.1.node.1.public-hostname=" + publicHostname, "-c", "stripe.1.node.1.public-port=" + publicPort), is(successful()));
 
     assertThat(
-        configTool("get", "-s", publicHostname + ":" + getNodePort(), "-c", "stripe.1.node.1.public-hostname", "-c", "stripe.1.node.1.public-port"),
+        configTool("get", "-s", publicHostname + ":" + getNodePort(), "-c", "stripe.1.node.1.public-hostname", "-c", "stripe.1.node.1.public-port", "-t", "index"),
         allOf(containsOutput("stripe.1.node.1.public-hostname=" + publicHostname), containsOutput("stripe.1.node.1.public-port=" + publicPort)));
   }
 

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/diagnostic/GetCommand1x1IT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/diagnostic/GetCommand1x1IT.java
@@ -59,7 +59,7 @@ public class GetCommand1x1IT extends DynamicConfigIT {
   @Test
   public void testNode_getAllDataDirs() {
     assertThat(
-        configTool("get", "-s", "localhost:" + getNodePort(), "-c", "stripe.1.node.1.data-dirs"),
+        configTool("get", "-s", "localhost:" + getNodePort(), "-c", "stripe.1.node.1.data-dirs", "-t", "index"),
         containsOutput("stripe.1.node.1.data-dirs=main:data-dir"));
   }
 
@@ -73,7 +73,7 @@ public class GetCommand1x1IT extends DynamicConfigIT {
   @Test
   public void testNode_getNodePort() {
     assertThat(
-        configTool("get", "-s", "localhost:" + getNodePort(), "-c", "stripe.1.node.1.port"),
+        configTool("get", "-s", "localhost:" + getNodePort(), "-c", "stripe.1.node.1.port", "-t", "index"),
         containsOutput("stripe.1.node.1.port=" + getNodePort()));
   }
 

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/diagnostic/GetCommand1x2IT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/diagnostic/GetCommand1x2IT.java
@@ -57,7 +57,7 @@ public class GetCommand1x2IT extends DynamicConfigIT {
   @Test
   public void testStripe_getAllDataDirs() {
     assertThat(
-        configTool("get", "-s", "localhost:" + getNodePort(), "-c", "data-dirs"),
+        configTool("get", "-s", "localhost:" + getNodePort(), "-c", "data-dirs", "-t", "index"),
         allOf(
             containsOutput("stripe.1.node.1.data-dirs=main:"),
             containsOutput("stripe.1.node.2.data-dirs=main:")));
@@ -66,7 +66,7 @@ public class GetCommand1x2IT extends DynamicConfigIT {
   @Test
   public void testStripe_getAllNodeHostnames() {
     assertThat(
-        configTool("get", "-s", "localhost:" + getNodePort(), "-c", "stripe.1.hostname"),
+        configTool("get", "-s", "localhost:" + getNodePort(), "-c", "stripe.1.hostname", "-t", "index"),
         allOf(
             containsOutput("stripe.1.node.1.hostname=localhost"),
             containsOutput("stripe.1.node.2.hostname=localhost")));

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/diagnostic/SetCommand1x1IT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/diagnostic/SetCommand1x1IT.java
@@ -49,7 +49,7 @@ public class SetCommand1x1IT extends DynamicConfigIT {
     assertThat(configTool("set", "-s", "localhost:" + getNodePort(), "-c", "stripe.1.node.1.tc-properties.something=value"), is(successful()));
 
     assertThat(
-        configTool("get", "-s", "localhost:" + getNodePort(), "-c", "stripe.1.node.1.tc-properties.something"),
+        configTool("get", "-s", "localhost:" + getNodePort(), "-c", "stripe.1.node.1.tc-properties.something", "-t", "index"),
         containsOutput("stripe.1.node.1.tc-properties.something=value"));
   }
 
@@ -67,7 +67,7 @@ public class SetCommand1x1IT extends DynamicConfigIT {
     assertThat(configTool("set", "-s", "localhost:" + getNodePort(), "-c", "stripe.1.node.1.group-port=9630"), is(successful()));
 
     assertThat(
-        configTool("get", "-s", "localhost:" + getNodePort(), "-c", "stripe.1.node.1.group-port"),
+        configTool("get", "-s", "localhost:" + getNodePort(), "-c", "stripe.1.node.1.group-port", "-t", "index"),
         containsOutput("stripe.1.node.1.group-port=9630"));
   }
 
@@ -76,7 +76,7 @@ public class SetCommand1x1IT extends DynamicConfigIT {
     assertThat(configTool("set", "-s", "localhost:" + getNodePort(), "-c", "stripe.1.node.1.data-dirs.main=user-data/main/stripe1-node1-data-dir"), is(successful()));
 
     assertThat(
-        configTool("get", "-s", "localhost:" + getNodePort(), "-c", "stripe.1.node.1.data-dirs.main"),
+        configTool("get", "-s", "localhost:" + getNodePort(), "-c", "stripe.1.node.1.data-dirs.main", "-t", "index"),
         containsOutput("stripe.1.node.1.data-dirs.main=user-data/main/stripe1-node1-data-dir"));
   }
 
@@ -85,7 +85,7 @@ public class SetCommand1x1IT extends DynamicConfigIT {
     assertThat(configTool("set", "-s", "localhost:" + getNodePort(), "-c", "stripe.1.node.1.backup-dir=backup/stripe1-node1-backup"), is(successful()));
 
     assertThat(
-        configTool("get", "-s", "localhost:" + getNodePort(), "-c", "stripe.1.node.1.backup-dir"),
+        configTool("get", "-s", "localhost:" + getNodePort(), "-c", "stripe.1.node.1.backup-dir", "-t", "index"),
         containsOutput("stripe.1.node.1.backup-dir=backup/stripe1-node1-backup"));
   }
 
@@ -94,7 +94,7 @@ public class SetCommand1x1IT extends DynamicConfigIT {
     assertThat(configTool("set", "-s", "localhost:" + getNodePort(), "-c", "offheap-resources.main=1GB", "-c", "stripe.1.node.1.data-dirs.main=stripe1-node1-data-dir"), is(successful()));
 
     assertThat(
-        configTool("get", "-s", "localhost:" + getNodePort(), "-c", "offheap-resources.main", "-c", "stripe.1.node.1.data-dirs.main"),
+        configTool("get", "-s", "localhost:" + getNodePort(), "-c", "offheap-resources.main", "-c", "stripe.1.node.1.data-dirs.main", "-t", "index"),
         allOf(containsOutput("offheap-resources.main=1GB"), containsOutput("stripe.1.node.1.data-dirs.main=stripe1-node1-data-dir")));
   }
 

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/diagnostic/SetCommand1x2IT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/diagnostic/SetCommand1x2IT.java
@@ -39,7 +39,7 @@ public class SetCommand1x2IT extends DynamicConfigIT {
     assertThat(configTool("set", "-s", "localhost:" + getNodePort(), "-c", "stripe.1.data-dirs.main=stripe1-node1-data-dir"), is(successful()));
 
     assertThat(
-        configTool("get", "-s", "localhost:" + getNodePort(), "-c", "data-dirs"),
+        configTool("get", "-s", "localhost:" + getNodePort(), "-c", "data-dirs", "-t", "index"),
         allOf(containsOutput("stripe.1.node.1.data-dirs=main:stripe1-node1-data-dir"), containsOutput("stripe.1.node.2.data-dirs=main:stripe1-node1-data-dir")));
   }
 
@@ -48,7 +48,7 @@ public class SetCommand1x2IT extends DynamicConfigIT {
     assertThat(configTool("set", "-s", "localhost:" + getNodePort(), "-c", "stripe.1.backup-dir=backup/stripe-1"), is(successful()));
 
     assertThat(
-        configTool("get", "-s", "localhost:" + getNodePort(), "-c", "backup-dir"),
+        configTool("get", "-s", "localhost:" + getNodePort(), "-c", "backup-dir", "-t", "index"),
         allOf(containsOutput("stripe.1.node.1.backup-dir=backup/stripe-1"), containsOutput("stripe.1.node.2.backup-dir=backup/stripe-1")));
   }
 
@@ -110,6 +110,25 @@ public class SetCommand1x2IT extends DynamicConfigIT {
   public void setDuplicateNodeName() {
     assertThat(
         configTool("set", "-s", "localhost:" + getNodePort(), "-c", "stripe.1.node.1.name=node-1-2"),
+        containsOutput("Error: Found duplicate node name: node-1-2"));
+  }
+
+  @Test
+  public void test_set_new_config() {
+    assertThat(configTool("set", "-s", "localhost:" + getNodePort(), "-c", "stripe.1.stripe-name=stripeA"), is(successful()));
+
+    assertThat(configTool("set", "-s", "localhost:" + getNodePort(), "-c", "stripeA:data-dirs.main=stripe1-node1-data-dir"), is(successful()));
+    assertThat(
+        configTool("get", "-s", "localhost:" + getNodePort(), "-c", "data-dirs"),
+        allOf(containsOutput("node-1-1:data-dirs=main:stripe1-node1-data-dir"), containsOutput("node-1-2:data-dirs=main:stripe1-node1-data-dir")));
+
+    assertThat(configTool("set", "-s", "localhost:" + getNodePort(), "-c", "stripe:stripeA:backup-dir=backup/stripe-1"), is(successful()));
+    assertThat(
+        configTool("get", "-s", "localhost:" + getNodePort(), "-c", "backup-dir"),
+        allOf(containsOutput("node:node-1-1:backup-dir=backup/stripe-1"), containsOutput("node-1-2:backup-dir=backup/stripe-1")));
+
+    assertThat(
+        configTool("set", "-s", "localhost:" + getNodePort(), "-c", "node-1-1:name=node-1-2"),
         containsOutput("Error: Found duplicate node name: node-1-2"));
   }
 }

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/diagnostic/SetCommand2x2IT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/diagnostic/SetCommand2x2IT.java
@@ -1,0 +1,315 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.dynamic_config.system_tests.diagnostic;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.terracotta.dynamic_config.test_support.ClusterDefinition;
+import org.terracotta.dynamic_config.test_support.DynamicConfigIT;
+
+import java.util.stream.Stream;
+
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.terracotta.angela.client.support.hamcrest.AngelaMatchers.containsOutput;
+import static org.terracotta.angela.client.support.hamcrest.AngelaMatchers.successful;
+
+@ClusterDefinition(stripes = 2, nodesPerStripe = 2)
+public class SetCommand2x2IT extends DynamicConfigIT {
+
+  private String connection;
+
+  @Before
+  public void before() {
+    connection = "localhost:" + getNodePort();
+    assertThat(configTool("attach", "-to-stripe", "localhost:" + getNodePort(), "-node", "localhost:" + getNodePort(1, 2)), is(successful()));
+    assertThat(configTool("attach", "-to-stripe", "localhost:" + getNodePort(2,1), "-node", "localhost:" + getNodePort(2, 2)), is(successful()));
+    assertThat(configTool("attach", "-to-cluster", "localhost:" + getNodePort(1,1), "-stripe", "localhost:" + getNodePort(2, 1)), is(successful()));
+
+    assertThat(configTool("set", "-connect-to", connection,
+      "-setting", "stripe.1.node.1.name=node1",
+      "-setting", "stripe.1.node.2.name=node2",
+      "-setting", "stripe.2.node.1.name=node3",
+      "-setting", "stripe.2.node.2.name=node4",
+      "-setting", "stripe.1.stripe-name=stripeA",
+      "-setting", "stripe.2.stripe-name=stripeB"
+      ), is(successful()));
+
+    assertThat(configTool("get", "-connect-to", connection,
+      "-setting", "name",
+      "-setting", "stripe-name"
+      ), allOf(containsOutput("node:node1:name=node1"),
+        containsOutput("node:node2:name=node2"),
+        containsOutput("node:node3:name=node3"),
+        containsOutput("node:node4:name=node4"),
+        containsOutput("stripe:stripeA:stripe-name=stripeA"),
+        containsOutput("stripe:stripeB:stripe-name=stripeB")));
+
+    assertThat(configTool("get", "-connect-to", connection, "-outputformat", "index",
+      "-setting", "name",
+      "-setting", "stripe-name"
+      ), allOf(containsOutput("stripe.1.node.1.name=node1"),
+        containsOutput("stripe.1.node.2.name=node2"),
+        containsOutput("stripe.2.node.1.name=node3"),
+        containsOutput("stripe.2.node.2.name=node4"),
+        containsOutput("stripe.1.stripe-name=stripeA"),
+        containsOutput("stripe.2.stripe-name=stripeB")));
+  }
+
+  @Test
+  public void test_get_set_scope_overrides() {
+
+    assertThat(configTool("set", "-connect-to", connection,
+      "-setting", "backup-dir=X"
+      ), is(successful()));
+
+    assertThat(configTool("get", "-connect-to", connection,
+      "-setting", "backup-dir"
+      ), allOf(containsOutput("node:node1:backup-dir=X"),
+        containsOutput("node:node2:backup-dir=X"),
+        containsOutput("node:node3:backup-dir=X"),
+        containsOutput("node:node4:backup-dir=X")));
+
+    assertThat(configTool("get", "-connect-to", connection, "-outputformat", "index",
+      "-setting", "backup-dir"
+      ), allOf(containsOutput("stripe.1.node.1.backup-dir=X"),
+        containsOutput("stripe.1.node.2.backup-dir=X"),
+        containsOutput("stripe.2.node.1.backup-dir=X"),
+        containsOutput("stripe.2.node.2.backup-dir=X")));
+
+    // Node overrides stripe and stripe overrides cluster-level settings
+
+    assertThat(configTool("set", "-connect-to", connection,
+      "-setting", "stripeB:backup-dir=YY",
+      "-setting", "backup-dir=XX",
+      "-setting", "node2:backup-dir=ZZ",
+      "-setting", "node4:backup-dir=ZZZ"
+      ), is(successful()));
+
+    assertThat(configTool("get", "-connect-to", connection,
+      "-setting", "backup-dir"
+      ), allOf(containsOutput("node:node1:backup-dir=XX"),
+        containsOutput("node:node2:backup-dir=ZZ"),
+        containsOutput("node:node3:backup-dir=YY"),
+        containsOutput("node:node4:backup-dir=ZZZ")));
+
+    assertThat(configTool("get", "-connect-to", connection, "-outputformat", "index",
+      "-setting", "backup-dir"
+      ), allOf(containsOutput("stripe.1.node.1.backup-dir=XX"),
+        containsOutput("stripe.1.node.2.backup-dir=ZZ"),
+        containsOutput("stripe.2.node.1.backup-dir=YY"),
+        containsOutput("stripe.2.node.2.backup-dir=ZZZ")));
+
+    // Stripe overrides cluster
+
+    assertThat(configTool("set", "-connect-to", connection,
+      "-setting", "backup-dir=Z",
+      "-setting", "stripeA:backup-dir=YY",
+      "-setting", "stripeB:backup-dir=YY"
+      ), is(successful()));
+
+    assertThat(configTool("set", "-connect-to", connection,
+      "-setting", "backup-dir=ZZZZZ",
+      "-setting", "stripeA:backup-dir=YY",
+      "-setting", "stripeB:backup-dir=YY"
+      ), containsOutput("The requested update will not result in any change to the cluster configuration"));
+  }
+
+  @Test
+  public void test_get_set_settings() {
+
+    // Other settings
+
+    assertThat(configTool("set", "-connect-to", connection,
+      "-setting", "stripeB:tc-properties.a=A",
+      "-setting", "tc-properties.a.b=AB",
+      "-setting", "node2:tc-properties.a.b=AABB",
+      "-setting", "node4:tc-properties.a.b.c=ABC"
+      ), is(successful()));
+
+    assertThat(configTool("get", "-connect-to", connection,
+      "-setting", "tc-properties"
+      ), allOf(containsOutput("node:node1:tc-properties=a.b:AB"),
+        containsOutput("node:node2:tc-properties=a.b:AABB"),
+        containsOutput("node:node3:tc-properties=a:A,a.b:AB"),
+        containsOutput("node:node4:tc-properties=a:A,a.b:AB,a.b.c:ABC")));
+
+    assertThat(configTool("get", "-connect-to", connection, "-outputformat", "index",
+      "-setting", "tc-properties"
+      ), allOf(containsOutput("stripe.1.node.1.tc-properties=a.b:AB"),
+        containsOutput("stripe.1.node.2.tc-properties=a.b:AABB"),
+        containsOutput("stripe.2.node.1.tc-properties=a:A,a.b:AB"),
+        containsOutput("stripe.2.node.2.tc-properties=a:A,a.b:AB,a.b.c:ABC")));
+ }
+
+  @Test
+  public void test_get_set_more_settings() {
+
+    // Other settings
+    assertThat(configTool("get", "-connect-to", connection,
+        "-setting", "client-reconnect-window",
+        "-setting", "offheap-resources.main"
+    ), allOf(containsOutput("client-reconnect-window=10s"),
+        containsOutput("offheap-resources.main=512MB")));
+
+    assertThat(configTool("set", "-connect-to", connection,
+        "-setting", "client-reconnect-window=120s",
+        "-setting", "offheap-resources.main=512MB"
+    ), is(successful()));
+
+    assertThat(configTool("get", "-connect-to", connection,
+        "-setting", "client-reconnect-window",
+        "-setting", "offheap-resources"
+    ), allOf(containsOutput("client-reconnect-window=120s"),
+        containsOutput("offheap-resources=foo:1GB,main:512MB")));
+
+    assertThat(configTool("get", "-connect-to", connection, "-outputformat", "index",
+        "-setting", "client-reconnect-window",
+        "-setting", "offheap-resources"
+    ), allOf(containsOutput("client-reconnect-window=120s"),
+        containsOutput("offheap-resources=foo:1GB,main:512MB")));
+  }
+
+  @Test
+  public void test_set_errors() {
+    assertThat(configTool("set", "-connect-to", connection,
+      "-setting", "stripe.1.node.2.backup-dir=Z",
+      "-setting", "node2:backup-dir=Z"
+      ), containsOutput("Error: Duplicate configurations found: stripe.1.node.2.backup-dir=Z and node2:backup-dir=Z"));
+
+    assertThat(configTool("set", "-connect-to", connection,
+      "-setting", "stripeeee:stripeA:backup-dir=Y"
+      ), containsOutput("Error: Scope 'stripeeee:' specified in property 'stripeeee:stripeA:backup-dir=Y' is invalid. " +
+        "Scope must be one of 'stripe:' or 'node:'"));
+
+    assertThat(configTool("set", "-connect-to", connection,
+      "-setting", "stripe:stripeAAA:backup-dir=Y"
+      ), containsOutput("Error: Name 'stripeAAA' in setting 'stripe:stripeAAA:backup-dir=Y' is not a recognized stripe."));
+
+    assertThat(configTool("set", "-connect-to", connection,
+      "-setting", "stripeAAA:backup-dir=Y"
+      ), containsOutput("Error: Name 'stripeAAA' in setting 'stripeAAA:backup-dir=Y' is not a recognized stripe or node."));
+
+    assertThat(configTool("set", "-connect-to", connection,
+      "-setting", "node:node111:backup-dir=Y"
+      ), containsOutput("Error: Name 'node111' in setting 'node:node111:backup-dir=Y' is not a recognized node."));
+
+    assertThat(configTool("set", "-connect-to", connection,
+      "-setting", "node111:backup-dir=Y"
+      ), containsOutput("Error: Name 'node111' in setting 'node111:backup-dir=Y' is not a recognized stripe or node."));
+
+    assertThat(configTool("set", "-connect-to", connection,
+      "-setting", "stripeA:stripe-name=node1"
+      ), is(successful()));
+    assertThat(configTool("set", "-connect-to", connection,
+      "-setting", "node1:backup-dir=Y"
+      ), containsOutput("Error: Name 'node1' in setting 'node1:backup-dir=Y' is both a stripe name and node name. " +
+        "It must be qualified with either 'stripe:' or 'node:'"));
+  }
+  @Test
+  public void test_forbidden_chars_in_names() {
+
+    // Invalid Character sets from ClusterValidator
+    Character[] FORBIDDEN_FILE_CHARS = {':', '/', '\\', '<', '>', '"', '|', '*', '?'};
+    Character[] FORBIDDEN_DC_CHARS_1 = {' ', ':', '{', '}', ','};
+    Character[] FORBIDDEN_DC_CHARS_2 = {'=', '%'};
+    Character[] ALLOWED_SPECIAL_CHARACTERS = {'~', '`', '!', '@', '#', '$', '^', '&', '(', ')', '-',  +
+        '_', '+', '.', ';', '\'', ']', '['};
+
+    Stream.of(FORBIDDEN_FILE_CHARS).forEach(c ->
+      assertThat(configTool("set", "-connect-to", connection,
+        "-setting", "node1:name=bad" + c + "name"
+        ), allOf(containsOutput("Error: Invalid character in node name"),
+          containsOutput("'" + c + "'"))));
+
+    Stream.of(FORBIDDEN_DC_CHARS_1).forEach(c ->
+      assertThat(configTool("set", "-connect-to", connection,
+        "-setting", "node1:name=bad" + c + "name"
+        ), allOf(containsOutput("Error: Invalid character in node name"),
+          containsOutput("'" + c + "'"))));
+
+    // These invalid chars are identified and thrown before ClusterValidator.validateName() sees them
+    Stream.of(FORBIDDEN_DC_CHARS_2).forEach(c ->
+      assertThat(configTool("set", "-connect-to", connection,
+        "-setting", "node1:name=bad" + c + "name"
+        ), containsOutput("Error: Invalid input")));
+
+    // A few more examples but using 'stripe' and displaying full error messages
+
+    assertThat(configTool("set", "-connect-to", connection,
+      "-setting", "stripeA:stripe-name=[bad{name}"
+      ), containsOutput("Error: Invalid character in stripe name: '{'"));
+
+    assertThat(configTool("set", "-connect-to", connection,
+      "-setting", "stripeB:stripe-name=[bad|name"
+      ), containsOutput("Error: Invalid character in stripe name: '|'"));
+
+    assertThat(configTool("set", "-connect-to", connection,
+      "-setting", "node1:name=]bad?name"
+      ), containsOutput("Error: Invalid character in node name: '?'"));
+
+    assertThat(configTool("set", "-connect-to", connection,
+      "-setting", "node1:name=#bad name"
+      ), containsOutput("Error: Invalid character in node name: ' '"));
+
+    // Test each of the allowed special characters (i.e. chars that do not appear in the FORBIDDEN lists)
+    Stream.of(ALLOWED_SPECIAL_CHARACTERS).forEach(c ->
+      assertThat(configTool("set", "-connect-to", connection,
+        "-setting", "stripe.1.node.1.name=good" + c + "name"), is(successful())));
+
+    // Test as a single ridiculous node name
+    assertThat(configTool("set", "-connect-to", connection,
+      "-setting", "stripe.1.node.1.name=~`!@#$^&()-_+.;']["), is(successful()));
+  }
+
+  @Test
+  public void test_set_missing_value_errors() {
+
+    assertThat(configTool("set", "-connect-to", connection,
+      "-setting", "stripeB:backup-dir="
+      ), containsOutput("Error: Invalid input: 'stripeB:backup-dir='. Reason: Operation set requires a value"));
+
+    assertThat(configTool("set", "-connect-to", connection,
+      "-setting", "stripe:stripeB:backup-dir="
+      ), containsOutput("Error: Invalid input: 'stripe:stripeB:backup-dir='. Reason: Operation set requires a value"));
+
+    assertThat(configTool("set", "-connect-to", connection,
+      "-setting", "stripeB:backup-dir"
+      ), containsOutput("Error: Invalid input: 'stripeB:backup-dir'. Reason: Operation set requires a value"));
+
+    assertThat(configTool("set", "-connect-to", connection,
+      "-setting", "stripe:stripeB:backup-dir"
+      ), containsOutput("Error: Invalid input: 'stripe:stripeB:backup-dir'. Reason: Operation set requires a value"));
+
+
+    assertThat(configTool("set", "-connect-to", connection,
+      "-setting", "node2:backup-dir="
+      ), containsOutput("Error: Invalid input: 'node2:backup-dir='. Reason: Operation set requires a value"));
+
+    assertThat(configTool("set", "-connect-to", connection,
+      "-setting", "node:node2:backup-dir="
+      ), containsOutput("Error: Invalid input: 'node:node2:backup-dir='. Reason: Operation set requires a value"));
+
+    assertThat(configTool("set", "-connect-to", connection,
+      "-setting", "node2:backup-dir"
+      ), containsOutput("Error: Invalid input: 'node2:backup-dir'. Reason: Operation set requires a value"));
+
+    assertThat(configTool("set", "-connect-to", connection,
+      "-setting", "node:node2:backup-dir"
+      ), containsOutput("Error: Invalid input: 'node:node2:backup-dir'. Reason: Operation set requires a value"));
+  }
+}


### PR DESCRIPTION
- New config file format supported at Config Tool cli for get, set and unset commands.
- New '-outputformat' option on get command will output results in index-based namespace format ('index') or name-based namespace format ('name').  Default is outputformat=name.