### PR TITLE
Unhide -auto-activate

### DIFF
--- a/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/startup/parsing/OptionsParsingImpl.java
+++ b/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/startup/parsing/OptionsParsingImpl.java
@@ -157,9 +157,7 @@ public class OptionsParsingImpl implements OptionsParsing {
   @Parameter(names = {"-" + HELP}, description = "provide usage information")
   private boolean help;
 
-  // hidden option that won't appear in the help file,
-  // so that we can start a pre-activated stripe directly in dev / test.
-  @Parameter(names = {"-" + AUTO_ACTIVATE}, hidden = true)
+  @Parameter(names = {"-" + AUTO_ACTIVATE}, description = "automatically activate the node so that it becomes active or joins a stripe (true|false)")
   private boolean allowsAutoActivation;
 
   private final Map<Setting, String> paramValueMap = new HashMap<>();


### PR DESCRIPTION
Now that we have DS and can add/remove nodes and stripes at runtime, we decided to re-activate `-auto-activate`, but warn people to not use this option ideally.

This option is required and useful in the case where the nodes need to be started pre-activated (1-1 cluster or to join a stripe) when the use of the config-tool is either not possible or complex)

