### PR TITLE
Fix: `-verbose` setting was not working with inline process mode...

### DIFF
--- a/dynamic-config/cli/cli-support/src/main/java/org/terracotta/dynamic_config/cli/command/LocalMainCommand.java
+++ b/dynamic-config/cli/cli-support/src/main/java/org/terracotta/dynamic_config/cli/command/LocalMainCommand.java
@@ -36,6 +36,9 @@ public class LocalMainCommand extends Command {
       Logger rootLogger = (Logger) LoggerFactory.getLogger(ROOT_LOGGER_NAME);
 
       ConsoleAppender<ILoggingEvent> appender = (ConsoleAppender<ILoggingEvent>) rootLogger.getAppender("STDERR");
+      if (appender == null) {
+        throw new IllegalStateException("Logging appender 'STDERR' is missing!");
+      }
       PatternLayoutEncoder ple = new PatternLayoutEncoder();
       ple.setPattern("%d{yyyy-MM-dd HH:mm:ss.SSS} %-5p %c{1}:%L - %msg%n");
       ple.setContext(appender.getContext());

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/diagnostic/GetCommand1x1IT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/diagnostic/GetCommand1x1IT.java
@@ -15,6 +15,7 @@
  */
 package org.terracotta.dynamic_config.system_tests.diagnostic;
 
+import org.junit.Ignore;
 import org.junit.Test;
 import org.terracotta.dynamic_config.test_support.ClusterDefinition;
 import org.terracotta.dynamic_config.test_support.DynamicConfigIT;
@@ -26,6 +27,15 @@ import static org.terracotta.angela.client.support.hamcrest.AngelaMatchers.conta
 
 @ClusterDefinition
 public class GetCommand1x1IT extends DynamicConfigIT {
+
+  @Test
+  @Ignore("activate only manually to test verbose mode because it will otherwise change the whole logging system of the JVM running tests")
+  public void ensureVerboseWorks() {
+    assertThat(
+        configTool("-verbose", "get", "-s", "localhost:" + getNodePort(), "-c", "offheap-resources.blah"),
+        not(containsOutput("offheap-resources.blah=")));
+  }
+
   @Test
   public void testNode_getOneOffheap_unknownOffheap() {
     assertThat(

--- a/dynamic-config/testing/system-tests/src/test/resources/logback-test.xml
+++ b/dynamic-config/testing/system-tests/src/test/resources/logback-test.xml
@@ -26,6 +26,13 @@
     </layout>
   </appender>
 
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <target>System.err</target>
+    <layout class="ch.qos.logback.classic.PatternLayout">
+      <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-5p %c{1}:%L - %msg%n</pattern>
+    </layout>
+  </appender>
+
   <root level="INFO">
     <appender-ref ref="STDOUT"/>
   </root>


### PR DESCRIPTION
…because no appender in local logback file for config-tool