### PR TITLE
Fix deadlock when a nomad transaction is committed through the Nomad entity at the same time a diagnostic call is made to query the state of the configuration system

### DIFF
--- a/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/service/DynamicConfigServiceImpl.java
+++ b/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/service/DynamicConfigServiceImpl.java
@@ -23,7 +23,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terracotta.dynamic_config.api.model.Cluster;
 import org.terracotta.dynamic_config.api.model.ClusterState;
-import org.terracotta.dynamic_config.api.model.FailoverPriority;
 import org.terracotta.dynamic_config.api.model.License;
 import org.terracotta.dynamic_config.api.model.Node;
 import org.terracotta.dynamic_config.api.model.NodeContext;
@@ -57,43 +56,31 @@ import org.terracotta.server.Server;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.StandardCopyOption;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import static java.lang.System.lineSeparator;
 import static java.util.Objects.requireNonNull;
-import static org.terracotta.dynamic_config.api.model.FailoverPriority.Type.CONSISTENCY;
 import static org.terracotta.server.StopAction.RESTART;
 import static org.terracotta.server.StopAction.ZAP;
 
 public class DynamicConfigServiceImpl implements TopologyService, DynamicConfigService, DynamicConfigListener, StateDumpable {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(DynamicConfigServiceImpl.class);
-  private static final String LICENSE_FILE_NAME = "license.xml";
 
-  private final LicenseService licenseService;
   private final NomadServerManager nomadServerManager;
-  private final Path licensePath;
   private final ObjectMapper objectMapper;
   private final Server server;
-
-  private volatile NodeContext upcomingNodeContext;
-  private volatile NodeContext runtimeNodeContext;
+  private final Topologies topologies;
+  private final Licensing licensing;
 
   public DynamicConfigServiceImpl(NodeContext nodeContext, LicenseService licenseService, NomadServerManager nomadServerManager, ObjectMapperFactory objectMapperFactory, Server server) {
-    this.upcomingNodeContext = requireNonNull(nodeContext);
-    this.runtimeNodeContext = requireNonNull(nodeContext);
-    this.licenseService = requireNonNull(licenseService);
+    this.topologies = new Topologies(nodeContext);
+    this.licensing = new Licensing(licenseService, nomadServerManager.getConfigurationManager().getLicensePath());
     this.nomadServerManager = requireNonNull(nomadServerManager);
-    this.licensePath = nomadServerManager.getConfigurationManager().getLicensePath().resolve(LICENSE_FILE_NAME);
     this.objectMapper = objectMapperFactory.create();
     this.server = requireNonNull(server);
 
@@ -102,50 +89,45 @@ public class DynamicConfigServiceImpl implements TopologyService, DynamicConfigS
     new ClusterValidator(nodeContext.getCluster()).validate(ClusterState.CONFIGURING);
   }
 
-  // do not move this method up in the interface otherwise any client could access the license content through diagnostic port
-  public synchronized Optional<String> getLicenseContent() {
-    Path targetLicensePath = nomadServerManager.getConfigurationManager().getLicensePath().resolve(LICENSE_FILE_NAME);
-    if (targetLicensePath.toFile().exists()) {
-      try {
-        return Optional.of(new String(Files.readAllBytes(targetLicensePath), StandardCharsets.UTF_8));
-      } catch (IOException e) {
-        throw new UncheckedIOException(e);
-      }
-    }
-    return Optional.empty();
+  @Override
+  public Optional<String> getLicenseContent() {
+    return licensing.read();
   }
 
   @Override
   public void resetAndSync(NomadChangeInfo[] nomadChanges, Cluster cluster) {
     DynamicConfigNomadServer nomadServer = nomadServerManager.getNomadServer();
-    DynamicConfigNomadSynchronizer nomadSynchronizer = new DynamicConfigNomadSynchronizer(
-        nomadServerManager.getConfiguration().orElse(null), nomadServer);
+    DynamicConfigNomadSynchronizer nomadSynchronizer = new DynamicConfigNomadSynchronizer(nomadServerManager.getConfiguration().orElse(null), nomadServer);
 
-    List<NomadChangeInfo> backup;
-    Cluster thisTopology = upcomingNodeContext.getCluster();
-    try {
-      backup = nomadServer.getChangeHistory();
-    } catch (NomadException e) {
-      throw new IllegalStateException("Unable to reset and sync Nomad system: " + e.getMessage(), e);
-    }
+    topologies.withUpcoming(upcomingNodeContext -> {
+      Cluster thisTopology = upcomingNodeContext.getCluster();
 
-    try {
-      nomadSynchronizer.syncNomadChanges(Arrays.asList(nomadChanges), cluster);
-    } catch (NomadException e) {
+      List<NomadChangeInfo> backup;
+
       try {
-        nomadServer.reset();
-        nomadSynchronizer.syncNomadChanges(backup, thisTopology);
-      } catch (NomadException nomadException) {
-        e.addSuppressed(nomadException);
+        backup = nomadServer.getChangeHistory();
+      } catch (NomadException e) {
+        throw new IllegalStateException("Unable to reset and sync Nomad system: " + e.getMessage(), e);
       }
-      throw new IllegalStateException("Unable to reset and sync Nomad system: " + e.getMessage(), e);
-    }
+
+      try {
+        nomadSynchronizer.syncNomadChanges(Arrays.asList(nomadChanges), cluster);
+      } catch (NomadException e) {
+        try {
+          nomadServer.reset();
+          nomadSynchronizer.syncNomadChanges(backup, thisTopology);
+        } catch (NomadException nomadException) {
+          e.addSuppressed(nomadException);
+        }
+        throw new IllegalStateException("Unable to reset and sync Nomad system: " + e.getMessage(), e);
+      }
+    });
   }
 
   @Override
   public void addStateTo(StateDumpCollector stateDumpCollector) {
-    stateDumpCollector.addState("licensePath", licensePath.toString());
-    stateDumpCollector.addState("hasLicenseFile", hasLicenseFile());
+    stateDumpCollector.addState("licensePath", licensing.getLicenseFile().toString());
+    stateDumpCollector.addState("hasLicenseFile", licensing.isInstalled());
     stateDumpCollector.addState("configurationDir", nomadServerManager.getConfigurationManager().getConfigurationDirectory().toString());
     stateDumpCollector.addState("activated", isActivated());
     stateDumpCollector.addState("mustBeRestarted", mustBeRestarted());
@@ -181,7 +163,7 @@ public class DynamicConfigServiceImpl implements TopologyService, DynamicConfigS
 
   @Override
   public void onSettingChanged(SettingNomadChange change, Cluster updated) {
-    if (change.canUpdateRuntimeTopology(runtimeNodeContext)) {
+    if (change.canUpdateRuntimeTopology(getRuntimeNodeContext())) {
       LOGGER.info("Configuration change: {} applied at runtime", change.getSummary());
     } else {
       LOGGER.info("Configuration change: {} will be applied after restart", change.getSummary());
@@ -195,22 +177,22 @@ public class DynamicConfigServiceImpl implements TopologyService, DynamicConfigS
 
   @Override
   public void onNodeRemoval(UID stripeUID, Node removedNode) {
-    LOGGER.info("Removed node: {} from stripe: {}", removedNode.getName(), runtimeNodeContext.getCluster().getStripe(stripeUID).get().getName());
+    LOGGER.info("Removed node: {} from stripe: {}", removedNode.getName(), getRuntimeNodeContext().getCluster().getStripe(stripeUID).get().getName());
   }
 
   @Override
   public void onNodeAddition(UID stripeUID, Node addedNode) {
-    LOGGER.info("Added node: {} to stripe: {}", addedNode.getName(), runtimeNodeContext.getCluster().getStripe(stripeUID).get().getName());
+    LOGGER.info("Added node: {} to stripe: {}", addedNode.getName(), getRuntimeNodeContext().getCluster().getStripe(stripeUID).get().getName());
   }
 
   @Override
   public void onStripeAddition(Stripe addedStripe) {
-    LOGGER.info("Added stripe: {} to cluster: {}", addedStripe.toShapeString(), runtimeNodeContext.getCluster().toShapeString());
+    LOGGER.info("Added stripe: {} to cluster: {}", addedStripe.toShapeString(), getRuntimeNodeContext().getCluster().toShapeString());
   }
 
   @Override
   public void onStripeRemoval(Stripe removedStripe) {
-    LOGGER.info("Removed stripe: {} from cluster: {}", removedStripe.toShapeString(), runtimeNodeContext.getCluster().toShapeString());
+    LOGGER.info("Removed stripe: {} from cluster: {}", removedStripe.toShapeString(), getRuntimeNodeContext().getCluster().toShapeString());
   }
 
   @Override
@@ -231,8 +213,6 @@ public class DynamicConfigServiceImpl implements TopologyService, DynamicConfigS
     }
   }
 
-  // this is the only real listener where we act on in this service
-
   @Override
   public void onNomadCommit(CommitMessage message, AcceptRejectResponse response, ChangeState<NodeContext> changeState) {
     if (response.isAccepted()) {
@@ -242,54 +222,40 @@ public class DynamicConfigServiceImpl implements TopologyService, DynamicConfigS
       // extract the changes since there can be multiple settings change
       List<? extends DynamicConfigNomadChange> nomadChanges = MultiSettingNomadChange.extractChanges(dynamicConfigNomadChange.unwrap());
 
-      // the following code will be executed on all the nodes, regardless of the applicability
-      // level to update the config
-      synchronized (this) {
-        for (DynamicConfigNomadChange nomadChange : nomadChanges) {
-          // first we update the upcoming one
-          Cluster upcomingCluster = nomadChange.apply(upcomingNodeContext.getCluster());
-          upcomingNodeContext = upcomingNodeContext.withCluster(upcomingCluster).orElseGet(upcomingNodeContext::alone);
-          // if the change can be applied at runtime, it was previously done in the config change handler.
-          // so update also the runtime topology there
-          if (nomadChange.canUpdateRuntimeTopology(runtimeNodeContext)) {
-            Cluster runtimeCluster = nomadChange.apply(runtimeNodeContext.getCluster());
-            runtimeNodeContext = runtimeNodeContext.withCluster(runtimeCluster).orElseGet(runtimeNodeContext::alone);
-          }
-        }
+      topologies.update(nomadChanges);
+
+      if (topologies.areSame()) {
+        LOGGER.info("New cluster configuration: {}{}", lineSeparator(), Props.toString(getRuntimeNodeContext().getCluster().toProperties(false, false, true)));
+      } else {
+        LOGGER.info("Pending cluster configuration: {}{}", lineSeparator(), Props.toString(getUpcomingNodeContext().getCluster().toProperties(false, false, true)));
       }
 
-      if (runtimeNodeContext.equals(upcomingNodeContext)) {
-        LOGGER.info("New cluster configuration: {}{}", lineSeparator(), Props.toString(runtimeNodeContext.getCluster().toProperties(false, false, true)));
-        warnIfProblematicConsistency(runtimeNodeContext);
-      } else {
-        LOGGER.info("Pending cluster configuration: {}{}", lineSeparator(), Props.toString(upcomingNodeContext.getCluster().toProperties(false, false, true)));
-        warnIfProblematicConsistency(upcomingNodeContext);
-      }
+      topologies.warnIfProblematicConsistency();
     } else {
       LOGGER.warn("Nomad change {} failed to commit: {}", message.getChangeUuid(), response);
     }
   }
 
   @Override
-  public synchronized NodeContext getUpcomingNodeContext() {
-    return upcomingNodeContext.clone();
+  public NodeContext getUpcomingNodeContext() {
+    return topologies.getUpcomingNodeContext();
   }
 
   @Override
-  public synchronized NodeContext getRuntimeNodeContext() {
-    return runtimeNodeContext.clone();
+  public NodeContext getRuntimeNodeContext() {
+    return topologies.getRuntimeNodeContext();
   }
 
   @Override
-  public synchronized boolean isActivated() {
+  public boolean isActivated() {
     // a node is activated when nomad is enabled and a last committed config is available
     return nomadServerManager.getNomadMode() == NomadMode.RW
         && nomadServerManager.getConfiguration().isPresent();
   }
 
   @Override
-  public synchronized boolean mustBeRestarted() {
-    return !runtimeNodeContext.equals(upcomingNodeContext);
+  public boolean mustBeRestarted() {
+    return !topologies.areSame();
   }
 
   @Override
@@ -298,66 +264,46 @@ public class DynamicConfigServiceImpl implements TopologyService, DynamicConfigS
   }
 
   @Override
-  public synchronized void setUpcomingCluster(Cluster updatedCluster) {
-    requireNonNull(updatedCluster);
-
+  public void setUpcomingCluster(Cluster updatedCluster) {
     if (isActivated()) {
-      throw new IllegalStateException("Use Nomad instead to change the topology of activated node: " + runtimeNodeContext.getNode().getName());
+      // we only allow direct replacement if the node is not activated
+      throw new IllegalStateException("Use Nomad instead to change the topology of activated node: " + getRuntimeNodeContext().getNode().getName());
     }
-
-    new ClusterValidator(updatedCluster).validate(ClusterState.CONFIGURING);
-
-    Node newMe = findMe(updatedCluster);
-
-    if (newMe != null) {
-      // we have updated the topology and I am still part of this cluster
-      LOGGER.info("Set upcoming topology to:\n{}", updatedCluster);
-      this.upcomingNodeContext = new NodeContext(updatedCluster, newMe.getUID());
-    } else {
-      // We have updated the topology and I am not part anymore of the cluster
-      // So we just reset the cluster object so that this node is alone
-      Node oldMe = upcomingNodeContext.getNode();
-      LOGGER.info("Node {} ({}) removed from pending topology: {}", oldMe.getName(), oldMe.getUID(), updatedCluster.toShapeString());
-      this.upcomingNodeContext = this.upcomingNodeContext.withOnlyNode(oldMe);
-    }
-
-    // When node is not yet activated, runtimeNodeContext == upcomingNodeContext
-    this.runtimeNodeContext = upcomingNodeContext;
+    topologies.install(updatedCluster);
   }
 
   @Override
-  public synchronized void activate(Cluster maybeUpdatedCluster, String licenseContent) {
+  public void activate(Cluster maybeUpdatedCluster, String licenseContent) {
     LOGGER.info("Activating configuration system on this node with topology: {}", maybeUpdatedCluster.toShapeString());
 
     // This check is only present to safeguard against the possibility of a missing cluster validation in the call path
     new ClusterValidator(maybeUpdatedCluster).validate(ClusterState.ACTIVATED);
 
     // validate that we are part of this cluster
-    if (findMe(maybeUpdatedCluster) == null) {
+    if (!topologies.containsMe(maybeUpdatedCluster)) {
       throw new IllegalArgumentException(String.format(
           "No match found for node: %s in cluster topology: %s",
-          upcomingNodeContext.getNodeUID(),
+          getUpcomingNodeContext().getNodeUID(),
           maybeUpdatedCluster
       ));
     }
 
-    // install the new topology and license
-    this.setUpcomingCluster(maybeUpdatedCluster);
+    NodeContext installed = topologies.install(maybeUpdatedCluster);
 
     // activate nomad system if this wasn't done before then just make sure we can send Nomad transactions
     nomadServerManager.initNomad();
     nomadServerManager.setNomad(NomadMode.RW);
 
     // install the license AFTER the nomad system is initialized (no config directory exist before)
-    this.installLicense(licenseContent);
+    licensing.install(licenseContent, installed.getCluster());
 
-    warnIfProblematicConsistency(upcomingNodeContext);
+    topologies.warnIfProblematicConsistency();
 
     LOGGER.info("Configuration system activated");
   }
 
   @Override
-  public synchronized void reset() {
+  public void reset() {
     LOGGER.info("Resetting...");
     try {
       nomadServerManager.reset();
@@ -403,13 +349,13 @@ public class DynamicConfigServiceImpl implements TopologyService, DynamicConfigS
   }
 
   @Override
-  public synchronized void upgradeLicense(String licenseContent) {
-    this.installLicense(licenseContent);
+  public void upgradeLicense(String licenseContent) {
+    licensing.install(licenseContent, getUpcomingNodeContext().getCluster());
   }
 
   @Override
-  public synchronized Optional<License> getLicense() {
-    return hasLicenseFile() ? Optional.of(licenseService.parse(licensePath)) : Optional.empty();
+  public Optional<License> getLicense() {
+    return licensing.parse();
   }
 
   @Override
@@ -422,14 +368,8 @@ public class DynamicConfigServiceImpl implements TopologyService, DynamicConfigS
   }
 
   @Override
-  public synchronized boolean validateAgainstLicense(Cluster cluster) throws InvalidLicenseException {
-    if (!hasLicenseFile()) {
-      LOGGER.warn("Unable to validate cluster against license: license not installed: {}", cluster.toShapeString());
-      return false;
-    }
-    licenseService.validate(licensePath, cluster);
-    LOGGER.debug("License is valid for cluster: {}", cluster.toShapeString());
-    return true;
+  public boolean validateAgainstLicense(Cluster cluster) throws InvalidLicenseException {
+    return licensing.validate(cluster);
   }
 
   private Map<String, ?> toMap(Object o) {
@@ -440,64 +380,6 @@ public class DynamicConfigServiceImpl implements TopologyService, DynamicConfigS
     } catch (IOException e) {
       throw new UncheckedIOException(e);
     }
-  }
-
-  private synchronized void installLicense(String licenseContent) {
-    if (licenseContent != null) {
-      Path tempFile = null;
-      try {
-        tempFile = Files.createTempFile("terracotta-license-", ".xml");
-        Files.write(tempFile, licenseContent.getBytes(StandardCharsets.UTF_8));
-        licenseService.validate(tempFile, upcomingNodeContext.getCluster());
-        LOGGER.info("License validated");
-        LOGGER.debug("Moving license file: {} to: {}", tempFile, licensePath);
-        org.terracotta.utilities.io.Files.relocate(tempFile, licensePath, StandardCopyOption.REPLACE_EXISTING);
-        LOGGER.info("License installed");
-      } catch (IOException e) {
-        throw new UncheckedIOException(e);
-      } finally {
-        if (tempFile != null) {
-          try {
-            org.terracotta.utilities.io.Files.deleteIfExists(tempFile);
-          } catch (IOException ignored) {
-          }
-        }
-      }
-      LOGGER.info("License installation successful");
-
-    } else {
-      LOGGER.info("No license installed");
-      try {
-        org.terracotta.utilities.io.Files.deleteIfExists(licensePath);
-      } catch (IOException e) {
-        LOGGER.warn("Error deleting existing license: " + e.getMessage(), e);
-      }
-    }
-  }
-
-  private boolean hasLicenseFile() {
-    return licensePath.toFile().exists() && Files.isRegularFile(licensePath) && Files.isReadable(licensePath);
-  }
-
-  /**
-   * Tries to find the node representing this process within the updated cluster.
-   * <p>
-   * - We cannot use the node hostname or port only, since they might have changed through a set command.
-   * - We cannot use the node name and stripe ID only, since the stripe ID can have changed in the new cluster with the attach/detach commands
-   * - Name could change following a set command when un-configured
-   * <p>
-   * So we try to find the best match we can...
-   */
-  private synchronized Node findMe(Cluster updatedCluster) {
-    final Node me = upcomingNodeContext.getNode();
-    for (Node node : updatedCluster.getNodes()) {
-      if (node.getUID().equals(me.getUID())
-          || node.getInternalAddress().equals(me.getInternalAddress())
-          || node.getName().equals(me.getName())) {
-        return node;
-      }
-    }
-    return null;
   }
 
   private void runAfterDelay(Duration delayInSeconds, Runnable runnable) {
@@ -525,24 +407,4 @@ public class DynamicConfigServiceImpl implements TopologyService, DynamicConfigS
     }.start();
   }
 
-  private void warnIfProblematicConsistency(NodeContext nodeContext) {
-    FailoverPriority failover = nodeContext.getCluster().getFailoverPriority().orElse(null);
-    if (failover != null && failover.getType() == CONSISTENCY) {
-      int voters = failover.getVoters();
-      List<Stripe> evenNodeStripes = nodeContext.getCluster().getStripes()
-          .stream().filter(s -> (s.getNodeCount() + voters) % 2 == 0).collect(Collectors.toList());
-      if (evenNodeStripes.size() > 0) {
-        StringBuilder warn = new StringBuilder(lineSeparator());
-        warn.append("===================================================================================================================").append(lineSeparator());
-        warn.append("When a cluster is configured with failover-priority=consistency, stripes with an even number").append(lineSeparator());
-        warn.append("of nodes plus voters are more likely to experience split brain situations.").append(lineSeparator());
-        warn.append("The following stripe(s) have an even number of nodes plus voters:").append(lineSeparator());
-        for (Stripe s : evenNodeStripes) {
-          warn.append("   Stripe: '").append(s.getName()).append("' has ").append(s.getNodeCount()).append(" nodes and ").append(voters).append(" voters.").append(lineSeparator());
-        }
-        warn.append("===================================================================================================================").append(lineSeparator());
-        LOGGER.warn(warn.toString());
-      }
-    }
-  }
 }

--- a/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/service/Licensing.java
+++ b/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/service/Licensing.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.dynamic_config.server.configuration.service;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.terracotta.dynamic_config.api.model.Cluster;
+import org.terracotta.dynamic_config.api.model.License;
+import org.terracotta.dynamic_config.server.api.InvalidLicenseException;
+import org.terracotta.dynamic_config.server.api.LicenseService;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.Optional;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * @author Mathieu Carbou
+ */
+class Licensing {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(Licensing.class);
+  private static final String LICENSE_FILE_NAME = "license.xml";
+
+  // guard access to the installed license
+  private final ReadWriteLock licenseLock = new ReentrantReadWriteLock();
+
+  private final LicenseService licenseService;
+  private final Path licenseFile;
+
+  public Licensing(LicenseService licenseService, Path licenseDir) {
+    this.licenseService = requireNonNull(licenseService);
+    this.licenseFile = requireNonNull(licenseDir).resolve(LICENSE_FILE_NAME);
+  }
+
+  public Path getLicenseFile() {
+    return licenseFile;
+  }
+
+  public boolean isInstalled() {
+    licenseLock.readLock().lock();
+    try {
+      return licenseFile.toFile().exists() && Files.isRegularFile(licenseFile) && Files.isReadable(licenseFile);
+    } finally {
+      licenseLock.readLock().unlock();
+    }
+  }
+
+  public Optional<String> read() throws UncheckedIOException, IllegalStateException {
+    licenseLock.readLock().lock();
+    try {
+      return licenseFile.toFile().exists() ?
+          Optional.of(new String(Files.readAllBytes(licenseFile), StandardCharsets.UTF_8)) :
+          Optional.empty();
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    } finally {
+      licenseLock.readLock().unlock();
+    }
+  }
+
+  public Optional<License> parse() {
+    licenseLock.readLock().lock();
+    try {
+      return isInstalled() ? Optional.of(licenseService.parse(licenseFile)) : Optional.empty();
+    } finally {
+      licenseLock.readLock().unlock();
+    }
+  }
+
+  /**
+   * @return false is license not installed, true if valid, {@code org.terracotta.dynamic_config.server.api.LicenseService#validate} will throw if invalid
+   */
+  public boolean validate(Cluster cluster) throws InvalidLicenseException {
+    licenseLock.readLock().lock();
+    try {
+      if (!isInstalled()) {
+        LOGGER.warn("Unable to validate cluster against license: license not installed: {}", cluster.toShapeString());
+        return false;
+      }
+      licenseService.validate(licenseFile, cluster);
+      LOGGER.debug("License is valid for cluster: {}", cluster.toShapeString());
+      return true;
+    } finally {
+      licenseLock.readLock().unlock();
+    }
+  }
+
+  public void install(String licenseContent, Cluster cluster) {
+    licenseLock.writeLock().lock();
+    try {
+      if (licenseContent != null) {
+        try {
+          final Path tempFile = Files.createTempFile("terracotta-license-", ".xml");
+          try {
+            Files.write(tempFile, licenseContent.getBytes(StandardCharsets.UTF_8));
+            licenseService.validate(tempFile, cluster);
+            LOGGER.info("License validated");
+            LOGGER.debug("Moving license file: {} to: {}", tempFile, licenseFile);
+            org.terracotta.utilities.io.Files.relocate(tempFile, licenseFile, StandardCopyOption.REPLACE_EXISTING);
+            LOGGER.info("License installed");
+          } finally {
+            try {
+              org.terracotta.utilities.io.Files.deleteIfExists(tempFile);
+            } catch (IOException ignored) {
+            }
+          }
+        } catch (IOException e) {
+          throw new UncheckedIOException(e);
+        }
+        LOGGER.info("License installation successful");
+      } else if (isInstalled()) {
+        try {
+          org.terracotta.utilities.io.Files.deleteIfExists(licenseFile);
+        } catch (IOException e) {
+          throw new UncheckedIOException("Error deleting existing license " + licenseFile + ": " + e.getMessage(), e);
+        }
+        LOGGER.info("License removal successful");
+      } else {
+        LOGGER.info("No license installed");
+      }
+    } finally {
+      licenseLock.writeLock().unlock();
+    }
+  }
+
+}

--- a/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/service/Topologies.java
+++ b/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/service/Topologies.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.dynamic_config.server.configuration.service;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.terracotta.dynamic_config.api.model.Cluster;
+import org.terracotta.dynamic_config.api.model.ClusterState;
+import org.terracotta.dynamic_config.api.model.FailoverPriority;
+import org.terracotta.dynamic_config.api.model.Node;
+import org.terracotta.dynamic_config.api.model.NodeContext;
+import org.terracotta.dynamic_config.api.model.Stripe;
+import org.terracotta.dynamic_config.api.model.nomad.DynamicConfigNomadChange;
+import org.terracotta.dynamic_config.api.service.ClusterValidator;
+
+import java.util.List;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+
+import static java.lang.System.lineSeparator;
+import static java.util.Objects.requireNonNull;
+import static org.terracotta.dynamic_config.api.model.FailoverPriority.Type.CONSISTENCY;
+
+/**
+ * @author Mathieu Carbou
+ */
+class Topologies {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(Topologies.class);
+
+  // guard access to the topologies
+  private final ReadWriteLock topologyLock = new ReentrantReadWriteLock();
+
+  private NodeContext upcomingNodeContext;
+  private NodeContext runtimeNodeContext;
+
+  Topologies(NodeContext nodeContext) {
+    upcomingNodeContext = runtimeNodeContext = requireNonNull(nodeContext);
+  }
+
+  public void withUpcoming(Consumer<NodeContext> c) {
+    topologyLock.readLock().lock();
+    try {
+      c.accept(upcomingNodeContext);
+    } finally {
+      topologyLock.readLock().unlock();
+    }
+  }
+
+  public NodeContext getUpcomingNodeContext() {
+    topologyLock.readLock().lock();
+    try {
+      return upcomingNodeContext.clone();
+    } finally {
+      topologyLock.readLock().unlock();
+    }
+  }
+
+  public NodeContext getRuntimeNodeContext() {
+    topologyLock.readLock().lock();
+    try {
+      return runtimeNodeContext.clone();
+    } finally {
+      topologyLock.readLock().unlock();
+    }
+  }
+
+  public boolean areSame() {
+    topologyLock.readLock().lock();
+    try {
+      return runtimeNodeContext.equals(upcomingNodeContext);
+    } finally {
+      topologyLock.readLock().unlock();
+    }
+  }
+
+  public NodeContext install(Cluster updatedCluster) {
+    requireNonNull(updatedCluster);
+
+    topologyLock.writeLock().lock();
+    try {
+      new ClusterValidator(updatedCluster).validate(ClusterState.CONFIGURING);
+
+      Node newMe = findMe(updatedCluster);
+
+      if (newMe != null) {
+        // we have updated the topology and I am still part of this cluster
+        LOGGER.info("Set upcoming topology to:\n{}", updatedCluster);
+        this.upcomingNodeContext = new NodeContext(updatedCluster, newMe.getUID());
+
+      } else {
+        // We have updated the topology and I am not part anymore of the cluster
+        // So we just reset the cluster object so that this node is alone
+        Node oldMe = upcomingNodeContext.getNode();
+        LOGGER.info("Node {} ({}) removed from pending topology: {}", oldMe.getName(), oldMe.getUID(), updatedCluster.toShapeString());
+        this.upcomingNodeContext = this.upcomingNodeContext.withOnlyNode(oldMe);
+      }
+
+      // When node is not yet activated, runtimeNodeContext == upcomingNodeContext
+      this.runtimeNodeContext = upcomingNodeContext;
+      return upcomingNodeContext;
+
+    } finally {
+      topologyLock.writeLock().unlock();
+    }
+  }
+
+  /**
+   * Tries to find the node representing this process within the updated cluster.
+   * <p>
+   * - We cannot use the node hostname or port only, since they might have changed through a set command.
+   * - We cannot use the node name and stripe ID only, since the stripe ID can have changed in the new cluster with the attach/detach commands
+   * - Name could change following a set command when un-configured
+   * <p>
+   * So we try to find the best match we can...
+   */
+  private Node findMe(Cluster updatedCluster) {
+    final Node me = getUpcomingNodeContext().getNode();
+    for (Node node : updatedCluster.getNodes()) {
+      if (node.getUID().equals(me.getUID())
+          || node.getInternalAddress().equals(me.getInternalAddress())
+          || node.getName().equals(me.getName())) {
+        return node;
+      }
+    }
+    return null;
+  }
+
+  public boolean containsMe(Cluster maybeUpdatedCluster) {
+    return findMe(maybeUpdatedCluster) != null;
+  }
+
+  public void update(List<? extends DynamicConfigNomadChange> nomadChanges) {
+    // the following code will be executed on all the nodes, regardless of the applicability
+    // level to update the config
+    topologyLock.writeLock().lock();
+    try {
+      for (DynamicConfigNomadChange nomadChange : nomadChanges) {
+        // first we update the upcoming one
+        Cluster upcomingCluster = nomadChange.apply(upcomingNodeContext.getCluster());
+        upcomingNodeContext = upcomingNodeContext.withCluster(upcomingCluster).orElseGet(upcomingNodeContext::alone);
+        // if the change can be applied at runtime, it was previously done in the config change handler.
+        // so update also the runtime topology there
+        if (nomadChange.canUpdateRuntimeTopology(runtimeNodeContext)) {
+          Cluster runtimeCluster = nomadChange.apply(runtimeNodeContext.getCluster());
+          runtimeNodeContext = runtimeNodeContext.withCluster(runtimeCluster).orElseGet(runtimeNodeContext::alone);
+        }
+      }
+    } finally {
+      topologyLock.writeLock().unlock();
+    }
+  }
+
+  public void warnIfProblematicConsistency() {
+    final NodeContext nodeContext = getUpcomingNodeContext();
+    FailoverPriority failover = nodeContext.getCluster().getFailoverPriority().orElse(null);
+    if (failover != null && failover.getType() == CONSISTENCY) {
+      int voters = failover.getVoters();
+      List<Stripe> evenNodeStripes = nodeContext.getCluster().getStripes()
+          .stream().filter(s -> (s.getNodeCount() + voters) % 2 == 0).collect(Collectors.toList());
+      if (evenNodeStripes.size() > 0) {
+        StringBuilder warn = new StringBuilder(lineSeparator());
+        warn.append("===================================================================================================================").append(lineSeparator());
+        warn.append("When a cluster is configured with failover-priority=consistency, stripes with an even number").append(lineSeparator());
+        warn.append("of nodes plus voters are more likely to experience split brain situations.").append(lineSeparator());
+        warn.append("The following stripe(s) have an even number of nodes plus voters:").append(lineSeparator());
+        for (Stripe s : evenNodeStripes) {
+          warn.append("   Stripe: '").append(s.getName()).append("' has ").append(s.getNodeCount()).append(" nodes and ").append(voters).append(" voters.").append(lineSeparator());
+        }
+        warn.append("===================================================================================================================").append(lineSeparator());
+        LOGGER.warn(warn.toString());
+      }
+    }
+  }
+}


### PR DESCRIPTION
I have also updated the other synchronization in this class. Historically this class was containing a lot of states, which are now moved elsewhere, but I forgot to update the sync. So this PR is syncing with more granularity now.

Note: there can still be some corner cases happening... I.e. when nodes are not activated and supposing someone is concurrently exporting a topology to the same node while reading the topology at the same time. But well, clearly this is asking for troubles...