### PR TITLE
Unhide -auto-activate

### DIFF
--- a/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/startup/parsing/OptionsParsingImpl.java
+++ b/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/startup/parsing/OptionsParsingImpl.java
@@ -157,9 +157,7 @@ public class OptionsParsingImpl implements OptionsParsing {
   @Parameter(names = {"-" + HELP}, description = "provide usage information")
   private boolean help;
 
-  // hidden option that won't appear in the help file,
-  // so that we can start a pre-activated stripe directly in dev / test.
-  @Parameter(names = {"-" + AUTO_ACTIVATE}, hidden = true)
+  @Parameter(names = {"-" + AUTO_ACTIVATE}, description = "automatically activate the node so that it becomes active or joins a stripe (true|false)")
   private boolean allowsAutoActivation;
 
   private final Map<Setting, String> paramValueMap = new HashMap<>();


### PR DESCRIPTION
Recall that this option was initially introduced to be able to start a node with a cluster topology (from CLI or config file), directly pre-activated without any interaction using config-tool. This can help in some cases where remote com. is difficult, or docker image where we want the node to start and join an existing cluster, etc.