### PR TITLE
Several lock fixes or simplifications

### DIFF
--- a/dynamic-config/cli/dynamic-config-cli-api/src/main/java/org/terracotta/dynamic_config/cli/api/output/InMemoryOutputService.java
+++ b/dynamic-config/cli/dynamic-config-cli-api/src/main/java/org/terracotta/dynamic_config/cli/api/output/InMemoryOutputService.java
@@ -17,42 +17,45 @@ package org.terracotta.dynamic_config.cli.api.output;
 
 import org.slf4j.helpers.MessageFormatter;
 
-import java.util.ArrayList;
-import java.util.LinkedList;
 import java.util.List;
+import java.util.Queue;
 import java.util.StringTokenizer;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.stream.Stream;
+
+import static java.util.Collections.emptyList;
 
 public class InMemoryOutputService implements OutputService {
 
-  private final List<String> lines;
+  private final Queue<String> lines = new ConcurrentLinkedQueue<>();
 
   public InMemoryOutputService() {
-    this(new LinkedList<>());
+    this(emptyList());
   }
 
   public InMemoryOutputService(List<String> buffer) {
-    this.lines = buffer;
+    this.lines.addAll(buffer);
   }
 
-  public synchronized void clear() {
+  public void clear() {
     lines.clear();
   }
 
-  public synchronized List<String> getOutput() {
-    return new ArrayList<>(lines);
+  public Stream<String> lines() {
+    return lines.stream();
   }
 
   @Override
-  public synchronized String toString() {
+  public String toString() {
     return "memory";
   }
 
   @Override
-  public synchronized void out(String format, Object... args) {
+  public void out(String format, Object... args) {
     // Split using both Windows and UNIX line separators
     StringTokenizer st = new StringTokenizer(MessageFormatter.arrayFormat(format, args).getMessage(), "\n\r");
     while (st.hasMoreTokens()) {
-      lines.add(st.nextToken());
+      lines.offer(st.nextToken());
     }
   }
 }

--- a/dynamic-config/model/src/main/java/org/terracotta/dynamic_config/api/service/ConfigurationParser.java
+++ b/dynamic-config/model/src/main/java/org/terracotta/dynamic_config/api/service/ConfigurationParser.java
@@ -52,6 +52,8 @@ import static org.terracotta.dynamic_config.api.model.Scope.STRIPE;
  * Parses CLI or config file into a Cluster object, but does not validate the cluster object
  * <p>
  * This class purpose is to be used internally in {@link ClusterFactory}
+ * <p>
+ * IMPORTANT: this class is not thread-safe. It has to be constructed and used (parse) by the same thread.
  */
 class ConfigurationParser {
 
@@ -73,7 +75,7 @@ class ConfigurationParser {
    * The cluster object is NOT validated and will need to be validated with the
    * {@link ClusterValidator}
    */
-  public synchronized Cluster parse() {
+  public Cluster parse() {
     // Determine the number of stripes and nodes.
     // This map gives a configuration list per node and stripe
     final TreeMap<Integer, TreeSet<Integer>> ids = configurations.stream()

--- a/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/service/AuditService.java
+++ b/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/service/AuditService.java
@@ -34,7 +34,7 @@ public class AuditService implements DynamicConfigService {
   }
 
   @Override
-  public synchronized Optional<String> getLicenseContent() {
+  public Optional<String> getLicenseContent() {
     server.audit("License retrieval requested", new Properties());
     return dynamicConfigService.getLicenseContent();
   }
@@ -52,7 +52,7 @@ public class AuditService implements DynamicConfigService {
   }
 
   @Override
-  public synchronized void activate(Cluster maybeUpdatedCluster, String licenseContent) {
+  public void activate(Cluster maybeUpdatedCluster, String licenseContent) {
     server.audit("Activate invoked", new Properties());
     dynamicConfigService.activate(maybeUpdatedCluster, licenseContent);
   }
@@ -88,7 +88,7 @@ public class AuditService implements DynamicConfigService {
   }
 
   @Override
-  public synchronized void upgradeLicense(String licenseContent) {
+  public void upgradeLicense(String licenseContent) {
     server.audit("Upgrade license invoked", new Properties());
     dynamicConfigService.upgradeLicense(licenseContent);
   }

--- a/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/service/NomadServerManager.java
+++ b/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/service/NomadServerManager.java
@@ -306,7 +306,7 @@ public class NomadServerManager {
     setNomad(NomadMode.RO);
   }
 
-  public synchronized NomadMode getNomadMode() {
+  public NomadMode getNomadMode() {
     return nomadServer.getChangeApplicator() == null ? NomadMode.RO : NomadMode.RW;
   }
 

--- a/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/service/ParameterSubstitutor.java
+++ b/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/service/ParameterSubstitutor.java
@@ -127,8 +127,14 @@ public class ParameterSubstitutor implements IParameterSubstitutor {
 
   @SuppressWarnings("ResultOfMethodCallIgnored")
   @SuppressFBWarnings("RV_RETURN_VALUE_IGNORED_BAD_PRACTICE")
-  private static synchronized String getUniqueTempDirectory() {
-    if (uniqueTempDirectory == null) {
+  private static String getUniqueTempDirectory() {
+    if (uniqueTempDirectory != null) {
+      return uniqueTempDirectory;
+    }
+    synchronized (ParameterSubstitutor.class) {
+      if (uniqueTempDirectory != null) {
+        return uniqueTempDirectory;
+      }
       try {
         File theFile = File.createTempFile("terracotta", "data");
         theFile.delete();
@@ -140,14 +146,12 @@ public class ParameterSubstitutor implements IParameterSubstitutor {
       } catch (IOException ioe) {
         uniqueTempDirectory = System.getProperty("java.io.tmpdir");
       }
+      return uniqueTempDirectory;
     }
-
-    return uniqueTempDirectory;
   }
 
-  private static synchronized String getDatestamp() {
-    SimpleDateFormat format = new SimpleDateFormat("yyyyMMddHHmmssSSS");
-    return format.format(new Date(System.currentTimeMillis()));
+  private static String getDatestamp() {
+    return new SimpleDateFormat("yyyyMMddHHmmssSSS").format(new Date(System.currentTimeMillis()));
   }
 
   public static String getCanonicalHostName() {

--- a/dynamic-config/server/configuration-repository/src/main/java/org/terracotta/dynamic_config/server/configuration/nomad/SingleThreadedNomadServer.java
+++ b/dynamic-config/server/configuration-repository/src/main/java/org/terracotta/dynamic_config/server/configuration/nomad/SingleThreadedNomadServer.java
@@ -33,12 +33,13 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
-import java.util.concurrent.locks.ReentrantLock;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.BiFunction;
 
 public class SingleThreadedNomadServer implements DynamicConfigNomadServer {
   private final DynamicConfigNomadServer underlying;
-  protected final ReentrantLock lock = new ReentrantLock(true);
+  private final ReadWriteLock lock = new ReentrantReadWriteLock(true);
 
   public SingleThreadedNomadServer(DynamicConfigNomadServer underlying) {
     this.underlying = underlying;
@@ -46,141 +47,141 @@ public class SingleThreadedNomadServer implements DynamicConfigNomadServer {
 
   @Override
   public void reset() throws NomadException {
-    lock.lock();
+    lock.writeLock().lock();
     try {
       underlying.reset();
     } finally {
-      lock.unlock();
+      lock.writeLock().unlock();
     }
   }
 
   @Override
   public void close() {
-    lock.lock();
+    lock.writeLock().lock();
     try {
       underlying.close();
     } finally {
-      lock.unlock();
+      lock.writeLock().unlock();
     }
   }
 
   @Override
   public DiscoverResponse<NodeContext> discover() throws NomadException {
-    lock.lock();
+    lock.readLock().lock();
     try {
       return underlying.discover();
     } finally {
-      lock.unlock();
+      lock.readLock().unlock();
     }
   }
 
   @Override
   public AcceptRejectResponse prepare(PrepareMessage message) throws NomadException {
-    lock.lock();
+    lock.writeLock().lock();
     try {
       return underlying.prepare(message);
     } finally {
-      lock.unlock();
+      lock.writeLock().unlock();
     }
   }
 
   @Override
   public AcceptRejectResponse commit(CommitMessage message) throws NomadException {
-    lock.lock();
+    lock.writeLock().lock();
     try {
       return underlying.commit(message);
     } finally {
-      lock.unlock();
+      lock.writeLock().unlock();
     }
   }
 
   @Override
   public AcceptRejectResponse rollback(RollbackMessage message) throws NomadException {
-    lock.lock();
+    lock.writeLock().lock();
     try {
       return underlying.rollback(message);
     } finally {
-      lock.unlock();
+      lock.writeLock().unlock();
     }
   }
 
   @Override
   public AcceptRejectResponse takeover(TakeoverMessage message) throws NomadException {
-    lock.lock();
+    lock.writeLock().lock();
     try {
       return underlying.takeover(message);
     } finally {
-      lock.unlock();
+      lock.writeLock().unlock();
     }
   }
 
   @Override
   public boolean hasIncompleteChange() {
-    lock.lock();
+    lock.readLock().lock();
     try {
       return underlying.hasIncompleteChange();
     } finally {
-      lock.unlock();
+      lock.readLock().unlock();
     }
   }
 
   @Override
   public Optional<ChangeState<NodeContext>> getConfig(UUID changeUUID) throws NomadException {
-    lock.lock();
+    lock.readLock().lock();
     try {
       return underlying.getConfig(changeUUID);
     } finally {
-      lock.unlock();
+      lock.readLock().unlock();
     }
   }
 
   @Override
   public Optional<NodeContext> getCurrentCommittedConfig() throws NomadException {
-    lock.lock();
+    lock.readLock().lock();
     try {
       return underlying.getCurrentCommittedConfig();
     } finally {
-      lock.unlock();
+      lock.readLock().unlock();
     }
   }
 
   @Override
   public void forceSync(Collection<NomadChangeInfo> changes, BiFunction<NodeContext, NomadChange, NodeContext> fn) throws NomadException {
-    lock.lock();
+    lock.writeLock().lock();
     try {
       underlying.forceSync(changes, fn);
     } finally {
-      lock.unlock();
+      lock.writeLock().unlock();
     }
   }
 
   @Override
   public void setChangeApplicator(ChangeApplicator<NodeContext> changeApplicator) {
-    lock.lock();
+    lock.writeLock().lock();
     try {
       underlying.setChangeApplicator(changeApplicator);
     } finally {
-      lock.unlock();
+      lock.writeLock().unlock();
     }
   }
 
   @Override
   public ChangeApplicator<NodeContext> getChangeApplicator() {
-    lock.lock();
+    lock.readLock().lock();
     try {
       return underlying.getChangeApplicator();
     } finally {
-      lock.unlock();
+      lock.readLock().unlock();
     }
   }
 
   @Override
   public List<NomadChangeInfo> getChangeHistory() throws NomadException {
-    lock.lock();
+    lock.readLock().lock();
     try {
       return underlying.getChangeHistory();
     } finally {
-      lock.unlock();
+      lock.readLock().unlock();
     }
   }
 }

--- a/dynamic-config/testing/support/src/main/java/org/terracotta/dynamic_config/test_support/DynamicConfigIT.java
+++ b/dynamic-config/testing/support/src/main/java/org/terracotta/dynamic_config/test_support/DynamicConfigIT.java
@@ -92,6 +92,7 @@ import java.util.stream.Stream;
 import static java.lang.System.lineSeparator;
 import static java.util.Collections.emptyList;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.stream.Collectors.toList;
 import static java.util.stream.IntStream.rangeClosed;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
@@ -892,7 +893,7 @@ public class DynamicConfigIT {
 
     @Override
     public List<String> getOutput() {
-      return delegate.getOutput();
+      return delegate.lines().collect(toList());
     }
 
     @Override


### PR DESCRIPTION
@GaryWKeim found another deadlock caused by an exclusive lock placed in `SingleThreadedNomadServer` (since this class was initially created) while a concurrent call to diagnostic port is happening.

So I did a review of the other `synchronized` and lock usages in DC to fix / simplify them.