### PR TITLE
TDB-5385: Add missing requirements and defaults for startup script options

### DIFF
--- a/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/GetCommand.java
+++ b/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/GetCommand.java
@@ -24,8 +24,8 @@ import org.terracotta.dynamic_config.cli.api.command.GetAction;
 import org.terracotta.dynamic_config.cli.api.command.Injector.Inject;
 import org.terracotta.dynamic_config.cli.command.Command;
 import org.terracotta.dynamic_config.cli.command.Usage;
-import org.terracotta.dynamic_config.cli.converter.ConfigurationInputConverter;
 import org.terracotta.dynamic_config.cli.converter.ConfigFormatConverter;
+import org.terracotta.dynamic_config.cli.converter.ConfigurationInputConverter;
 import org.terracotta.dynamic_config.cli.converter.InetSocketAddressConverter;
 import org.terracotta.dynamic_config.cli.converter.MultiConfigCommaSplitter;
 
@@ -42,7 +42,7 @@ public class GetCommand extends Command {
   @Parameter(names = {"-setting"}, description = "Configuration properties", splitter = MultiConfigCommaSplitter.class, required = true, converter = ConfigurationInputConverter.class)
   List<ConfigurationInput> inputs;
 
-  @Parameter(names = {"-runtime"}, description = "Read the properties from the current runtime configuration instead of reading them from the last configuration saved on disk", converter = BooleanConverter.class)
+  @Parameter(names = {"-runtime"}, description = "Read the properties from the current runtime configuration instead of reading them from the last configuration saved on disk. Default: false", converter = BooleanConverter.class)
   private boolean wantsRuntimeConfig;
 
   @Parameter(names = {"-output-format", "-outputformat"}, description = "Output format <cfg|properties>. Default: cfg", converter = ConfigFormatConverter.class)

--- a/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/SetCommand.java
+++ b/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/SetCommand.java
@@ -42,7 +42,7 @@ public class SetCommand extends Command {
   @Parameter(names = {"-setting"}, description = "Configuration properties", splitter = MultiConfigCommaSplitter.class, required = true, converter = ConfigurationInputConverter.class)
   List<ConfigurationInput> inputs;
 
-  @Parameter(names = {"-auto-restart"}, description = "If a change requires some nodes to be restarted, the command will try to restart them if there are at least 2 nodes online per stripe.")
+  @Parameter(names = {"-auto-restart"}, description = "If a change requires some nodes to be restarted, the command will try to restart them if there are at least 2 nodes online per stripe. Default: false")
   boolean autoRestart = false;
 
   @Parameter(names = {"-restart-wait-time"}, description = "Maximum time to wait for the nodes to restart. Default: 120s", converter = TimeUnitConverter.class)

--- a/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/UnsetCommand.java
+++ b/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/UnsetCommand.java
@@ -42,7 +42,7 @@ public class UnsetCommand extends Command {
   @Parameter(names = {"-setting"}, description = "Configuration properties", splitter = MultiConfigCommaSplitter.class, required = true, converter = ConfigurationInputConverter.class)
   List<ConfigurationInput> inputs;
 
-  @Parameter(names = {"-auto-restart"}, description = "If a change requires some nodes to be restarted, the command will try to restart them if there are at least 2 nodes online per stripe.")
+  @Parameter(names = {"-auto-restart"}, description = "If a change requires some nodes to be restarted, the command will try to restart them if there are at least 2 nodes online per stripe. Default: false")
   boolean autoRestart = false;
 
   @Parameter(names = {"-restart-wait-time"}, description = "Maximum time to wait for the nodes to restart. Default: 120s", converter = TimeUnitConverter.class)

--- a/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/startup/parsing/OptionsParsingImpl.java
+++ b/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/startup/parsing/OptionsParsingImpl.java
@@ -67,82 +67,82 @@ import static org.terracotta.dynamic_config.server.configuration.startup.Console
 @Parameters(separators = "=")
 public class OptionsParsingImpl implements OptionsParsing {
 
-  @Parameter(names = {"-" + NODE_HOSTNAME}, description = "node host name")
+  @Parameter(names = {"-" + NODE_HOSTNAME}, description = "Node host name. Default: %h")
   private String hostname;
 
-  @Parameter(names = {"-" + NODE_PUBLIC_HOSTNAME}, description = "public node host name")
+  @Parameter(names = {"-" + NODE_PUBLIC_HOSTNAME}, description = "Public node host name. Default: <unset>")
   private String publicHostname;
 
-  @Parameter(names = {"-" + NODE_PORT}, description = "node port")
+  @Parameter(names = {"-" + NODE_PORT}, description = "Node port. Default: 9410")
   private String port;
 
-  @Parameter(names = {"-" + NODE_PUBLIC_PORT}, description = "public node port")
+  @Parameter(names = {"-" + NODE_PUBLIC_PORT}, description = "Public node port. Default: <unset>")
   private String publicPort;
 
-  @Parameter(names = {"-" + NODE_GROUP_PORT}, description = "node port used for intra-stripe communication")
+  @Parameter(names = {"-" + NODE_GROUP_PORT}, description = "Node port used for intra-stripe communication. Default: 9430")
   private String groupPort;
 
-  @Parameter(names = {"-" + NODE_NAME}, description = "node name")
+  @Parameter(names = {"-" + NODE_NAME}, description = "Node name. Default: <generated>")
   private String nodeName;
 
-  @Parameter(names = {"-" + STRIPE_NAME}, description = "stripe name")
+  @Parameter(names = {"-" + STRIPE_NAME}, description = "Stripe name. Default: <generated>")
   private String stripeName;
 
-  @Parameter(names = {"-" + NODE_BIND_ADDRESS}, description = "node bind address for port")
+  @Parameter(names = {"-" + NODE_BIND_ADDRESS}, description = "Node bind address for node port. Default: 0.0.0.0")
   private String bindAddress;
 
-  @Parameter(names = {"-" + NODE_GROUP_BIND_ADDRESS}, description = "node bind address for group port")
+  @Parameter(names = {"-" + NODE_GROUP_BIND_ADDRESS}, description = "Node bind address for group port. Default: 0.0.0.0")
   private String groupBindAddress;
 
-  @Parameter(names = {"-" + NODE_CONFIG_DIR}, description = "node configuration directory")
+  @Parameter(names = {"-" + NODE_CONFIG_DIR}, description = "Node configuration directory. Default: %H/terracotta/config")
   private String configDir;
 
-  @Parameter(names = {"-" + NODE_METADATA_DIR}, description = "node metadata directory")
+  @Parameter(names = {"-" + NODE_METADATA_DIR}, description = "Node metadata directory. Default: %H/terracotta/metadata")
   private String metadataDir;
 
-  @Parameter(names = {"-" + NODE_LOG_DIR}, description = "node log directory")
+  @Parameter(names = {"-" + NODE_LOG_DIR}, description = "Node log directory. Default: %H/terracotta/logs")
   private String logDir;
 
-  @Parameter(names = {"-" + NODE_BACKUP_DIR}, description = "node backup directory")
+  @Parameter(names = {"-" + NODE_BACKUP_DIR}, description = "Node backup directory. Default: <unset>")
   private String backupDir;
 
-  @Parameter(names = {"-" + SECURITY_DIR}, description = "security root directory")
+  @Parameter(names = {"-" + SECURITY_DIR}, description = "Security root directory. Default: <unset>")
   private String securityDir;
 
-  @Parameter(names = {"-" + SECURITY_AUDIT_LOG_DIR}, description = "security audit log directory")
+  @Parameter(names = {"-" + SECURITY_AUDIT_LOG_DIR}, description = "Security audit log directory. Default: <unset>")
   private String securityAuditLogDir;
 
-  @Parameter(names = {"-" + SECURITY_AUTHC}, description = "security authentication setting (file|ldap|certificate)")
+  @Parameter(names = {"-" + SECURITY_AUTHC}, description = "Security authentication setting (file|ldap|certificate). Default: <unset>")
   private String securityAuthc;
 
-  @Parameter(names = {"-" + SECURITY_SSL_TLS}, description = "ssl-tls setting (true|false)")
+  @Parameter(names = {"-" + SECURITY_SSL_TLS}, description = "SSL/TLS setting (true|false). Default: false")
   private String securitySslTls;
 
-  @Parameter(names = {"-" + SECURITY_WHITELIST}, description = "security whitelist (true|false)")
+  @Parameter(names = {"-" + SECURITY_WHITELIST}, description = "Security whitelist (true|false). Default: false")
   private String securityWhitelist;
 
-  @Parameter(names = {"-" + FAILOVER_PRIORITY}, description = "failover priority setting (availability|consistency)")
+  @Parameter(names = {"-" + FAILOVER_PRIORITY}, description = "Failover priority setting (availability|consistency), required with more than 1 node. Default: <unset>")
   private String failoverPriority;
 
-  @Parameter(names = {"-" + CLIENT_RECONNECT_WINDOW}, description = "client reconnect window")
+  @Parameter(names = {"-" + CLIENT_RECONNECT_WINDOW}, description = "Client reconnect window. Default: 120s")
   private String clientReconnectWindow;
 
-  @Parameter(names = {"-" + CLIENT_LEASE_DURATION}, description = "client lease duration")
+  @Parameter(names = {"-" + CLIENT_LEASE_DURATION}, description = "Client lease duration. Default: 150s")
   private String clientLeaseDuration;
 
-  @Parameter(names = {"-" + OFFHEAP_RESOURCES}, description = "offheap resources")
+  @Parameter(names = {"-" + OFFHEAP_RESOURCES}, description = "Off-heap resources. Default: main:512MB")
   private String offheapResources;
 
-  @Parameter(names = {"-" + DATA_DIRS}, description = "data directory")
+  @Parameter(names = {"-" + DATA_DIRS}, description = "Data directories. Default: main:%H/terracotta/user-data/main")
   private String dataDirs;
 
-  @Parameter(names = {"-" + CONFIG_FILE}, description = "configuration properties file")
+  @Parameter(names = {"-" + CONFIG_FILE}, description = "Configuration file to load")
   private String configFile;
 
-  @Parameter(names = {"-" + TC_PROPERTIES}, description = "tc-properties")
+  @Parameter(names = {"-" + TC_PROPERTIES}, description = "Node properties. Default: <unset>")
   private String tcProperties;
 
-  @Parameter(names = {"-" + CLUSTER_NAME}, description = "cluster name")
+  @Parameter(names = {"-" + CLUSTER_NAME}, description = "Cluster name. Default: <unset>")
   private String clusterName;
 
   @Parameter(names = {"-" + LICENSE_FILE}, hidden = true)
@@ -151,13 +151,13 @@ public class OptionsParsingImpl implements OptionsParsing {
   @Parameter(names = {"-" + NODE_HOME_DIR}, hidden = true)
   private String serverHome;
 
-  @Parameter(names = {"-" + REPAIR_MODE}, description = "node repair mode (true|false)")
+  @Parameter(names = {"-" + REPAIR_MODE}, description = "Start node in repair mode")
   private boolean wantsRepairMode;
 
-  @Parameter(names = {"-" + HELP}, description = "provide usage information")
+  @Parameter(names = {"-" + HELP}, description = "Command-line help")
   private boolean help;
 
-  @Parameter(names = {"-" + AUTO_ACTIVATE}, description = "automatically activate the node so that it becomes active or joins a stripe (true|false)")
+  @Parameter(names = {"-" + AUTO_ACTIVATE}, description = "Automatically activate the node so that it becomes active or joins a stripe")
   private boolean allowsAutoActivation;
 
   private final Map<Setting, String> paramValueMap = new HashMap<>();


### PR DESCRIPTION
This PR adds the missing requirement and defaults for each option for the node startup script.

CLI tools already have these things, they were missing from the startup script.

### BEFORE

```
    -audit-log-dir              security audit log directory
    -authc                      security authentication setting (file|ldap|certificate)
    -auto-activate              automatically activate the node so that it becomes active or joins a stripe (true|false)
    -backup-dir                 node backup directory
    -bind-address               node bind address for port
    -client-lease-duration      client lease duration
    -client-reconnect-window    client reconnect window
    -cluster-name               cluster name
    -config-dir                 node configuration directory
    -config-file                configuration properties file
    -data-dirs                  data directory
    -failover-priority          failover priority setting (availability|consistency)
    -group-bind-address         node bind address for group port
    -group-port                 node port used for intra-stripe communication
    -help                       provide usage information
    -hostname                   node host name
    -log-dir                    node log directory
    -metadata-dir               node metadata directory
    -name                       node name
    -offheap-resources          offheap resources
    -port                       node port
    -public-hostname            public node host name
    -public-port                public node port
    -repair-mode                node repair mode (true|false)
    -security-dir               security root directory
    -ssl-tls                    ssl-tls setting (true|false)
    -stripe-name                stripe name
    -tc-properties              tc-properties
    -whitelist                  security whitelist (true|false)
```

### AFTER

```
    -audit-log-dir              Security audit log directory. Default: <unset>
    -authc                      Security authentication setting (file|ldap|certificate). Default: <unset>
    -auto-activate              Automatically activate the node so that it becomes active or joins a stripe
    -backup-dir                 Node backup directory. Default: <unset>
    -bind-address               Node bind address for node port. Default: 0.0.0.0
    -client-lease-duration      Client lease duration. Default: 150s
    -client-reconnect-window    Client reconnect window. Default: 120s
    -cluster-name               Cluster name. Default: <unset>
    -config-dir                 Node configuration directory. Default: %H/terracotta/config
    -config-file                Configuration file to load
    -data-dirs                  Data directories. Default: main:%H/terracotta/user-data/main
    -failover-priority          Failover priority setting (availability|consistency), required with more than 1 node. Default: <unset>
    -group-bind-address         Node bind address for group port. Default: 0.0.0.0
    -group-port                 Node port used for intra-stripe communication. Default: 9430
    -help                       Command-line help
    -hostname                   Node host name. Default: %h
    -log-dir                    Node log directory. Default: %H/terracotta/logs
    -metadata-dir               Node metadata directory. Default: %H/terracotta/metadata
    -name                       Node name. Default: <generated>
    -offheap-resources          Off-heap resources. Default: main:512MB
    -port                       Node port. Default: 9410
    -public-hostname            Public node host name. Default: <unset>
    -public-port                Public node port. Default: <unset>
    -repair-mode                Start node in repair mode
    -security-dir               Security root directory. Default: <unset>
    -ssl-tls                    SSL/TLS setting (true|false). Default: false
    -stripe-name                Stripe name. Default: <generated>
    -tc-properties              Node properties. Default: <unset>
    -whitelist                  Security whitelist (true|false). Default: false
```