### PR TITLE
Passive redirection should consider the topology configuration to redirect to the right active endpoint

### DIFF
--- a/dynamic-config/server/services/pom.xml
+++ b/dynamic-config/server/services/pom.xml
@@ -62,6 +62,11 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>org.terracotta.internal</groupId>
+      <artifactId>server-spi</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>org.terracotta</groupId>
       <artifactId>standard-cluster-services</artifactId>
       <scope>provided</scope>

--- a/dynamic-config/server/services/src/main/java/org/terracotta/dynamic_config/server/service/DynamicConfigNetworkTranslator.java
+++ b/dynamic-config/server/services/src/main/java/org/terracotta/dynamic_config/server/service/DynamicConfigNetworkTranslator.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.dynamic_config.server.service;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.terracotta.dynamic_config.api.model.Cluster;
+import org.terracotta.dynamic_config.api.model.Node;
+import org.terracotta.dynamic_config.api.service.TopologyService;
+import org.terracotta.inet.InetSocketAddressConverter;
+
+import java.net.InetSocketAddress;
+import java.util.Optional;
+
+/**
+ * This service implements a network translator to support TC deployment behind a NAT-ed network for example.
+ * <p>
+ * If TC nodes are deployed in a separate network, recommendation is to configure public hostname/port on the
+ * nodes and have all clients reach the nodes by using only public endpoints. The user will be responsible to
+ * setup his networks (NAT, DNS ,etc) accordingly so that public endpoints can resolve to the nodes whether the
+ * clients are "inside" or "outside" of the TC node network.
+ * <p>
+ * This is not possible to correctly support a mix of clients connecting to the cluster, some with public
+ * endpoints and some with internal endpoints, because the NetworkTranslator has no way to know in a reliable
+ * way which endpoint was used by the user in the URI to initiate the connection.
+ *
+ * @author Mathieu Carbou
+ */
+class DynamicConfigNetworkTranslator implements com.tc.spi.NetworkTranslator {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(DynamicConfigNetworkTranslator.class);
+
+  private final TopologyService topologyService;
+
+  public DynamicConfigNetworkTranslator(TopologyService topologyService) {
+    this.topologyService = topologyService;
+  }
+
+  /**
+   * This implementation will return the right endpoint to use when a passive node is redirecting a client to an active node.
+   * <p>
+   * If the cluster is configured with public addresses, the public endpoint of the active server will be used.
+   * <p>
+   * If the cluster is not configured with public addresses, the internal endpoint will be used (which will be the parameter passed).
+   * <p>
+   * If the serverHostPort parameter passed does not allow us to correctly find the active node in the runtime topology, the parameter is returned.
+   * But this situation should not happen because a removal of an active node is not permitted. So when a client connects, the active should be there.
+   *
+   * @param initiator      The remote address of the client
+   * @param serverHostPort The internal address of the current active server
+   * @return the endpoint to use to connect to the active server
+   */
+  @Override
+  public String redirectTo(InetSocketAddress initiator, String serverHostPort) {
+    final Cluster cluster = topologyService.getRuntimeNodeContext().getCluster();
+    InetSocketAddress proposedRedirect;
+    try {
+      proposedRedirect = InetSocketAddressConverter.getInetSocketAddress(serverHostPort);
+    } catch (IllegalArgumentException e) {
+      // Workaround because core does not correctly support / adhere to the new Ipv6 format for InetSocketAddresses (https://bugs.openjdk.java.net/browse/JDK-8232002)
+      // In core, the same "hack" is used to extract the port when we know that a string contains a concatenation of ip:port
+      int column = serverHostPort.lastIndexOf(':');
+      if (column == -1) {
+        throw e;
+      }
+      proposedRedirect = InetSocketAddress.createUnresolved(serverHostPort.substring(0, column), Integer.parseInt(serverHostPort.substring(column + 1)));
+    }
+    Optional<Node.Endpoint> publicEndpoint = cluster.findReachableNode(proposedRedirect).flatMap(Node::getPublicEndpoint);
+    if (publicEndpoint.isPresent()) {
+      LOGGER.trace("Redirecting client: {} to node: {} through public endpoint", initiator, publicEndpoint.get());
+      return publicEndpoint.get().getAddress().toString();
+    } else {
+      // we were not able to find the serverHostPort in the topology.
+      LOGGER.warn("Redirecting client: {} to proposed address: {}", initiator, serverHostPort);
+      return serverHostPort;
+    }
+  }
+}

--- a/dynamic-config/server/services/src/main/java/org/terracotta/dynamic_config/server/service/DynamicConfigNetworkTranslator.java
+++ b/dynamic-config/server/services/src/main/java/org/terracotta/dynamic_config/server/service/DynamicConfigNetworkTranslator.java
@@ -84,7 +84,7 @@ class DynamicConfigNetworkTranslator implements com.tc.spi.NetworkTranslator {
       return publicEndpoint.get().getAddress().toString();
     } else {
       // we were not able to find the serverHostPort in the topology.
-      LOGGER.warn("Redirecting client: {} to proposed address: {}", initiator, serverHostPort);
+      LOGGER.trace("Redirecting client: {} to proposed address: {}", initiator, serverHostPort);
       return serverHostPort;
     }
   }

--- a/dynamic-config/server/services/src/main/java/org/terracotta/dynamic_config/server/service/DynamicConfigServiceProvider.java
+++ b/dynamic-config/server/services/src/main/java/org/terracotta/dynamic_config/server/service/DynamicConfigServiceProvider.java
@@ -16,6 +16,7 @@
 package org.terracotta.dynamic_config.server.service;
 
 import com.tc.classloader.BuiltinService;
+import com.tc.spi.NetworkTranslator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terracotta.dynamic_config.api.model.Configuration;
@@ -117,6 +118,9 @@ public class DynamicConfigServiceProvider implements ServiceProvider {
 
   @Override
   public <T> T getService(long consumerID, ServiceConfiguration<T> configuration) {
+    if (configuration.getServiceType() == NetworkTranslator.class) {
+      return configuration.getServiceType().cast(new DynamicConfigNetworkTranslator(findService(TopologyService.class)));
+    }
     return findService(configuration.getServiceType());
   }
 
@@ -135,7 +139,8 @@ public class DynamicConfigServiceProvider implements ServiceProvider {
         NomadPermissionChangeProcessor.class,
         LicenseService.class,
         PathResolver.class,
-        Server.class
+        Server.class,
+        NetworkTranslator.class
     );
   }
 

--- a/dynamic-config/testing/support/src/main/java/org/terracotta/dynamic_config/test_support/DynamicConfigIT.java
+++ b/dynamic-config/testing/support/src/main/java/org/terracotta/dynamic_config/test_support/DynamicConfigIT.java
@@ -352,7 +352,11 @@ public class DynamicConfigIT {
   }
 
   protected final InetSocketAddress getNodeAddress(int stripeId, int nodeId) {
-    return InetSocketAddress.createUnresolved("localhost", getNodePort(stripeId, nodeId));
+    return InetSocketAddress.createUnresolved(getDefaultHostname(stripeId, nodeId), getNodePort(stripeId, nodeId));
+  }
+
+  protected String getDefaultHostname(int stripeId, int nodeId) {
+    return "localhost";
   }
 
   protected ToolExecutionResult activateCluster() {
@@ -515,7 +519,7 @@ public class DynamicConfigIT {
   }
 
   protected TerracottaServer createNode(int stripeId, int nodeId) {
-    return server(getNodeName(stripeId, nodeId), "localhost")
+    return server(getNodeName(stripeId, nodeId), getDefaultHostname(stripeId, nodeId))
         .configRepo("config")
         .logs("logs")
         .dataDir("main:data-dir")
@@ -708,7 +712,7 @@ public class DynamicConfigIT {
   }
 
   protected final Cluster getUpcomingCluster(int stripeId, int nodeId) {
-    return getUpcomingCluster("localhost", getNodePort(stripeId, nodeId));
+    return getUpcomingCluster(getDefaultHostname(stripeId, nodeId), getNodePort(stripeId, nodeId));
   }
 
   // =========================================
@@ -720,7 +724,7 @@ public class DynamicConfigIT {
   }
 
   protected final Cluster getRuntimeCluster(int stripeId, int nodeId) {
-    return getUpcomingCluster("localhost", getNodePort(stripeId, nodeId));
+    return getUpcomingCluster(getDefaultHostname(stripeId, nodeId), getNodePort(stripeId, nodeId));
   }
 
   protected final Cluster getRuntimeCluster(String host, int port) {
@@ -728,7 +732,7 @@ public class DynamicConfigIT {
   }
 
   protected final void withTopologyService(int stripeId, int nodeId, Consumer<TopologyService> consumer) {
-    withTopologyService("localhost", getNodePort(stripeId, nodeId), consumer);
+    withTopologyService(getDefaultHostname(stripeId, nodeId), getNodePort(stripeId, nodeId), consumer);
   }
 
   protected final void withTopologyService(String host, int port, Consumer<TopologyService> consumer) {
@@ -739,7 +743,7 @@ public class DynamicConfigIT {
   }
 
   protected final <T> T usingTopologyService(int stripeId, int nodeId, Function<TopologyService, T> fn) {
-    return usingTopologyService("localhost", getNodePort(stripeId, nodeId), fn);
+    return usingTopologyService(getDefaultHostname(stripeId, nodeId), getNodePort(stripeId, nodeId), fn);
   }
 
   protected final <T> T usingTopologyService(String host, int port, Function<TopologyService, T> fn) {
@@ -747,7 +751,7 @@ public class DynamicConfigIT {
   }
 
   protected final <T> T usingDiagnosticService(int stripeId, int nodeId, Function<DiagnosticService, T> fn) {
-    return usingDiagnosticService("localhost", getNodePort(stripeId, nodeId), fn);
+    return usingDiagnosticService(getDefaultHostname(stripeId, nodeId), getNodePort(stripeId, nodeId), fn);
   }
 
   protected final <T> T usingDiagnosticService(String host, int port, Function<DiagnosticService, T> fn) {

--- a/dynamic-config/testing/system-tests/pom.xml
+++ b/dynamic-config/testing/system-tests/pom.xml
@@ -142,10 +142,11 @@
           </execution>
         </executions>
         <configuration>
+
           <scripts>
             <script><![CDATA[
-new File("${project.build.directory}/fake-hosts.txt").text = "127.0.0.1 testhostname ${InetAddress.getLocalHost().getHostName()}"
-println(new File("${project.build.directory}/fake-hosts.txt").text)
+new File(project.build.directory, "fake-hosts.txt").text = "127.0.0.1 testhostname ${InetAddress.getLocalHost().getHostName()}"
+println(new File(project.build.directory, "fake-hosts.txt").text)
           ]]></script>
           </scripts>
         </configuration>

--- a/dynamic-config/testing/system-tests/pom.xml
+++ b/dynamic-config/testing/system-tests/pom.xml
@@ -129,6 +129,36 @@
         </executions>
       </plugin>
       <plugin>
+        <groupId>org.codehaus.gmavenplus</groupId>
+        <artifactId>gmavenplus-plugin</artifactId>
+        <version>1.13.0</version>
+        <executions>
+          <execution>
+            <id>fake-hosts</id>
+            <phase>pre-integration-test</phase>
+            <goals>
+              <goal>execute</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <scripts>
+            <script><![CDATA[
+new File("${project.build.directory}/fake-hosts.txt").text = "127.0.0.1 testhostname ${InetAddress.getLocalHost().getHostName()}"
+println(new File("${project.build.directory}/fake-hosts.txt").text)
+          ]]></script>
+          </scripts>
+        </configuration>
+        <dependencies>
+          <dependency>
+            <groupId>org.codehaus.groovy</groupId>
+            <artifactId>groovy</artifactId>
+            <version>3.0.7</version>
+            <scope>runtime</scope>
+          </dependency>
+        </dependencies>
+      </plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
         <configuration>
@@ -142,7 +172,9 @@
             <angela.distribution>${project.version}</angela.distribution>
             <angela.kitInstallationDir>${project.build.directory}/angela/platform-kit-${project.version}</angela.kitInstallationDir>
             <angela.java.resolver>user</angela.java.resolver>
+            <angela.ssh.strictHostKeyChecking>false</angela.ssh.strictHostKeyChecking>
             <org.terracotta.voter.topology.fetch.interval>9000</org.terracotta.voter.topology.fetch.interval>
+            <jdk.net.hosts.file>${project.build.directory}/fake-hosts.txt</jdk.net.hosts.file>
           </systemPropertyVariables>
           <argLine>-XX:+UseG1GC -Xmx1g -Dorg.terracotta.disablePortReleaseCheck=true</argLine>
         </configuration>

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/PassiveRedirection1x2IT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/PassiveRedirection1x2IT.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.dynamic_config.system_tests.activated;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.terracotta.connection.Connection;
+import org.terracotta.connection.ConnectionException;
+import org.terracotta.connection.ConnectionFactory;
+import org.terracotta.dynamic_config.test_support.ClusterDefinition;
+import org.terracotta.dynamic_config.test_support.DynamicConfigIT;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.util.Properties;
+
+import static java.util.Collections.singletonList;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.startsWith;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeThat;
+import static org.terracotta.angela.client.support.hamcrest.AngelaMatchers.successful;
+
+@ClusterDefinition(nodesPerStripe = 2)
+public class PassiveRedirection1x2IT extends DynamicConfigIT {
+
+  @BeforeClass
+  public static void beforeClass() throws Exception {
+    assumeThat(System.getProperty("java.version"), not(startsWith("1.8")));
+  }
+
+  @Override
+  protected String getDefaultHostname(int stripeId, int nodeId) {
+    return "testhostname";
+  }
+
+  @Test
+  public void passiveRedirectsToInternalAddress() throws ConnectionException, IOException {
+    attachAll();
+    activateCluster();
+    int passiveId = findPassives(1)[0];
+    int activeId = findActive(1).getAsInt();
+
+    assertThat(
+        configTool("set", "-s", "localhost:" + getNodePort(), "-c", "logger-overrides=org.terracotta.dynamic_config.server.service.DynamicConfigNetworkTranslator:TRACE"),
+        is(successful()));
+
+    // Redirecting client: /127.0.0.1:58937 to proposed address: C02YJ2F2JGH6.local:46238
+    try (Connection connection = ConnectionFactory.connect(singletonList(getNodeAddress(1, passiveId)), new Properties())) {
+      assertTrue(connection.isValid());
+      waitUntilServerLogs(getNode(1, passiveId), "Redirecting client: ");
+      waitUntilServerLogs(getNode(1, passiveId), " to proposed address: " + getNodeAddress(1, activeId)); // localhost:port (== <hostname>:<bind-port>)
+    }
+  }
+
+  @Test
+  public void passiveRedirectsToPublicAddress() throws IOException, ConnectionException {
+    attachAll();
+    activateCluster();
+    int passiveId = findPassives(1)[0];
+    int activeId = findActive(1).getAsInt();
+
+    assertThat(
+        configTool("set", "-s", "localhost:" + getNodePort(), "-c", "logger-overrides=org.terracotta.dynamic_config.server.service.DynamicConfigNetworkTranslator:TRACE"),
+        is(successful()));
+
+    assertThat(
+        configTool("set", "-s", "localhost:" + getNodePort(),
+            "-c", "stripe.1.node.1.public-hostname=localhost",
+            "-c", "stripe.1.node.1.public-port=" + getNodePort(1, 1),
+            "-c", "stripe.1.node.2.public-hostname=localhost",
+            "-c", "stripe.1.node.2.public-port=" + getNodePort(1, 2)
+        ),
+        is(successful()));
+
+    // Redirecting client: /127.0.0.1:59121 to node: node-1-1@localhost:42894 through public endpoint
+    try (Connection connection = ConnectionFactory.connect(singletonList(InetSocketAddress.createUnresolved(getDefaultHostname(1, passiveId), getNodePort(1, passiveId))), new Properties())) {
+      assertTrue(connection.isValid());
+      waitUntilServerLogs(getNode(1, passiveId), "Redirecting client: ");
+      waitUntilServerLogs(getNode(1, passiveId), " to node: " + getNodeName(1, activeId) + "@localhost:" + getNodePort(1, activeId) + " through public endpoint");
+    }
+  }
+
+  @Test
+  public void passiveRedirectsToBindAddress() throws IOException, ConnectionException {
+    assertThat(
+        configTool("set", "-connect-to", "localhost:" + getNodePort(), "-auto-restart",
+            "-setting", "logger-overrides=org.terracotta.dynamic_config.server.service.DynamicConfigNetworkTranslator:TRACE",
+            "-setting", "bind-address=127.0.0.1"
+        ),
+        is(successful()));
+
+    attachAll();
+    activateCluster();
+    waitForActive(1);
+    waitForPassives(1);
+
+    int passiveId = findPassives(1)[0];
+    int activeId = findActive(1).getAsInt();
+
+    // Redirecting client: /127.0.0.1:59053 to proposed address: 127.0.0.1:37132
+    try (Connection connection = ConnectionFactory.connect(singletonList(InetSocketAddress.createUnresolved(getDefaultHostname(1, passiveId), getNodePort(1, passiveId))), new Properties())) {
+      assertTrue(connection.isValid());
+      waitUntilServerLogs(getNode(1, passiveId), "Redirecting client: ");
+      waitUntilServerLogs(getNode(1, passiveId), " to proposed address: 127.0.0.1:" + getNodePort(1, activeId)); // 127.0.0.1:port (== <bind-addr>:<bind-port>)
+    }
+  }
+
+  @Test
+  public void passiveRedirectsToBindAddressWithPublicEndpoint() throws IOException, ConnectionException {
+    assertThat(
+        configTool("set", "-connect-to", "localhost:" + getNodePort(), "-auto-restart",
+            "-setting", "logger-overrides=org.terracotta.dynamic_config.server.service.DynamicConfigNetworkTranslator:TRACE",
+            "-setting", "bind-address=127.0.0.1"
+        ),
+        is(successful()));
+
+    attachAll();
+    activateCluster();
+    waitForActive(1);
+    waitForPassives(1);
+
+    int passiveId = findPassives(1)[0];
+    int activeId = findActive(1).getAsInt();
+
+    assertThat(
+        configTool("set", "-s", "localhost:" + getNodePort(),
+            "-c", "stripe.1.node.1.public-hostname=localhost",
+            "-c", "stripe.1.node.1.public-port=" + getNodePort(1, 1),
+            "-c", "stripe.1.node.2.public-hostname=localhost",
+            "-c", "stripe.1.node.2.public-port=" + getNodePort(1, 2)
+        ),
+        is(successful()));
+
+    // Redirecting client: /127.0.0.1:59447 to node: node-1-2@localhost:46384 through public endpoint
+    try (Connection connection = ConnectionFactory.connect(singletonList(InetSocketAddress.createUnresolved(getDefaultHostname(1, passiveId), getNodePort(1, passiveId))), new Properties())) {
+      assertTrue(connection.isValid());
+      waitUntilServerLogs(getNode(1, passiveId), "Redirecting client: ");
+      waitUntilServerLogs(getNode(1, passiveId), " to node: " + getNodeName(1, activeId) + "@localhost:" + getNodePort(1, activeId) + " through public endpoint");
+    }
+  }
+}


### PR DESCRIPTION
Implementation of a `NetworkTranslator` for 10.x that will correctly pick the right endpoint for the active node when a passive sends a redirection back to a client.

A terracotta cluster is either meant to be used with the internal endpoints of the nodes, or the public configured endpoints if configured, but not both at the same time.

If public endpoints are not configured, all clients need to use the internal endpoints, and they must be reachable from all clients.

If public endpoints are configured, all clients need to use these public endpoints, not internal ones. All the clients will have to be able to reach the nodes by using these public endpoints.

Technically, it means that if all clients are in the same network as all nodes, public endpoints are not necessary. If clients are in another network and internal endpoints cannot be reached, then public endpoints can be configured to reach them. The user will be responsible to configure NAT / DNS / etc. 

If some clients need to be in the same network as nodes (so clients being both outside and inside), then the user will have to make sure that the public endpoints also resolve to the node internal endpoints, even within the same network.

The `NetworkTranslator` was always returning the "internal" endpoint of the active server, which of course is not always accessible from clients outside an isolated "terracotta network", which could prevent them from connecting to the cluster.

This fix works this way:
- If a public hostname/port is configured for the active node, it will be returned
- otherwise, the normal hostname/port is returned

CC @tglaeser