### PR TITLE
TDB-5405 DiagnosticService call to Connected Client version info

### DIFF
--- a/diagnostic/client/src/main/java/org/terracotta/diagnostic/client/DiagnosticService.java
+++ b/diagnostic/client/src/main/java/org/terracotta/diagnostic/client/DiagnosticService.java
@@ -15,6 +15,7 @@
  */
 package org.terracotta.diagnostic.client;
 
+import org.terracotta.diagnostic.model.ConnectedClientInformation;
 import org.terracotta.diagnostic.model.KitInformation;
 import org.terracotta.diagnostic.model.LogicalServerState;
 
@@ -128,6 +129,10 @@ public interface DiagnosticService extends DiagnosticMBeanSupport, Closeable {
 
   default boolean isReconnectWindow() {
     return Boolean.parseBoolean(invoke(MBEAN_SERVER, "isReconnectWindow"));
+  }
+
+  default ConnectedClientInformation getConnectedClientInformation() {
+    return ConnectedClientInformation.fromProperties(invoke(MBEAN_SERVER, "getConnectedClients"));
   }
 
   // DiagnosticsHandler

--- a/diagnostic/model/src/main/java/org/terracotta/diagnostic/model/ClientInfo.java
+++ b/diagnostic/model/src/main/java/org/terracotta/diagnostic/model/ClientInfo.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.diagnostic.model;
+
+public class ClientInfo {
+
+  private final String id;
+  private final String name;
+  private final String version;
+  private final String revision;
+  private final String ipAddress;
+
+  public ClientInfo(String[] params) {
+    this(params[0], params[1], params[2], params[3], params[4]);
+  }
+
+  public ClientInfo(String id, String name, String version, String revision, String ipAddress) {
+    this.id = id;
+    this.name = name;
+    this.version = version;
+    this.revision = revision;
+    this.ipAddress = ipAddress;
+  }
+
+  public String getId() {
+    return id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public String getVersion() {
+    return version;
+  }
+
+  public String getRevision() {
+    return revision;
+  }
+
+  public String getIpAddress() {
+    return ipAddress;
+  }
+
+  public String getFormattedVersion() {
+    return version + "/" + (revision.isEmpty() ? "revision not available" : revision);
+  }
+}

--- a/diagnostic/model/src/main/java/org/terracotta/diagnostic/model/ConnectedClientInformation.java
+++ b/diagnostic/model/src/main/java/org/terracotta/diagnostic/model/ConnectedClientInformation.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.diagnostic.model;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.io.UncheckedIOException;
+import java.util.List;
+import java.util.Properties;
+import java.util.stream.Stream;
+
+import static java.lang.Integer.parseInt;
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.IntStream.range;
+
+public class ConnectedClientInformation {
+
+  static final String PROP_ID = "id";
+  static final String PROP_NAME = "name";
+  static final String PROP_VERSION = "version";
+  static final String PROP_REVISION = "revision";
+  static final String PROP_IPADDRESS = "ipAddress";
+
+  List<ClientInfo> connectedClientsInfo;
+
+  public ConnectedClientInformation(List<ClientInfo> clients) {
+    this.connectedClientsInfo = clients;
+  }
+
+  public List<ClientInfo> getConnectedClients() {
+    return connectedClientsInfo;
+  }
+
+  @Override
+  public String toString() {
+    try {
+      StringWriter sw = new StringWriter();
+      toProperties().store(sw, null);
+      return sw.toString();
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+
+  public Properties toProperties() {
+    final String format = "clients.%d.%s";
+    final int numClients = connectedClientsInfo.size();
+    Properties props = new Properties();
+    props.setProperty("clients.count", Integer.toString(numClients));
+    for (int i = 0; i < numClients; i++) {
+      ClientInfo c = connectedClientsInfo.get(i);
+      props.setProperty(String.format(format, i, PROP_ID), c.getId());
+      props.setProperty(String.format(format, i, PROP_NAME), c.getName());
+      props.setProperty(String.format(format, i, PROP_VERSION), c.getVersion());
+      props.setProperty(String.format(format, i, PROP_REVISION), c.getRevision());
+      props.setProperty(String.format(format, i, PROP_IPADDRESS), c.getIpAddress());
+    }
+    return props;
+  }
+
+  public static ConnectedClientInformation fromProperties(String props) {
+    try {
+      Properties p = new Properties();
+      p.load(new StringReader(props));
+      return fromProperties(p);
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+
+  public static ConnectedClientInformation fromProperties(Properties props) {
+    return new ConnectedClientInformation(range(0, parseInt(props.getProperty("clients.count")))
+        .mapToObj(i ->
+            new ClientInfo(Stream.of(PROP_ID, PROP_NAME, PROP_VERSION, PROP_REVISION, PROP_IPADDRESS)
+                .map(k -> props.getProperty("clients." + i + "." + k))
+                .toArray(String[]::new)))
+        .collect(toList()));
+  }
+}

--- a/diagnostic/model/src/main/java/org/terracotta/diagnostic/model/KitInformation.java
+++ b/diagnostic/model/src/main/java/org/terracotta/diagnostic/model/KitInformation.java
@@ -59,6 +59,10 @@ public class KitInformation {
     return branch;
   }
 
+  public String getFormattedVersion() {
+    return version + "/" + (revision.isEmpty() ? "revision not available" : revision);
+  }
+
   public Properties toProperties() {
     Properties props = new Properties();
     props.setProperty("version", getVersion().toString());

--- a/diagnostic/model/src/test/java/org/terracotta/diagnostic/model/ConnectedClientInfoTest.java
+++ b/diagnostic/model/src/test/java/org/terracotta/diagnostic/model/ConnectedClientInfoTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.diagnostic.model;
+
+import org.junit.Test;
+
+import java.util.Properties;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+public class ConnectedClientInfoTest {
+
+  @Test
+  public void parse() {
+
+    Properties props = new Properties();
+
+    props.setProperty("clients.0.id", "ddf594de4b4c4ec79b4e275a3eb82b5e");
+    props.setProperty("clients.0.name", "TMS:MyCluster");
+    props.setProperty("clients.0.version", "10.7.0-SNAPSHOT");
+    props.setProperty("clients.0.revision", "3b5da0ab6ff7754c7da436651da2dee6ca16de78");
+    props.setProperty("clients.0.ipAddress", "host1:62497");
+    props.setProperty("clients.count", "1");
+
+    ConnectedClientInformation info = ConnectedClientInformation.fromProperties(props);
+
+    assertThat(info.connectedClientsInfo.size(), equalTo(1));
+    ClientInfo c = info.connectedClientsInfo.get(0);
+    assertThat(c.getName(), equalTo("TMS:MyCluster"));
+    assertThat(c.getVersion(), equalTo("10.7.0-SNAPSHOT"));
+    assertThat(c.getRevision(), equalTo("3b5da0ab6ff7754c7da436651da2dee6ca16de78"));
+    assertThat(c.getIpAddress(), equalTo("host1:62497"));
+  }
+
+  @Test
+  public void parse_convert() {
+
+    Properties props = new Properties();
+
+    props.setProperty("clients.0.id", "ddf594de4b4c4ec79b4e275a3eb82b5e");
+    props.setProperty("clients.0.name", "TMS:MyCluster");
+    props.setProperty("clients.0.version", "10.7.0-SNAPSHOT");
+    props.setProperty("clients.0.revision", "3b5da0ab6ff7754c7da436651da2dee6ca16de78");
+    props.setProperty("clients.0.ipAddress", "host1:62497");
+
+    props.setProperty("clients.1.id", "c0393a4de644415a86d33880c747255f");
+    props.setProperty("clients.1.name", "Store:TC Client");
+    props.setProperty("clients.1.version", "10.7.0-SNAPSHOT");
+    props.setProperty("clients.1.revision", "3b5da0ab6ff7754c7da436651da2dee6ca16de78");
+    props.setProperty("clients.1.ipAddress", "host1:62515");
+
+    props.setProperty("clients.count", "2");
+
+    ConnectedClientInformation clientInfo = ConnectedClientInformation.fromProperties(props);
+    assertThat(clientInfo.connectedClientsInfo.size(), equalTo(2));
+
+    String propsAsString = clientInfo.toString();
+    clientInfo = ConnectedClientInformation.fromProperties(propsAsString);
+    assertThat(clientInfo.connectedClientsInfo.size(), equalTo(2));
+  }
+}

--- a/management/testing/integration-tests/src/test/java/org/terracotta/management/integration/tests/AbstractTest.java
+++ b/management/testing/integration-tests/src/test/java/org/terracotta/management/integration/tests/AbstractTest.java
@@ -243,7 +243,8 @@ public abstract class AbstractTest {
         .replaceAll("\"vmId\":\"[^\"]*\"", "\"vmId\":\"0@127.0.0.1\"")
         .replaceAll("-2", "")
         .replaceAll("testServer1", "testServer0")
-        .replaceAll("\"(clientReportedAddress)\":\"[^\"]*\"", "\"$1\":\"<$1>\"");
+        .replaceAll("\"(clientReportedAddress)\":\"[^\"]*\"", "\"$1\":\"<$1>\"")
+        .replaceAll("\"clientRevision\":\"[^\"]*\"", "\"clientRevision\":\"<uuid>\"");
   }
 
   protected void triggerServerStatComputation() throws Exception {

--- a/management/testing/integration-tests/src/test/resources/notifications.json
+++ b/management/testing/integration-tests/src/test/resources/notifications.json
@@ -12,6 +12,7 @@
   },
   {"attributes":{"version":"<version>"},"context":{"clientId":"0@127.0.0.1:pet-clinic:<uuid>"},"type":"CLIENT_PROPERTY_ADDED"},
   {"attributes":{"clientReportedAddress":"<clientReportedAddress>"},"context":{"clientId":"0@127.0.0.1:pet-clinic:<uuid>"},"type":"CLIENT_PROPERTY_ADDED"},
+  {"attributes":{"clientRevision":"<uuid>"},"context":{"clientId":"0@127.0.0.1:pet-clinic:<uuid>"},"type":"CLIENT_PROPERTY_ADDED"},
   {
     "attributes": {
       "clientId": "0@127.0.0.1:pet-clinic:<uuid>"
@@ -62,6 +63,7 @@
   },
   {"attributes":{"version":"<version>"},"context":{"clientId":"0@127.0.0.1:pet-clinic:<uuid>"},"type":"CLIENT_PROPERTY_ADDED"},
   {"attributes":{"clientReportedAddress":"<clientReportedAddress>"},"context":{"clientId":"0@127.0.0.1:pet-clinic:<uuid>"},"type":"CLIENT_PROPERTY_ADDED"},
+  {"attributes":{"clientRevision":"<uuid>"},"context":{"clientId":"0@127.0.0.1:pet-clinic:<uuid>"},"type":"CLIENT_PROPERTY_ADDED"},
   {
     "attributes": {
       "clientId": "0@127.0.0.1:pet-clinic:<uuid>"

--- a/management/testing/integration-tests/src/test/resources/topology-after-failover.json
+++ b/management/testing/integration-tests/src/test/resources/topology-after-failover.json
@@ -499,7 +499,8 @@
       "tags": [],
       "properties": {
         "version": "<version>",
-        "clientReportedAddress": "<clientReportedAddress>"
+        "clientReportedAddress": "<clientReportedAddress>",
+        "clientRevision": "<uuid>"
       },
       "connections": [
         {
@@ -533,6 +534,7 @@
       ],
       "properties": {
         "clientReportedAddress": "<clientReportedAddress>",
+        "clientRevision": "<uuid>",
         "version": "<version>"
       },
       "connections": [
@@ -732,6 +734,7 @@
       ],
       "properties": {
         "clientReportedAddress": "<clientReportedAddress>",
+        "clientRevision": "<uuid>",
         "version": "<version>"
       },
       "connections": [

--- a/management/testing/integration-tests/src/test/resources/topology-before-reconfigure.json
+++ b/management/testing/integration-tests/src/test/resources/topology-before-reconfigure.json
@@ -499,7 +499,8 @@
       "tags": [],
       "properties": {
         "version": "<version>",
-        "clientReportedAddress": "<clientReportedAddress>"
+        "clientReportedAddress": "<clientReportedAddress>",
+        "clientRevision": "<uuid>"
       },
       "connections": [
         {
@@ -533,7 +534,8 @@
       ],
       "properties": {
         "version": "<version>",
-        "clientReportedAddress": "<clientReportedAddress>"
+        "clientReportedAddress": "<clientReportedAddress>",
+        "clientRevision": "<uuid>"
       },
       "connections": [
         {
@@ -732,7 +734,8 @@
       ],
       "properties": {
         "version": "<version>",
-        "clientReportedAddress": "<clientReportedAddress>"
+        "clientReportedAddress": "<clientReportedAddress>",
+        "clientRevision": "<uuid>"
       },
       "connections": [
         {

--- a/management/testing/integration-tests/src/test/resources/topology-reconfigured.json
+++ b/management/testing/integration-tests/src/test/resources/topology-reconfigured.json
@@ -499,7 +499,8 @@
       "tags": [],
       "properties": {
         "version": "<version>",
-        "clientReportedAddress": "<clientReportedAddress>"
+        "clientReportedAddress": "<clientReportedAddress>",
+        "clientRevision": "<uuid>"
       },
       "connections": [
         {
@@ -533,7 +534,8 @@
       ],
       "properties": {
         "version": "<version>",
-        "clientReportedAddress": "<clientReportedAddress>"
+        "clientReportedAddress": "<clientReportedAddress>",
+        "clientRevision": "<uuid>"
       },
       "connections": [
         {
@@ -732,7 +734,8 @@
       ],
       "properties": {
         "version": "<version>",
-        "clientReportedAddress": "<clientReportedAddress>"
+        "clientReportedAddress": "<clientReportedAddress>",
+        "clientRevision": "<uuid>"
       },
       "connections": [
         {

--- a/management/testing/integration-tests/src/test/resources/topology.json
+++ b/management/testing/integration-tests/src/test/resources/topology.json
@@ -499,7 +499,8 @@
       "tags": [],
       "properties": {
         "version": "<version>",
-        "clientReportedAddress": "<clientReportedAddress>"
+        "clientReportedAddress": "<clientReportedAddress>",
+        "clientRevision": "<uuid>"
       },
       "connections": [
         {
@@ -533,7 +534,8 @@
       ],
       "properties": {
         "version": "<version>",
-        "clientReportedAddress": "<clientReportedAddress>"
+        "clientReportedAddress": "<clientReportedAddress>",
+        "clientRevision": "<uuid>"
       },
       "connections": [
         {
@@ -732,7 +734,8 @@
       ],
       "properties": {
         "version": "<version>",
-        "clientReportedAddress": "<clientReportedAddress>"
+        "clientReportedAddress": "<clientReportedAddress>",
+        "clientRevision": "<uuid>"
       },
       "connections": [
         {

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
     <terracotta-apis.version>1.8.1</terracotta-apis.version>
     <terracotta-configuration.version>10.7.1</terracotta-configuration.version>
     <passthrough-testing.version>1.8.2</passthrough-testing.version>
-    <terracotta-core.version>5.8.2</terracotta-core.version>
+    <terracotta-core.version>5.8.3-pre2</terracotta-core.version>
     <tripwire.version>1.0.2</tripwire.version>
     <galvan.version>1.6.3</galvan.version>
     <angela.version>3.1.24</angela.version>


### PR DESCRIPTION
Implements a new DiagnosticService call to retrieve connected client version information from the server.
Core version bumped as well.

Corresponding core changes were completed in https://github.com/Terracotta-OSS/terracotta-core/pull/1234