### PR TITLE
UX: failover-priority not required in diagnostic mode and with a 1-node cluster

### DIFF
--- a/dynamic-config/api/src/main/java/org/terracotta/dynamic_config/api/service/FormatUpgrade.java
+++ b/dynamic-config/api/src/main/java/org/terracotta/dynamic_config/api/service/FormatUpgrade.java
@@ -16,6 +16,7 @@
 package org.terracotta.dynamic_config.api.service;
 
 import org.terracotta.dynamic_config.api.model.Cluster;
+import org.terracotta.dynamic_config.api.model.ClusterState;
 import org.terracotta.dynamic_config.api.model.Version;
 
 import java.util.Random;
@@ -60,7 +61,7 @@ public class FormatUpgrade {
       NameGenerator.assignFriendlyStripeNames(upgraded, new Random(clusterName.hashCode()));
     }
 
-    new ClusterValidator(upgraded).validate();
+    new ClusterValidator(upgraded).validate(ClusterState.CONFIGURING);
 
     return upgraded;
   }

--- a/dynamic-config/cli/dynamic-config-cli-api/src/main/java/org/terracotta/dynamic_config/cli/api/command/ActivateAction.java
+++ b/dynamic-config/cli/dynamic-config-cli-api/src/main/java/org/terracotta/dynamic_config/cli/api/command/ActivateAction.java
@@ -18,6 +18,7 @@ package org.terracotta.dynamic_config.cli.api.command;
 import org.terracotta.common.struct.Measure;
 import org.terracotta.common.struct.TimeUnit;
 import org.terracotta.dynamic_config.api.model.Cluster;
+import org.terracotta.dynamic_config.api.model.ClusterState;
 import org.terracotta.dynamic_config.api.model.Node.Endpoint;
 import org.terracotta.dynamic_config.api.service.ClusterFactory;
 import org.terracotta.dynamic_config.api.service.ClusterValidator;
@@ -86,7 +87,7 @@ public class ActivateAction extends RemoteAction {
       throw new IllegalArgumentException("Cluster name is missing");
     }
 
-    new ClusterValidator(cluster).validate();
+    new ClusterValidator(cluster).validate(ClusterState.ACTIVATED);
 
     // getting the list of nodes where to push the same topology
 

--- a/dynamic-config/cli/dynamic-config-cli-api/src/main/java/org/terracotta/dynamic_config/cli/api/command/AttachAction.java
+++ b/dynamic-config/cli/dynamic-config-cli-api/src/main/java/org/terracotta/dynamic_config/cli/api/command/AttachAction.java
@@ -120,8 +120,8 @@ public class AttachAction extends TopologyAction {
               "Please refer to the Troubleshooting Guide for more help.");
 
       Stripe destinationStripe = destinationCluster.getStripeByNode(destination.getNodeUID()).get();
-      FailoverPriority failoverPriority = destinationCluster.getFailoverPriority();
-      if (failoverPriority.getType() == CONSISTENCY) {
+      FailoverPriority failoverPriority = destinationCluster.getFailoverPriority().orElse(null);
+      if (failoverPriority != null && failoverPriority.getType() == CONSISTENCY) {
         int voterCount = failoverPriority.getVoters();
         int nodeCount = destinationStripe.getNodes().size();
         int sum = voterCount + nodeCount;

--- a/dynamic-config/cli/dynamic-config-cli-api/src/main/java/org/terracotta/dynamic_config/cli/api/command/ConfigurationMutationAction.java
+++ b/dynamic-config/cli/dynamic-config-cli-api/src/main/java/org/terracotta/dynamic_config/cli/api/command/ConfigurationMutationAction.java
@@ -52,6 +52,8 @@ import static org.terracotta.diagnostic.model.LogicalServerState.ACTIVE;
 import static org.terracotta.diagnostic.model.LogicalServerState.ACTIVE_RECONNECTING;
 import static org.terracotta.diagnostic.model.LogicalServerState.PASSIVE;
 import static org.terracotta.diagnostic.model.LogicalServerState.UNREACHABLE;
+import static org.terracotta.dynamic_config.api.model.ClusterState.ACTIVATED;
+import static org.terracotta.dynamic_config.api.model.ClusterState.CONFIGURING;
 import static org.terracotta.dynamic_config.api.model.Requirement.CLUSTER_ONLINE;
 import static org.terracotta.dynamic_config.api.model.Requirement.CLUSTER_RESTART;
 import static org.terracotta.dynamic_config.api.model.Requirement.NODE_RESTART;
@@ -126,7 +128,6 @@ public abstract class ConfigurationMutationAction extends ConfigurationAction {
           "=======================================================================================" + lineSeparator());
       return;
     }
-    new ClusterValidator(updatedCluster).validate();
 
     // get the current state of the nodes
     // this call can take some time and we can have some timeout
@@ -134,6 +135,9 @@ public abstract class ConfigurationMutationAction extends ConfigurationAction {
     LOGGER.debug("Online nodes: {}", onlineNodes);
 
     boolean allOnlineNodesActivated = areAllNodesActivated(onlineNodes.keySet());
+
+    new ClusterValidator(updatedCluster).validate(allOnlineNodesActivated ? ACTIVATED : CONFIGURING);
+
     if (allOnlineNodesActivated) {
       licenseValidation(node, updatedCluster);
     }

--- a/dynamic-config/cli/dynamic-config-cli-api/src/main/java/org/terracotta/dynamic_config/cli/api/command/DetachAction.java
+++ b/dynamic-config/cli/dynamic-config-cli-api/src/main/java/org/terracotta/dynamic_config/cli/api/command/DetachAction.java
@@ -95,8 +95,8 @@ public class DetachAction extends TopologyAction {
         throw new IllegalStateException("Unable to detach since destination stripe contains only 1 node");
       }
 
-      FailoverPriority failoverPriority = destinationCluster.getFailoverPriority();
-      if (failoverPriority.getType() == CONSISTENCY) {
+      FailoverPriority failoverPriority = destinationCluster.getFailoverPriority().orElse(null);
+      if (failoverPriority != null && failoverPriority.getType() == CONSISTENCY) {
         int voterCount = failoverPriority.getVoters();
         int nodeCount = destinationStripe.getNodes().size();
         int sum = voterCount + nodeCount;

--- a/dynamic-config/cli/dynamic-config-cli-api/src/main/java/org/terracotta/dynamic_config/cli/api/command/ImportAction.java
+++ b/dynamic-config/cli/dynamic-config-cli-api/src/main/java/org/terracotta/dynamic_config/cli/api/command/ImportAction.java
@@ -20,6 +20,7 @@ import org.slf4j.LoggerFactory;
 import org.terracotta.common.struct.Tuple2;
 import org.terracotta.diagnostic.client.connection.DiagnosticServices;
 import org.terracotta.dynamic_config.api.model.Cluster;
+import org.terracotta.dynamic_config.api.model.ClusterState;
 import org.terracotta.dynamic_config.api.model.FailoverPriority;
 import org.terracotta.dynamic_config.api.model.Node;
 import org.terracotta.dynamic_config.api.model.Stripe;
@@ -56,8 +57,8 @@ public class ImportAction extends RemoteAction {
   @Override
   public final void run() {
     Cluster cluster = loadCluster();
-    FailoverPriority failoverPriority = cluster.getFailoverPriority();
-    if (failoverPriority.getType() == CONSISTENCY) {
+    FailoverPriority failoverPriority = cluster.getFailoverPriority().orElse(null);
+    if (failoverPriority != null && failoverPriority.getType() == CONSISTENCY) {
       int voterCount = failoverPriority.getVoters();
       for (Stripe stripe : cluster.getStripes()) {
         int nodeCount = stripe.getNodes().size();
@@ -76,7 +77,7 @@ public class ImportAction extends RemoteAction {
     Collection<Node.Endpoint> runtimePeers = cluster.getEndpoints(node);
 
     // validate the topology
-    new ClusterValidator(cluster).validate();
+    new ClusterValidator(cluster).validate(ClusterState.CONFIGURING);
 
     if (node != null) {
       // verify the activated state of the nodes

--- a/dynamic-config/cli/dynamic-config-cli-api/src/main/java/org/terracotta/dynamic_config/cli/api/command/TopologyAction.java
+++ b/dynamic-config/cli/dynamic-config-cli-api/src/main/java/org/terracotta/dynamic_config/cli/api/command/TopologyAction.java
@@ -36,6 +36,8 @@ import java.util.Set;
 import java.util.function.Supplier;
 
 import static java.lang.System.lineSeparator;
+import static org.terracotta.dynamic_config.api.model.ClusterState.ACTIVATED;
+import static org.terracotta.dynamic_config.api.model.ClusterState.CONFIGURING;
 
 /**
  * @author Mathieu Carbou
@@ -94,7 +96,7 @@ public abstract class TopologyAction extends RemoteAction {
     Cluster result = updateTopology();
 
     // triggers validation
-    new ClusterValidator(result).validate();
+    new ClusterValidator(result).validate(destinationClusterActivated ? ACTIVATED : CONFIGURING);
 
     if (LOGGER.isDebugEnabled()) {
       try {

--- a/dynamic-config/cli/upgrade-tools/src/main/java/org/terracotta/dynamic_config/cli/upgrade_tools/config_converter/ConfigConverter.java
+++ b/dynamic-config/cli/upgrade-tools/src/main/java/org/terracotta/dynamic_config/cli/upgrade_tools/config_converter/ConfigConverter.java
@@ -18,6 +18,7 @@ package org.terracotta.dynamic_config.cli.upgrade_tools.config_converter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terracotta.dynamic_config.api.model.Cluster;
+import org.terracotta.dynamic_config.api.model.ClusterState;
 import org.terracotta.dynamic_config.api.model.Node;
 import org.terracotta.dynamic_config.api.model.RawPath;
 import org.terracotta.dynamic_config.api.model.SettingName;
@@ -62,7 +63,7 @@ public class ConfigConverter {
     Cluster cluster = mapper.parseConfig(clusterName, stripeNames, tcConfigPaths);
     validateAgainstRelativePath(cluster);
 
-    new ClusterValidator(cluster).validate();
+    new ClusterValidator(cluster).validate(ClusterState.ACTIVATED);
 
     postConversionProcessor.accept(cluster);
   }

--- a/dynamic-config/model/src/main/java/org/terracotta/dynamic_config/api/model/Cluster.java
+++ b/dynamic-config/model/src/main/java/org/terracotta/dynamic_config/api/model/Cluster.java
@@ -54,6 +54,7 @@ import static java.util.stream.Stream.of;
 import static org.terracotta.dynamic_config.api.model.Scope.CLUSTER;
 import static org.terracotta.dynamic_config.api.model.Setting.CLIENT_LEASE_DURATION;
 import static org.terracotta.dynamic_config.api.model.Setting.CLIENT_RECONNECT_WINDOW;
+import static org.terracotta.dynamic_config.api.model.Setting.FAILOVER_PRIORITY;
 import static org.terracotta.dynamic_config.api.model.Setting.LOCK_CONTEXT;
 import static org.terracotta.dynamic_config.api.model.Setting.OFFHEAP_RESOURCES;
 import static org.terracotta.dynamic_config.api.model.Setting.SECURITY_AUTHC;
@@ -114,8 +115,8 @@ public class Cluster implements Cloneable, PropertyHolder {
     return OptionalConfig.of(SECURITY_WHITELIST, securityWhitelist);
   }
 
-  public FailoverPriority getFailoverPriority() {
-    return failoverPriority;
+  public OptionalConfig<FailoverPriority> getFailoverPriority() {
+    return OptionalConfig.of(FAILOVER_PRIORITY, failoverPriority);
   }
 
   public OptionalConfig<Measure<TimeUnit>> getClientReconnectWindow() {
@@ -146,7 +147,7 @@ public class Cluster implements Cloneable, PropertyHolder {
   }
 
   public Cluster setFailoverPriority(FailoverPriority failoverPriority) {
-    this.failoverPriority = requireNonNull(failoverPriority);
+    this.failoverPriority = failoverPriority;
     return this;
   }
 

--- a/dynamic-config/model/src/main/java/org/terracotta/dynamic_config/api/model/Requirement.java
+++ b/dynamic-config/model/src/main/java/org/terracotta/dynamic_config/api/model/Requirement.java
@@ -45,7 +45,7 @@ public enum Requirement {
   RESOLVE_EAGERLY,
 
   /**
-   * A setting that must be set by the user or which must have a default because teh presence of a value is required at runtime
+   * A setting that must be set by the user or which must have a default because the presence of a value is required at runtime
    */
   PRESENCE,
 

--- a/dynamic-config/model/src/main/java/org/terracotta/dynamic_config/api/model/Setting.java
+++ b/dynamic-config/model/src/main/java/org/terracotta/dynamic_config/api/model/Setting.java
@@ -573,12 +573,12 @@ public enum Setting {
       always(null),
       CLUSTER,
       fromCluster(Cluster::getFailoverPriority),
-      intoCluster((cluster, value) -> cluster.setFailoverPriority(FailoverPriority.valueOf(value))),
+      intoCluster((cluster, value) -> cluster.setFailoverPriority(value == null ? null : FailoverPriority.valueOf(value))),
       asList(
-          when(CONFIGURING).allow(IMPORT).atLevel(CLUSTER),
-          when(CONFIGURING, ACTIVATED).allow(GET, SET).atLevel(CLUSTER)
+          when(CONFIGURING).allowAnyOperations().atLevel(CLUSTER),
+          when(ACTIVATED).allow(GET, SET).atLevel(CLUSTER)
       ),
-      of(CLUSTER_ONLINE, CLUSTER_RESTART, PRESENCE, CONFIG, RESOLVE_EAGERLY),
+      of(CLUSTER_ONLINE, CLUSTER_RESTART),
       emptyList(),
       emptyList(),
       (key, value) -> DEFAULT_VALIDATOR.andThen((k, v) -> FailoverPriority.valueOf(v.t2)).accept(SettingName.FAILOVER_PRIORITY, tuple2(key, value))

--- a/dynamic-config/model/src/main/java/org/terracotta/dynamic_config/api/service/ClusterFactory.java
+++ b/dynamic-config/model/src/main/java/org/terracotta/dynamic_config/api/service/ClusterFactory.java
@@ -18,6 +18,7 @@ package org.terracotta.dynamic_config.api.service;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terracotta.dynamic_config.api.model.Cluster;
+import org.terracotta.dynamic_config.api.model.ClusterState;
 import org.terracotta.dynamic_config.api.model.ConfigFormat;
 import org.terracotta.dynamic_config.api.model.Configuration;
 import org.terracotta.dynamic_config.api.model.Setting;
@@ -128,7 +129,8 @@ public class ClusterFactory {
   }
 
   private Cluster validated(Cluster cluster) {
-    new ClusterValidator(cluster).validate(version);
+    // do a minimal validation after having parsed the CLI or config
+    new ClusterValidator(cluster).validate(ClusterState.CONFIGURING, version);
     return cluster;
   }
 

--- a/dynamic-config/model/src/test/java/org/terracotta/dynamic_config/api/model/NodeContextTest.java
+++ b/dynamic-config/model/src/test/java/org/terracotta/dynamic_config/api/model/NodeContextTest.java
@@ -58,7 +58,7 @@ public class NodeContextTest {
 
   @Before
   public void setUp() throws Exception {
-    new ClusterValidator(cluster).validate();
+    new ClusterValidator(cluster).validate(ClusterState.ACTIVATED);
   }
 
   @Test

--- a/dynamic-config/model/src/test/java/org/terracotta/dynamic_config/api/model/SettingValidatorTest.java
+++ b/dynamic-config/model/src/test/java/org/terracotta/dynamic_config/api/model/SettingValidatorTest.java
@@ -196,7 +196,7 @@ public class SettingValidatorTest {
 
   @Test
   public void test_FAILOVER_PRIORITY() {
-    validateRequired(FAILOVER_PRIORITY);
+    validateOptional(FAILOVER_PRIORITY);
     Stream.of(
         "foo",
         "availability:8",

--- a/dynamic-config/model/src/test/java/org/terracotta/dynamic_config/api/service/ClusterFactoryTest.java
+++ b/dynamic-config/model/src/test/java/org/terracotta/dynamic_config/api/service/ClusterFactoryTest.java
@@ -23,6 +23,7 @@ import org.terracotta.common.struct.MemoryUnit;
 import org.terracotta.common.struct.TimeUnit;
 import org.terracotta.dynamic_config.api.json.DynamicConfigModelJsonModule;
 import org.terracotta.dynamic_config.api.model.Cluster;
+import org.terracotta.dynamic_config.api.model.ClusterState;
 import org.terracotta.dynamic_config.api.model.LockContext;
 import org.terracotta.dynamic_config.api.model.RawPath;
 import org.terracotta.dynamic_config.api.model.Setting;
@@ -149,14 +150,14 @@ public class ClusterFactoryTest {
 
   @Test
   public void test_create_cli_validated() {
-    assertCliFail(cli("failover-priority=availability", "ssl-tls=false", "authc=certificate"), securityDisallowedError);
-    assertCliFail(cli("failover-priority=availability", "ssl-tls=true", "authc=certificate"), securityDisallowedError);
-    assertCliFail(cli("failover-priority=availability", "ssl-tls=true"), securityDisallowedError);
-    assertCliFail(cli("failover-priority=availability", "authc=file"), securityDisallowedError);
-    assertCliFail(cli("failover-priority=availability", "authc=ldap"), securityDisallowedError);
-    assertCliFail(cli("failover-priority=availability", "audit-log-dir=foo"), auditLogDirDisallowedError);
-    assertCliFail(cli("failover-priority=availability", "whitelist=true"), securityDisallowedError);
-    assertCliFail(cli("failover-priority=availability", "security-dir=foo"), minimumSecurityError);
+    assertCliFail(cli("cluster-name=foo", "failover-priority=availability", "ssl-tls=false", "authc=certificate"), securityDisallowedError);
+    assertCliFail(cli("cluster-name=foo", "failover-priority=availability", "ssl-tls=true", "authc=certificate"), securityDisallowedError);
+    assertCliFail(cli("cluster-name=foo", "failover-priority=availability", "ssl-tls=true"), securityDisallowedError);
+    assertCliFail(cli("cluster-name=foo", "failover-priority=availability", "authc=file"), securityDisallowedError);
+    assertCliFail(cli("cluster-name=foo", "failover-priority=availability", "authc=ldap"), securityDisallowedError);
+    assertCliFail(cli("cluster-name=foo", "failover-priority=availability", "audit-log-dir=foo"), auditLogDirDisallowedError);
+    assertCliFail(cli("cluster-name=foo", "failover-priority=availability", "whitelist=true"), securityDisallowedError);
+    assertCliFail(cli("cluster-name=foo", "failover-priority=availability", "security-dir=foo"), minimumSecurityError);
   }
 
   @Test
@@ -269,42 +270,43 @@ public class ClusterFactoryTest {
   public void test_create_config_validated() {
     // security
     assertConfigFail(
-        config("failover-priority=availability", "stripe.1.node.1.hostname=localhost",
+        config("cluster-name=foo", "failover-priority=availability", "stripe.1.node.1.hostname=localhost",
             "ssl-tls=false", "authc=certificate"), securityDisallowedError);
     assertConfigFail(
-        config("failover-priority=availability", "stripe.1.node.1.hostname=localhost",
+        config("cluster-name=foo", "failover-priority=availability", "stripe.1.node.1.hostname=localhost",
             "ssl-tls=true", "authc=certificate"), securityDisallowedError);
     assertConfigFail(
-        config("failover-priority=availability", "stripe.1.node.1.hostname=localhost",
+        config("cluster-name=foo", "failover-priority=availability", "stripe.1.node.1.hostname=localhost",
             "ssl-tls=true"), securityDisallowedError);
     assertConfigFail(
-        config("failover-priority=availability", "stripe.1.node.1.hostname=localhost",
+        config("cluster-name=foo", "failover-priority=availability", "stripe.1.node.1.hostname=localhost",
             "authc=file"), securityDisallowedError);
     assertConfigFail(
-        config("failover-priority=availability", "stripe.1.node.1.hostname=localhost",
+        config("cluster-name=foo", "failover-priority=availability", "stripe.1.node.1.hostname=localhost",
             "authc=ldap"), securityDisallowedError);
     assertConfigFail(
-        config("failover-priority=availability", "stripe.1.node.1.hostname=localhost",
+        config("cluster-name=foo", "failover-priority=availability", "stripe.1.node.1.hostname=localhost",
             "stripe.1.node.1.audit-log-dir=foo"), auditLogDirDisallowedError);
     assertConfigFail(
-        config("failover-priority=availability", "stripe.1.node.1.hostname=localhost",
+        config("cluster-name=foo", "failover-priority=availability", "stripe.1.node.1.hostname=localhost",
             "whitelist=true"), securityDisallowedError);
     assertConfigFail(
-        config("failover-priority=availability", "stripe.1.node.1.hostname=localhost",
+        config("cluster-name=foo", "failover-priority=availability", "stripe.1.node.1.hostname=localhost",
             "stripe.1.node.1.security-dir=foo"), minimumSecurityError);
     assertConfigFail(
-        config("failover-priority=availability", "stripe.1.node.1.hostname=localhost",
+        config("cluster-name=foo", "failover-priority=availability", "stripe.1.node.1.hostname=localhost",
             "stripe.1.node.1.security-dir=foo", "ssl-tls=false", "authc=certificate"), certificateSslTlsError);
     assertConfigFail(
-        config("failover-priority=availability", "stripe.1.node.1.hostname=localhost1", "stripe.1.node.2.hostname=localhost2",
+        config("cluster-name=foo", "failover-priority=availability", "stripe.1.node.1.hostname=localhost1", "stripe.1.node.2.hostname=localhost2",
             "stripe.1.node.1.security-dir=foo"), securityDirError);
     assertConfigFail(
-        config("failover-priority=availability", "stripe.1.node.1.hostname=localhost1", "stripe.1.node.2.hostname=localhost2",
+        config("cluster-name=foo", "failover-priority=availability", "stripe.1.node.1.hostname=localhost1", "stripe.1.node.2.hostname=localhost2",
             "stripe.1.node.1.security-dir=foo", "stripe.1.node.2.security-dir=foo", "whitelist=true", "stripe.1.node.1.audit-log-dir=foo"), auditLogDirError);
 
     // duplicate node name
     assertConfigFail(
         config(
+            "cluster-name=foo",
             "failover-priority=availability",
             "stripe.1.node.1.hostname=localhost1", "stripe.1.node.1.name=foo",
             "stripe.1.node.2.hostname=localhost2", "stripe.1.node.2.name=foo"
@@ -312,6 +314,7 @@ public class ClusterFactoryTest {
         "Found duplicate node name: foo");
     assertConfigFail(
         config(
+            "cluster-name=foo",
             "failover-priority=availability",
             "stripe.1.node.1.hostname=localhost1", "stripe.1.node.1.name=foo",
             "stripe.2.node.1.hostname=localhost2", "stripe.2.node.1.name=foo"
@@ -441,7 +444,7 @@ public class ClusterFactoryTest {
 
   private void assertCliFail(Map<Setting, String> params, String err) {
     assertThat(
-        () -> clusterFactory.create(params, substitutor),
+        () -> new ClusterValidator(clusterFactory.create(params, substitutor)).validate(ClusterState.ACTIVATED),
         is(throwing(instanceOf(MalformedClusterException.class)).andMessage(containsString(err))));
   }
 
@@ -459,7 +462,7 @@ public class ClusterFactoryTest {
 
   private void assertConfigFail(Properties config, String err) {
     assertThat(
-        () -> clusterFactory.create(config),
+        () -> new ClusterValidator(clusterFactory.create(config)).validate(ClusterState.ACTIVATED),
         is(throwing(instanceOf(MalformedClusterException.class)).andMessage(containsString(err))));
   }
 

--- a/dynamic-config/model/src/test/java/org/terracotta/dynamic_config/api/service/ClusterValidatorTest.java
+++ b/dynamic-config/model/src/test/java/org/terracotta/dynamic_config/api/service/ClusterValidatorTest.java
@@ -19,6 +19,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.terracotta.dynamic_config.api.model.Cluster;
+import org.terracotta.dynamic_config.api.model.ClusterState;
 import org.terracotta.dynamic_config.api.model.Node;
 import org.terracotta.dynamic_config.api.model.RawPath;
 import org.terracotta.dynamic_config.api.model.Testing;
@@ -60,7 +61,7 @@ public class ClusterValidatorTest {
 
     assertClusterValidationFails(
         "Duplicate UID for node: foo2 in stripe: stripe1. UID: jUhhu1kRQd-x6iNgpo9Xyw was used on node: foo1 in stripe: stripe1",
-        newTestCluster(newTestStripe("stripe1").addNodes(node1, node2)));
+        newTestCluster("foo", newTestStripe("stripe1").addNodes(node1, node2)));
   }
 
   @Test
@@ -70,7 +71,7 @@ public class ClusterValidatorTest {
 
     assertClusterValidationFails(
         "Duplicate UID for node: foo2 in stripe: stripe2. UID: jUhhu1kRQd-x6iNgpo9Xyw was used on node: foo1 in stripe: stripe1",
-        newTestCluster(newTestStripe("stripe1").addNode(node1), newTestStripe("stripe2").setUID(Testing.S_UIDS[2]).addNode(node2)));
+        newTestCluster("foo", newTestStripe("stripe1").addNode(node1), newTestStripe("stripe2").setUID(Testing.S_UIDS[2]).addNode(node2)));
   }
 
   @Test
@@ -80,7 +81,7 @@ public class ClusterValidatorTest {
 
     assertClusterValidationFails(
         "Duplicate UID for stripe: stripe2. UID: 5Zv3uphiRLavoGZthy7JNg was used on stripe: stripe1",
-        newTestCluster(newTestStripe("stripe1").addNode(node1), newTestStripe("stripe2").addNode(node2)));
+        newTestCluster("foo", newTestStripe("stripe1").addNode(node1), newTestStripe("stripe2").addNode(node2)));
   }
 
   @Test
@@ -90,23 +91,23 @@ public class ClusterValidatorTest {
 
     assertClusterValidationFails(
         "Duplicate UID for stripe: stripe2. UID: jUhhu1kRQd-x6iNgpo9Xyw was used on node: foo1 in stripe: stripe1",
-        newTestCluster(newTestStripe("stripe1").addNode(node1), newTestStripe("stripe2").setUID(Testing.N_UIDS[1]).addNode(node2)));
+        newTestCluster("foo", newTestStripe("stripe1").addNode(node1), newTestStripe("stripe2").setUID(Testing.N_UIDS[1]).addNode(node2)));
 
     assertClusterValidationFails(
         "Duplicate UID for node: foo1 in stripe: stripe1. UID: jUhhu1kRQd-x6iNgpo9Xyw was used on cluster",
-        newTestCluster(newTestStripe("stripe1").addNode(node1)).setUID(Testing.N_UIDS[1]));
+        newTestCluster("foo", newTestStripe("stripe1").addNode(node1)).setUID(Testing.N_UIDS[1]));
 
     assertClusterValidationFails(
         "Duplicate UID for stripe: stripe1. UID: 5Zv3uphiRLavoGZthy7JNg was used on cluster",
-        newTestCluster(newTestStripe("stripe1").addNode(node1)).setUID(Testing.S_UIDS[1]));
+        newTestCluster("foo", newTestStripe("stripe1").addNode(node1)).setUID(Testing.S_UIDS[1]));
 
     assertClusterValidationFails(
         "Duplicate UID for stripe: stripe1. UID: YLQguzhRSdS6y5M9vnA5mw was used on cluster",
-        newTestCluster(newTestStripe("stripe1").addNode(node1).setUID(Testing.C_UIDS[0])));
+        newTestCluster("foo", newTestStripe("stripe1").addNode(node1).setUID(Testing.C_UIDS[0])));
 
     assertClusterValidationFails(
         "Duplicate UID for node: foo1 in stripe: stripe1. UID: jUhhu1kRQd-x6iNgpo9Xyw was used on stripe: stripe1",
-        newTestCluster(newTestStripe("stripe1").addNode(node1).setUID(Testing.N_UIDS[1])));
+        newTestCluster("foo", newTestStripe("stripe1").addNode(node1).setUID(Testing.N_UIDS[1])));
   }
 
   @Test
@@ -114,7 +115,7 @@ public class ClusterValidatorTest {
     Node node1 = newTestNode("foo", "localhost1");
     Node node2 = newTestNode("foo", "localhost2", Testing.N_UIDS[2]);
 
-    assertClusterValidationFails("Found duplicate node name: foo", newTestCluster(newTestStripe("stripe1").addNodes(node1, node2)));
+    assertClusterValidationFails("Found duplicate node name: foo", newTestCluster("foo", newTestStripe("stripe1").addNodes(node1, node2)));
   }
 
   @Test
@@ -122,7 +123,7 @@ public class ClusterValidatorTest {
     Node node1 = newTestNode("foo", "localhost1");
     Node node2 = newTestNode("foo", "localhost2", Testing.N_UIDS[2]);
 
-    assertClusterValidationFails("Found duplicate node name: foo", newTestCluster(newTestStripe("stripe1").addNodes(node1), newTestStripe("stripe2", Testing.S_UIDS[2]).addNodes(node2)));
+    assertClusterValidationFails("Found duplicate node name: foo", newTestCluster("foo", newTestStripe("stripe1").addNodes(node1), newTestStripe("stripe2", Testing.S_UIDS[2]).addNodes(node2)));
   }
 
   @Test
@@ -132,7 +133,7 @@ public class ClusterValidatorTest {
 
     assertClusterValidationFails(
         "Nodes with names: foo1, foo2 have the same address: 'localhost:9410'",
-        newTestCluster(newTestStripe("stripe1").addNodes(node1, node2)));
+        newTestCluster("foo", newTestStripe("stripe1").addNodes(node1, node2)));
   }
 
   @Test
@@ -142,7 +143,7 @@ public class ClusterValidatorTest {
 
     assertClusterValidationFails(
         "Nodes with names: foo1, foo2 have the same public address: 'public-host:9510'",
-        newTestCluster(newTestStripe("stripe1").addNodes(node1, node2)));
+        newTestCluster("foo", newTestStripe("stripe1").addNodes(node1, node2)));
   }
 
   @Test
@@ -152,20 +153,20 @@ public class ClusterValidatorTest {
 
     assertClusterValidationFails(
         "Nodes with names: [foo2] don't have public addresses defined, but other nodes in the cluster do. Mutative operations on public addresses must be done simultaneously on every node in the cluster",
-        newTestCluster(newTestStripe("stripe1").addNodes(node1, node2)));
+        newTestCluster("foo", newTestStripe("stripe1").addNodes(node1, node2)));
   }
 
   @Test
   public void testSamePublicAndPrivateAddressOnSameNode() {
     Node node = newTestNode("foo1", "host").setPort(9410).setPublicHostname("host").setPublicPort(9410);
-    new ClusterValidator(newTestCluster(newTestStripe("stripe1").addNodes(node))).validate();
+    new ClusterValidator(newTestCluster("foo", newTestStripe("stripe1").addNodes(node))).validate(ClusterState.ACTIVATED);
   }
 
   @Test
   public void testSamePublicAndPrivateAddressAcrossNodes() {
     Node node1 = newTestNode("foo1", "host1").setPort(9410).setPublicHostname("host2").setPublicPort(9410);
     Node node2 = newTestNode("foo2", "host2", Testing.N_UIDS[2]).setPort(9410).setPublicHostname("host1").setPublicPort(9410);
-    new ClusterValidator(newTestCluster(newTestStripe("stripe1").addNodes(node1, node2))).validate();
+    new ClusterValidator(newTestCluster("foo", newTestStripe("stripe1").addNodes(node1, node2))).validate(ClusterState.ACTIVATED);
   }
 
   @Test
@@ -175,21 +176,21 @@ public class ClusterValidatorTest {
 
     assertClusterValidationFails(
         "Nodes with names: foo1, foo2 have the same address: 'localhost:9410'",
-        newTestCluster(newTestStripe("stripe1").addNodes(node1, node2)));
+        newTestCluster("foo", newTestStripe("stripe1").addNodes(node1, node2)));
   }
 
   @Test
   public void testMalformedPublicAddress_missingPublicPort() {
     Node node = newTestNode("foo", "localhost").setPublicHostname("public-host");
     assertClusterValidationFails("Public address: 'public-host:null' of node with name: foo isn't well-formed. Public hostname and port need to be set (or unset) together",
-        newTestCluster(newTestStripe("stripe1").addNodes(node)));
+        newTestCluster("foo", newTestStripe("stripe1").addNodes(node)));
   }
 
   @Test
   public void testMalformedPublicAddress_missingPublicHostname() {
     Node node = newTestNode("foo", "localhost").setPublicPort(9410);
     assertClusterValidationFails("Public address: 'null:9410' of node with name: foo isn't well-formed. Public hostname and port need to be set (or unset) together",
-        newTestCluster(newTestStripe("stripe1").addNodes(node)));
+        newTestCluster("foo", newTestStripe("stripe1").addNodes(node)));
   }
 
   @Test
@@ -199,7 +200,7 @@ public class ClusterValidatorTest {
     node1.putDataDir("dir-1", RawPath.valueOf("data"));
     node2.putDataDir("dir-2", RawPath.valueOf("data"));
 
-    assertClusterValidationFails("Data directory names need to match across the cluster, but found the following mismatches: [[dir-2, main], [dir-1, main]]. Mutative operations on data dirs must be done simultaneously on every node in the cluster", newTestCluster(newTestStripe("stripe1").addNodes(node1, node2)));
+    assertClusterValidationFails("Data directory names need to match across the cluster, but found the following mismatches: [[dir-2, main], [dir-1, main]]. Mutative operations on data dirs must be done simultaneously on every node in the cluster", newTestCluster("foo", newTestStripe("stripe1").addNodes(node1, node2)));
   }
 
   @Test
@@ -208,7 +209,7 @@ public class ClusterValidatorTest {
     Node node2 = newTestNode("node2", "localhost2", Testing.N_UIDS[2]);
     node1.setBackupDir(RawPath.valueOf("backup"));
     node2.setBackupDir(RawPath.valueOf("backup"));
-    new ClusterValidator(newTestCluster(newTestStripe("stripe1").addNodes(node1), newTestStripe("stripe2", Testing.S_UIDS[2]).addNodes(node2))).validate();
+    new ClusterValidator(newTestCluster("foo", newTestStripe("stripe1").addNodes(node1), newTestStripe("stripe2", Testing.S_UIDS[2]).addNodes(node2))).validate(ClusterState.ACTIVATED);
   }
 
   @Test
@@ -217,7 +218,7 @@ public class ClusterValidatorTest {
     Node node2 = newTestNode("node2", "localhost2", Testing.N_UIDS[2]);
     node1.setBackupDir(RawPath.valueOf("backup-1"));
     node2.setBackupDir(RawPath.valueOf("backup-2"));
-    new ClusterValidator(newTestCluster(newTestStripe("stripe1").addNodes(node1), newTestStripe("stripe2", Testing.S_UIDS[2]).addNodes(node2))).validate();
+    new ClusterValidator(newTestCluster("foo", newTestStripe("stripe1").addNodes(node1), newTestStripe("stripe2", Testing.S_UIDS[2]).addNodes(node2))).validate(ClusterState.ACTIVATED);
   }
 
   @Test
@@ -228,7 +229,7 @@ public class ClusterValidatorTest {
 
     assertClusterValidationFails(
         "Nodes: [foo] currently have (or will have) backup directories defined, while some nodes in the cluster do not (or will not). Within a cluster, all nodes must have a backup directory defined or no backup directory defined.",
-        newTestCluster(newTestStripe("stripe1").addNodes(node1, node2)));
+        newTestCluster("foo", newTestStripe("stripe1").addNodes(node1, node2)));
   }
 
   @Test
@@ -250,7 +251,7 @@ public class ClusterValidatorTest {
         .setBindAddress(generateAddress())
         .setGroupBindAddress(generateAddress())
     ).toArray(Node[]::new);
-    Cluster cluster = newTestCluster(newTestStripe("stripe1").addNodes(nodes))
+    Cluster cluster = newTestCluster("foo", newTestStripe("stripe1").addNodes(nodes))
         .setSecurityAuthc("file")
         .setSecuritySslTls(true)
         .setSecurityWhitelist(false)
@@ -258,7 +259,7 @@ public class ClusterValidatorTest {
         .setFailoverPriority(consistency())
         .setClientReconnectWindow(100L, SECONDS)
         .setClientLeaseDuration(100L, SECONDS);
-    new ClusterValidator(cluster).validate();
+    new ClusterValidator(cluster).validate(ClusterState.ACTIVATED);
   }
 
   @Test
@@ -266,8 +267,8 @@ public class ClusterValidatorTest {
     Node node1 = newTestNode("node1", "localhost1").setSecurityDir(RawPath.valueOf("security-dir")).setSecurityAuditLogDir(RawPath.valueOf("security-audit-dir"));
     Node node2 = newTestNode("node2", "localhost2", Testing.N_UIDS[2]).setSecurityDir(RawPath.valueOf("security-dir")).setSecurityAuditLogDir(RawPath.valueOf("security-audit-dir"));
 
-    Cluster cluster = newTestCluster(newTestStripe("stripe1").addNodes(node1, node2)).setSecuritySslTls(false).setSecurityWhitelist(true);
-    new ClusterValidator(cluster).validate();
+    Cluster cluster = newTestCluster("foo", newTestStripe("stripe1").addNodes(node1, node2)).setSecuritySslTls(false).setSecurityWhitelist(true);
+    new ClusterValidator(cluster).validate(ClusterState.ACTIVATED);
   }
 
   @Test
@@ -275,16 +276,16 @@ public class ClusterValidatorTest {
     Node node1 = newTestNode("node1", "localhost1").setSecurityDir(RawPath.valueOf("security-dir")).setSecurityAuditLogDir(RawPath.valueOf("security-audit-dir"));
     Node node2 = newTestNode("node2", "localhost2", Testing.N_UIDS[2]).setSecurityDir(RawPath.valueOf("security-dir")).setSecurityAuditLogDir(RawPath.valueOf("security-audit-dir"));
 
-    Cluster cluster = newTestCluster(newTestStripe("stripe1").addNodes(node1, node2)).setSecurityWhitelist(true);
-    new ClusterValidator(cluster).validate();
+    Cluster cluster = newTestCluster("foo", newTestStripe("stripe1").addNodes(node1, node2)).setSecurityWhitelist(true);
+    new ClusterValidator(cluster).validate(ClusterState.ACTIVATED);
   }
 
   @Test
   public void testGoodSecurity_3() {
     Node node1 = newTestNode("node1", "localhost1").setSecurityDir(RawPath.valueOf("security-root-dir"));
     Node node2 = newTestNode("node2", "localhost2", Testing.N_UIDS[2]).setSecurityDir(RawPath.valueOf("security-root-dir"));
-    Cluster cluster = newTestCluster(newTestStripe("stripe1").addNodes(node1, node2)).setSecurityAuthc("file");
-    new ClusterValidator(cluster).validate();
+    Cluster cluster = newTestCluster("foo", newTestStripe("stripe1").addNodes(node1, node2)).setSecurityAuthc("file");
+    new ClusterValidator(cluster).validate(ClusterState.ACTIVATED);
   }
 
   @Test
@@ -292,8 +293,8 @@ public class ClusterValidatorTest {
     Node node1 = newTestNode("node1", "localhost1").setSecurityDir(RawPath.valueOf("security-root-dir"));
     Node node2 = newTestNode("node2", "localhost2", Testing.N_UIDS[2]).setSecurityDir(RawPath.valueOf("security-root-dir"));
 
-    Cluster cluster = newTestCluster(newTestStripe("stripe1").addNodes(node1, node2)).setSecuritySslTls(true).setSecurityAuthc("certificate");
-    new ClusterValidator(cluster).validate();
+    Cluster cluster = newTestCluster("foo", newTestStripe("stripe1").addNodes(node1, node2)).setSecuritySslTls(true).setSecurityAuthc("certificate");
+    new ClusterValidator(cluster).validate(ClusterState.ACTIVATED);
   }
 
   @Test
@@ -301,18 +302,18 @@ public class ClusterValidatorTest {
     Node node1 = newTestNode("node1", "localhost1").setSecurityDir(RawPath.valueOf("security-root-dir")).setSecurityAuditLogDir(RawPath.valueOf("security-audit-dir"));
     Node node2 = newTestNode("node2", "localhost2", Testing.N_UIDS[2]).setSecurityDir(RawPath.valueOf("security-root-dir")).setSecurityAuditLogDir(RawPath.valueOf("security-audit-dir"));
 
-    Cluster cluster = newTestCluster(newTestStripe("stripe1").addNodes(node1, node2))
+    Cluster cluster = newTestCluster("foo", newTestStripe("stripe1").addNodes(node1, node2))
         .setSecuritySslTls(true)
         .setSecurityAuthc("certificate")
         .setSecurityWhitelist(true);
-    new ClusterValidator(cluster).validate();
+    new ClusterValidator(cluster).validate(ClusterState.ACTIVATED);
   }
 
   @Test
   public void testBadSecurity_notAllNodesHaveSecurityDir() {
     Node node1 = newTestNode("node1", "localhost1").setSecurityDir(RawPath.valueOf("security-dir"));
     Node node2 = newTestNode("node2", "localhost2");
-    Cluster cluster = newTestCluster(newTestStripe("stripe1").addNodes(node1, node2));
+    Cluster cluster = newTestCluster("foo", newTestStripe("stripe1").addNodes(node1, node2));
 
     assertClusterValidationFailsContainsMessage(securityDirError, cluster);
   }
@@ -320,7 +321,7 @@ public class ClusterValidatorTest {
   @Test
   public void testBadSecurity_authcWithoutSslTlsWithoutSecurityDir() {
     Node node = newTestNode("node1", "localhost1");
-    Cluster cluster = newTestCluster(newTestStripe("stripe1").addNodes(node))
+    Cluster cluster = newTestCluster("foo", newTestStripe("stripe1").addNodes(node))
         .setSecuritySslTls(false)
         .setSecurityAuthc("certificate");
 
@@ -330,7 +331,7 @@ public class ClusterValidatorTest {
   @Test
   public void testBadSecurity_authcWithoutSslTlsWithSecurityDir() {
     Node node = newTestNode("node1", "localhost1").setSecurityDir(RawPath.valueOf("security-dir"));
-    Cluster cluster = newTestCluster(newTestStripe("stripe1").addNodes(node))
+    Cluster cluster = newTestCluster("foo", newTestStripe("stripe1").addNodes(node))
         .setSecuritySslTls(false)
         .setSecurityAuthc("certificate");
 
@@ -340,7 +341,7 @@ public class ClusterValidatorTest {
   @Test
   public void testBadSecurity_sslTlsAuthcWithoutSecurityDir() {
     Node node = newTestNode("node1", "localhost1");
-    Cluster cluster = newTestCluster(newTestStripe("stripe1").addNodes(node))
+    Cluster cluster = newTestCluster("foo", newTestStripe("stripe1").addNodes(node))
         .setSecuritySslTls(true)
         .setSecurityAuthc("certificate");
 
@@ -350,7 +351,7 @@ public class ClusterValidatorTest {
   @Test
   public void testBadSecurity_sslTlsWithoutSecurityDir() {
     Node node = newTestNode("node1", "localhost1");
-    Cluster cluster = newTestCluster(newTestStripe("stripe1").addNodes(node)).setSecuritySslTls(true);
+    Cluster cluster = newTestCluster("foo", newTestStripe("stripe1").addNodes(node)).setSecuritySslTls(true);
 
     assertClusterValidationFailsContainsMessage(securityDisallowedError, cluster);
   }
@@ -358,7 +359,7 @@ public class ClusterValidatorTest {
   @Test
   public void testBadSecurity_authcWithoutSecurityDir() {
     Node node = newTestNode("node1", "localhost1");
-    Cluster cluster = newTestCluster(newTestStripe("stripe1").addNodes(node)).setSecurityAuthc("file");
+    Cluster cluster = newTestCluster("foo", newTestStripe("stripe1").addNodes(node)).setSecurityAuthc("file");
 
     assertClusterValidationFailsContainsMessage(securityDisallowedError, cluster);
   }
@@ -366,7 +367,7 @@ public class ClusterValidatorTest {
   @Test
   public void testBadSecurity_auditLogDirWithoutSecurityDir() {
     Node node = newTestNode("node1", "localhost1").setSecurityAuditLogDir(RawPath.valueOf("."));
-    Cluster cluster = newTestCluster(newTestStripe("stripe1").addNodes(node));
+    Cluster cluster = newTestCluster("foo", newTestStripe("stripe1").addNodes(node));
 
     assertClusterValidationFailsContainsMessage(auditLogDirDisallowedError, cluster);
   }
@@ -374,7 +375,7 @@ public class ClusterValidatorTest {
   @Test
   public void testBadSecurity_whitelistWithoutSecurityDir() {
     Node node = newTestNode("node1", "localhost1");
-    Cluster cluster = newTestCluster(newTestStripe("stripe1").addNodes(node)).setSecurityWhitelist(true);
+    Cluster cluster = newTestCluster("foo", newTestStripe("stripe1").addNodes(node)).setSecurityWhitelist(true);
 
     assertClusterValidationFailsContainsMessage(securityDisallowedError, cluster);
   }
@@ -382,7 +383,7 @@ public class ClusterValidatorTest {
   @Test
   public void testBadSecurity_securityDirWithoutSecurity() {
     Node node = newTestNode("node1", "localhost1").setSecurityDir(RawPath.valueOf("security-dir"));
-    Cluster cluster = newTestCluster(newTestStripe("stripe1").addNodes(node));
+    Cluster cluster = newTestCluster("foo", newTestStripe("stripe1").addNodes(node));
 
     assertClusterValidationFailsContainsMessage(minimumSecurityError, cluster);
   }
@@ -391,7 +392,7 @@ public class ClusterValidatorTest {
   public void testBadSecurity_notAllNodesHaveAuditLogDirWithSecurityDir() {
     Node node1 = newTestNode("node1", "localhost1").setSecurityDir(RawPath.valueOf("security-dir")).setSecurityAuditLogDir(RawPath.valueOf("audit"));
     Node node2 = newTestNode("node2", "localhost2", Testing.N_UIDS[2]).setSecurityDir(RawPath.valueOf("security-dir"));
-    Cluster cluster = newTestCluster(newTestStripe("stripe1").addNodes(node1, node2)).setSecurityWhitelist(true);
+    Cluster cluster = newTestCluster("foo", newTestStripe("stripe1").addNodes(node1, node2)).setSecurityWhitelist(true);
 
     assertClusterValidationFailsContainsMessage(auditLogDirError, cluster);
   }
@@ -400,7 +401,7 @@ public class ClusterValidatorTest {
   public void testBadSecurity_notAllNodesHaveAuditLogDirWithoutSecurityDir() {
     Node node1 = newTestNode("node1", "localhost1").setSecurityAuditLogDir(RawPath.valueOf("audit"));
     Node node2 = newTestNode("node2", "localhost2", Testing.N_UIDS[2]);
-    Cluster cluster = newTestCluster(newTestStripe("stripe1").addNodes(node1, node2));
+    Cluster cluster = newTestCluster("foo", newTestStripe("stripe1").addNodes(node1, node2));
 
     assertClusterValidationFailsContainsMessage(auditLogDirDisallowedError, cluster);
   }
@@ -421,13 +422,13 @@ public class ClusterValidatorTest {
     assertClusterValidationFailsContainsMessage("Invalid ending character in stripe name: '.'", newTestCluster("my-cluster", newTestStripe("end-by-.").addNodes(newTestNode("my-node", "localhost1"))));
     assertClusterValidationFailsContainsMessage("Invalid ending character in node name: '.'", newTestCluster("my-cluster", newTestStripe("my-stripe").addNodes(newTestNode("end-by-.", "localhost1"))));
 
-    new ClusterValidator(newTestCluster("my.company.com", newTestStripe("my-stripe").addNodes(newTestNode("my-node", "localhost1")))).validate();
-    new ClusterValidator(newTestCluster("m-cluster", newTestStripe("my.company.com").addNodes(newTestNode("my-node", "localhost1")))).validate();
-    new ClusterValidator(newTestCluster("m-cluster", newTestStripe("my-stripe").addNodes(newTestNode("my.company.com", "localhost1")))).validate();
+    new ClusterValidator(newTestCluster("my.company.com", newTestStripe("my-stripe").addNodes(newTestNode("my-node", "localhost1")))).validate(ClusterState.ACTIVATED);
+    new ClusterValidator(newTestCluster("m-cluster", newTestStripe("my.company.com").addNodes(newTestNode("my-node", "localhost1")))).validate(ClusterState.ACTIVATED);
+    new ClusterValidator(newTestCluster("m-cluster", newTestStripe("my-stripe").addNodes(newTestNode("my.company.com", "localhost1")))).validate(ClusterState.ACTIVATED);
 
-    new ClusterValidator(newTestCluster("foo@my.company.com", newTestStripe("my-stripe").addNodes(newTestNode("my-node", "localhost1")))).validate();
-    new ClusterValidator(newTestCluster("m-cluster", newTestStripe("foo@my.company.com").addNodes(newTestNode("my-node", "localhost1")))).validate();
-    new ClusterValidator(newTestCluster("m-cluster", newTestStripe("my-stripe").addNodes(newTestNode("foo@my.company.com", "localhost1")))).validate();
+    new ClusterValidator(newTestCluster("foo@my.company.com", newTestStripe("my-stripe").addNodes(newTestNode("my-node", "localhost1")))).validate(ClusterState.ACTIVATED);
+    new ClusterValidator(newTestCluster("m-cluster", newTestStripe("foo@my.company.com").addNodes(newTestNode("my-node", "localhost1")))).validate(ClusterState.ACTIVATED);
+    new ClusterValidator(newTestCluster("m-cluster", newTestStripe("my-stripe").addNodes(newTestNode("foo@my.company.com", "localhost1")))).validate(ClusterState.ACTIVATED);
   }
 
   private String generateAddress() {
@@ -435,10 +436,10 @@ public class ClusterValidatorTest {
   }
 
   private void assertClusterValidationFails(String message, Cluster cluster) {
-    assertThat(() -> new ClusterValidator(cluster).validate(), is(throwing(instanceOf(MalformedClusterException.class)).andMessage(is(equalTo(message)))));
+    assertThat(() -> new ClusterValidator(cluster).validate(ClusterState.ACTIVATED), is(throwing(instanceOf(MalformedClusterException.class)).andMessage(is(equalTo(message)))));
   }
 
   private void assertClusterValidationFailsContainsMessage(String message, Cluster cluster) {
-    assertThat(() -> new ClusterValidator(cluster).validate(), is(throwing(instanceOf(MalformedClusterException.class)).andMessage(is(containsString(message)))));
+    assertThat(() -> new ClusterValidator(cluster).validate(ClusterState.ACTIVATED), is(throwing(instanceOf(MalformedClusterException.class)).andMessage(is(containsString(message)))));
   }
 }

--- a/dynamic-config/model/src/test/java/org/terracotta/dynamic_config/api/service/ConfigurationParserTest.java
+++ b/dynamic-config/model/src/test/java/org/terracotta/dynamic_config/api/service/ConfigurationParserTest.java
@@ -269,28 +269,16 @@ public class ConfigurationParserTest {
     // minimal config is to only have hostname, but to facilitate testing we add name
     assertConfigEquals(
         config(
-            "failover-priority=availability",
             "stripe.1.stripe-name=<GENERATED>",
             "stripe.1.node.1.name=node1",
             "stripe.1.node.1.hostname=localhost",
             "cluster-name=foo"
         ),
-        Testing.newTestCluster("foo", new Stripe().addNodes(Testing.newTestNode("node1", "localhost"))),
+        Testing.newTestCluster("foo", new Stripe().addNodes(Testing.newTestNode("node1", "localhost"))).setFailoverPriority(null),
         "cluster-uid=<GENERATED>",
         "stripe.1.stripe-uid=<GENERATED>",
         "stripe.1.node.1.node-uid=<GENERATED>"
     );
-  }
-
-  @Test
-  public void test_parsing_complete_1x1_no_failover() {
-    // minimal config is to only have hostname, but to facilitate testing we add name
-    assertConfigFail(
-        config(
-            "stripe.1.node.1.name=node1",
-            "stripe.1.node.1.hostname=localhost",
-            "cluster-name=foo"
-        ), "Required setting: 'failover-priority' is missing");
   }
 
   @Test

--- a/dynamic-config/model/src/test/java/org/terracotta/dynamic_config/api/service/NameGeneratorTest.java
+++ b/dynamic-config/model/src/test/java/org/terracotta/dynamic_config/api/service/NameGeneratorTest.java
@@ -17,6 +17,7 @@ package org.terracotta.dynamic_config.api.service;
 
 import org.junit.Test;
 import org.terracotta.dynamic_config.api.model.Cluster;
+import org.terracotta.dynamic_config.api.model.ClusterState;
 import org.terracotta.dynamic_config.api.model.Node;
 import org.terracotta.dynamic_config.api.model.Stripe;
 import org.terracotta.dynamic_config.api.model.UID;
@@ -56,7 +57,7 @@ public class NameGeneratorTest {
     NameGenerator.assignFriendlyNames(cluster, newStripe);
 
     assertThat(newStripe.getName(), is(equalTo("stripe-3")));
-    new ClusterValidator(cluster).validate();
+    new ClusterValidator(cluster).validate(ClusterState.ACTIVATED);
   }
 
   @Test
@@ -76,6 +77,6 @@ public class NameGeneratorTest {
     NameGenerator.assignFriendlyNodeName(cluster, newNode);
 
     assertThat(newNode.getName(), is(equalTo("Canidae-3")));
-    new ClusterValidator(cluster).validate();
+    new ClusterValidator(cluster).validate(ClusterState.ACTIVATED);
   }
 }

--- a/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/service/ConfigChangeApplicator.java
+++ b/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/service/ConfigChangeApplicator.java
@@ -18,6 +18,7 @@ package org.terracotta.dynamic_config.server.configuration.service;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terracotta.dynamic_config.api.model.Cluster;
+import org.terracotta.dynamic_config.api.model.ClusterState;
 import org.terracotta.dynamic_config.api.model.NodeContext;
 import org.terracotta.dynamic_config.api.model.UID;
 import org.terracotta.dynamic_config.api.model.nomad.DynamicConfigNomadChange;
@@ -61,7 +62,7 @@ public class ConfigChangeApplicator implements ChangeApplicator<NodeContext> {
     NodeContext newConfiguration = newConfiguration(baseConfig, updated);
 
     try {
-      new ClusterValidator(updated).validate();
+      new ClusterValidator(updated).validate(ClusterState.ACTIVATED);
       // validate the change thanks to external processors
       processor.validate(baseConfig, dynamicConfigNomadChange);
       return PotentialApplicationResult.allow(newConfiguration);

--- a/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/service/nomad/processor/FormatUpgradeNomadChangeProcessor.java
+++ b/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/service/nomad/processor/FormatUpgradeNomadChangeProcessor.java
@@ -15,6 +15,7 @@
  */
 package org.terracotta.dynamic_config.server.configuration.service.nomad.processor;
 
+import org.terracotta.dynamic_config.api.model.ClusterState;
 import org.terracotta.dynamic_config.api.model.NodeContext;
 import org.terracotta.dynamic_config.api.model.nomad.FormatUpgradeNomadChange;
 import org.terracotta.dynamic_config.api.service.ClusterValidator;
@@ -23,7 +24,7 @@ import org.terracotta.dynamic_config.server.api.NomadChangeProcessor;
 public class FormatUpgradeNomadChangeProcessor implements NomadChangeProcessor<FormatUpgradeNomadChange> {
   @Override
   public void validate(NodeContext baseConfig, FormatUpgradeNomadChange change) {
-    new ClusterValidator(change.getCluster()).validate();
+    new ClusterValidator(change.getCluster()).validate(ClusterState.ACTIVATED);
   }
 
   @Override

--- a/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/service/nomad/processor/NodeAdditionNomadChangeProcessor.java
+++ b/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/service/nomad/processor/NodeAdditionNomadChangeProcessor.java
@@ -18,6 +18,7 @@ package org.terracotta.dynamic_config.server.configuration.service.nomad.process
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terracotta.dynamic_config.api.model.Cluster;
+import org.terracotta.dynamic_config.api.model.ClusterState;
 import org.terracotta.dynamic_config.api.model.Node;
 import org.terracotta.dynamic_config.api.model.NodeContext;
 import org.terracotta.dynamic_config.api.model.nomad.NodeAdditionNomadChange;
@@ -61,7 +62,7 @@ public class NodeAdditionNomadChangeProcessor implements NomadChangeProcessor<No
     try {
       checkMBeanOperation();
       Cluster updated = change.apply(baseConfig.getCluster());
-      new ClusterValidator(updated).validate();
+      new ClusterValidator(updated).validate(ClusterState.ACTIVATED);
     } catch (RuntimeException e) {
       throw new NomadException("Error when trying to apply: '" + change.getSummary() + "': " + e.getMessage(), e);
     }

--- a/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/service/nomad/processor/NodeRemovalNomadChangeProcessor.java
+++ b/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/service/nomad/processor/NodeRemovalNomadChangeProcessor.java
@@ -18,6 +18,7 @@ package org.terracotta.dynamic_config.server.configuration.service.nomad.process
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terracotta.dynamic_config.api.model.Cluster;
+import org.terracotta.dynamic_config.api.model.ClusterState;
 import org.terracotta.dynamic_config.api.model.Node;
 import org.terracotta.dynamic_config.api.model.NodeContext;
 import org.terracotta.dynamic_config.api.model.nomad.NodeRemovalNomadChange;
@@ -57,7 +58,7 @@ public class NodeRemovalNomadChangeProcessor implements NomadChangeProcessor<Nod
     try {
       checkMBeanOperation();
       Cluster updated = change.apply(baseConfig.getCluster());
-      new ClusterValidator(updated).validate();
+      new ClusterValidator(updated).validate(ClusterState.ACTIVATED);
     } catch (RuntimeException e) {
       throw new NomadException("Error when trying to apply: '" + change.getSummary() + "': " + e.getMessage(), e);
     }

--- a/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/service/nomad/processor/StripeAdditionNomadChangeProcessor.java
+++ b/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/service/nomad/processor/StripeAdditionNomadChangeProcessor.java
@@ -18,6 +18,7 @@ package org.terracotta.dynamic_config.server.configuration.service.nomad.process
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terracotta.dynamic_config.api.model.Cluster;
+import org.terracotta.dynamic_config.api.model.ClusterState;
 import org.terracotta.dynamic_config.api.model.NodeContext;
 import org.terracotta.dynamic_config.api.model.nomad.StripeAdditionNomadChange;
 import org.terracotta.dynamic_config.api.service.ClusterValidator;
@@ -50,7 +51,7 @@ public class StripeAdditionNomadChangeProcessor implements NomadChangeProcessor<
     }
     try {
       Cluster updated = change.apply(baseConfig.getCluster());
-      new ClusterValidator(updated).validate();
+      new ClusterValidator(updated).validate(ClusterState.ACTIVATED);
       topologyService.getLicense().ifPresent(l -> licenseService.validate(l, updated));
     } catch (RuntimeException e) {
       throw new NomadException("Error when trying to apply: '" + change.getSummary() + "': " + e.getMessage(), e);

--- a/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/service/nomad/processor/StripeRemovalNomadChangeProcessor.java
+++ b/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/service/nomad/processor/StripeRemovalNomadChangeProcessor.java
@@ -18,6 +18,7 @@ package org.terracotta.dynamic_config.server.configuration.service.nomad.process
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terracotta.dynamic_config.api.model.Cluster;
+import org.terracotta.dynamic_config.api.model.ClusterState;
 import org.terracotta.dynamic_config.api.model.NodeContext;
 import org.terracotta.dynamic_config.api.model.nomad.StripeRemovalNomadChange;
 import org.terracotta.dynamic_config.api.service.ClusterValidator;
@@ -47,7 +48,7 @@ public class StripeRemovalNomadChangeProcessor implements NomadChangeProcessor<S
     }
     try {
       Cluster updated = change.apply(baseConfig.getCluster());
-      new ClusterValidator(updated).validate();
+      new ClusterValidator(updated).validate(ClusterState.ACTIVATED);
     } catch (RuntimeException e) {
       throw new NomadException("Error when trying to apply: '" + change.getSummary() + "': " + e.getMessage(), e);
     }

--- a/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/startup/ConfigRepoCommandLineProcessor.java
+++ b/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/startup/ConfigRepoCommandLineProcessor.java
@@ -16,7 +16,6 @@
 package org.terracotta.dynamic_config.server.configuration.startup;
 
 import org.terracotta.dynamic_config.api.model.Cluster;
-import org.terracotta.dynamic_config.api.model.FailoverPriority;
 import org.terracotta.dynamic_config.api.model.NodeContext;
 import org.terracotta.dynamic_config.api.model.Setting;
 import org.terracotta.dynamic_config.api.service.ClusterFactory;
@@ -27,10 +26,6 @@ import java.nio.file.Path;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
-
-import static org.terracotta.dynamic_config.api.model.Setting.FAILOVER_PRIORITY;
-
-;
 
 public class ConfigRepoCommandLineProcessor implements CommandLineProcessor {
   private final Options options;
@@ -64,7 +59,6 @@ public class ConfigRepoCommandLineProcessor implements CommandLineProcessor {
       // Build an alternate topology from the CLI in case we cannot load any config from the existing config repo.
       // This can happen in case a node is not properly activated
       Map<Setting, String> cliOptions = new LinkedHashMap<>(options.getTopologyOptions());
-      cliOptions.putIfAbsent(FAILOVER_PRIORITY, FailoverPriority.availability().toString());
       Cluster cluster = clusterCreator.create(cliOptions, parameterSubstitutor);
       NodeContext alternate = new NodeContext(cluster, cluster.getSingleNode().get().getUID());
 

--- a/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/startup/ConsoleCommandLineProcessor.java
+++ b/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/startup/ConsoleCommandLineProcessor.java
@@ -23,7 +23,6 @@ import org.terracotta.dynamic_config.api.service.IParameterSubstitutor;
 import org.terracotta.server.Server;
 
 import static java.util.Objects.requireNonNull;
-import static org.terracotta.dynamic_config.api.model.SettingName.FAILOVER_PRIORITY;
 
 public class ConsoleCommandLineProcessor implements CommandLineProcessor {
   private final Options options;
@@ -48,9 +47,6 @@ public class ConsoleCommandLineProcessor implements CommandLineProcessor {
   @Override
   public void process() {
     server.console("Starting node from command-line parameters");
-    if (options.getFailoverPriority() == null) {
-      throw new IllegalArgumentException(FAILOVER_PRIORITY + " is required");
-    }
 
     Cluster cluster = clusterCreator.create(options.getTopologyOptions(), parameterSubstitutor);
     Node node = cluster.getSingleNode().get(); // Cluster object will have only 1 node, just get that

--- a/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/startup/StartupConfiguration.java
+++ b/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/startup/StartupConfiguration.java
@@ -152,7 +152,10 @@ public class StartupConfiguration implements Configuration, PrettyPrintable, Sta
 
   @Override
   public FailoverBehavior getFailoverPriority() {
-    final FailoverPriority failoverPriority = nodeContextSupplier.get().getCluster().getFailoverPriority();
+    final FailoverPriority failoverPriority = nodeContextSupplier.get().getCluster().getFailoverPriority().orElse(null);
+    if(failoverPriority == null) {
+      return null;
+    }
     switch (failoverPriority.getType()) {
       case CONSISTENCY:
         return new FailoverBehavior(FailoverBehavior.Type.CONSISTENCY, failoverPriority.getVoters());

--- a/dynamic-config/server/configuration-provider/src/test/java/org/terracotta/dynamic_config/server/configuration/startup/CommandLineProcessorChainTest.java
+++ b/dynamic-config/server/configuration-provider/src/test/java/org/terracotta/dynamic_config/server/configuration/startup/CommandLineProcessorChainTest.java
@@ -295,8 +295,8 @@ public class CommandLineProcessorChainTest {
 
   @Test
   public void testUnconfiguredWithCliParams() {
+    cluster.setFailoverPriority(null);
     when(clusterCreator.create(paramValueMap, parameterSubstitutor)).thenReturn(cluster);
-    when(options.getFailoverPriority()).thenReturn(availability().toString());
 
     mainCommandLineProcessor.process();
 
@@ -304,12 +304,5 @@ public class CommandLineProcessorChainTest {
     verify(configurationGeneratorVisitor).findNodeName(any(), any(IParameterSubstitutor.class));
     verify(configurationGeneratorVisitor).startUnconfigured(nodeContext, null);
     verifyNoMoreInteractions(configurationGeneratorVisitor);
-  }
-
-  @Test
-  public void testWithCliParams_missingFailoverPriority() {
-    expectedException.expect(IllegalArgumentException.class);
-    expectedException.expectMessage("failover-priority is required");
-    mainCommandLineProcessor.process();
   }
 }

--- a/dynamic-config/server/configuration-repository/src/test/java/org/terracotta/dynamic_config/server/configuration/nomad/persistence/SanskritNomadServerStateTest.java
+++ b/dynamic-config/server/configuration-repository/src/test/java/org/terracotta/dynamic_config/server/configuration/nomad/persistence/SanskritNomadServerStateTest.java
@@ -29,7 +29,6 @@ import org.terracotta.dynamic_config.api.model.Testing;
 import org.terracotta.dynamic_config.api.model.Version;
 import org.terracotta.dynamic_config.api.model.nomad.Applicability;
 import org.terracotta.dynamic_config.api.model.nomad.SettingNomadChange;
-import org.terracotta.dynamic_config.api.service.ClusterValidator;
 import org.terracotta.json.ObjectMapperFactory;
 import org.terracotta.nomad.client.change.NomadChange;
 import org.terracotta.nomad.server.ChangeRequest;
@@ -79,7 +78,6 @@ public class SanskritNomadServerStateTest {
   @Before
   public void before() {
     Testing.replaceUIDs(topology.getCluster());
-    new ClusterValidator(topology.getCluster()).validate();
     ObjectMapper objectMapper = new ObjectMapperFactory().withModule(new DynamicConfigApiJsonModule()).create();
     when(sanskrit.newMutableSanskritObject()).thenReturn(new SanskritObjectImpl(ObjectMapperSupplier.notVersioned(objectMapper)));
     state = new SanskritNomadServerState(sanskrit, configStorage, new DefaultHashComputer());

--- a/dynamic-config/testing/entity/src/main/java/org/terracotta/dynamic_config/test_support/processor/MyDummyNomadAdditionChangeProcessor.java
+++ b/dynamic-config/testing/entity/src/main/java/org/terracotta/dynamic_config/test_support/processor/MyDummyNomadAdditionChangeProcessor.java
@@ -18,6 +18,7 @@ package org.terracotta.dynamic_config.test_support.processor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terracotta.dynamic_config.api.model.Cluster;
+import org.terracotta.dynamic_config.api.model.ClusterState;
 import org.terracotta.dynamic_config.api.model.Node;
 import org.terracotta.dynamic_config.api.model.NodeContext;
 import org.terracotta.dynamic_config.api.model.nomad.NodeAdditionNomadChange;
@@ -66,7 +67,7 @@ public class MyDummyNomadAdditionChangeProcessor implements NomadChangeProcessor
     try {
       checkMBeanOperation();
       Cluster updated = change.apply(baseConfig.getCluster());
-      new ClusterValidator(updated).validate();
+      new ClusterValidator(updated).validate(ClusterState.ACTIVATED);
     } catch (RuntimeException e) {
       throw new NomadException("Error when trying to apply: '" + change.getSummary() + "': " + e.getMessage(), e);
     }

--- a/dynamic-config/testing/entity/src/main/java/org/terracotta/dynamic_config/test_support/processor/MyDummyNomadRemovalChangeProcessor.java
+++ b/dynamic-config/testing/entity/src/main/java/org/terracotta/dynamic_config/test_support/processor/MyDummyNomadRemovalChangeProcessor.java
@@ -18,6 +18,7 @@ package org.terracotta.dynamic_config.test_support.processor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terracotta.dynamic_config.api.model.Cluster;
+import org.terracotta.dynamic_config.api.model.ClusterState;
 import org.terracotta.dynamic_config.api.model.Node;
 import org.terracotta.dynamic_config.api.model.NodeContext;
 import org.terracotta.dynamic_config.api.model.nomad.NodeRemovalNomadChange;
@@ -75,7 +76,7 @@ public class MyDummyNomadRemovalChangeProcessor implements NomadChangeProcessor<
     try {
       checkMBeanOperation();
       Cluster updated = change.apply(baseConfig.getCluster());
-      new ClusterValidator(updated).validate();
+      new ClusterValidator(updated).validate(ClusterState.ACTIVATED);
     } catch (RuntimeException e) {
       throw new NomadException("Error when trying to apply: '" + change.getSummary() + "': " + e.getMessage(), e);
     }

--- a/dynamic-config/testing/support/src/main/java/org/terracotta/dynamic_config/test_support/ClusterDefinition.java
+++ b/dynamic-config/testing/support/src/main/java/org/terracotta/dynamic_config/test_support/ClusterDefinition.java
@@ -37,4 +37,6 @@ public @interface ClusterDefinition {
   boolean netDisruptionEnabled() default false;
 
   boolean inlineServers() default true;
+
+  String failoverPriority() default "availability";
 }

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/ConfigConversionIT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/ConfigConversionIT.java
@@ -74,7 +74,7 @@ public class ConfigConversionIT {
     assertThat(cluster.getName(), is("my-cluster"));
     assertThat(cluster.getDataDirNames().size(), is(1));
     assertThat(cluster.getOffheapResources().get().size(), is(1));
-    assertThat(cluster.getFailoverPriority(), is(FailoverPriority.availability()));
+    assertThat(cluster.getFailoverPriority().get(), is(FailoverPriority.availability()));
     assertFalse(cluster.getClientLeaseDuration().isConfigured());
     assertThat(cluster.getClientLeaseDuration().orDefault(), is(Measure.of(150, TimeUnit.SECONDS)));
     assertThat(cluster.getClientReconnectWindow().get(), is(Measure.of(120, TimeUnit.SECONDS)));
@@ -282,7 +282,7 @@ public class ConfigConversionIT {
     Path config = tmpDir.getRoot().resolve("generated-configs").resolve("cluster_default_lease_failover_reconnect_window.properties");
     assertTrue(Files.exists(config));
     Cluster cluster = new ClusterFactory().create(config);
-    assertThat(cluster.getFailoverPriority(), is(FailoverPriority.availability()));
+    assertThat(cluster.getFailoverPriority().get(), is(FailoverPriority.availability()));
   }
 
   @Test
@@ -325,7 +325,7 @@ public class ConfigConversionIT {
     Path config = tmpDir.getRoot().resolve("generated-configs").resolve("cluster_lease_failover_reconnect_window.properties");
     assertTrue(Files.exists(config));
     Cluster cluster = new ClusterFactory().create(config);
-    assertThat(cluster.getFailoverPriority(), is(FailoverPriority.availability()));
+    assertThat(cluster.getFailoverPriority().get(), is(FailoverPriority.availability()));
   }
 
   @Test

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/DiagnosticsIT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/DiagnosticsIT.java
@@ -33,7 +33,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.terracotta.angela.client.support.hamcrest.AngelaMatchers.successful;
 
-@ClusterDefinition(autoActivate = true)
+@ClusterDefinition(autoActivate = true, failoverPriority = "")
 public class DiagnosticsIT extends DynamicConfigIT {
   @Test
   public void testGetConfigByAddingOffheapResource() throws Exception {

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/DynamicTopologyEntityIT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/DynamicTopologyEntityIT.java
@@ -34,7 +34,7 @@ import static org.hamcrest.Matchers.nullValue;
 /**
  * @author Mathieu Carbou
  */
-@ClusterDefinition(autoActivate = true)
+@ClusterDefinition(autoActivate = true, failoverPriority = "")
 public class DynamicTopologyEntityIT extends DynamicConfigIT {
   @Test
   public void test_topology_entity() throws Exception {

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/GetCommand1x1IT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/GetCommand1x1IT.java
@@ -22,7 +22,7 @@ import org.terracotta.dynamic_config.test_support.DynamicConfigIT;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.terracotta.angela.client.support.hamcrest.AngelaMatchers.containsOutput;
 
-@ClusterDefinition(autoActivate = true)
+@ClusterDefinition(autoActivate = true, failoverPriority = "")
 public class GetCommand1x1IT extends DynamicConfigIT {
 
   @Test

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/RepairCommand1x1IT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/RepairCommand1x1IT.java
@@ -38,7 +38,7 @@ import static org.terracotta.angela.client.support.hamcrest.AngelaMatchers.succe
 /**
  * @author Mathieu Carbou
  */
-@ClusterDefinition(autoActivate = true)
+@ClusterDefinition(autoActivate = true, failoverPriority = "")
 public class RepairCommand1x1IT extends DynamicConfigIT {
 
   public RepairCommand1x1IT() {

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/SetCommand1x1IT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/SetCommand1x1IT.java
@@ -36,7 +36,7 @@ import static org.hamcrest.Matchers.not;
 import static org.terracotta.angela.client.support.hamcrest.AngelaMatchers.containsOutput;
 import static org.terracotta.angela.client.support.hamcrest.AngelaMatchers.successful;
 
-@ClusterDefinition(autoActivate = true)
+@ClusterDefinition(autoActivate = true, failoverPriority = "")
 public class SetCommand1x1IT extends DynamicConfigIT {
   @Test
   public void setOffheapResource_decreaseSize() {

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/SimulationHandlerIT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/SimulationHandlerIT.java
@@ -25,7 +25,7 @@ import static org.terracotta.angela.client.support.hamcrest.AngelaMatchers.conta
 /**
  * @author Mathieu Carbou
  */
-@ClusterDefinition(autoActivate = true)
+@ClusterDefinition(autoActivate = true, failoverPriority = "")
 public class SimulationHandlerIT extends DynamicConfigIT {
   @Test
   public void test_missing_value() {

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activation/ActivateCommand1x2IT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activation/ActivateCommand1x2IT.java
@@ -72,6 +72,20 @@ public class ActivateCommand1x2IT extends DynamicConfigIT {
   }
 
   @Test
+  public void testSingleNodeActivationWithConfigFileNoFailover() throws Exception {
+    assertThat(
+        configTool("activate", "-f", copyConfigProperty("/config-property-files/single-stripe-no-fo.properties").toString(), "-n", "my-cluster"),
+        allOf(containsOutput("No license installed"), containsOutput("came back up")));
+
+    waitForActive(1, 1);
+
+    withTopologyService("localhost", getNodePort(), topologyService -> {
+      NodeContext runtimeNodeContext = topologyService.getRuntimeNodeContext();
+      assertThat(runtimeNodeContext.getCluster().getName(), is(equalTo("my-cluster")));
+    });
+  }
+
+  @Test
   public void testMultiNodeSingleStripeActivationWithConfigFile() {
     assertThat(
         configTool("activate", "-f", copyConfigProperty("/config-property-files/single-stripe_multi-node.properties").toString()),
@@ -79,6 +93,13 @@ public class ActivateCommand1x2IT extends DynamicConfigIT {
 
     waitForActive(1);
     waitForPassives(1);
+  }
+
+  @Test
+  public void testMultiNodeSingleStripeActivationWithConfigFileNoFailover() {
+    assertThat(
+        configTool("activate", "-f", copyConfigProperty("/config-property-files/single-stripe_multi-node-no-fo.properties").toString()),
+        containsOutput("failover-priority setting is not configured"));
   }
 
   @Test

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activation/AutoActivateNewPassive1x2IT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activation/AutoActivateNewPassive1x2IT.java
@@ -43,6 +43,13 @@ public class AutoActivateNewPassive1x2IT extends DynamicConfigIT {
   }
 
   @Test
+  public void test_auto_activation_success_for_1x1_cluster_no_failover() {
+    Path configurationFile = copyConfigProperty("/config-property-files/1x1-no-fo.properties");
+    startNode(1, 1, "--auto-activate", "-f", configurationFile.toString(), "--config-dir", "config/stripe1/1-1");
+    waitForActive(1, 1);
+  }
+
+  @Test
   public void test_auto_activation_failure_for_different_1x2_cluster() {
     startNode(1, 1, "--auto-activate", "-f", copyConfigProperty("/config-property-files/1x2.properties").toString(), "-s", "localhost", "-p", String.valueOf(getNodePort(1, 1)), "--config-dir", "config/stripe1/1-1");
     waitForActive(1, 1);
@@ -55,6 +62,17 @@ public class AutoActivateNewPassive1x2IT extends DynamicConfigIT {
       fail();
     } catch (Throwable e) {
       assertThatServerLogs(getNode(1, 2), "Unable to find any change in the source node matching the topology used to activate this node");
+    }
+  }
+
+  @Test
+  public void test_auto_activation_failure_1x2_cluster_no_failover() {
+    Path configurationFile = copyConfigProperty("/config-property-files/1x2-no-fo.properties");
+    try {
+      startNode(1, 1, "--auto-activate", "-f", configurationFile.toString(), "-s", "localhost", "-p", String.valueOf(getNodePort(1, 1)), "--config-dir", "config/stripe1/1-1");
+      fail();
+    } catch (Throwable e) {
+      assertThatServerLogs(getNode(1, 1), "failover-priority setting is not configured");
     }
   }
 

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activation/Ipv6ConfigActivationIT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activation/Ipv6ConfigActivationIT.java
@@ -25,7 +25,7 @@ import java.nio.file.Path;
 import static org.junit.Assert.assertThat;
 import static org.terracotta.angela.client.support.hamcrest.AngelaMatchers.containsOutput;
 
-@ClusterDefinition(autoStart = false)
+@ClusterDefinition(autoStart = false, failoverPriority = "")
 public class Ipv6ConfigActivationIT extends DynamicConfigIT {
 
   @Test

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/diagnostic/AttachCommand1x2IT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/diagnostic/AttachCommand1x2IT.java
@@ -29,7 +29,7 @@ import static org.terracotta.angela.client.support.hamcrest.AngelaMatchers.succe
 /**
  * @author Mathieu Carbou
  */
-@ClusterDefinition(nodesPerStripe = 2)
+@ClusterDefinition(nodesPerStripe = 2, failoverPriority = "")
 public class AttachCommand1x2IT extends DynamicConfigIT {
 
   public AttachCommand1x2IT() {

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/diagnostic/AttachCommand2x1IT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/diagnostic/AttachCommand2x1IT.java
@@ -27,7 +27,7 @@ import static org.terracotta.angela.client.support.hamcrest.AngelaMatchers.conta
 /**
  * @author Mathieu Carbou
  */
-@ClusterDefinition(stripes = 2, nodesPerStripe = 1, autoStart = false)
+@ClusterDefinition(stripes = 2, nodesPerStripe = 1, autoStart = false, failoverPriority = "")
 public class AttachCommand2x1IT extends DynamicConfigIT {
 
   @Override

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/diagnostic/AttachCommand2x2IT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/diagnostic/AttachCommand2x2IT.java
@@ -29,7 +29,7 @@ import static org.terracotta.angela.client.support.hamcrest.AngelaMatchers.succe
 /**
  * @author Mathieu Carbou
  */
-@ClusterDefinition(stripes = 2, nodesPerStripe = 2)
+@ClusterDefinition(stripes = 2, nodesPerStripe = 2, failoverPriority = "")
 public class AttachCommand2x2IT extends DynamicConfigIT {
 
   public AttachCommand2x2IT() {

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/diagnostic/AttachDetachCommand2x2IT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/diagnostic/AttachDetachCommand2x2IT.java
@@ -32,7 +32,7 @@ import static org.terracotta.angela.client.support.hamcrest.AngelaMatchers.succe
 /**
  * @author Mathieu Carbou
  */
-@ClusterDefinition(stripes = 2, nodesPerStripe = 2)
+@ClusterDefinition(stripes = 2, nodesPerStripe = 2, failoverPriority = "")
 public class AttachDetachCommand2x2IT extends DynamicConfigIT {
   private static final String OUTPUT_JSON_FILE = "attach-detach-output.json";
 

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/diagnostic/DetachCommand1x2IT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/diagnostic/DetachCommand1x2IT.java
@@ -30,7 +30,7 @@ import static org.terracotta.angela.client.support.hamcrest.AngelaMatchers.succe
 /**
  * @author Mathieu Carbou
  */
-@ClusterDefinition(nodesPerStripe = 2)
+@ClusterDefinition(nodesPerStripe = 2, failoverPriority = "")
 public class DetachCommand1x2IT extends DynamicConfigIT {
 
   public DetachCommand1x2IT() {

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/diagnostic/DetachCommand2x2IT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/diagnostic/DetachCommand2x2IT.java
@@ -30,7 +30,7 @@ import static org.terracotta.angela.client.support.hamcrest.AngelaMatchers.succe
 /**
  * @author Mathieu Carbou
  */
-@ClusterDefinition(stripes = 2, nodesPerStripe = 2)
+@ClusterDefinition(stripes = 2, nodesPerStripe = 2, failoverPriority = "")
 public class DetachCommand2x2IT extends DynamicConfigIT {
 
   public DetachCommand2x2IT() {

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/diagnostic/DiagnosticIT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/diagnostic/DiagnosticIT.java
@@ -31,7 +31,7 @@ import static org.junit.Assert.assertThat;
 /**
  * @author Mathieu Carbou
  */
-@ClusterDefinition
+@ClusterDefinition(failoverPriority = "")
 public class DiagnosticIT extends DynamicConfigIT {
 
   @Override

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/diagnostic/GetCommand1x1IT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/diagnostic/GetCommand1x1IT.java
@@ -25,7 +25,7 @@ import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.not;
 import static org.terracotta.angela.client.support.hamcrest.AngelaMatchers.containsOutput;
 
-@ClusterDefinition
+@ClusterDefinition(failoverPriority = "")
 public class GetCommand1x1IT extends DynamicConfigIT {
 
   @Test

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/diagnostic/GetCommand1x2IT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/diagnostic/GetCommand1x2IT.java
@@ -26,8 +26,9 @@ import static org.hamcrest.Matchers.is;
 import static org.terracotta.angela.client.support.hamcrest.AngelaMatchers.containsOutput;
 import static org.terracotta.angela.client.support.hamcrest.AngelaMatchers.successful;
 
-@ClusterDefinition(nodesPerStripe = 2)
+@ClusterDefinition(nodesPerStripe = 2, failoverPriority = "")
 public class GetCommand1x2IT extends DynamicConfigIT {
+
   @Before
   public void before() throws Exception {
     assertThat(configTool("attach", "-d", "localhost:" + getNodePort(), "-s", "localhost:" + getNodePort(1, 2)), is(successful()));

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/diagnostic/ImportCommand2x1IT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/diagnostic/ImportCommand2x1IT.java
@@ -29,8 +29,9 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.terracotta.angela.client.support.hamcrest.AngelaMatchers.successful;
 
-@ClusterDefinition(stripes = 2)
+@ClusterDefinition(stripes = 2, failoverPriority = "")
 public class ImportCommand2x1IT extends DynamicConfigIT {
+
   @Test
   public void test_import() throws Exception {
     getUpcomingCluster("localhost", getNodePort()).toProperties(false, true, true);

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/diagnostic/Ipv6ConfigIT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/diagnostic/Ipv6ConfigIT.java
@@ -27,7 +27,7 @@ import static org.junit.Assert.assertThat;
 import static org.terracotta.angela.client.support.hamcrest.AngelaMatchers.containsOutput;
 import static org.terracotta.angela.client.support.hamcrest.AngelaMatchers.successful;
 
-@ClusterDefinition(nodesPerStripe = 2, autoStart = false)
+@ClusterDefinition(nodesPerStripe = 2, autoStart = false, failoverPriority = "")
 public class Ipv6ConfigIT extends DynamicConfigIT {
 
   @Test

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/diagnostic/NodeStartupIT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/diagnostic/NodeStartupIT.java
@@ -35,7 +35,7 @@ import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
-@ClusterDefinition(autoStart = false)
+@ClusterDefinition(autoStart = false, failoverPriority = "")
 public class NodeStartupIT extends DynamicConfigIT {
 
   @Test
@@ -309,7 +309,6 @@ public class NodeStartupIT extends DynamicConfigIT {
   private void startSingleNode(String... args) {
     // these arguments are required to be added to isolate the node data files into the build/test-data directory to not conflict with other processes
     Collection<String> defaultArgs = new ArrayList<>(Arrays.asList(
-        "--failover-priority", "availability",
         "--hostname", "localhost",
         "--log-dir", "logs",
         "--backup-dir", "backup",

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/diagnostic/SetCommand1x1IT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/diagnostic/SetCommand1x1IT.java
@@ -29,7 +29,7 @@ import static org.junit.Assert.assertThat;
 import static org.terracotta.angela.client.support.hamcrest.AngelaMatchers.containsOutput;
 import static org.terracotta.angela.client.support.hamcrest.AngelaMatchers.successful;
 
-@ClusterDefinition
+@ClusterDefinition(failoverPriority = "")
 public class SetCommand1x1IT extends DynamicConfigIT {
 
   @Rule

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/diagnostic/SetCommand1x2IT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/diagnostic/SetCommand1x2IT.java
@@ -26,7 +26,7 @@ import static org.junit.Assert.assertThat;
 import static org.terracotta.angela.client.support.hamcrest.AngelaMatchers.containsOutput;
 import static org.terracotta.angela.client.support.hamcrest.AngelaMatchers.successful;
 
-@ClusterDefinition(nodesPerStripe = 2)
+@ClusterDefinition(nodesPerStripe = 2, failoverPriority = "")
 public class SetCommand1x2IT extends DynamicConfigIT {
 
   @Before

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/diagnostic/SetCommand2x2IT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/diagnostic/SetCommand2x2IT.java
@@ -28,7 +28,7 @@ import static org.junit.Assert.assertThat;
 import static org.terracotta.angela.client.support.hamcrest.AngelaMatchers.containsOutput;
 import static org.terracotta.angela.client.support.hamcrest.AngelaMatchers.successful;
 
-@ClusterDefinition(stripes = 2, nodesPerStripe = 2)
+@ClusterDefinition(stripes = 2, nodesPerStripe = 2, failoverPriority = "")
 public class SetCommand2x2IT extends DynamicConfigIT {
 
   private String connection;

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/diagnostic/TopologyServiceIT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/diagnostic/TopologyServiceIT.java
@@ -38,7 +38,7 @@ import static org.terracotta.dynamic_config.api.model.Testing.newTestStripe;
 /**
  * @author Mathieu Carbou
  */
-@ClusterDefinition
+@ClusterDefinition(failoverPriority = "")
 public class TopologyServiceIT extends DynamicConfigIT {
 
   Path config;

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/diagnostic/UnsetCommand1x2IT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/diagnostic/UnsetCommand1x2IT.java
@@ -27,7 +27,7 @@ import static org.junit.Assert.assertThat;
 import static org.terracotta.angela.client.support.hamcrest.AngelaMatchers.containsOutput;
 import static org.terracotta.angela.client.support.hamcrest.AngelaMatchers.successful;
 
-@ClusterDefinition(nodesPerStripe = 2)
+@ClusterDefinition(nodesPerStripe = 2, failoverPriority = "")
 public class UnsetCommand1x2IT extends DynamicConfigIT {
 
   @Before

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/permission/SetUnsetSettingsIT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/permission/SetUnsetSettingsIT.java
@@ -41,7 +41,7 @@ import static org.junit.Assert.assertThat;
 import static org.terracotta.angela.client.support.hamcrest.AngelaMatchers.containsOutput;
 import static org.terracotta.angela.client.support.hamcrest.AngelaMatchers.successful;
 
-@ClusterDefinition(nodesPerStripe = 1)
+@ClusterDefinition(nodesPerStripe = 1, failoverPriority = "")
 public class SetUnsetSettingsIT extends DynamicConfigIT {
   @Test
   public void testUnsetOffHeapAtClusterLevelAfterActivate() throws IOException, SanskritException {

--- a/dynamic-config/testing/system-tests/src/test/resources/config-property-files/1x1-no-fo.properties
+++ b/dynamic-config/testing/system-tests/src/test/resources/config-property-files/1x1-no-fo.properties
@@ -1,0 +1,30 @@
+#
+# Copyright Terracotta, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+client-lease-duration=20s
+cluster-name=my-cluster
+failover-priority=availability
+offheap-resources=main\:512MB,second\:1GB
+
+stripe.1.node.1.data-dirs=main\:user-data/main/stripe1
+stripe.1.node.1.backup-dir=backup/stripe1
+stripe.1.node.1.group-port=${GROUP-PORT-1-1}
+stripe.1.node.1.hostname=localhost
+stripe.1.node.1.log-dir=logs/stripe1
+stripe.1.node.1.metadata-dir=metadata/stripe1
+stripe.1.node.1.name=node-1-1
+stripe.1.node.1.port=${PORT-1-1}
+stripe.1.stripe-name=stripe1

--- a/dynamic-config/testing/system-tests/src/test/resources/config-property-files/1x2-no-fo.properties
+++ b/dynamic-config/testing/system-tests/src/test/resources/config-property-files/1x2-no-fo.properties
@@ -1,0 +1,39 @@
+#
+# Copyright Terracotta, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+client-lease-duration=20s
+cluster-name=my-cluster
+offheap-resources=main\:512MB,second\:1GB
+
+stripe.1.node.1.data-dirs=main\:user-data/main/stripe1
+stripe.1.node.1.backup-dir=backup/stripe1
+stripe.1.node.1.group-port=${GROUP-PORT-1-1}
+stripe.1.node.1.hostname=localhost
+stripe.1.node.1.log-dir=logs/stripe1
+stripe.1.node.1.metadata-dir=metadata/stripe1
+stripe.1.node.1.name=node-1-1
+stripe.1.node.1.port=${PORT-1-1}
+
+stripe.1.node.2.data-dirs=main\:user-data/main/stripe1
+stripe.1.node.2.backup-dir=backup/stripe1
+stripe.1.node.2.group-port=${GROUP-PORT-1-2}
+stripe.1.node.2.hostname=localhost
+stripe.1.node.2.log-dir=logs/stripe1
+stripe.1.node.2.metadata-dir=metadata/stripe1
+stripe.1.node.2.name=node-1-2
+stripe.1.node.2.port=${PORT-1-2}
+
+stripe.1.stripe-name=stripe1

--- a/dynamic-config/testing/system-tests/src/test/resources/config-property-files/single-stripe-no-fo.properties
+++ b/dynamic-config/testing/system-tests/src/test/resources/config-property-files/single-stripe-no-fo.properties
@@ -1,0 +1,26 @@
+#
+# Copyright Terracotta, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+client-lease-duration=20s
+stripe.1.node.1.data-dirs=main\:user-data/main/stripe1
+stripe.1.node.1.backup-dir=backup/stripe1
+stripe.1.node.1.group-port=${GROUP-PORT-1-1}
+stripe.1.node.1.hostname=localhost
+stripe.1.node.1.log-dir=logs/stripe1
+stripe.1.node.1.metadata-dir=metadata/stripe1
+stripe.1.node.1.name=node-1-1
+stripe.1.node.1.port=${PORT-1-1}
+stripe.1.stripe-name=stripe1

--- a/dynamic-config/testing/system-tests/src/test/resources/config-property-files/single-stripe_multi-node-no-fo.properties
+++ b/dynamic-config/testing/system-tests/src/test/resources/config-property-files/single-stripe_multi-node-no-fo.properties
@@ -1,0 +1,36 @@
+#
+# Copyright Terracotta, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+client-lease-duration=20s
+cluster-name=my-cluster
+offheap-resources=main\:512MB,second\:1GB
+stripe.1.node.1.data-dirs=main\:user-data/main/stripe1
+stripe.1.node.1.backup-dir=backup/stripe1
+stripe.1.node.1.group-port=${GROUP-PORT-1-1}
+stripe.1.node.1.hostname=localhost
+stripe.1.node.1.log-dir=logs/stripe1
+stripe.1.node.1.metadata-dir=metadata/stripe1
+stripe.1.node.1.name=node-1-1
+stripe.1.node.1.port=${PORT-1-1}
+stripe.1.node.2.data-dirs=main\:user-data/main/stripe1
+stripe.1.node.2.backup-dir=backup/stripe1
+stripe.1.node.2.group-port=${GROUP-PORT-1-2}
+stripe.1.node.2.hostname=localhost
+stripe.1.node.2.log-dir=logs/stripe1
+stripe.1.node.2.metadata-dir=metadata/stripe1
+stripe.1.node.2.name=node-1-2
+stripe.1.node.2.port=${PORT-1-2}
+stripe.1.stripe-name=stripe1


### PR DESCRIPTION
Reviewed when and how the cluster validation is called
- Ability to run cluster validation depending on the cluster state
- Failover priority now works like cluster-name: only required when activating and when activated
- Failover priority is not required for a 1-node cluster
- Operation permissions for `failover-priority` are now the same as `cluster-name`: required only on activation or when activated
- `failover-priority` is not more required in CLI or in config file when in diagnostic mode node (startup or config-tool import or activated 1-node cluster)