### PR TITLE
Update to final release versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,12 +33,12 @@
     <maven.version>3.6.3</maven.version>
     <slf4j.version>1.7.25</slf4j.version>
     <logback.version>1.2.3</logback.version>
-    <terracotta-apis.version>1.8.0-pre3</terracotta-apis.version>
+    <terracotta-apis.version>1.8.0</terracotta-apis.version>
     <terracotta-configuration.version>10.7.1</terracotta-configuration.version>
-    <passthrough-testing.version>1.8.0-pre5</passthrough-testing.version>
-    <terracotta-core.version>5.8.0-pre5</terracotta-core.version>
+    <passthrough-testing.version>1.8.0</passthrough-testing.version>
+    <terracotta-core.version>5.8.0</terracotta-core.version>
     <tripwire.version>1.0.1</tripwire.version>
-    <galvan.version>1.6.0-pre6</galvan.version>
+    <galvan.version>1.6.0</galvan.version>
     <angela.version>3.1.19</angela.version>
     <statistics.version>2.1</statistics.version>
     <jackson.version>2.12.2</jackson.version>


### PR DESCRIPTION
 - terracotta-apis 1.8.0
 - terracotta-core 5.8.0
 - tc-passthrough-testing 1.8.0
 - galvan 1.6.0