### PR TITLE
support jar version/info reporting

### DIFF
--- a/client-message-tracker/pom.xml
+++ b/client-message-tracker/pom.xml
@@ -40,6 +40,11 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>org.terracotta.internal</groupId>
+      <artifactId>common-spi</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
       <scope>provided</scope>

--- a/client-message-tracker/src/main/java/org/terracotta/client/message/tracker/ClientMessageTrackerExtensionInfo.java
+++ b/client-message-tracker/src/main/java/org/terracotta/client/message/tracker/ClientMessageTrackerExtensionInfo.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.client.message.tracker;
+
+import com.tc.productinfo.ExtensionInfo;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.Collections;
+import java.util.Map;
+import java.util.jar.JarFile;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static java.lang.System.lineSeparator;
+
+public class ClientMessageTrackerExtensionInfo implements ExtensionInfo {
+
+  private static final String PLUGIN_NAME = "Client Message Tracker Service";
+  private static final String[] BASE_ATTRIBUTES = {"Bundle-Version", "BuildInfo-Timestamp", "Build-Jdk"};
+  private Map<String, String> getJarManifestInfo() {
+    try {
+      File file = new File(this.getClass().getProtectionDomain().getCodeSource().getLocation().toURI());
+      if (file.isDirectory()) {
+        return Collections.emptyMap();
+      }
+      try (JarFile jar = new JarFile(file)) {
+        return jar.getManifest().getMainAttributes().entrySet().stream()
+            .collect(Collectors.toMap(e -> e.getKey().toString(), e -> e.getValue().toString()));
+      }
+    } catch (IOException | URISyntaxException e) {
+      throw new IllegalStateException(e);
+    }
+  }
+
+  @Override
+  public String getExtensionInfo() {
+    Map<String, String> attributes = getJarManifestInfo();
+    return PLUGIN_NAME + ":" + lineSeparator() + Stream.of(BASE_ATTRIBUTES)
+        .filter(attributes::containsKey)
+        .map(n -> n + ": " + attributes.get(n))
+        .collect(Collectors.joining(lineSeparator())) + lineSeparator();
+  }
+
+  @Override
+  public String getValue(String name) {
+    if (name.equals(DESCRIPTION)) {
+      return getExtensionInfo();
+    } else {
+      return "";
+    }
+  }
+}

--- a/client-message-tracker/src/main/resources/META-INF/services/com.tc.productinfo.Description
+++ b/client-message-tracker/src/main/resources/META-INF/services/com.tc.productinfo.Description
@@ -1,0 +1,18 @@
+#
+# The contents of this file are subject to the Terracotta Public License Version
+# 2.0 (the "License"); You may not use this file except in compliance with the
+# License. You may obtain a copy of the License at
+#
+# http://terracotta.org/legal/terracotta-public-license.
+#
+# Software distributed under the License is distributed on an "AS IS" basis,
+# WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+# the specific language governing rights and limitations under the License.
+#
+# The Covered Software is Terracotta Platform.
+#
+# The Initial Developer of the Covered Software is
+# Terracotta, Inc., a Software AG company
+#
+
+org.terracotta.client.message.tracker.ClientMessageTrackerExtensionInfo

--- a/concurrent-map-entity/server/pom.xml
+++ b/concurrent-map-entity/server/pom.xml
@@ -42,6 +42,11 @@
       <artifactId>entity-server-api</artifactId>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>org.terracotta.internal</groupId>
+      <artifactId>common-spi</artifactId>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
 
 

--- a/concurrent-map-entity/server/src/main/java/org/terracotta/entity/map/server/ClusteredMapServerExtensionInfo.java
+++ b/concurrent-map-entity/server/src/main/java/org/terracotta/entity/map/server/ClusteredMapServerExtensionInfo.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.entity.map.server;
+
+import com.tc.productinfo.ExtensionInfo;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.Collections;
+import java.util.Map;
+import java.util.jar.JarFile;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static java.lang.System.lineSeparator;
+
+public class ClusteredMapServerExtensionInfo implements ExtensionInfo {
+
+  private static final String PLUGIN_NAME = "Clustered Map Server Plugin";
+  private static final String[] BASE_ATTRIBUTES = {"Bundle-Version", "BuildInfo-Timestamp", "Build-Jdk"};
+  private Map<String, String> getJarManifestInfo() {
+    try {
+      File file = new File(this.getClass().getProtectionDomain().getCodeSource().getLocation().toURI());
+      if (file.isDirectory()) {
+        return Collections.emptyMap();
+      }
+      try (JarFile jar = new JarFile(file)) {
+        return jar.getManifest().getMainAttributes().entrySet().stream()
+            .collect(Collectors.toMap(e -> e.getKey().toString(), e -> e.getValue().toString()));
+      }
+    } catch (IOException | URISyntaxException e) {
+      throw new IllegalStateException(e);
+    }
+  }
+
+  @Override
+  public String getExtensionInfo() {
+    Map<String, String> attributes = getJarManifestInfo();
+    return PLUGIN_NAME + ":" + lineSeparator() + Stream.of(BASE_ATTRIBUTES)
+        .filter(attributes::containsKey)
+        .map(n -> n + ": " + attributes.get(n))
+        .collect(Collectors.joining(lineSeparator())) + lineSeparator();
+  }
+
+  @Override
+  public String getValue(String name) {
+    if (name.equals(DESCRIPTION)) {
+      return getExtensionInfo();
+    } else {
+      return "";
+    }
+  }
+}

--- a/concurrent-map-entity/server/src/main/resources/META-INF/services/com.tc.productinfo.Description
+++ b/concurrent-map-entity/server/src/main/resources/META-INF/services/com.tc.productinfo.Description
@@ -1,0 +1,18 @@
+#
+# The contents of this file are subject to the Terracotta Public License Version
+# 2.0 (the "License"); You may not use this file except in compliance with the
+# License. You may obtain a copy of the License at
+#
+# http://terracotta.org/legal/terracotta-public-license.
+#
+# Software distributed under the License is distributed on an "AS IS" basis,
+# WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+# the specific language governing rights and limitations under the License.
+#
+# The Covered Software is Terracotta Platform.
+#
+# The Initial Developer of the Covered Software is
+# Terracotta, Inc., a Software AG company
+#
+
+org.terracotta.entity.map.server.ClusteredMapServerExtensionInfo

--- a/data-root-resource/pom.xml
+++ b/data-root-resource/pom.xml
@@ -74,6 +74,11 @@
       <artifactId>entity-server-api</artifactId>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>org.terracotta.internal</groupId>
+      <artifactId>common-spi</artifactId>
+      <scope>provided</scope>
+    </dependency>
 
     <dependency>
       <groupId>junit</groupId>

--- a/data-root-resource/src/main/java/org/terracotta/config/data_roots/DataRootResourceExtensionInfo.java
+++ b/data-root-resource/src/main/java/org/terracotta/config/data_roots/DataRootResourceExtensionInfo.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.config.data_roots;
+
+import com.tc.productinfo.ExtensionInfo;
+import org.terracotta.dynamic_config.server.api.ManifestInfo;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static java.lang.System.lineSeparator;
+
+public class DataRootResourceExtensionInfo implements ExtensionInfo {
+
+  private static final String PLUGIN_NAME = "Data Root Plugin";
+
+  @Override
+  public String getExtensionInfo() {
+    Map<String, String> attributes = ManifestInfo.getJarManifestInfo(this.getClass());
+    return PLUGIN_NAME + ":" + lineSeparator() + Stream.of(ManifestInfo.BASE_ATTRIBUTES)
+        .filter(attributes::containsKey)
+        .map(n -> n + ": " + attributes.get(n))
+        .collect(Collectors.joining(lineSeparator())) + lineSeparator();
+  }
+
+  @Override
+  public String getValue(String name) {
+    if (name.equals(DESCRIPTION)) {
+      return getExtensionInfo();
+    } else {
+      return "";
+    }
+  }
+}

--- a/data-root-resource/src/main/resources/META-INF/services/com.tc.productinfo.Description
+++ b/data-root-resource/src/main/resources/META-INF/services/com.tc.productinfo.Description
@@ -1,0 +1,18 @@
+#
+# The contents of this file are subject to the Terracotta Public License Version
+# 2.0 (the "License"); You may not use this file except in compliance with the
+# License. You may obtain a copy of the License at
+#
+# http://terracotta.org/legal/terracotta-public-license.
+#
+# Software distributed under the License is distributed on an "AS IS" basis,
+# WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+# the specific language governing rights and limitations under the License.
+#
+# The Covered Software is Terracotta Platform.
+#
+# The Initial Developer of the Covered Software is
+# Terracotta, Inc., a Software AG company
+#
+
+org.terracotta.config.data_roots.DataRootResourceExtensionInfo

--- a/diagnostic/service/src/main/java/org/terracotta/diagnostic/server/DiagnosticServiceExtensionInfo.java
+++ b/diagnostic/service/src/main/java/org/terracotta/diagnostic/server/DiagnosticServiceExtensionInfo.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.diagnostic.server;
+
+import com.tc.productinfo.ExtensionInfo;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.Collections;
+import java.util.Map;
+import java.util.jar.JarFile;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static java.lang.System.lineSeparator;
+
+public class DiagnosticServiceExtensionInfo implements ExtensionInfo {
+
+  private static final String PLUGIN_NAME = "Diagnostic Service";
+  private static final String[] BASE_ATTRIBUTES = {"Bundle-Version", "BuildInfo-Timestamp", "Build-Jdk"};
+  private Map<String, String> getJarManifestInfo() {
+    try {
+      File file = new File(this.getClass().getProtectionDomain().getCodeSource().getLocation().toURI());
+      if (file.isDirectory()) {
+        return Collections.emptyMap();
+      }
+      try (JarFile jar = new JarFile(file)) {
+        return jar.getManifest().getMainAttributes().entrySet().stream()
+            .collect(Collectors.toMap(e -> e.getKey().toString(), e -> e.getValue().toString()));
+      }
+    } catch (IOException | URISyntaxException e) {
+      throw new IllegalStateException(e);
+    }
+  }
+
+  @Override
+  public String getExtensionInfo() {
+    Map<String, String> attributes = getJarManifestInfo();
+    return PLUGIN_NAME + ":" + lineSeparator() + Stream.of(BASE_ATTRIBUTES)
+        .filter(attributes::containsKey)
+        .map(n -> n + ": " + attributes.get(n))
+        .collect(Collectors.joining(lineSeparator())) + lineSeparator();
+  }
+
+  @Override
+  public String getValue(String name) {
+    if (name.equals(DESCRIPTION)) {
+      return getExtensionInfo();
+    } else {
+      return "";
+    }
+  }
+}

--- a/diagnostic/service/src/main/resources/META-INF/services/com.tc.productinfo.Description
+++ b/diagnostic/service/src/main/resources/META-INF/services/com.tc.productinfo.Description
@@ -1,0 +1,18 @@
+#
+# The contents of this file are subject to the Terracotta Public License Version
+# 2.0 (the "License"); You may not use this file except in compliance with the
+# License. You may obtain a copy of the License at
+#
+# http://terracotta.org/legal/terracotta-public-license.
+#
+# Software distributed under the License is distributed on an "AS IS" basis,
+# WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+# the specific language governing rights and limitations under the License.
+#
+# The Covered Software is Terracotta Platform.
+#
+# The Initial Developer of the Covered Software is
+# Terracotta, Inc., a Software AG company
+#
+
+org.terracotta.diagnostic.server.DiagnosticServiceExtensionInfo

--- a/dynamic-config/entities/management-entity/server/pom.xml
+++ b/dynamic-config/entities/management-entity/server/pom.xml
@@ -54,5 +54,10 @@
       <artifactId>standard-cluster-services</artifactId>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>org.terracotta.internal</groupId>
+      <artifactId>common-spi</artifactId>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/dynamic-config/entities/management-entity/server/src/main/java/org/terracotta/dynamic_config/entity/management/server/ManagementEntityServerExtensionInfo.java
+++ b/dynamic-config/entities/management-entity/server/src/main/java/org/terracotta/dynamic_config/entity/management/server/ManagementEntityServerExtensionInfo.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.dynamic_config.entity.management.server;
+
+import com.tc.productinfo.ExtensionInfo;
+import org.terracotta.dynamic_config.server.api.ManifestInfo;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static java.lang.System.lineSeparator;
+
+public class ManagementEntityServerExtensionInfo implements ExtensionInfo {
+
+  private static final String PLUGIN_NAME = "Dynamic Configuration Management";
+
+  @Override
+  public String getExtensionInfo() {
+    Map<String, String> attributes = ManifestInfo.getJarManifestInfo(this.getClass());
+    return PLUGIN_NAME + ":" + lineSeparator() + Stream.of(ManifestInfo.BASE_ATTRIBUTES)
+        .filter(attributes::containsKey)
+        .map(n -> n + ": " + attributes.get(n))
+        .collect(Collectors.joining(lineSeparator())) + lineSeparator();
+  }
+
+  @Override
+  public String getValue(String name) {
+    if (name.equals(DESCRIPTION)) {
+      return getExtensionInfo();
+    } else {
+      return "";
+    }
+  }
+}

--- a/dynamic-config/entities/management-entity/server/src/main/resources/META-INF/services/com.tc.productinfo.Description
+++ b/dynamic-config/entities/management-entity/server/src/main/resources/META-INF/services/com.tc.productinfo.Description
@@ -1,0 +1,18 @@
+#
+# The contents of this file are subject to the Terracotta Public License Version
+# 2.0 (the "License"); You may not use this file except in compliance with the
+# License. You may obtain a copy of the License at
+#
+# http://terracotta.org/legal/terracotta-public-license.
+#
+# Software distributed under the License is distributed on an "AS IS" basis,
+# WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+# the specific language governing rights and limitations under the License.
+#
+# The Covered Software is Terracotta Platform.
+#
+# The Initial Developer of the Covered Software is
+# Terracotta, Inc., a Software AG company
+#
+
+org.terracotta.dynamic_config.entity.management.server.ManagementEntityServerExtensionInfo

--- a/dynamic-config/entities/nomad-entity/server/pom.xml
+++ b/dynamic-config/entities/nomad-entity/server/pom.xml
@@ -54,6 +54,11 @@
       <artifactId>standard-cluster-services</artifactId>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>org.terracotta.internal</groupId>
+      <artifactId>common-spi</artifactId>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
 
 </project>

--- a/dynamic-config/entities/nomad-entity/server/src/main/java/org/terracotta/nomad/entity/server/NomadServerExtensionInfo.java
+++ b/dynamic-config/entities/nomad-entity/server/src/main/java/org/terracotta/nomad/entity/server/NomadServerExtensionInfo.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.nomad.entity.server;
+
+import com.tc.productinfo.ExtensionInfo;
+import org.terracotta.dynamic_config.server.api.ManifestInfo;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static java.lang.System.lineSeparator;
+
+public class NomadServerExtensionInfo implements ExtensionInfo {
+
+  private static final String PLUGIN_NAME = "Dynamic Configuration Transaction";
+
+  @Override
+  public String getExtensionInfo() {
+    Map<String, String> attributes = ManifestInfo.getJarManifestInfo(this.getClass());
+    return PLUGIN_NAME + ":" + lineSeparator() + Stream.of(ManifestInfo.BASE_ATTRIBUTES)
+        .filter(attributes::containsKey)
+        .map(n -> n + ": " + attributes.get(n))
+        .collect(Collectors.joining(lineSeparator())) + lineSeparator();
+  }
+
+  @Override
+  public String getValue(String name) {
+    if (name.equals(DESCRIPTION)) {
+      return getExtensionInfo();
+    } else {
+      return "";
+    }
+  }
+}

--- a/dynamic-config/entities/nomad-entity/server/src/main/resources/META-INF/services/com.tc.productinfo.Description
+++ b/dynamic-config/entities/nomad-entity/server/src/main/resources/META-INF/services/com.tc.productinfo.Description
@@ -1,0 +1,18 @@
+#
+# The contents of this file are subject to the Terracotta Public License Version
+# 2.0 (the "License"); You may not use this file except in compliance with the
+# License. You may obtain a copy of the License at
+#
+# http://terracotta.org/legal/terracotta-public-license.
+#
+# Software distributed under the License is distributed on an "AS IS" basis,
+# WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+# the specific language governing rights and limitations under the License.
+#
+# The Covered Software is Terracotta Platform.
+#
+# The Initial Developer of the Covered Software is
+# Terracotta, Inc., a Software AG company
+#
+
+org.terracotta.nomad.entity.server.NomadServerExtensionInfo

--- a/dynamic-config/entities/topology-entity/server/pom.xml
+++ b/dynamic-config/entities/topology-entity/server/pom.xml
@@ -53,6 +53,11 @@
       <artifactId>standard-cluster-services</artifactId>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>org.terracotta.internal</groupId>
+      <artifactId>common-spi</artifactId>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
 
 </project>

--- a/dynamic-config/entities/topology-entity/server/src/main/java/org/terracotta/dynamic_config/entity/topology/server/DynamicTopologyServerExtensionInfo.java
+++ b/dynamic-config/entities/topology-entity/server/src/main/java/org/terracotta/dynamic_config/entity/topology/server/DynamicTopologyServerExtensionInfo.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.dynamic_config.entity.topology.server;
+
+import com.tc.productinfo.ExtensionInfo;
+import org.terracotta.dynamic_config.server.api.ManifestInfo;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static java.lang.System.lineSeparator;
+
+public class DynamicTopologyServerExtensionInfo implements ExtensionInfo {
+
+  private static final String PLUGIN_NAME = "Dynamic Configuration Topology";
+
+  @Override
+  public String getExtensionInfo() {
+    Map<String, String> attributes = ManifestInfo.getJarManifestInfo(this.getClass());
+    return PLUGIN_NAME + ":" + lineSeparator() + Stream.of(ManifestInfo.BASE_ATTRIBUTES)
+        .filter(attributes::containsKey)
+        .map(n -> n + ": " + attributes.get(n))
+        .collect(Collectors.joining(lineSeparator())) + lineSeparator();
+  }
+
+  @Override
+  public String getValue(String name) {
+    if (name.equals(DESCRIPTION)) {
+      return getExtensionInfo();
+    } else {
+      return "";
+    }
+  }
+}

--- a/dynamic-config/entities/topology-entity/server/src/main/resources/META-INF/services/com.tc.productinfo.Description
+++ b/dynamic-config/entities/topology-entity/server/src/main/resources/META-INF/services/com.tc.productinfo.Description
@@ -1,0 +1,18 @@
+#
+# The contents of this file are subject to the Terracotta Public License Version
+# 2.0 (the "License"); You may not use this file except in compliance with the
+# License. You may obtain a copy of the License at
+#
+# http://terracotta.org/legal/terracotta-public-license.
+#
+# Software distributed under the License is distributed on an "AS IS" basis,
+# WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+# the specific language governing rights and limitations under the License.
+#
+# The Covered Software is Terracotta Platform.
+#
+# The Initial Developer of the Covered Software is
+# Terracotta, Inc., a Software AG company
+#
+
+org.terracotta.dynamic_config.entity.topology.server.DynamicTopologyServerExtensionInfo

--- a/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/DynamicConfigConfigurationProviderExtensionInfo.java
+++ b/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/DynamicConfigConfigurationProviderExtensionInfo.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.dynamic_config.server.configuration;
+
+import com.tc.productinfo.ExtensionInfo;
+import org.terracotta.dynamic_config.server.api.ManifestInfo;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static java.lang.System.lineSeparator;
+
+public class DynamicConfigConfigurationProviderExtensionInfo implements ExtensionInfo {
+
+  private static final String PLUGIN_NAME = "Dynamic Configuration Startup";
+
+  @Override
+  public String getExtensionInfo() {
+    Map<String, String> attributes = ManifestInfo.getJarManifestInfo(this.getClass());
+    return PLUGIN_NAME + ":" + lineSeparator() + Stream.of(ManifestInfo.BASE_ATTRIBUTES)
+        .filter(attributes::containsKey)
+        .map(n -> n + ": " + attributes.get(n))
+        .collect(Collectors.joining(lineSeparator())) + lineSeparator();
+  }
+
+  @Override
+  public String getValue(String name) {
+    if (name.equals(DESCRIPTION)) {
+      return getExtensionInfo();
+    } else {
+      return "";
+    }
+  }
+}

--- a/dynamic-config/server/configuration-provider/src/main/resources/META-INF/services/com.tc.productinfo.Description
+++ b/dynamic-config/server/configuration-provider/src/main/resources/META-INF/services/com.tc.productinfo.Description
@@ -1,0 +1,18 @@
+#
+# The contents of this file are subject to the Terracotta Public License Version
+# 2.0 (the "License"); You may not use this file except in compliance with the
+# License. You may obtain a copy of the License at
+#
+# http://terracotta.org/legal/terracotta-public-license.
+#
+# Software distributed under the License is distributed on an "AS IS" basis,
+# WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+# the specific language governing rights and limitations under the License.
+#
+# The Covered Software is Terracotta Platform.
+#
+# The Initial Developer of the Covered Software is
+# Terracotta, Inc., a Software AG company
+#
+
+org.terracotta.dynamic_config.server.configuration.DynamicConfigConfigurationProviderExtensionInfo

--- a/dynamic-config/server/server-api/src/main/java/org/terracotta/dynamic_config/server/api/ManifestInfo.java
+++ b/dynamic-config/server/server-api/src/main/java/org/terracotta/dynamic_config/server/api/ManifestInfo.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.dynamic_config.server.api;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.Collections;
+import java.util.Map;
+import java.util.jar.JarFile;
+import java.util.stream.Collectors;
+
+public class ManifestInfo {
+
+  public static final String[] BASE_ATTRIBUTES = {"Bundle-Version", "BuildInfo-Timestamp", "Build-Jdk"};
+
+  public static <T> Map<String, String> getJarManifestInfo(Class<T> cls) {
+    try {
+      File file = new File(cls.getProtectionDomain().getCodeSource().getLocation().toURI());
+      if (file.isDirectory()) {
+        return Collections.emptyMap();
+      }
+      try (JarFile jar = new JarFile(file)) {
+        return jar.getManifest().getMainAttributes().entrySet().stream()
+          .collect(Collectors.toMap(e -> e.getKey().toString(), e -> e.getValue().toString()));
+      }
+    } catch (IOException | URISyntaxException e) {
+      throw new IllegalStateException(e);
+    }
+  }
+}

--- a/dynamic-config/server/services/pom.xml
+++ b/dynamic-config/server/services/pom.xml
@@ -62,6 +62,11 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>org.terracotta.internal</groupId>
+      <artifactId>common-spi</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>org.terracotta</groupId>
       <artifactId>standard-cluster-services</artifactId>
       <scope>provided</scope>

--- a/dynamic-config/server/services/src/main/java/org/terracotta/dynamic_config/server/service/DynamicConfigServiceExtensionInfo.java
+++ b/dynamic-config/server/services/src/main/java/org/terracotta/dynamic_config/server/service/DynamicConfigServiceExtensionInfo.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.dynamic_config.server.service;
+
+import com.tc.productinfo.ExtensionInfo;
+import org.terracotta.dynamic_config.server.api.ManifestInfo;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static java.lang.System.lineSeparator;
+
+public class DynamicConfigServiceExtensionInfo implements ExtensionInfo {
+
+  private static final String PLUGIN_NAME = "Dynamic Configuration Services";
+
+  @Override
+  public String getExtensionInfo() {
+    Map<String, String> attributes = ManifestInfo.getJarManifestInfo(this.getClass());
+    return PLUGIN_NAME + ":" + lineSeparator() + Stream.of(ManifestInfo.BASE_ATTRIBUTES)
+        .filter(attributes::containsKey)
+        .map(n -> n + ": " + attributes.get(n))
+        .collect(Collectors.joining(lineSeparator())) + lineSeparator();
+  }
+
+  @Override
+  public String getValue(String name) {
+    if (name.equals(DESCRIPTION)) {
+      return getExtensionInfo();
+    } else {
+      return "";
+    }
+  }
+}

--- a/dynamic-config/server/services/src/main/resources/META-INF/services/com.tc.productinfo.Description
+++ b/dynamic-config/server/services/src/main/resources/META-INF/services/com.tc.productinfo.Description
@@ -1,0 +1,18 @@
+#
+# The contents of this file are subject to the Terracotta Public License Version
+# 2.0 (the "License"); You may not use this file except in compliance with the
+# License. You may obtain a copy of the License at
+#
+# http://terracotta.org/legal/terracotta-public-license.
+#
+# Software distributed under the License is distributed on an "AS IS" basis,
+# WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+# the specific language governing rights and limitations under the License.
+#
+# The Covered Software is Terracotta Platform.
+#
+# The Initial Developer of the Covered Software is
+# Terracotta, Inc., a Software AG company
+#
+
+org.terracotta.dynamic_config.server.service.DynamicConfigServiceExtensionInfo

--- a/healthchecker-entity/server-impl/pom.xml
+++ b/healthchecker-entity/server-impl/pom.xml
@@ -29,20 +29,25 @@
   <artifactId>healthchecker-server</artifactId>
 
   <dependencies>
-  <dependency>
+    <dependency>
       <groupId>org.terracotta</groupId>
       <artifactId>healthchecker-common</artifactId>
       <version>${project.version}</version>
-  </dependency>
+    </dependency>
     <dependency>
       <groupId>org.terracotta</groupId>
       <artifactId>entity-server-api</artifactId>
       <scope>provided</scope>
     </dependency>
     <dependency>
-        <groupId>org.terracotta</groupId>
-        <artifactId>packaging-support</artifactId>
-        <scope>provided</scope>
+      <groupId>org.terracotta</groupId>
+      <artifactId>packaging-support</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.terracotta.internal</groupId>
+      <artifactId>common-spi</artifactId>
+      <scope>provided</scope>
     </dependency>
   </dependencies>
 </project>

--- a/healthchecker-entity/server-impl/src/main/java/org/terracotta/healthchecker/HealthCheckerServerExtensionInfo.java
+++ b/healthchecker-entity/server-impl/src/main/java/org/terracotta/healthchecker/HealthCheckerServerExtensionInfo.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.healthchecker;
+
+import com.tc.productinfo.ExtensionInfo;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.Collections;
+import java.util.Map;
+import java.util.jar.JarFile;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static java.lang.System.lineSeparator;
+
+public class HealthCheckerServerExtensionInfo implements ExtensionInfo {
+
+  private static final String PLUGIN_NAME = "Health Checker Server Plugin";
+  private static final String[] BASE_ATTRIBUTES = {"Bundle-Version", "BuildInfo-Timestamp", "Build-Jdk"};
+  private Map<String, String> getJarManifestInfo() {
+    try {
+      File file = new File(this.getClass().getProtectionDomain().getCodeSource().getLocation().toURI());
+      if (file.isDirectory()) {
+        return Collections.emptyMap();
+      }
+      try (JarFile jar = new JarFile(file)) {
+        return jar.getManifest().getMainAttributes().entrySet().stream()
+            .collect(Collectors.toMap(e -> e.getKey().toString(), e -> e.getValue().toString()));
+      }
+    } catch (IOException | URISyntaxException e) {
+      throw new IllegalStateException(e);
+    }
+  }
+
+  @Override
+  public String getExtensionInfo() {
+    Map<String, String> attributes = getJarManifestInfo();
+    return PLUGIN_NAME + ":" + lineSeparator() + Stream.of(BASE_ATTRIBUTES)
+        .filter(attributes::containsKey)
+        .map(n -> n + ": " + attributes.get(n))
+        .collect(Collectors.joining(lineSeparator())) + lineSeparator();
+  }
+
+  @Override
+  public String getValue(String name) {
+    if (name.equals(DESCRIPTION)) {
+      return getExtensionInfo();
+    } else {
+      return "";
+    }
+  }
+}

--- a/healthchecker-entity/server-impl/src/main/resources/META-INF/services/com.tc.productinfo.Description
+++ b/healthchecker-entity/server-impl/src/main/resources/META-INF/services/com.tc.productinfo.Description
@@ -1,0 +1,18 @@
+#
+# The contents of this file are subject to the Terracotta Public License Version
+# 2.0 (the "License"); You may not use this file except in compliance with the
+# License. You may obtain a copy of the License at
+#
+# http://terracotta.org/legal/terracotta-public-license.
+#
+# Software distributed under the License is distributed on an "AS IS" basis,
+# WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+# the specific language governing rights and limitations under the License.
+#
+# The Covered Software is Terracotta Platform.
+#
+# The Initial Developer of the Covered Software is
+# Terracotta, Inc., a Software AG company
+#
+
+org.terracotta.healthchecker.HealthCheckerServerExtensionInfo

--- a/lease/entity-server/pom.xml
+++ b/lease/entity-server/pom.xml
@@ -62,6 +62,11 @@
       <artifactId>tc-config-parser</artifactId>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>org.terracotta.internal</groupId>
+      <artifactId>common-spi</artifactId>
+      <scope>provided</scope>
+    </dependency>
 
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/lease/entity-server/src/main/java/org/terracotta/lease/service/LeaseServiceExtensionInfo.java
+++ b/lease/entity-server/src/main/java/org/terracotta/lease/service/LeaseServiceExtensionInfo.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.lease.service;
+
+import com.tc.productinfo.ExtensionInfo;
+import org.terracotta.dynamic_config.server.api.ManifestInfo;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static java.lang.System.lineSeparator;
+
+public class LeaseServiceExtensionInfo implements ExtensionInfo {
+
+  private static final String PLUGIN_NAME = "Lease Service";
+
+  @Override
+  public String getExtensionInfo() {
+    Map<String, String> attributes = ManifestInfo.getJarManifestInfo(this.getClass());
+    return PLUGIN_NAME + ":" + lineSeparator() + Stream.of(ManifestInfo.BASE_ATTRIBUTES)
+        .filter(attributes::containsKey)
+        .map(n -> n + ": " + attributes.get(n))
+        .collect(Collectors.joining(lineSeparator())) + lineSeparator();
+  }
+
+  @Override
+  public String getValue(String name) {
+    if (name.equals(DESCRIPTION)) {
+      return getExtensionInfo();
+    } else {
+      return "";
+    }
+  }
+}

--- a/lease/entity-server/src/main/resources/META-INF/services/com.tc.productinfo.Description
+++ b/lease/entity-server/src/main/resources/META-INF/services/com.tc.productinfo.Description
@@ -1,0 +1,18 @@
+#
+# The contents of this file are subject to the Terracotta Public License Version
+# 2.0 (the "License"); You may not use this file except in compliance with the
+# License. You may obtain a copy of the License at
+#
+# http://terracotta.org/legal/terracotta-public-license.
+#
+# Software distributed under the License is distributed on an "AS IS" basis,
+# WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+# the specific language governing rights and limitations under the License.
+#
+# The Covered Software is Terracotta Platform.
+#
+# The Initial Developer of the Covered Software is
+# Terracotta, Inc., a Software AG company
+#
+
+org.terracotta.lease.service.LeaseServiceExtensionInfo

--- a/management/monitoring-service/pom.xml
+++ b/management/monitoring-service/pom.xml
@@ -73,6 +73,11 @@
       <artifactId>standard-cluster-services</artifactId>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>org.terracotta.internal</groupId>
+      <artifactId>common-spi</artifactId>
+      <scope>provided</scope>
+    </dependency>
 
     <dependency>
       <groupId>junit</groupId>

--- a/management/monitoring-service/src/main/java/org/terracotta/management/service/monitoring/MonitoringServiceExtensionInfo.java
+++ b/management/monitoring-service/src/main/java/org/terracotta/management/service/monitoring/MonitoringServiceExtensionInfo.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.management.service.monitoring;
+
+import com.tc.productinfo.ExtensionInfo;
+import org.terracotta.dynamic_config.server.api.ManifestInfo;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static java.lang.System.lineSeparator;
+
+public class MonitoringServiceExtensionInfo implements ExtensionInfo {
+
+  private static final String PLUGIN_NAME = "Monitoring Service";
+
+  @Override
+  public String getExtensionInfo() {
+    Map<String, String> attributes = ManifestInfo.getJarManifestInfo(this.getClass());
+    return PLUGIN_NAME + ":" + lineSeparator() + Stream.of(ManifestInfo.BASE_ATTRIBUTES)
+        .filter(attributes::containsKey)
+        .map(n -> n + ": " + attributes.get(n))
+        .collect(Collectors.joining(lineSeparator())) + lineSeparator();
+  }
+
+  @Override
+  public String getValue(String name) {
+    if (name.equals(DESCRIPTION)) {
+      return getExtensionInfo();
+    } else {
+      return "";
+    }
+  }
+}

--- a/management/monitoring-service/src/main/resources/META-INF/services/com.tc.productinfo.Description
+++ b/management/monitoring-service/src/main/resources/META-INF/services/com.tc.productinfo.Description
@@ -1,0 +1,18 @@
+#
+# The contents of this file are subject to the Terracotta Public License Version
+# 2.0 (the "License"); You may not use this file except in compliance with the
+# License. You may obtain a copy of the License at
+#
+# http://terracotta.org/legal/terracotta-public-license.
+#
+# Software distributed under the License is distributed on an "AS IS" basis,
+# WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+# the specific language governing rights and limitations under the License.
+#
+# The Covered Software is Terracotta Platform.
+#
+# The Initial Developer of the Covered Software is
+# Terracotta, Inc., a Software AG company
+#
+
+org.terracotta.management.service.monitoring.MonitoringServiceExtensionInfo

--- a/management/nms-agent-entity/nms-agent-entity-server/pom.xml
+++ b/management/nms-agent-entity/nms-agent-entity-server/pom.xml
@@ -73,5 +73,10 @@
       <artifactId>standard-cluster-services</artifactId>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>org.terracotta.internal</groupId>
+      <artifactId>common-spi</artifactId>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/management/nms-agent-entity/nms-agent-entity-server/src/main/java/org/terracotta/management/entity/nms/agent/server/NmsAgentEntityServerExtensionInfo.java
+++ b/management/nms-agent-entity/nms-agent-entity-server/src/main/java/org/terracotta/management/entity/nms/agent/server/NmsAgentEntityServerExtensionInfo.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.management.entity.nms.agent.server;
+
+import com.tc.productinfo.ExtensionInfo;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.Collections;
+import java.util.Map;
+import java.util.jar.JarFile;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static java.lang.System.lineSeparator;
+
+public class NmsAgentEntityServerExtensionInfo implements ExtensionInfo {
+
+  private static final String PLUGIN_NAME = "Monitoring Agent";
+  private static final String[] BASE_ATTRIBUTES = {"Bundle-Version", "BuildInfo-Timestamp", "Build-Jdk"};
+  private Map<String, String> getJarManifestInfo() {
+    try {
+      File file = new File(this.getClass().getProtectionDomain().getCodeSource().getLocation().toURI());
+      if (file.isDirectory()) {
+        return Collections.emptyMap();
+      }
+      try (JarFile jar = new JarFile(file)) {
+        return jar.getManifest().getMainAttributes().entrySet().stream()
+            .collect(Collectors.toMap(e -> e.getKey().toString(), e -> e.getValue().toString()));
+      }
+    } catch (IOException | URISyntaxException e) {
+      throw new IllegalStateException(e);
+    }
+  }
+
+  @Override
+  public String getExtensionInfo() {
+    Map<String, String> attributes = getJarManifestInfo();
+    return PLUGIN_NAME + ":" + lineSeparator() + Stream.of(BASE_ATTRIBUTES)
+        .filter(attributes::containsKey)
+        .map(n -> n + ": " + attributes.get(n))
+        .collect(Collectors.joining(lineSeparator())) + lineSeparator();
+  }
+
+  @Override
+  public String getValue(String name) {
+    if (name.equals(DESCRIPTION)) {
+      return getExtensionInfo();
+    } else {
+      return "";
+    }
+  }
+}

--- a/management/nms-agent-entity/nms-agent-entity-server/src/main/resources/META-INF/services/com.tc.productinfo.Description
+++ b/management/nms-agent-entity/nms-agent-entity-server/src/main/resources/META-INF/services/com.tc.productinfo.Description
@@ -1,0 +1,18 @@
+#
+# The contents of this file are subject to the Terracotta Public License Version
+# 2.0 (the "License"); You may not use this file except in compliance with the
+# License. You may obtain a copy of the License at
+#
+# http://terracotta.org/legal/terracotta-public-license.
+#
+# Software distributed under the License is distributed on an "AS IS" basis,
+# WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+# the specific language governing rights and limitations under the License.
+#
+# The Covered Software is Terracotta Platform.
+#
+# The Initial Developer of the Covered Software is
+# Terracotta, Inc., a Software AG company
+#
+
+org.terracotta.management.entity.nms.agent.server.NmsAgentEntityServerExtensionInfo

--- a/management/nms-entity/nms-entity-server/pom.xml
+++ b/management/nms-entity/nms-entity-server/pom.xml
@@ -79,6 +79,10 @@
       <artifactId>standard-cluster-services</artifactId>
       <scope>provided</scope>
     </dependency>
-
+    <dependency>
+      <groupId>org.terracotta.internal</groupId>
+      <artifactId>common-spi</artifactId>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/management/nms-entity/nms-entity-server/src/main/java/org/terracotta/management/entity/nms/server/NmsEntityServerExtensionInfo.java
+++ b/management/nms-entity/nms-entity-server/src/main/java/org/terracotta/management/entity/nms/server/NmsEntityServerExtensionInfo.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.management.entity.nms.server;
+
+import com.tc.productinfo.ExtensionInfo;
+import org.terracotta.dynamic_config.server.api.ManifestInfo;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static java.lang.System.lineSeparator;
+
+public class NmsEntityServerExtensionInfo implements ExtensionInfo {
+
+  private static final String PLUGIN_NAME = "Monitoring Platform";
+
+  @Override
+  public String getExtensionInfo() {
+    Map<String, String> attributes = ManifestInfo.getJarManifestInfo(this.getClass());
+    return PLUGIN_NAME + ":" + lineSeparator() + Stream.of(ManifestInfo.BASE_ATTRIBUTES)
+        .filter(attributes::containsKey)
+        .map(n -> n + ": " + attributes.get(n))
+        .collect(Collectors.joining(lineSeparator())) + lineSeparator();
+  }
+
+  @Override
+  public String getValue(String name) {
+    if (name.equals(DESCRIPTION)) {
+      return getExtensionInfo();
+    } else {
+      return "";
+    }
+  }
+}

--- a/management/nms-entity/nms-entity-server/src/main/resources/META-INF/services/com.tc.productinfo.Description
+++ b/management/nms-entity/nms-entity-server/src/main/resources/META-INF/services/com.tc.productinfo.Description
@@ -1,0 +1,18 @@
+#
+# The contents of this file are subject to the Terracotta Public License Version
+# 2.0 (the "License"); You may not use this file except in compliance with the
+# License. You may obtain a copy of the License at
+#
+# http://terracotta.org/legal/terracotta-public-license.
+#
+# Software distributed under the License is distributed on an "AS IS" basis,
+# WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+# the specific language governing rights and limitations under the License.
+#
+# The Covered Software is Terracotta Platform.
+#
+# The Initial Developer of the Covered Software is
+# Terracotta, Inc., a Software AG company
+#
+
+org.terracotta.management.entity.nms.server.NmsEntityServerExtensionInfo

--- a/offheap-resource/pom.xml
+++ b/offheap-resource/pom.xml
@@ -69,6 +69,11 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>org.terracotta.internal</groupId>
+      <artifactId>common-spi</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>org.terracotta</groupId>
       <artifactId>packaging-support</artifactId>
       <scope>provided</scope>

--- a/offheap-resource/src/main/java/org/terracotta/offheapresource/OffHeapResourceExtensionInfo.java
+++ b/offheap-resource/src/main/java/org/terracotta/offheapresource/OffHeapResourceExtensionInfo.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.offheapresource;
+
+import com.tc.productinfo.ExtensionInfo;
+import org.terracotta.dynamic_config.server.api.ManifestInfo;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static java.lang.System.lineSeparator;
+
+public class OffHeapResourceExtensionInfo implements ExtensionInfo {
+
+  public static final String PLUGIN_NAME = "Off Heap Plugin";
+
+  @Override
+  public String getExtensionInfo() {
+    Map<String, String> attributes = ManifestInfo.getJarManifestInfo(this.getClass());
+    return PLUGIN_NAME + ":" + lineSeparator() + Stream.of(ManifestInfo.BASE_ATTRIBUTES)
+        .filter(attributes::containsKey)
+        .map(n -> n + ": " + attributes.get(n))
+        .collect(Collectors.joining(lineSeparator())) + lineSeparator();
+  }
+
+  @Override
+  public String getValue(String name) {
+    if (name.equals(DESCRIPTION)) {
+      return getExtensionInfo();
+    } else {
+      return "";
+    }
+  }
+}

--- a/offheap-resource/src/main/resources/META-INF/services/com.tc.productinfo.Description
+++ b/offheap-resource/src/main/resources/META-INF/services/com.tc.productinfo.Description
@@ -1,0 +1,18 @@
+#
+# The contents of this file are subject to the Terracotta Public License Version
+# 2.0 (the "License"); You may not use this file except in compliance with the
+# License. You may obtain a copy of the License at
+#
+# http://terracotta.org/legal/terracotta-public-license.
+#
+# Software distributed under the License is distributed on an "AS IS" basis,
+# WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+# the specific language governing rights and limitations under the License.
+#
+# The Covered Software is Terracotta Platform.
+#
+# The Initial Developer of the Covered Software is
+# Terracotta, Inc., a Software AG company
+#
+
+org.terracotta.offheapresource.OffHeapResourceExtensionInfo

--- a/platform-base/pom.xml
+++ b/platform-base/pom.xml
@@ -41,6 +41,11 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>org.terracotta.internal</groupId>
+      <artifactId>common-spi</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>

--- a/platform-base/src/main/java/org/terracotta/platform/PlatformBaseExtensionInfo.java
+++ b/platform-base/src/main/java/org/terracotta/platform/PlatformBaseExtensionInfo.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.platform;
+
+import com.tc.productinfo.ExtensionInfo;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.Collections;
+import java.util.Map;
+import java.util.jar.JarFile;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static java.lang.System.lineSeparator;
+
+public class PlatformBaseExtensionInfo implements ExtensionInfo {
+
+  private static final String PLUGIN_NAME = "Server Information";
+  private static final String[] BASE_ATTRIBUTES = {"Bundle-Version", "BuildInfo-Timestamp", "Build-Jdk"};
+  private Map<String, String> getJarManifestInfo() {
+    try {
+      File file = new File(this.getClass().getProtectionDomain().getCodeSource().getLocation().toURI());
+      if (file.isDirectory()) {
+        return Collections.emptyMap();
+      }
+      try (JarFile jar = new JarFile(file)) {
+        return jar.getManifest().getMainAttributes().entrySet().stream()
+            .collect(Collectors.toMap(e -> e.getKey().toString(), e -> e.getValue().toString()));
+      }
+    } catch (IOException | URISyntaxException e) {
+      throw new IllegalStateException(e);
+    }
+  }
+
+  @Override
+  public String getExtensionInfo() {
+    Map<String, String> attributes = getJarManifestInfo();
+    return PLUGIN_NAME + ":" + lineSeparator() + Stream.of(BASE_ATTRIBUTES)
+        .filter(attributes::containsKey)
+        .map(n -> n + ": " + attributes.get(n))
+        .collect(Collectors.joining(lineSeparator())) + lineSeparator();
+  }
+
+  @Override
+  public String getValue(String name) {
+    if (name.equals(DESCRIPTION)) {
+      return getExtensionInfo();
+    } else {
+      return "";
+    }
+  }
+}

--- a/platform-base/src/main/resources/META-INF/services/com.tc.productinfo.Description
+++ b/platform-base/src/main/resources/META-INF/services/com.tc.productinfo.Description
@@ -1,0 +1,18 @@
+#
+# The contents of this file are subject to the Terracotta Public License Version
+# 2.0 (the "License"); You may not use this file except in compliance with the
+# License. You may obtain a copy of the License at
+#
+# http://terracotta.org/legal/terracotta-public-license.
+#
+# Software distributed under the License is distributed on an "AS IS" basis,
+# WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+# the specific language governing rights and limitations under the License.
+#
+# The Covered Software is Terracotta Platform.
+#
+# The Initial Developer of the Covered Software is
+# Terracotta, Inc., a Software AG company
+#
+
+org.terracotta.platform.PlatformBaseExtensionInfo


### PR DESCRIPTION
Supporting core's 'ExtensionInfo' jar version reporting for logging on server startup.
Added a new descriptor for all platform plugin/lib jars possessing one or more of the following descriptors:
- ServiceProvider
- EntityServerService
- ConfigurationProvider 
- DynamicConfigExtension

See attached file for sample output.
[terracotta.server.log](https://github.com/Terracotta-OSS/terracotta-platform/files/6496016/terracotta.server.log)
