### PR TITLE
Shortening the extension output which also appears in the help output

### DIFF
--- a/client-message-tracker/src/main/java/org/terracotta/client/message/tracker/ClientMessageTrackerExtensionInfo.java
+++ b/client-message-tracker/src/main/java/org/terracotta/client/message/tracker/ClientMessageTrackerExtensionInfo.java
@@ -17,51 +17,34 @@ package org.terracotta.client.message.tracker;
 
 import com.tc.productinfo.ExtensionInfo;
 
-import java.io.File;
-import java.io.IOException;
-import java.net.URISyntaxException;
-import java.util.Collections;
 import java.util.Map;
-import java.util.jar.JarFile;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
-import static java.lang.System.lineSeparator;
+import static org.terracotta.client.message.tracker.ManifestInfo.BUILD_JDK;
+import static org.terracotta.client.message.tracker.ManifestInfo.BUILD_TIMESTAMP;
+import static org.terracotta.client.message.tracker.ManifestInfo.VERSION;
+import static org.terracotta.client.message.tracker.ManifestInfo.getJarManifestInfo;
 
 public class ClientMessageTrackerExtensionInfo implements ExtensionInfo {
 
-  private static final String PLUGIN_NAME = "Client Message Tracker Service";
-  private static final String[] BASE_ATTRIBUTES = {"Bundle-Version", "BuildInfo-Timestamp", "Build-Jdk"};
-  private Map<String, String> getJarManifestInfo() {
-    try {
-      File file = new File(this.getClass().getProtectionDomain().getCodeSource().getLocation().toURI());
-      if (file.isDirectory()) {
-        return Collections.emptyMap();
-      }
-      try (JarFile jar = new JarFile(file)) {
-        return jar.getManifest().getMainAttributes().entrySet().stream()
-            .collect(Collectors.toMap(e -> e.getKey().toString(), e -> e.getValue().toString()));
-      }
-    } catch (IOException | URISyntaxException e) {
-      throw new IllegalStateException(e);
-    }
-  }
+  private static final String PLUGIN_NAME = "Service: Client Message Tracker";
 
   @Override
   public String getExtensionInfo() {
-    Map<String, String> attributes = getJarManifestInfo();
-    return PLUGIN_NAME + ":" + lineSeparator() + Stream.of(BASE_ATTRIBUTES)
-        .filter(attributes::containsKey)
-        .map(n -> n + ": " + attributes.get(n))
-        .collect(Collectors.joining(lineSeparator())) + lineSeparator();
+    return getValue(DESCRIPTION);
   }
 
   @Override
   public String getValue(String name) {
-    if (name.equals(DESCRIPTION)) {
-      return getExtensionInfo();
-    } else {
-      return "";
+    switch (name) {
+      case "type":
+        return "SERVICE";
+      case DESCRIPTION:
+        Map<String, String> attributes = getJarManifestInfo(this.getClass());
+        return String.format(" * %-35s %-15s (built on %s with JDK %s)", PLUGIN_NAME, attributes.get(VERSION), attributes.get(BUILD_TIMESTAMP), attributes.get(BUILD_JDK));
+      case NAME:
+        return PLUGIN_NAME;
+      default:
+        return getJarManifestInfo(this.getClass()).getOrDefault(name, "");
     }
   }
 }

--- a/client-message-tracker/src/main/java/org/terracotta/client/message/tracker/ManifestInfo.java
+++ b/client-message-tracker/src/main/java/org/terracotta/client/message/tracker/ManifestInfo.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.terracotta.dynamic_config.server.api;
+package org.terracotta.client.message.tracker;
 
 import java.io.File;
 import java.io.IOException;

--- a/concurrent-map-entity/server/src/main/java/org/terracotta/entity/map/server/ClusteredMapServerExtensionInfo.java
+++ b/concurrent-map-entity/server/src/main/java/org/terracotta/entity/map/server/ClusteredMapServerExtensionInfo.java
@@ -17,51 +17,34 @@ package org.terracotta.entity.map.server;
 
 import com.tc.productinfo.ExtensionInfo;
 
-import java.io.File;
-import java.io.IOException;
-import java.net.URISyntaxException;
-import java.util.Collections;
 import java.util.Map;
-import java.util.jar.JarFile;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
-import static java.lang.System.lineSeparator;
+import static org.terracotta.entity.map.server.ManifestInfo.BUILD_JDK;
+import static org.terracotta.entity.map.server.ManifestInfo.BUILD_TIMESTAMP;
+import static org.terracotta.entity.map.server.ManifestInfo.VERSION;
+import static org.terracotta.entity.map.server.ManifestInfo.getJarManifestInfo;
 
 public class ClusteredMapServerExtensionInfo implements ExtensionInfo {
 
-  private static final String PLUGIN_NAME = "Clustered Map Server Plugin";
-  private static final String[] BASE_ATTRIBUTES = {"Bundle-Version", "BuildInfo-Timestamp", "Build-Jdk"};
-  private Map<String, String> getJarManifestInfo() {
-    try {
-      File file = new File(this.getClass().getProtectionDomain().getCodeSource().getLocation().toURI());
-      if (file.isDirectory()) {
-        return Collections.emptyMap();
-      }
-      try (JarFile jar = new JarFile(file)) {
-        return jar.getManifest().getMainAttributes().entrySet().stream()
-            .collect(Collectors.toMap(e -> e.getKey().toString(), e -> e.getValue().toString()));
-      }
-    } catch (IOException | URISyntaxException e) {
-      throw new IllegalStateException(e);
-    }
-  }
+  private static final String PLUGIN_NAME = "Entity : Clustered Map";
 
   @Override
   public String getExtensionInfo() {
-    Map<String, String> attributes = getJarManifestInfo();
-    return PLUGIN_NAME + ":" + lineSeparator() + Stream.of(BASE_ATTRIBUTES)
-        .filter(attributes::containsKey)
-        .map(n -> n + ": " + attributes.get(n))
-        .collect(Collectors.joining(lineSeparator())) + lineSeparator();
+    return getValue(DESCRIPTION);
   }
 
   @Override
   public String getValue(String name) {
-    if (name.equals(DESCRIPTION)) {
-      return getExtensionInfo();
-    } else {
-      return "";
+    switch (name) {
+      case "type":
+        return "ENTITY";
+      case DESCRIPTION:
+        Map<String, String> attributes = getJarManifestInfo(this.getClass());
+        return String.format(" * %-35s %-15s (built on %s with JDK %s)", PLUGIN_NAME, attributes.get(VERSION), attributes.get(BUILD_TIMESTAMP), attributes.get(BUILD_JDK));
+      case NAME:
+        return PLUGIN_NAME;
+      default:
+        return getJarManifestInfo(this.getClass()).getOrDefault(name, "");
     }
   }
 }

--- a/concurrent-map-entity/server/src/main/java/org/terracotta/entity/map/server/ManifestInfo.java
+++ b/concurrent-map-entity/server/src/main/java/org/terracotta/entity/map/server/ManifestInfo.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.terracotta.dynamic_config.server.api;
+package org.terracotta.entity.map.server;
 
 import java.io.File;
 import java.io.IOException;

--- a/data-root-resource/src/main/java/org/terracotta/config/data_roots/DataRootResourceExtensionInfo.java
+++ b/data-root-resource/src/main/java/org/terracotta/config/data_roots/DataRootResourceExtensionInfo.java
@@ -16,33 +16,35 @@
 package org.terracotta.config.data_roots;
 
 import com.tc.productinfo.ExtensionInfo;
-import org.terracotta.dynamic_config.server.api.ManifestInfo;
 
 import java.util.Map;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
-import static java.lang.System.lineSeparator;
+import static org.terracotta.dynamic_config.server.api.ManifestInfo.BUILD_JDK;
+import static org.terracotta.dynamic_config.server.api.ManifestInfo.BUILD_TIMESTAMP;
+import static org.terracotta.dynamic_config.server.api.ManifestInfo.VERSION;
+import static org.terracotta.dynamic_config.server.api.ManifestInfo.getJarManifestInfo;
 
 public class DataRootResourceExtensionInfo implements ExtensionInfo {
 
-  private static final String PLUGIN_NAME = "Data Root Plugin";
+  private static final String PLUGIN_NAME = "Plugin : Data Directories";
 
   @Override
   public String getExtensionInfo() {
-    Map<String, String> attributes = ManifestInfo.getJarManifestInfo(this.getClass());
-    return PLUGIN_NAME + ":" + lineSeparator() + Stream.of(ManifestInfo.BASE_ATTRIBUTES)
-        .filter(attributes::containsKey)
-        .map(n -> n + ": " + attributes.get(n))
-        .collect(Collectors.joining(lineSeparator())) + lineSeparator();
+    return getValue(DESCRIPTION);
   }
 
   @Override
   public String getValue(String name) {
-    if (name.equals(DESCRIPTION)) {
-      return getExtensionInfo();
-    } else {
-      return "";
+    switch (name) {
+      case "type":
+        return "PLUGIN";
+      case DESCRIPTION:
+        Map<String, String> attributes = getJarManifestInfo(this.getClass());
+        return String.format(" * %-35s %-15s (built on %s with JDK %s)", PLUGIN_NAME, attributes.get(VERSION), attributes.get(BUILD_TIMESTAMP), attributes.get(BUILD_JDK));
+      case NAME:
+        return PLUGIN_NAME;
+      default:
+        return getJarManifestInfo(this.getClass()).getOrDefault(name, "");
     }
   }
 }

--- a/diagnostic/service/src/main/java/org/terracotta/diagnostic/server/DiagnosticServiceExtensionInfo.java
+++ b/diagnostic/service/src/main/java/org/terracotta/diagnostic/server/DiagnosticServiceExtensionInfo.java
@@ -17,51 +17,34 @@ package org.terracotta.diagnostic.server;
 
 import com.tc.productinfo.ExtensionInfo;
 
-import java.io.File;
-import java.io.IOException;
-import java.net.URISyntaxException;
-import java.util.Collections;
 import java.util.Map;
-import java.util.jar.JarFile;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
-import static java.lang.System.lineSeparator;
+import static org.terracotta.diagnostic.server.ManifestInfo.BUILD_JDK;
+import static org.terracotta.diagnostic.server.ManifestInfo.BUILD_TIMESTAMP;
+import static org.terracotta.diagnostic.server.ManifestInfo.VERSION;
+import static org.terracotta.diagnostic.server.ManifestInfo.getJarManifestInfo;
 
 public class DiagnosticServiceExtensionInfo implements ExtensionInfo {
 
-  private static final String PLUGIN_NAME = "Diagnostic Service";
-  private static final String[] BASE_ATTRIBUTES = {"Bundle-Version", "BuildInfo-Timestamp", "Build-Jdk"};
-  private Map<String, String> getJarManifestInfo() {
-    try {
-      File file = new File(this.getClass().getProtectionDomain().getCodeSource().getLocation().toURI());
-      if (file.isDirectory()) {
-        return Collections.emptyMap();
-      }
-      try (JarFile jar = new JarFile(file)) {
-        return jar.getManifest().getMainAttributes().entrySet().stream()
-            .collect(Collectors.toMap(e -> e.getKey().toString(), e -> e.getValue().toString()));
-      }
-    } catch (IOException | URISyntaxException e) {
-      throw new IllegalStateException(e);
-    }
-  }
+  private static final String PLUGIN_NAME = "Service: Diagnostic Communication";
 
   @Override
   public String getExtensionInfo() {
-    Map<String, String> attributes = getJarManifestInfo();
-    return PLUGIN_NAME + ":" + lineSeparator() + Stream.of(BASE_ATTRIBUTES)
-        .filter(attributes::containsKey)
-        .map(n -> n + ": " + attributes.get(n))
-        .collect(Collectors.joining(lineSeparator())) + lineSeparator();
+    return getValue(DESCRIPTION);
   }
 
   @Override
   public String getValue(String name) {
-    if (name.equals(DESCRIPTION)) {
-      return getExtensionInfo();
-    } else {
-      return "";
+    switch (name) {
+      case "type":
+        return "SERVICE";
+      case DESCRIPTION:
+        Map<String, String> attributes = getJarManifestInfo(this.getClass());
+        return String.format(" * %-35s %-15s (built on %s with JDK %s)", PLUGIN_NAME, attributes.get(VERSION), attributes.get(BUILD_TIMESTAMP), attributes.get(BUILD_JDK));
+      case NAME:
+        return PLUGIN_NAME;
+      default:
+        return getJarManifestInfo(this.getClass()).getOrDefault(name, "");
     }
   }
 }

--- a/diagnostic/service/src/main/java/org/terracotta/diagnostic/server/ManifestInfo.java
+++ b/diagnostic/service/src/main/java/org/terracotta/diagnostic/server/ManifestInfo.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.terracotta.dynamic_config.server.api;
+package org.terracotta.diagnostic.server;
 
 import java.io.File;
 import java.io.IOException;

--- a/dynamic-config/entities/management-entity/server/src/main/java/org/terracotta/dynamic_config/entity/management/server/ManagementEntityServerExtensionInfo.java
+++ b/dynamic-config/entities/management-entity/server/src/main/java/org/terracotta/dynamic_config/entity/management/server/ManagementEntityServerExtensionInfo.java
@@ -16,33 +16,35 @@
 package org.terracotta.dynamic_config.entity.management.server;
 
 import com.tc.productinfo.ExtensionInfo;
-import org.terracotta.dynamic_config.server.api.ManifestInfo;
 
 import java.util.Map;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
-import static java.lang.System.lineSeparator;
+import static org.terracotta.dynamic_config.server.api.ManifestInfo.BUILD_JDK;
+import static org.terracotta.dynamic_config.server.api.ManifestInfo.BUILD_TIMESTAMP;
+import static org.terracotta.dynamic_config.server.api.ManifestInfo.VERSION;
+import static org.terracotta.dynamic_config.server.api.ManifestInfo.getJarManifestInfo;
 
 public class ManagementEntityServerExtensionInfo implements ExtensionInfo {
 
-  private static final String PLUGIN_NAME = "Dynamic Configuration Management";
+  private static final String PLUGIN_NAME = "Service: Configuration Monitoring";
 
   @Override
   public String getExtensionInfo() {
-    Map<String, String> attributes = ManifestInfo.getJarManifestInfo(this.getClass());
-    return PLUGIN_NAME + ":" + lineSeparator() + Stream.of(ManifestInfo.BASE_ATTRIBUTES)
-        .filter(attributes::containsKey)
-        .map(n -> n + ": " + attributes.get(n))
-        .collect(Collectors.joining(lineSeparator())) + lineSeparator();
+    return getValue(DESCRIPTION);
   }
 
   @Override
   public String getValue(String name) {
-    if (name.equals(DESCRIPTION)) {
-      return getExtensionInfo();
-    } else {
-      return "";
+    switch (name) {
+      case "type":
+        return "SERVICE";
+      case DESCRIPTION:
+        Map<String, String> attributes = getJarManifestInfo(this.getClass());
+        return String.format(" * %-35s %-15s (built on %s with JDK %s)", PLUGIN_NAME, attributes.get(VERSION), attributes.get(BUILD_TIMESTAMP), attributes.get(BUILD_JDK));
+      case NAME:
+        return PLUGIN_NAME;
+      default:
+        return getJarManifestInfo(this.getClass()).getOrDefault(name, "");
     }
   }
 }

--- a/dynamic-config/entities/nomad-entity/server/src/main/java/org/terracotta/nomad/entity/server/NomadServerExtensionInfo.java
+++ b/dynamic-config/entities/nomad-entity/server/src/main/java/org/terracotta/nomad/entity/server/NomadServerExtensionInfo.java
@@ -16,33 +16,35 @@
 package org.terracotta.nomad.entity.server;
 
 import com.tc.productinfo.ExtensionInfo;
-import org.terracotta.dynamic_config.server.api.ManifestInfo;
 
 import java.util.Map;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
-import static java.lang.System.lineSeparator;
+import static org.terracotta.dynamic_config.server.api.ManifestInfo.BUILD_JDK;
+import static org.terracotta.dynamic_config.server.api.ManifestInfo.BUILD_TIMESTAMP;
+import static org.terracotta.dynamic_config.server.api.ManifestInfo.VERSION;
+import static org.terracotta.dynamic_config.server.api.ManifestInfo.getJarManifestInfo;
 
 public class NomadServerExtensionInfo implements ExtensionInfo {
 
-  private static final String PLUGIN_NAME = "Dynamic Configuration Transaction";
+  private static final String PLUGIN_NAME = "Entity : Nomad";
 
   @Override
   public String getExtensionInfo() {
-    Map<String, String> attributes = ManifestInfo.getJarManifestInfo(this.getClass());
-    return PLUGIN_NAME + ":" + lineSeparator() + Stream.of(ManifestInfo.BASE_ATTRIBUTES)
-        .filter(attributes::containsKey)
-        .map(n -> n + ": " + attributes.get(n))
-        .collect(Collectors.joining(lineSeparator())) + lineSeparator();
+    return getValue(DESCRIPTION);
   }
 
   @Override
   public String getValue(String name) {
-    if (name.equals(DESCRIPTION)) {
-      return getExtensionInfo();
-    } else {
-      return "";
+    switch (name) {
+      case "type":
+        return "ENTITY";
+      case DESCRIPTION:
+        Map<String, String> attributes = getJarManifestInfo(this.getClass());
+        return String.format(" * %-35s %-15s (built on %s with JDK %s)", PLUGIN_NAME, attributes.get(VERSION), attributes.get(BUILD_TIMESTAMP), attributes.get(BUILD_JDK));
+      case NAME:
+        return PLUGIN_NAME;
+      default:
+        return getJarManifestInfo(this.getClass()).getOrDefault(name, "");
     }
   }
 }

--- a/dynamic-config/entities/topology-entity/server/src/main/java/org/terracotta/dynamic_config/entity/topology/server/DynamicTopologyServerExtensionInfo.java
+++ b/dynamic-config/entities/topology-entity/server/src/main/java/org/terracotta/dynamic_config/entity/topology/server/DynamicTopologyServerExtensionInfo.java
@@ -16,33 +16,35 @@
 package org.terracotta.dynamic_config.entity.topology.server;
 
 import com.tc.productinfo.ExtensionInfo;
-import org.terracotta.dynamic_config.server.api.ManifestInfo;
 
 import java.util.Map;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
-import static java.lang.System.lineSeparator;
+import static org.terracotta.dynamic_config.server.api.ManifestInfo.BUILD_JDK;
+import static org.terracotta.dynamic_config.server.api.ManifestInfo.BUILD_TIMESTAMP;
+import static org.terracotta.dynamic_config.server.api.ManifestInfo.VERSION;
+import static org.terracotta.dynamic_config.server.api.ManifestInfo.getJarManifestInfo;
 
 public class DynamicTopologyServerExtensionInfo implements ExtensionInfo {
 
-  private static final String PLUGIN_NAME = "Dynamic Configuration Topology";
+  private static final String PLUGIN_NAME = "Entity : Cluster Topology";
 
   @Override
   public String getExtensionInfo() {
-    Map<String, String> attributes = ManifestInfo.getJarManifestInfo(this.getClass());
-    return PLUGIN_NAME + ":" + lineSeparator() + Stream.of(ManifestInfo.BASE_ATTRIBUTES)
-        .filter(attributes::containsKey)
-        .map(n -> n + ": " + attributes.get(n))
-        .collect(Collectors.joining(lineSeparator())) + lineSeparator();
+    return getValue(DESCRIPTION);
   }
 
   @Override
   public String getValue(String name) {
-    if (name.equals(DESCRIPTION)) {
-      return getExtensionInfo();
-    } else {
-      return "";
+    switch (name) {
+      case "type":
+        return "ENTITY";
+      case DESCRIPTION:
+        Map<String, String> attributes = getJarManifestInfo(this.getClass());
+        return String.format(" * %-35s %-15s (built on %s with JDK %s)", PLUGIN_NAME, attributes.get(VERSION), attributes.get(BUILD_TIMESTAMP), attributes.get(BUILD_JDK));
+      case NAME:
+        return PLUGIN_NAME;
+      default:
+        return getJarManifestInfo(this.getClass()).getOrDefault(name, "");
     }
   }
 }

--- a/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/DynamicConfigConfigurationProviderExtensionInfo.java
+++ b/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/DynamicConfigConfigurationProviderExtensionInfo.java
@@ -16,33 +16,35 @@
 package org.terracotta.dynamic_config.server.configuration;
 
 import com.tc.productinfo.ExtensionInfo;
-import org.terracotta.dynamic_config.server.api.ManifestInfo;
 
 import java.util.Map;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
-import static java.lang.System.lineSeparator;
+import static org.terracotta.dynamic_config.server.api.ManifestInfo.BUILD_JDK;
+import static org.terracotta.dynamic_config.server.api.ManifestInfo.BUILD_TIMESTAMP;
+import static org.terracotta.dynamic_config.server.api.ManifestInfo.VERSION;
+import static org.terracotta.dynamic_config.server.api.ManifestInfo.getJarManifestInfo;
 
 public class DynamicConfigConfigurationProviderExtensionInfo implements ExtensionInfo {
 
-  private static final String PLUGIN_NAME = "Dynamic Configuration Startup";
+  private static final String PLUGIN_NAME = "Config : Dynamic";
 
   @Override
   public String getExtensionInfo() {
-    Map<String, String> attributes = ManifestInfo.getJarManifestInfo(this.getClass());
-    return PLUGIN_NAME + ":" + lineSeparator() + Stream.of(ManifestInfo.BASE_ATTRIBUTES)
-        .filter(attributes::containsKey)
-        .map(n -> n + ": " + attributes.get(n))
-        .collect(Collectors.joining(lineSeparator())) + lineSeparator();
+    return getValue(DESCRIPTION);
   }
 
   @Override
   public String getValue(String name) {
-    if (name.equals(DESCRIPTION)) {
-      return getExtensionInfo();
-    } else {
-      return "";
+    switch (name) {
+      case "type":
+        return "CONFIG";
+      case DESCRIPTION:
+        Map<String, String> attributes = getJarManifestInfo(this.getClass());
+        return String.format(" * %-35s %-15s (built on %s with JDK %s)", PLUGIN_NAME, attributes.get(VERSION), attributes.get(BUILD_TIMESTAMP), attributes.get(BUILD_JDK));
+      case NAME:
+        return PLUGIN_NAME;
+      default:
+        return getJarManifestInfo(this.getClass()).getOrDefault(name, "");
     }
   }
 }

--- a/dynamic-config/server/services/src/main/java/org/terracotta/dynamic_config/server/service/DynamicConfigServiceExtensionInfo.java
+++ b/dynamic-config/server/services/src/main/java/org/terracotta/dynamic_config/server/service/DynamicConfigServiceExtensionInfo.java
@@ -16,33 +16,35 @@
 package org.terracotta.dynamic_config.server.service;
 
 import com.tc.productinfo.ExtensionInfo;
-import org.terracotta.dynamic_config.server.api.ManifestInfo;
 
 import java.util.Map;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
-import static java.lang.System.lineSeparator;
+import static org.terracotta.dynamic_config.server.api.ManifestInfo.BUILD_JDK;
+import static org.terracotta.dynamic_config.server.api.ManifestInfo.BUILD_TIMESTAMP;
+import static org.terracotta.dynamic_config.server.api.ManifestInfo.VERSION;
+import static org.terracotta.dynamic_config.server.api.ManifestInfo.getJarManifestInfo;
 
 public class DynamicConfigServiceExtensionInfo implements ExtensionInfo {
 
-  private static final String PLUGIN_NAME = "Dynamic Configuration Services";
+  private static final String PLUGIN_NAME = "Service: Dynamic Configuration";
 
   @Override
   public String getExtensionInfo() {
-    Map<String, String> attributes = ManifestInfo.getJarManifestInfo(this.getClass());
-    return PLUGIN_NAME + ":" + lineSeparator() + Stream.of(ManifestInfo.BASE_ATTRIBUTES)
-        .filter(attributes::containsKey)
-        .map(n -> n + ": " + attributes.get(n))
-        .collect(Collectors.joining(lineSeparator())) + lineSeparator();
+    return getValue(DESCRIPTION);
   }
 
   @Override
   public String getValue(String name) {
-    if (name.equals(DESCRIPTION)) {
-      return getExtensionInfo();
-    } else {
-      return "";
+    switch (name) {
+      case "type":
+        return "SERVICE";
+      case DESCRIPTION:
+        Map<String, String> attributes = getJarManifestInfo(this.getClass());
+        return String.format(" * %-35s %-15s (built on %s with JDK %s)", PLUGIN_NAME, attributes.get(VERSION), attributes.get(BUILD_TIMESTAMP), attributes.get(BUILD_JDK));
+      case NAME:
+        return PLUGIN_NAME;
+      default:
+        return getJarManifestInfo(this.getClass()).getOrDefault(name, "");
     }
   }
 }

--- a/healthchecker-entity/server-impl/src/main/java/org/terracotta/healthchecker/HealthCheckerServerExtensionInfo.java
+++ b/healthchecker-entity/server-impl/src/main/java/org/terracotta/healthchecker/HealthCheckerServerExtensionInfo.java
@@ -17,51 +17,34 @@ package org.terracotta.healthchecker;
 
 import com.tc.productinfo.ExtensionInfo;
 
-import java.io.File;
-import java.io.IOException;
-import java.net.URISyntaxException;
-import java.util.Collections;
 import java.util.Map;
-import java.util.jar.JarFile;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
-import static java.lang.System.lineSeparator;
+import static org.terracotta.healthchecker.ManifestInfo.BUILD_JDK;
+import static org.terracotta.healthchecker.ManifestInfo.BUILD_TIMESTAMP;
+import static org.terracotta.healthchecker.ManifestInfo.VERSION;
+import static org.terracotta.healthchecker.ManifestInfo.getJarManifestInfo;
 
 public class HealthCheckerServerExtensionInfo implements ExtensionInfo {
 
-  private static final String PLUGIN_NAME = "Health Checker Server Plugin";
-  private static final String[] BASE_ATTRIBUTES = {"Bundle-Version", "BuildInfo-Timestamp", "Build-Jdk"};
-  private Map<String, String> getJarManifestInfo() {
-    try {
-      File file = new File(this.getClass().getProtectionDomain().getCodeSource().getLocation().toURI());
-      if (file.isDirectory()) {
-        return Collections.emptyMap();
-      }
-      try (JarFile jar = new JarFile(file)) {
-        return jar.getManifest().getMainAttributes().entrySet().stream()
-            .collect(Collectors.toMap(e -> e.getKey().toString(), e -> e.getValue().toString()));
-      }
-    } catch (IOException | URISyntaxException e) {
-      throw new IllegalStateException(e);
-    }
-  }
+  private static final String PLUGIN_NAME = "Entity : Health Checker";
 
   @Override
   public String getExtensionInfo() {
-    Map<String, String> attributes = getJarManifestInfo();
-    return PLUGIN_NAME + ":" + lineSeparator() + Stream.of(BASE_ATTRIBUTES)
-        .filter(attributes::containsKey)
-        .map(n -> n + ": " + attributes.get(n))
-        .collect(Collectors.joining(lineSeparator())) + lineSeparator();
+    return getValue(DESCRIPTION);
   }
 
   @Override
   public String getValue(String name) {
-    if (name.equals(DESCRIPTION)) {
-      return getExtensionInfo();
-    } else {
-      return "";
+    switch (name) {
+      case "type":
+        return "ENTITY";
+      case DESCRIPTION:
+        Map<String, String> attributes = getJarManifestInfo(this.getClass());
+        return String.format(" * %-35s %-15s (built on %s with JDK %s)", PLUGIN_NAME, attributes.get(VERSION), attributes.get(BUILD_TIMESTAMP), attributes.get(BUILD_JDK));
+      case NAME:
+        return PLUGIN_NAME;
+      default:
+        return getJarManifestInfo(this.getClass()).getOrDefault(name, "");
     }
   }
 }

--- a/healthchecker-entity/server-impl/src/main/java/org/terracotta/healthchecker/ManifestInfo.java
+++ b/healthchecker-entity/server-impl/src/main/java/org/terracotta/healthchecker/ManifestInfo.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.terracotta.dynamic_config.server.api;
+package org.terracotta.healthchecker;
 
 import java.io.File;
 import java.io.IOException;

--- a/lease/entity-server/src/main/java/org/terracotta/lease/service/LeaseServiceExtensionInfo.java
+++ b/lease/entity-server/src/main/java/org/terracotta/lease/service/LeaseServiceExtensionInfo.java
@@ -16,33 +16,35 @@
 package org.terracotta.lease.service;
 
 import com.tc.productinfo.ExtensionInfo;
-import org.terracotta.dynamic_config.server.api.ManifestInfo;
 
 import java.util.Map;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
-import static java.lang.System.lineSeparator;
+import static org.terracotta.dynamic_config.server.api.ManifestInfo.BUILD_JDK;
+import static org.terracotta.dynamic_config.server.api.ManifestInfo.BUILD_TIMESTAMP;
+import static org.terracotta.dynamic_config.server.api.ManifestInfo.VERSION;
+import static org.terracotta.dynamic_config.server.api.ManifestInfo.getJarManifestInfo;
 
 public class LeaseServiceExtensionInfo implements ExtensionInfo {
 
-  private static final String PLUGIN_NAME = "Lease Service";
+  private static final String PLUGIN_NAME = "Service: Lease";
 
   @Override
   public String getExtensionInfo() {
-    Map<String, String> attributes = ManifestInfo.getJarManifestInfo(this.getClass());
-    return PLUGIN_NAME + ":" + lineSeparator() + Stream.of(ManifestInfo.BASE_ATTRIBUTES)
-        .filter(attributes::containsKey)
-        .map(n -> n + ": " + attributes.get(n))
-        .collect(Collectors.joining(lineSeparator())) + lineSeparator();
+    return getValue(DESCRIPTION);
   }
 
   @Override
   public String getValue(String name) {
-    if (name.equals(DESCRIPTION)) {
-      return getExtensionInfo();
-    } else {
-      return "";
+    switch (name) {
+      case "type":
+        return "SERVICE";
+      case DESCRIPTION:
+        Map<String, String> attributes = getJarManifestInfo(this.getClass());
+        return String.format(" * %-35s %-15s (built on %s with JDK %s)", PLUGIN_NAME, attributes.get(VERSION), attributes.get(BUILD_TIMESTAMP), attributes.get(BUILD_JDK));
+      case NAME:
+        return PLUGIN_NAME;
+      default:
+        return getJarManifestInfo(this.getClass()).getOrDefault(name, "");
     }
   }
 }

--- a/management/monitoring-service/src/main/java/org/terracotta/management/service/monitoring/MonitoringServiceExtensionInfo.java
+++ b/management/monitoring-service/src/main/java/org/terracotta/management/service/monitoring/MonitoringServiceExtensionInfo.java
@@ -16,33 +16,35 @@
 package org.terracotta.management.service.monitoring;
 
 import com.tc.productinfo.ExtensionInfo;
-import org.terracotta.dynamic_config.server.api.ManifestInfo;
 
 import java.util.Map;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
-import static java.lang.System.lineSeparator;
+import static org.terracotta.dynamic_config.server.api.ManifestInfo.BUILD_JDK;
+import static org.terracotta.dynamic_config.server.api.ManifestInfo.BUILD_TIMESTAMP;
+import static org.terracotta.dynamic_config.server.api.ManifestInfo.VERSION;
+import static org.terracotta.dynamic_config.server.api.ManifestInfo.getJarManifestInfo;
 
 public class MonitoringServiceExtensionInfo implements ExtensionInfo {
 
-  private static final String PLUGIN_NAME = "Monitoring Service";
+  private static final String PLUGIN_NAME = "Service: Monitoring";
 
   @Override
   public String getExtensionInfo() {
-    Map<String, String> attributes = ManifestInfo.getJarManifestInfo(this.getClass());
-    return PLUGIN_NAME + ":" + lineSeparator() + Stream.of(ManifestInfo.BASE_ATTRIBUTES)
-        .filter(attributes::containsKey)
-        .map(n -> n + ": " + attributes.get(n))
-        .collect(Collectors.joining(lineSeparator())) + lineSeparator();
+    return getValue(DESCRIPTION);
   }
 
   @Override
   public String getValue(String name) {
-    if (name.equals(DESCRIPTION)) {
-      return getExtensionInfo();
-    } else {
-      return "";
+    switch (name) {
+      case "type":
+        return "SERVICE";
+      case DESCRIPTION:
+        Map<String, String> attributes = getJarManifestInfo(this.getClass());
+        return String.format(" * %-35s %-15s (built on %s with JDK %s)", PLUGIN_NAME, attributes.get(VERSION), attributes.get(BUILD_TIMESTAMP), attributes.get(BUILD_JDK));
+      case NAME:
+        return PLUGIN_NAME;
+      default:
+        return getJarManifestInfo(this.getClass()).getOrDefault(name, "");
     }
   }
 }

--- a/management/nms-agent-entity/nms-agent-entity-server/src/main/java/org/terracotta/management/entity/nms/agent/server/ManifestInfo.java
+++ b/management/nms-agent-entity/nms-agent-entity-server/src/main/java/org/terracotta/management/entity/nms/agent/server/ManifestInfo.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.terracotta.dynamic_config.server.api;
+package org.terracotta.management.entity.nms.agent.server;
 
 import java.io.File;
 import java.io.IOException;

--- a/management/nms-entity/nms-entity-server/src/main/java/org/terracotta/management/entity/nms/server/NmsEntityServerExtensionInfo.java
+++ b/management/nms-entity/nms-entity-server/src/main/java/org/terracotta/management/entity/nms/server/NmsEntityServerExtensionInfo.java
@@ -16,33 +16,35 @@
 package org.terracotta.management.entity.nms.server;
 
 import com.tc.productinfo.ExtensionInfo;
-import org.terracotta.dynamic_config.server.api.ManifestInfo;
 
 import java.util.Map;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
-import static java.lang.System.lineSeparator;
+import static org.terracotta.dynamic_config.server.api.ManifestInfo.BUILD_JDK;
+import static org.terracotta.dynamic_config.server.api.ManifestInfo.BUILD_TIMESTAMP;
+import static org.terracotta.dynamic_config.server.api.ManifestInfo.VERSION;
+import static org.terracotta.dynamic_config.server.api.ManifestInfo.getJarManifestInfo;
 
 public class NmsEntityServerExtensionInfo implements ExtensionInfo {
 
-  private static final String PLUGIN_NAME = "Monitoring Platform";
+  private static final String PLUGIN_NAME = "Entity : Monitoring Platform";
 
   @Override
   public String getExtensionInfo() {
-    Map<String, String> attributes = ManifestInfo.getJarManifestInfo(this.getClass());
-    return PLUGIN_NAME + ":" + lineSeparator() + Stream.of(ManifestInfo.BASE_ATTRIBUTES)
-        .filter(attributes::containsKey)
-        .map(n -> n + ": " + attributes.get(n))
-        .collect(Collectors.joining(lineSeparator())) + lineSeparator();
+    return getValue(DESCRIPTION);
   }
 
   @Override
   public String getValue(String name) {
-    if (name.equals(DESCRIPTION)) {
-      return getExtensionInfo();
-    } else {
-      return "";
+    switch (name) {
+      case "type":
+        return "ENTITY";
+      case DESCRIPTION:
+        Map<String, String> attributes = getJarManifestInfo(this.getClass());
+        return String.format(" * %-35s %-15s (built on %s with JDK %s)", PLUGIN_NAME, attributes.get(VERSION), attributes.get(BUILD_TIMESTAMP), attributes.get(BUILD_JDK));
+      case NAME:
+        return PLUGIN_NAME;
+      default:
+        return getJarManifestInfo(this.getClass()).getOrDefault(name, "");
     }
   }
 }

--- a/offheap-resource/src/main/java/org/terracotta/offheapresource/OffHeapResourceExtensionInfo.java
+++ b/offheap-resource/src/main/java/org/terracotta/offheapresource/OffHeapResourceExtensionInfo.java
@@ -16,33 +16,35 @@
 package org.terracotta.offheapresource;
 
 import com.tc.productinfo.ExtensionInfo;
-import org.terracotta.dynamic_config.server.api.ManifestInfo;
 
 import java.util.Map;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
-import static java.lang.System.lineSeparator;
+import static org.terracotta.dynamic_config.server.api.ManifestInfo.BUILD_JDK;
+import static org.terracotta.dynamic_config.server.api.ManifestInfo.BUILD_TIMESTAMP;
+import static org.terracotta.dynamic_config.server.api.ManifestInfo.VERSION;
+import static org.terracotta.dynamic_config.server.api.ManifestInfo.getJarManifestInfo;
 
 public class OffHeapResourceExtensionInfo implements ExtensionInfo {
 
-  public static final String PLUGIN_NAME = "Off Heap Plugin";
+  public static final String PLUGIN_NAME = "Plugin : Off-Heap";
 
   @Override
   public String getExtensionInfo() {
-    Map<String, String> attributes = ManifestInfo.getJarManifestInfo(this.getClass());
-    return PLUGIN_NAME + ":" + lineSeparator() + Stream.of(ManifestInfo.BASE_ATTRIBUTES)
-        .filter(attributes::containsKey)
-        .map(n -> n + ": " + attributes.get(n))
-        .collect(Collectors.joining(lineSeparator())) + lineSeparator();
+    return getValue(DESCRIPTION);
   }
 
   @Override
   public String getValue(String name) {
-    if (name.equals(DESCRIPTION)) {
-      return getExtensionInfo();
-    } else {
-      return "";
+    switch (name) {
+      case "type":
+        return "PLUGIN";
+      case DESCRIPTION:
+        Map<String, String> attributes = getJarManifestInfo(this.getClass());
+        return String.format(" * %-35s %-15s (built on %s with JDK %s)", PLUGIN_NAME, attributes.get(VERSION), attributes.get(BUILD_TIMESTAMP), attributes.get(BUILD_JDK));
+      case NAME:
+        return PLUGIN_NAME;
+      default:
+        return getJarManifestInfo(this.getClass()).getOrDefault(name, "");
     }
   }
 }

--- a/platform-base/src/main/java/org/terracotta/platform/ManifestInfo.java
+++ b/platform-base/src/main/java/org/terracotta/platform/ManifestInfo.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.terracotta.dynamic_config.server.api;
+package org.terracotta.platform;
 
 import java.io.File;
 import java.io.IOException;

--- a/platform-base/src/main/java/org/terracotta/platform/PlatformBaseExtensionInfo.java
+++ b/platform-base/src/main/java/org/terracotta/platform/PlatformBaseExtensionInfo.java
@@ -17,51 +17,34 @@ package org.terracotta.platform;
 
 import com.tc.productinfo.ExtensionInfo;
 
-import java.io.File;
-import java.io.IOException;
-import java.net.URISyntaxException;
-import java.util.Collections;
 import java.util.Map;
-import java.util.jar.JarFile;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
-import static java.lang.System.lineSeparator;
+import static org.terracotta.platform.ManifestInfo.BUILD_JDK;
+import static org.terracotta.platform.ManifestInfo.BUILD_TIMESTAMP;
+import static org.terracotta.platform.ManifestInfo.VERSION;
+import static org.terracotta.platform.ManifestInfo.getJarManifestInfo;
 
 public class PlatformBaseExtensionInfo implements ExtensionInfo {
 
-  private static final String PLUGIN_NAME = "Server Information";
-  private static final String[] BASE_ATTRIBUTES = {"Bundle-Version", "BuildInfo-Timestamp", "Build-Jdk"};
-  private Map<String, String> getJarManifestInfo() {
-    try {
-      File file = new File(this.getClass().getProtectionDomain().getCodeSource().getLocation().toURI());
-      if (file.isDirectory()) {
-        return Collections.emptyMap();
-      }
-      try (JarFile jar = new JarFile(file)) {
-        return jar.getManifest().getMainAttributes().entrySet().stream()
-            .collect(Collectors.toMap(e -> e.getKey().toString(), e -> e.getValue().toString()));
-      }
-    } catch (IOException | URISyntaxException e) {
-      throw new IllegalStateException(e);
-    }
-  }
+  private static final String PLUGIN_NAME = "Service: Server Information";
 
   @Override
   public String getExtensionInfo() {
-    Map<String, String> attributes = getJarManifestInfo();
-    return PLUGIN_NAME + ":" + lineSeparator() + Stream.of(BASE_ATTRIBUTES)
-        .filter(attributes::containsKey)
-        .map(n -> n + ": " + attributes.get(n))
-        .collect(Collectors.joining(lineSeparator())) + lineSeparator();
+    return getValue(DESCRIPTION);
   }
 
   @Override
   public String getValue(String name) {
-    if (name.equals(DESCRIPTION)) {
-      return getExtensionInfo();
-    } else {
-      return "";
+    switch (name) {
+      case "type":
+        return "SERVICE";
+      case DESCRIPTION:
+        Map<String, String> attributes = getJarManifestInfo(this.getClass());
+        return String.format(" * %-35s %-15s (built on %s with JDK %s)", PLUGIN_NAME, attributes.get(VERSION), attributes.get(BUILD_TIMESTAMP), attributes.get(BUILD_JDK));
+      case NAME:
+        return PLUGIN_NAME;
+      default:
+        return getJarManifestInfo(this.getClass()).getOrDefault(name, "");
     }
   }
 }


### PR DESCRIPTION
@myronkscott : I don't really like the fact that `-help` is polluted by the logging in INFO.

@tmesic99: as a workaround right now I have reduced the extension description (1 line instead of 4)

I have also refactored the implementations to support exposing more information, which I will use for next PR for TDB-5308

### New help output

```bash
❯  ./kit/target/platform-kit-5.8-SNAPSHOT/platform-kit-5.8-SNAPSHOT/server/bin/start-tc-server.sh -help
2021-06-23 22:32:07,312 INFO - Terracotta 5.8.2-pre5, as of 2021-06-22 at 19:40:16 UTC (Revision f61e7ba47428e3bc5703c6071169755ed83b1ac2 from UNKNOWN)
2021-06-23 22:32:07,398 INFO - Extensions:
2021-06-23 22:32:07,411 INFO -  * Entity : Cluster Topology           5.8.0.SNAPSHOT  (built on 2021-06-24T02:30:30Z with JDK 1.8.0_282)
2021-06-23 22:32:07,412 INFO -  * Config : Dynamic                    5.8.0.SNAPSHOT  (built on 2021-06-24T02:30:30Z with JDK 1.8.0_282)
2021-06-23 22:32:07,412 INFO -  * Service: Client Message Tracker     5.8.0.SNAPSHOT  (built on 2021-06-24T02:30:30Z with JDK 1.8.0_282)
2021-06-23 22:32:07,412 INFO -  * Entity : Monitoring Agent           5.8.0.SNAPSHOT  (built on 2021-06-24T02:30:30Z with JDK 1.8.0_282)
2021-06-23 22:32:07,412 INFO -  * Plugin : Off-Heap                   5.8.0.SNAPSHOT  (built on 2021-06-24T02:30:30Z with JDK 1.8.0_282)
2021-06-23 22:32:07,412 INFO -  * Service: Dynamic Configuration      5.8.0.SNAPSHOT  (built on 2021-06-24T02:30:30Z with JDK 1.8.0_282)
2021-06-23 22:32:07,412 INFO -  * Entity : Monitoring Platform        5.8.0.SNAPSHOT  (built on 2021-06-24T02:30:30Z with JDK 1.8.0_282)
2021-06-23 22:32:07,412 INFO -  * Entity : Nomad                      5.8.0.SNAPSHOT  (built on 2021-06-24T02:30:30Z with JDK 1.8.0_282)
2021-06-23 22:32:07,412 INFO -  * Service: Monitoring                 5.8.0.SNAPSHOT  (built on 2021-06-24T02:30:30Z with JDK 1.8.0_282)
2021-06-23 22:32:07,412 INFO -  * Service: Configuration Monitoring   5.8.0.SNAPSHOT  (built on 2021-06-24T02:30:30Z with JDK 1.8.0_282)
2021-06-23 22:32:07,412 INFO -  * Service: Diagnostic Communication   5.8.0.SNAPSHOT  (built on 2021-06-24T02:30:30Z with JDK 1.8.0_282)
2021-06-23 22:32:07,412 INFO -  * Service: Server Information         5.8.0.SNAPSHOT  (built on 2021-06-24T02:30:30Z with JDK 1.8.0_282)
2021-06-23 22:32:07,412 INFO -  * Service: Lease                      5.8.0.SNAPSHOT  (built on 2021-06-24T02:30:30Z with JDK 1.8.0_282)
2021-06-23 22:32:07,422 INFO - PID is 28363
2021-06-23 22:32:07,813 INFO - 
    -audit-log-dir              security audit log directory
    -authc                      security authentication setting (file|ldap|certificate)
    -auto-activate              automatically activate the node so that it becomes active or joins a stripe (true|false)
    -backup-dir                 node backup directory
    -bind-address               node bind address for port
    -client-lease-duration      client lease duration
    -client-reconnect-window    client reconnect window
    -cluster-name               cluster name
    -config-dir                 node configuration directory
    -config-file                configuration properties file
    -data-dirs                  data directory
    -failover-priority          failover priority setting (availability|consistency)
    -group-bind-address         node bind address for group port
    -group-port                 node port used for intra-stripe communication
    -help                       provide usage information
    -hostname                   node host name
    -log-dir                    node log directory
    -metadata-dir               node metadata directory
    -name                       node name
    -offheap-resources          offheap resources
    -port                       node port
    -public-hostname            public node host name
    -public-port                public node port
    -repair-mode                node repair mode (true|false)
    -security-dir               security root directory
    -ssl-tls                    ssl-tls setting (true|false)
    -stripe-name                stripe name
    -tc-properties              tc-properties
    -whitelist                  security whitelist (true|false)

Allowed substitution parameters:
    %v    version of the operating system. Same as java 'os.version' property
    %h    host name of the machine
    %H    home directory of the user. Same as java 'user.home' property
    %i    IP address of the machine corresponding to localhost
    %n    username of the user. Same as java 'user.name' property
    %o    name of the operating system. Same as java 'os.name' property
    %a    architecture of the machine. Same as java 'os.arch' property
    %c    canonical host name of the machine
    %t    temporary directory of the machine. Same as java 'java.io.tmpdir' property
    %d    unique temporary directory
    %D    date stamp corresponding to current time

2021-06-23 22:32:07,814 INFO - providing usage information
2021-06-23 22:32:07,814 INFO - ExitState : CallbackOnExitState[Throwable: class org.terracotta.configuration.ConfigurationException; RestartNeeded: false]; AutoRestart: true
2021-06-23 22:32:07,815 INFO - Stopping server
```