### PR TITLE
Fixing method names and correctness

### DIFF
--- a/dynamic-config/cli/dynamic-config-cli-api/src/main/java/org/terracotta/dynamic_config/cli/api/command/ActivateAction.java
+++ b/dynamic-config/cli/dynamic-config-cli-api/src/main/java/org/terracotta/dynamic_config/cli/api/command/ActivateAction.java
@@ -93,7 +93,7 @@ public class ActivateAction extends RemoteAction {
 
     Collection<Endpoint> runtimePeers = restrictedActivation ?
         singletonList(getEndpoint(node)) : // if restrictive activation, we only activate the node supplied
-        cluster.getEndpoints(node); // if normal activation the nodes to activate are those found in the config file or in the topology loaded from the node
+        cluster.determineEndpoints(node); // if normal activation the nodes to activate are those found in the config file or in the topology loaded from the node
 
     // verify the activated state of the nodes
     if (areAllNodesActivated(runtimePeers)) {

--- a/dynamic-config/cli/dynamic-config-cli-api/src/main/java/org/terracotta/dynamic_config/cli/api/command/AttachAction.java
+++ b/dynamic-config/cli/dynamic-config-cli-api/src/main/java/org/terracotta/dynamic_config/cli/api/command/AttachAction.java
@@ -90,7 +90,7 @@ public class AttachAction extends TopologyAction {
           "Impossible to do any topology change. Node: " + endpoint + " is waiting to be restarted to apply some pending changes. Please refer to the Troubleshooting Guide for more help.");
     }
 
-    Collection<Endpoint> destinationPeers = destinationCluster.getSimilarEndpoints(destination);
+    Collection<Endpoint> destinationPeers = destinationCluster.determineEndpoints(destination);
     if (destinationPeers.contains(source)) {
       throw new IllegalArgumentException("Source node: " + source + " is already part of cluster: " + destinationCluster.toShapeString());
     }
@@ -153,7 +153,7 @@ public class AttachAction extends TopologyAction {
     } else {
       // we attach a whole stripe
       sourceCluster.getStripeByNode(source.getNodeUID()).get().getNodes().stream()
-          .map(node -> node.getSimilarEndpoint(source))
+          .map(node -> node.determineEndpoint(source))
           .forEach(endpoint -> newOnlineNodes.put(endpoint, getUpcomingCluster(endpoint)));
     }
 

--- a/dynamic-config/cli/dynamic-config-cli-api/src/main/java/org/terracotta/dynamic_config/cli/api/command/ImportAction.java
+++ b/dynamic-config/cli/dynamic-config-cli-api/src/main/java/org/terracotta/dynamic_config/cli/api/command/ImportAction.java
@@ -74,7 +74,7 @@ public class ImportAction extends RemoteAction {
       }
     }
 
-    Collection<Node.Endpoint> runtimePeers = cluster.getEndpoints(node);
+    Collection<Node.Endpoint> runtimePeers = cluster.determineEndpoints(node);
 
     // validate the topology
     new ClusterValidator(cluster).validate(ClusterState.CONFIGURING);

--- a/dynamic-config/cli/dynamic-config-cli-api/src/main/java/org/terracotta/dynamic_config/cli/api/command/RemoteAction.java
+++ b/dynamic-config/cli/dynamic-config-cli-api/src/main/java/org/terracotta/dynamic_config/cli/api/command/RemoteAction.java
@@ -353,7 +353,7 @@ public abstract class RemoteAction implements Runnable {
     LOGGER.trace("getEndpoint({})", expectedOnlineNode);
     try (DiagnosticService diagnosticService = diagnosticServiceProvider.fetchDiagnosticService(expectedOnlineNode)) {
       Node node = diagnosticService.getProxy(TopologyService.class).getRuntimeNodeContext().getNode();
-      return node.getEndpoint(expectedOnlineNode).orElseGet(() -> node.getPublicEndpoint().orElseGet(node::getInternalEndpoint));
+      return node.determineEndpoint(expectedOnlineNode);
     }
   }
 
@@ -432,7 +432,7 @@ public abstract class RemoteAction implements Runnable {
   protected final Collection<Endpoint> findRuntimePeers(InetSocketAddress expectedOnlineNode) {
     LOGGER.trace("findRuntimePeers({})", expectedOnlineNode);
     Cluster cluster = getRuntimeCluster(expectedOnlineNode);
-    Collection<Endpoint> peers = cluster.getEndpoints(expectedOnlineNode);
+    Collection<Endpoint> peers = cluster.determineEndpoints(expectedOnlineNode);
     if (LOGGER.isDebugEnabled()) {
       LOGGER.debug("Discovered nodes:{} through: {}", toString(peers), expectedOnlineNode);
     }
@@ -442,7 +442,7 @@ public abstract class RemoteAction implements Runnable {
   protected final Map<Endpoint, LogicalServerState> findRuntimePeersStatus(InetSocketAddress expectedOnlineNode) {
     LOGGER.trace("findRuntimePeersStatus({})", expectedOnlineNode);
     Cluster cluster = getRuntimeCluster(expectedOnlineNode);
-    Collection<Endpoint> endpoints = cluster.getEndpoints(expectedOnlineNode);
+    Collection<Endpoint> endpoints = cluster.determineEndpoints(expectedOnlineNode);
     output.info("Connecting to: {} (this can take time if some nodes are not reachable)", toString(endpoints));
     try (DiagnosticServices<UID> diagnosticServices = multiDiagnosticServiceProvider.fetchDiagnosticServices(endpointsToMap(endpoints))) {
       LinkedHashMap<Endpoint, LogicalServerState> status = endpoints.stream()

--- a/dynamic-config/cli/dynamic-config-cli-api/src/main/java/org/terracotta/dynamic_config/cli/api/nomad/DefaultNomadManager.java
+++ b/dynamic-config/cli/dynamic-config-cli-api/src/main/java/org/terracotta/dynamic_config/cli/api/nomad/DefaultNomadManager.java
@@ -152,7 +152,7 @@ public class DefaultNomadManager<T> implements NomadManager<T> {
       for (Node node : stripe.getNodes()) {
         for (Endpoint endpoint : onlineNodes.keySet()) {
           if (endpoint.getNodeUID().equals(node.getUID())) {
-            stripeNodes.add(node.getSimilarEndpoint(endpoint));
+            stripeNodes.add(node.determineEndpoint(endpoint));
           }
         }
       }

--- a/dynamic-config/cli/dynamic-config-cli-api/src/test/java/org/terracotta/dynamic_config/cli/api/restart/RestartServiceTest.java
+++ b/dynamic-config/cli/dynamic-config-cli-api/src/test/java/org/terracotta/dynamic_config/cli/api/restart/RestartServiceTest.java
@@ -94,7 +94,7 @@ public class RestartServiceTest extends BaseTest {
   public void test_restart() throws InterruptedException {
     mockSuccessfulServerRestart();
 
-    RestartProgress restartProgress = restartService.restartNodes(cluster.getEndpoints(null), Duration.ofSeconds(2), STATES);
+    RestartProgress restartProgress = restartService.restartNodes(cluster.determineEndpoints(), Duration.ofSeconds(2), STATES);
     assertThat(restartProgress.getErrors().size(), is(equalTo(0)));
 
     Map<Endpoint, LogicalServerState> restarted = restartProgress.await(Duration.ofSeconds(10));
@@ -116,7 +116,7 @@ public class RestartServiceTest extends BaseTest {
       doThrow(new DiagnosticOperationTimeoutException("")).when(dynamicConfigService).restart(any());
     });
 
-    RestartProgress restartProgress = restartService.restartNodes(cluster.getEndpoints(null), Duration.ofSeconds(2), STATES);
+    RestartProgress restartProgress = restartService.restartNodes(cluster.determineEndpoints(), Duration.ofSeconds(2), STATES);
     assertThat(restartProgress.getErrors().size(), is(equalTo(6)));
 
     Map<Endpoint, LogicalServerState> restarted = restartProgress.await(Duration.ofSeconds(10));
@@ -135,7 +135,7 @@ public class RestartServiceTest extends BaseTest {
       doThrow(new DiagnosticServiceProviderException("error")).when(dynamicConfigService).restart(any());
     });
 
-    RestartProgress restartProgress = restartService.restartNodes(cluster.getEndpoints(null), Duration.ofSeconds(2), STATES);
+    RestartProgress restartProgress = restartService.restartNodes(cluster.determineEndpoints(), Duration.ofSeconds(2), STATES);
     assertThat(restartProgress.getErrors().size(), is(equalTo(6)));
 
     Map<Endpoint, LogicalServerState> restarted = restartProgress.await(Duration.ofSeconds(10));
@@ -153,7 +153,7 @@ public class RestartServiceTest extends BaseTest {
 
     when(diagnosticServiceMock("localhost", 9411).getLogicalServerState()).thenAnswer(sleep(SYNCHRONIZING, 60, SECONDS));
 
-    RestartProgress restartProgress = restartService.restartNodes(cluster.getEndpoints(null), Duration.ofSeconds(2), STATES);
+    RestartProgress restartProgress = restartService.restartNodes(cluster.determineEndpoints(), Duration.ofSeconds(2), STATES);
     assertThat(restartProgress.getErrors().size(), is(equalTo(0)));
 
     Map<Endpoint, LogicalServerState> restarted = restartProgress.await(Duration.ofSeconds(8));
@@ -177,7 +177,7 @@ public class RestartServiceTest extends BaseTest {
     when(diagnosticServiceMock("localhost", 9422).getLogicalServerState()).thenReturn(UNINITIALIZED);
     when(diagnosticServiceMock("localhost", 9423).getLogicalServerState()).thenReturn(START_SUSPENDED);
 
-    RestartProgress restartProgress = restartService.restartNodes(cluster.getEndpoints(null), Duration.ofSeconds(2), STATES);
+    RestartProgress restartProgress = restartService.restartNodes(cluster.determineEndpoints(), Duration.ofSeconds(2), STATES);
     assertThat(restartProgress.getErrors().size(), is(equalTo(0)));
 
     Map<Endpoint, LogicalServerState> restarted = restartProgress.await(Duration.ofSeconds(8));

--- a/dynamic-config/model/src/main/java/org/terracotta/dynamic_config/api/json/DynamicConfigModelJsonModule.java
+++ b/dynamic-config/model/src/main/java/org/terracotta/dynamic_config/api/json/DynamicConfigModelJsonModule.java
@@ -293,6 +293,12 @@ public class DynamicConfigModelJsonModule extends SimpleModule {
 
     @JsonIgnore
     @Override
+    public Collection<Endpoint> getEndpoints() {
+      return super.getEndpoints();
+    }
+
+    @JsonIgnore
+    @Override
     public Endpoint getInternalEndpoint() {
       return super.getInternalEndpoint();
     }

--- a/dynamic-config/model/src/main/java/org/terracotta/dynamic_config/api/json/DynamicConfigModelJsonModuleV1.java
+++ b/dynamic-config/model/src/main/java/org/terracotta/dynamic_config/api/json/DynamicConfigModelJsonModuleV1.java
@@ -32,6 +32,7 @@ import org.terracotta.dynamic_config.api.model.UID;
 import java.net.InetSocketAddress;
 import java.nio.file.Path;
 import java.time.LocalDate;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
@@ -137,6 +138,12 @@ public class DynamicConfigModelJsonModuleV1 extends SimpleModule {
     @Override
     public Endpoint getBindEndpoint() {
       return super.getBindEndpoint();
+    }
+
+    @JsonIgnore
+    @Override
+    public Collection<Endpoint> getEndpoints() {
+      return super.getEndpoints();
     }
 
     @JsonIgnore

--- a/dynamic-config/model/src/test/java/org/terracotta/dynamic_config/api/model/NodeTest.java
+++ b/dynamic-config/model/src/test/java/org/terracotta/dynamic_config/api/model/NodeTest.java
@@ -132,37 +132,37 @@ public class NodeTest {
 
   @Test
   public void test_getEndpoint() {
-    assertThat(node.getEndpoint("localhost", 9410).get(), is(equalTo(node.getInternalEndpoint())));
-    assertFalse(node.getEndpoint("127.0.0.1", 9410).isPresent()); // this is normal, DC never resolves, only matches with configured entries
+    assertThat(node.findEndpoint("localhost", 9410).get(), is(equalTo(node.getInternalEndpoint())));
+    assertFalse(node.findEndpoint("127.0.0.1", 9410).isPresent()); // this is normal, DC never resolves, only matches with configured entries
 
     node = node.clone().setBindAddress("127.0.0.1");
-    assertThat(node.getEndpoint("localhost", 9410).get(), is(equalTo(node.getInternalEndpoint())));
-    assertThat(node.getEndpoint("127.0.0.1", 9410).get(), is(equalTo(node.getBindEndpoint())));
+    assertThat(node.findEndpoint("localhost", 9410).get(), is(equalTo(node.getInternalEndpoint())));
+    assertThat(node.findEndpoint("127.0.0.1", 9410).get(), is(equalTo(node.getBindEndpoint())));
 
     node = node.clone().setBindAddress("127.0.0.1").setPublicEndpoint("foo", 9610);
-    assertThat(node.getEndpoint("localhost", 9410).get(), is(equalTo(node.getInternalEndpoint())));
-    assertThat(node.getEndpoint("127.0.0.1", 9410).get(), is(equalTo(node.getBindEndpoint())));
-    assertThat(node.getEndpoint("foo", 9610).get(), is(equalTo(node.getBindEndpoint())));
+    assertThat(node.findEndpoint("localhost", 9410).get(), is(equalTo(node.getInternalEndpoint())));
+    assertThat(node.findEndpoint("127.0.0.1", 9410).get(), is(equalTo(node.getBindEndpoint())));
+    assertThat(node.findEndpoint("foo", 9610).get(), is(equalTo(node.getBindEndpoint())));
   }
 
   @Test
   public void test_getSimilarEndpoint() {
     node = node.clone();
-    assertThat(node.getSimilarEndpoint(node.getInternalEndpoint()), is(equalTo(node.getInternalEndpoint())));
-    assertThat(node.getSimilarEndpoint(node.getBindEndpoint()), is(equalTo(node.getInternalEndpoint())));
+    assertThat(node.determineEndpoint(node.getInternalEndpoint()), is(equalTo(node.getInternalEndpoint())));
+    assertThat(node.determineEndpoint(node.getBindEndpoint()), is(equalTo(node.getInternalEndpoint())));
 
     node = node.clone().setBindAddress("127.0.0.1");
-    assertThat(node.getSimilarEndpoint(node.getInternalEndpoint()), is(equalTo(node.getInternalEndpoint())));
-    assertThat(node.getSimilarEndpoint(node.getBindEndpoint()), is(equalTo(node.getBindEndpoint())));
+    assertThat(node.determineEndpoint(node.getInternalEndpoint()), is(equalTo(node.getInternalEndpoint())));
+    assertThat(node.determineEndpoint(node.getBindEndpoint()), is(equalTo(node.getBindEndpoint())));
 
     node = node.clone().setPublicEndpoint("foo", 9610);
-    assertThat(node.getSimilarEndpoint(node.getInternalEndpoint()), is(equalTo(node.getInternalEndpoint())));
-    assertThat(node.getSimilarEndpoint(node.getBindEndpoint()), is(equalTo(node.getBindEndpoint())));
-    assertThat(node.getSimilarEndpoint(node.getPublicEndpoint().get()), is(equalTo(node.getPublicEndpoint().get())));
+    assertThat(node.determineEndpoint(node.getInternalEndpoint()), is(equalTo(node.getInternalEndpoint())));
+    assertThat(node.determineEndpoint(node.getBindEndpoint()), is(equalTo(node.getBindEndpoint())));
+    assertThat(node.determineEndpoint(node.getPublicEndpoint().get()), is(equalTo(node.getPublicEndpoint().get())));
 
     node = node.clone().setBindAddress("0.0.0.0").setPublicEndpoint("foo", 9610);
-    assertThat(node.getSimilarEndpoint(node.getInternalEndpoint()), is(equalTo(node.getInternalEndpoint())));
-    assertThat(node.getSimilarEndpoint(node.getBindEndpoint()), is(equalTo(node.getPublicEndpoint().get())));
-    assertThat(node.getSimilarEndpoint(node.getPublicEndpoint().get()), is(equalTo(node.getPublicEndpoint().get())));
+    assertThat(node.determineEndpoint(node.getInternalEndpoint()), is(equalTo(node.getInternalEndpoint())));
+    assertThat(node.determineEndpoint(node.getBindEndpoint()), is(equalTo(node.getPublicEndpoint().get())));
+    assertThat(node.determineEndpoint(node.getPublicEndpoint().get()), is(equalTo(node.getPublicEndpoint().get())));
   }
 }


### PR DESCRIPTION
Follows PR #1055 : I saw some naming issues when integrating that in EE so fixing in this PR.

Naming:
- find for methods returning optional: `Optional<X> findX`
- determineEndpoint() => contains logic to default to public or internal endpoint
- added search capabilities because I saw a lot of redundant code in EE and Ehcache