### PR TITLE
Display, in startup console, in warning, the CLI parameters that do not match the persisted config anymore

### DIFF
--- a/dynamic-config/model/src/main/java/org/terracotta/dynamic_config/api/model/NodeContext.java
+++ b/dynamic-config/model/src/main/java/org/terracotta/dynamic_config/api/model/NodeContext.java
@@ -62,6 +62,23 @@ public class NodeContext implements Cloneable {
     return stripe.getUID();
   }
 
+  public Optional<String> getProperty(Setting setting) {
+    return setting.getProperty(getObject(setting.getScope()));
+  }
+
+  public PropertyHolder getObject(Scope scope) {
+    switch (scope) {
+      case CLUSTER:
+        return getCluster();
+      case STRIPE:
+        return getStripe();
+      case NODE:
+        return getNode();
+      default:
+        throw new AssertionError(scope);
+    }
+  }
+
   @Override
   @SuppressWarnings("MethodDoesntCallSuperMethod")
   @SuppressFBWarnings("CN_IDIOM_NO_SUPER_CALL")

--- a/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/startup/ConfigurationGeneratorVisitor.java
+++ b/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/startup/ConfigurationGeneratorVisitor.java
@@ -85,6 +85,10 @@ public class ConfigurationGeneratorVisitor {
     this.server = server;
   }
 
+  public TopologyService getTopologyService() {
+    return nomadServerManager.getTopologyService();
+  }
+
   public StartupConfiguration generateConfiguration() {
     requireNonNull(nomadServerManager);
     requireNonNull(nodeContext);

--- a/dynamic-config/server/configuration-provider/src/test/java/org/terracotta/dynamic_config/server/configuration/startup/CommandLineProcessorChainTest.java
+++ b/dynamic-config/server/configuration-provider/src/test/java/org/terracotta/dynamic_config/server/configuration/startup/CommandLineProcessorChainTest.java
@@ -28,6 +28,7 @@ import org.terracotta.dynamic_config.api.model.Stripe;
 import org.terracotta.dynamic_config.api.model.Testing;
 import org.terracotta.dynamic_config.api.service.ClusterFactory;
 import org.terracotta.dynamic_config.api.service.IParameterSubstitutor;
+import org.terracotta.dynamic_config.api.service.TopologyService;
 import org.terracotta.server.Server;
 
 import java.nio.file.Paths;
@@ -90,11 +91,16 @@ public class CommandLineProcessorChainTest {
     when(configurationGeneratorVisitor.findNodeName(eq(Paths.get(NODE_REPOSITORY_DIR)), any(IParameterSubstitutor.class))).thenReturn(Optional.of(NODE_NAME));
     when(clusterCreator.create(any(), eq(parameterSubstitutor))).thenReturn(cluster);
 
+    TopologyService topologyService = mock(TopologyService.class);
+    when(topologyService.getUpcomingNodeContext()).thenReturn(nodeContext);
+    when(configurationGeneratorVisitor.getTopologyService()).thenReturn(topologyService);
+
     mainCommandLineProcessor.process();
 
     verify(configurationGeneratorVisitor).getOrDefaultConfigurationDirectory(null);
     verify(configurationGeneratorVisitor).findNodeName(eq(Paths.get(NODE_REPOSITORY_DIR)), any(IParameterSubstitutor.class));
     verify(configurationGeneratorVisitor).startUsingConfigRepo(Paths.get(NODE_REPOSITORY_DIR), NODE_NAME, false, nodeContext);
+    verify(configurationGeneratorVisitor).getTopologyService();
     verifyNoMoreInteractions(configurationGeneratorVisitor);
   }
 
@@ -105,11 +111,16 @@ public class CommandLineProcessorChainTest {
     when(configurationGeneratorVisitor.findNodeName(eq(Paths.get(NODE_REPOSITORY_DIR)), any(IParameterSubstitutor.class))).thenReturn(Optional.of(NODE_NAME));
     when(clusterCreator.create(any(), eq(parameterSubstitutor))).thenReturn(cluster);
 
+    TopologyService topologyService = mock(TopologyService.class);
+    when(topologyService.getUpcomingNodeContext()).thenReturn(nodeContext);
+    when(configurationGeneratorVisitor.getTopologyService()).thenReturn(topologyService);
+
     mainCommandLineProcessor.process();
 
     verify(configurationGeneratorVisitor).getOrDefaultConfigurationDirectory(NODE_REPOSITORY_DIR);
     verify(configurationGeneratorVisitor).findNodeName(eq(Paths.get(NODE_REPOSITORY_DIR)), any(IParameterSubstitutor.class));
     verify(configurationGeneratorVisitor).startUsingConfigRepo(Paths.get(NODE_REPOSITORY_DIR), NODE_NAME, false, nodeContext);
+    verify(configurationGeneratorVisitor).getTopologyService();
     verifyNoMoreInteractions(configurationGeneratorVisitor);
   }
 


### PR DESCRIPTION
Here are some examples of output that we can see in the console log at startup:

```
2021-06-04 16:23:23,871 [Thread-299] INFO org.terracotta.console - 

=================================================================================================================
Node is starting from an existing configuration directory.
The following command-line (CLI) parameters differ from the loaded configuration. 
They have been ignored and can be removed from the CLI.
 - Setting: 'name': CLI=node-1-1 vs CONFIG=foo
=================================================================================================================
```

```
2021-06-04 16:22:44,530 [Thread-84] INFO org.terracotta.console - 

=================================================================================================================
Node is starting from an existing configuration directory.
The following command-line (CLI) parameters differ from the loaded configuration. 
They have been ignored and can be removed from the CLI.                                       
 - Setting: 'log-dir': CLI=logs vs CONFIG=logs/stripe1
 - Setting: 'metadata-dir': CLI=metadata vs CONFIG=metadata/stripe1
 - Setting: 'data-dirs': CLI=main:data-dir vs CONFIG=main:user-data/main/stripe1
 - Setting: 'offheap-resources': CLI=foo:1GB,main:512MB vs CONFIG=main:512MB,second:1GB
 - Setting: 'client-reconnect-window': CLI=10s vs CONFIG=<unspecified>
 - Setting: 'cluster-name': CLI=tc-cluster vs CONFIG=my-cluster
=================================================================================================================
```