### PR TITLE
Fix: Remove the license validation check done by DC at startup...

### DIFF
--- a/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/service/DynamicConfigServiceImpl.java
+++ b/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/service/DynamicConfigServiceImpl.java
@@ -96,9 +96,6 @@ public class DynamicConfigServiceImpl implements TopologyService, DynamicConfigS
     this.licensePath = nomadServerManager.getConfigurationManager().getLicensePath().resolve(LICENSE_FILE_NAME);
     this.objectMapper = objectMapperFactory.create();
     this.server = requireNonNull(server);
-    if (hasLicenseFile()) {
-      validateAgainstLicense(upcomingNodeContext.getCluster());
-    }
 
     // This check is only present to safeguard against the possibility of a missing cluster validation in the call path
     new ClusterValidator(nodeContext.getCluster()).validate();


### PR DESCRIPTION
... because this check might prevent the server from starting up depending how the license checker is implemented in EE.
This is up to EE license service to decide what to do. Not DC code.
DC just needs to access the license service to validate the topology at some point but it shouldn't do it at startup.