### PR TITLE
Fix: Problems in the activation flow

### DIFF
--- a/dynamic-config/api/src/main/java/org/terracotta/dynamic_config/api/service/DynamicConfigService.java
+++ b/dynamic-config/api/src/main/java/org/terracotta/dynamic_config/api/service/DynamicConfigService.java
@@ -37,7 +37,7 @@ public interface DynamicConfigService {
    * <p>
    * License can be null.
    */
-  void activate(Cluster validatedTopology, String licenseContent);
+  void enableNomad(Cluster validatedTopology, String licenseContent);
 
   /**
    * Validate and install a new license over an existing one, or for the first time.

--- a/dynamic-config/cli/dynamic-config-cli-api/src/main/java/org/terracotta/dynamic_config/cli/api/command/RemoteAction.java
+++ b/dynamic-config/cli/dynamic-config-cli-api/src/main/java/org/terracotta/dynamic_config/cli/api/command/RemoteAction.java
@@ -123,7 +123,7 @@ public abstract class RemoteAction implements Runnable {
     try (DiagnosticServices<UID> diagnosticServices = multiDiagnosticServiceProvider.fetchOnlineDiagnosticServices(endpointsToMap(newNodes))) {
       dynamicConfigServices(diagnosticServices)
           .map(Tuple2::getT2)
-          .forEach(service -> service.activate(cluster, licenseContent));
+          .forEach(service -> service.enableNomad(cluster, licenseContent));
       if (licenseContent == null) {
         output.info("No license installed. If you are attaching a node, the license will be synced.");
       } else {

--- a/dynamic-config/cli/dynamic-config-cli-api/src/test/java/org/terracotta/dynamic_config/cli/api/command/ActivateActionTest.java
+++ b/dynamic-config/cli/dynamic-config-cli-api/src/test/java/org/terracotta/dynamic_config/cli/api/command/ActivateActionTest.java
@@ -175,7 +175,7 @@ public class ActivateActionTest extends BaseTest {
         ))));
 
     IntStream.of(ports).forEach(rethrow(port -> {
-      verify(dynamicConfigServiceMock("localhost", port), times(1)).activate(eq(command.getCluster()), eq(null));
+      verify(dynamicConfigServiceMock("localhost", port), times(1)).enableNomad(eq(command.getCluster()), eq(null));
 
       NomadServer<NodeContext> mock = nomadServerMock("localhost", port);
       verify(mock, times(2)).discover();
@@ -213,7 +213,7 @@ public class ActivateActionTest extends BaseTest {
         ))));
 
     IntStream.of(ports).forEach(rethrow(port -> {
-      verify(dynamicConfigServiceMock("localhost", port), times(1)).activate(eq(command.getCluster()), eq(null));
+      verify(dynamicConfigServiceMock("localhost", port), times(1)).enableNomad(eq(command.getCluster()), eq(null));
 
       NomadServer<NodeContext> mock = nomadServerMock("localhost", port);
       verify(mock, times(2)).discover();
@@ -266,7 +266,7 @@ public class ActivateActionTest extends BaseTest {
     command.run();
 
     IntStream.of(ports).forEach(rethrow(port -> {
-      verify(dynamicConfigServiceMock("localhost", port), times(1)).activate(eq(command.getCluster()), eq(null));
+      verify(dynamicConfigServiceMock("localhost", port), times(1)).enableNomad(eq(command.getCluster()), eq(null));
       verify(dynamicConfigServiceMock("localhost", port), times(1)).restart(any());
       verify(nomadServerMock("localhost", port), times(2)).discover();
       verify(diagnosticServiceMock("localhost", port), times(1)).getLogicalServerState();

--- a/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/service/AuditService.java
+++ b/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/service/AuditService.java
@@ -52,9 +52,9 @@ public class AuditService implements DynamicConfigService {
   }
 
   @Override
-  public synchronized void activate(Cluster maybeUpdatedCluster, String licenseContent) {
+  public synchronized void enableNomad(Cluster maybeUpdatedCluster, String licenseContent) {
     server.audit("Activate invoked", new Properties());
-    dynamicConfigService.activate(maybeUpdatedCluster, licenseContent);
+    dynamicConfigService.enableNomad(maybeUpdatedCluster, licenseContent);
   }
 
   @Override

--- a/dynamic-config/server/configuration-provider/src/test/java/org/terracotta/dynamic_config/server/configuration/service/DesynchronizedNomadConfigTest.java
+++ b/dynamic-config/server/configuration-provider/src/test/java/org/terracotta/dynamic_config/server/configuration/service/DesynchronizedNomadConfigTest.java
@@ -175,7 +175,7 @@ public class DesynchronizedNomadConfigTest {
       try (FakeNode passive = FakeNode.create(root.resolve("node2").resolve("config"), passiveDetails);
            NomadClient<NodeContext> passiveNomadClient = passive.createNomadClient()) {
         passive.manager.getDynamicConfigService().setUpcomingCluster(lastTopology);
-        passive.manager.getDynamicConfigService().activate(lastTopology, null);
+        passive.manager.getDynamicConfigService().enableNomad(lastTopology, null);
 
         NomadFailureReceiver<NodeContext> failureRecorder = new NomadFailureReceiver<>();
         passiveNomadClient.tryApplyChange(failureRecorder, new ClusterActivationNomadChange(lastTopology));
@@ -423,7 +423,7 @@ public class DesynchronizedNomadConfigTest {
 
     void reset() throws NomadException {
       nomad.reset();
-      manager.downgradeForRead();
+      manager.disableNomad();
     }
 
     /**
@@ -499,7 +499,7 @@ public class DesynchronizedNomadConfigTest {
 
       // activate the node
       if (nodeName != null) {
-        dynamicConfigService.activate(topologyService.getUpcomingNodeContext().getCluster(), dynamicConfigService.getLicenseContent().orElse(null));
+        dynamicConfigService.enableNomad(topologyService.getUpcomingNodeContext().getCluster(), dynamicConfigService.getLicenseContent().orElse(null));
       }
 
       // create the sync service


### PR DESCRIPTION
- To remove the un-necessary boolean state "activated"
- To introduce the concept of enabling/disabling Nomad
- To correctly report when a node is activated
- To avoid starting a node that was incorrectly activated with an alternate topology if not started in repair mode