### PR TITLE
Notify that a client/entity registry is AVAILABLE after it has changed in any way.

### DIFF
--- a/management/monitoring-service/src/main/java/org/terracotta/management/service/monitoring/TopologyService.java
+++ b/management/monitoring-service/src/main/java/org/terracotta/management/service/monitoring/TopologyService.java
@@ -437,9 +437,8 @@ class TopologyService implements PlatformListener {
     LOGGER.trace("[{}] willSetClientManagementRegistry({}, {})", consumerId, clientDescriptor, newRegistry);
 
     whenFetchClient(consumerId, clientDescriptor).executeOrDelay("client-registry", client -> {
-      boolean hadRegistry = client.getManagementRegistry().isPresent();
-      client.setManagementRegistry(newRegistry);
-      if (!hadRegistry) {
+      if (!newRegistry.equals(client.getManagementRegistry().orElse(null))) {
+        client.setManagementRegistry(newRegistry);
         firingService.fireNotification(new ContextualNotification(client.getContext(), Notification.CLIENT_REGISTRY_AVAILABLE.name()));
       }
     });
@@ -502,11 +501,8 @@ class TopologyService implements PlatformListener {
     LOGGER.trace("[{}] willSetEntityManagementRegistry({}, {})", consumerId, serverName, names);
 
     whenServerEntity(consumerId, serverName).executeOrDelay("entity-registry", serverEntity -> {
-      List<String> names2 = newRegistry.getCapabilities().stream().map(Capability::getName).collect(Collectors.toList());
-
-      boolean hadRegistry = serverEntity.getManagementRegistry().isPresent();
-      serverEntity.setManagementRegistry(newRegistry);
-      if (!hadRegistry) {
+      if (!newRegistry.equals(serverEntity.getManagementRegistry().orElse(null))) {
+        serverEntity.setManagementRegistry(newRegistry);
         firingService.fireNotification(new ContextualNotification(serverEntity.getContext(), Notification.ENTITY_REGISTRY_AVAILABLE.name()));
       }
     });

--- a/management/monitoring-service/src/test/java/org/terracotta/management/service/monitoring/ManagementRegistryServiceTest.java
+++ b/management/monitoring-service/src/test/java/org/terracotta/management/service/monitoring/ManagementRegistryServiceTest.java
@@ -129,7 +129,7 @@ public class ManagementRegistryServiceTest {
     registry.register(new MyObject("myCacheManagerName2", "myCacheName2"));
     registry.refresh();
 
-    assertThat(buffer.size(), equalTo(0));
+    assertThat(buffer.size(), equalTo(1));
   }
 
 }

--- a/management/monitoring-service/src/test/java/org/terracotta/management/service/monitoring/VoltronMonitoringServiceTest.java
+++ b/management/monitoring-service/src/test/java/org/terracotta/management/service/monitoring/VoltronMonitoringServiceTest.java
@@ -362,7 +362,7 @@ public class VoltronMonitoringServiceTest {
         new DefaultCapability("capabilityName", new CapabilityContext(), new CallDescriptor("myMethod", "java.lang.String")));
 
     messages = messages();
-    assertThat(messages.size(), equalTo(0));
+    assertThat(messages.size(), equalTo(1));
   }
 
   @Test

--- a/management/testing/integration-tests/src/test/java/org/terracotta/management/integration/tests/ReconfigureEntityIT.java
+++ b/management/testing/integration-tests/src/test/java/org/terracotta/management/integration/tests/ReconfigureEntityIT.java
@@ -25,6 +25,7 @@ import org.terracotta.management.entity.sample.client.CacheEntityFactory;
 import org.terracotta.management.model.cluster.Cluster;
 import org.terracotta.management.model.notification.ContextualNotification;
 
+import java.util.Arrays;
 import java.util.List;
 
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -101,6 +102,7 @@ public class ReconfigureEntityIT extends AbstractSingleTest {
 
     String[] latestReceivedNotifs = {"SERVER_CACHE_DESTROYED", "SERVER_CACHE_CREATED", "CLIENT_ATTACHED", "CLIENT_ATTACHED", "SERVER_ENTITY_RECONFIGURED"};
     List<ContextualNotification> notifs = waitForAllNotifications(latestReceivedNotifs);
+    notifs.removeIf(notif -> !Arrays.asList(latestReceivedNotifs).contains(notif.getType()));
     notifs = notifs.subList(notifs.size() - latestReceivedNotifs.length, notifs.size());
 
     JsonNode actual = removeRandomValues(toJson(notifs));

--- a/management/testing/integration-tests/src/test/resources/notifications.json
+++ b/management/testing/integration-tests/src/test/resources/notifications.json
@@ -158,6 +158,19 @@
   {
     "attributes": {},
     "context": {
+      "stripeId": "stripe[0]",
+      "serverId": "testServer0",
+      "serverName": "testServer0",
+      "entityId": "pet-clinic/pets:org.terracotta.management.entity.sample.client.CacheEntity",
+      "entityName": "pet-clinic/pets",
+      "entityType": "org.terracotta.management.entity.sample.client.CacheEntity",
+      "consumerId": "7"
+    },
+    "type": "ENTITY_REGISTRY_AVAILABLE"
+  },
+  {
+    "attributes": {},
+    "context": {
       "consumerId": "7",
       "alias": "0@127.0.0.1:pet-clinic:<uuid>",
       "type": "ClientState",
@@ -169,6 +182,13 @@
       "entityType": "org.terracotta.management.entity.sample.client.CacheEntity"
     },
     "type": "CLIENT_ATTACHED"
+  },
+  {
+    "attributes": {},
+    "context": {
+      "clientId": "0@127.0.0.1:pet-clinic:<uuid>"
+    },
+    "type": "CLIENT_REGISTRY_AVAILABLE"
   },
   {
     "attributes": {},
@@ -197,6 +217,19 @@
   {
     "attributes": {},
     "context": {
+      "stripeId": "stripe[0]",
+      "serverId": "testServer0",
+      "serverName": "testServer0",
+      "entityId": "pet-clinic/pets:org.terracotta.management.entity.sample.client.CacheEntity",
+      "entityName": "pet-clinic/pets",
+      "entityType": "org.terracotta.management.entity.sample.client.CacheEntity",
+      "consumerId": "7"
+    },
+    "type": "ENTITY_REGISTRY_AVAILABLE"
+  },
+  {
+    "attributes": {},
+    "context": {
       "consumerId": "7",
       "alias": "0@127.0.0.1:pet-clinic:<uuid>",
       "type": "ClientState",
@@ -208,6 +241,13 @@
       "entityType": "org.terracotta.management.entity.sample.client.CacheEntity"
     },
     "type": "CLIENT_ATTACHED"
+  },
+  {
+    "attributes": {},
+    "context": {
+      "clientId": "0@127.0.0.1:pet-clinic:<uuid>"
+    },
+    "type": "CLIENT_REGISTRY_AVAILABLE"
   },
   {
     "attributes": {},
@@ -277,6 +317,19 @@
   {
     "attributes": {},
     "context": {
+      "stripeId": "stripe[0]",
+      "serverId": "testServer0",
+      "serverName": "testServer0",
+      "entityId": "pet-clinic/clients:org.terracotta.management.entity.sample.client.CacheEntity",
+      "entityName": "pet-clinic/clients",
+      "entityType": "org.terracotta.management.entity.sample.client.CacheEntity",
+      "consumerId": "8"
+    },
+    "type": "ENTITY_REGISTRY_AVAILABLE"
+  },
+  {
+    "attributes": {},
+    "context": {
       "consumerId": "8",
       "alias": "0@127.0.0.1:pet-clinic:<uuid>",
       "type": "ClientState",
@@ -288,6 +341,13 @@
       "entityType": "org.terracotta.management.entity.sample.client.CacheEntity"
     },
     "type": "CLIENT_ATTACHED"
+  },
+  {
+    "attributes": {},
+    "context": {
+      "clientId": "0@127.0.0.1:pet-clinic:<uuid>"
+    },
+    "type": "CLIENT_REGISTRY_AVAILABLE"
   },
   {
     "attributes": {},
@@ -316,6 +376,19 @@
   {
     "attributes": {},
     "context": {
+      "stripeId": "stripe[0]",
+      "serverId": "testServer0",
+      "serverName": "testServer0",
+      "entityId": "pet-clinic/clients:org.terracotta.management.entity.sample.client.CacheEntity",
+      "entityName": "pet-clinic/clients",
+      "entityType": "org.terracotta.management.entity.sample.client.CacheEntity",
+      "consumerId": "8"
+    },
+    "type": "ENTITY_REGISTRY_AVAILABLE"
+  },
+  {
+    "attributes": {},
+    "context": {
       "consumerId": "8",
       "alias": "0@127.0.0.1:pet-clinic:<uuid>",
       "type": "ClientState",
@@ -327,6 +400,13 @@
       "entityType": "org.terracotta.management.entity.sample.client.CacheEntity"
     },
     "type": "CLIENT_ATTACHED"
+  },
+  {
+    "attributes": {},
+    "context": {
+      "clientId": "0@127.0.0.1:pet-clinic:<uuid>"
+    },
+    "type": "CLIENT_REGISTRY_AVAILABLE"
   },
   {
     "attributes": {},


### PR DESCRIPTION
This defect shows itself as the no statistics appearing in the Server Resource Usage panel for newly attached stripes.
