### PR TITLE
Fix missing "instanceId" routing information for monitoring events and management calls

### DIFF
--- a/management/cluster-topology/src/main/java/org/terracotta/management/model/cluster/AbstractManageableNode.java
+++ b/management/cluster-topology/src/main/java/org/terracotta/management/model/cluster/AbstractManageableNode.java
@@ -15,6 +15,7 @@
  */
 package org.terracotta.management.model.cluster;
 
+import org.terracotta.management.model.context.Context;
 import org.terracotta.management.model.context.Contextual;
 
 import java.util.Optional;
@@ -44,6 +45,11 @@ public abstract class AbstractManageableNode<P extends Contextual> extends Abstr
 
   public final boolean isManageable() {
     return managementRegistry != null;
+  }
+
+  @Override
+  public Context getContext() {
+    return super.getContext().with(getManagementRegistry().map(ManagementRegistry::getContext).orElse(Context.empty()));
   }
 
   @Override

--- a/management/cluster-topology/src/test/java/org/terracotta/management/model/cluster/AbstractTest.java
+++ b/management/cluster-topology/src/test/java/org/terracotta/management/model/cluster/AbstractTest.java
@@ -21,6 +21,7 @@ import org.junit.runners.JUnit4;
 import org.terracotta.management.model.capabilities.Capability;
 import org.terracotta.management.model.capabilities.DefaultCapability;
 import org.terracotta.management.model.capabilities.context.CapabilityContext;
+import org.terracotta.management.model.context.Context;
 import org.terracotta.management.model.context.ContextContainer;
 
 import java.util.function.Supplier;
@@ -47,14 +48,14 @@ public abstract class AbstractTest {
 
     Supplier<ServerEntity> serverEntitySupplier = () -> {
       ServerEntity s = ServerEntity.create("ehcache-entity-name-1", "org.ehcache.clustered.client.internal.EhcacheClientEntity");
-      s.setManagementRegistry(ManagementRegistry.create(serverContextContainer)
+      s.setManagementRegistry(ManagementRegistry.create(Context.empty(), serverContextContainer)
           .addCapabilities(action));
       return s;
     };
 
     Supplier<Client> clientSupplier = () -> {
       Client c = Client.create("12345@127.0.0.1:ehcache:uid");
-      c.setManagementRegistry(ManagementRegistry.create(clientContextContainer)
+      c.setManagementRegistry(ManagementRegistry.create(Context.empty(), clientContextContainer)
           .addCapability(action));
       return c;
     };

--- a/management/cluster-topology/src/test/java/org/terracotta/management/model/cluster/ClusterTest.java
+++ b/management/cluster-topology/src/test/java/org/terracotta/management/model/cluster/ClusterTest.java
@@ -217,7 +217,7 @@ public class ClusterTest extends AbstractTest {
     Map actual = cluster1.toMap();
     ObjectMapper mapper = new ObjectMapper();
     mapper.configure(SerializationFeature.INDENT_OUTPUT, true);
-    JSONAssert.assertEquals(expectedJson, mapper.writeValueAsString(actual), true);
+    JSONAssert.assertEquals(mapper.writeValueAsString(actual), expectedJson, mapper.writeValueAsString(actual), true);
   }
 
   @SuppressWarnings("unchecked")

--- a/management/cluster-topology/src/test/resources/cluster.json
+++ b/management/cluster-topology/src/test/resources/cluster.json
@@ -1,150 +1,179 @@
 {
-  "stripes" : [ {
-    "id" : "stripe-1",
-    "name" : "stripe-1",
-    "servers" : [ {
-      "id" : "server-1",
-      "serverEntities" : [ {
-        "id" : "ehcache-entity-name-1:org.ehcache.clustered.client.internal.EhcacheClientEntity",
-        "type" : "org.ehcache.clustered.client.internal.EhcacheClientEntity",
-        "name" : "ehcache-entity-name-1",
-        "consumerId" : 0,
-        "managementRegistry" : {
-          "contextContainer" : {
-            "entityName" : "ehcache-entity-name-1",
-            "subContexts" : [ ]
-          },
-          "capabilities" : [ {
-            "name" : "ActionCapability",
-            "context" : [ ],
-            "descriptors" : [ ]
-          } ]
+  "stripes": [
+    {
+      "id": "stripe-1",
+      "name": "stripe-1",
+      "servers": [
+        {
+          "id": "server-1",
+          "serverEntities": [
+            {
+              "id": "ehcache-entity-name-1:org.ehcache.clustered.client.internal.EhcacheClientEntity",
+              "type": "org.ehcache.clustered.client.internal.EhcacheClientEntity",
+              "name": "ehcache-entity-name-1",
+              "consumerId": 0,
+              "managementRegistry": {
+                "rootContext": {},
+                "contextContainer": {
+                  "entityName": "ehcache-entity-name-1",
+                  "subContexts": []
+                },
+                "capabilities": [
+                  {
+                    "name": "ActionCapability",
+                    "context": [],
+                    "descriptors": []
+                  }
+                ]
+              }
+            }
+          ],
+          "serverName": "server-1",
+          "hostName": "hostname-1",
+          "hostAddress": null,
+          "bindAddress": "0.0.0.0",
+          "bindPort": 8881,
+          "groupPort": 0,
+          "state": "ACTIVE",
+          "version": null,
+          "buildId": null,
+          "startTime": 0,
+          "upTimeSec": 0,
+          "activateTime": 0
+        },
+        {
+          "id": "server-2",
+          "serverEntities": [],
+          "serverName": "server-2",
+          "hostName": "hostname-2",
+          "hostAddress": null,
+          "bindAddress": "0.0.0.0",
+          "bindPort": 8881,
+          "groupPort": 0,
+          "state": "PASSIVE",
+          "version": null,
+          "buildId": null,
+          "startTime": 0,
+          "upTimeSec": 0,
+          "activateTime": 0
         }
-      } ],
-      "serverName" : "server-1",
-      "hostName" : "hostname-1",
-      "hostAddress" : null,
-      "bindAddress" : "0.0.0.0",
-      "bindPort" : 8881,
-      "groupPort" : 0,
-      "state" : "ACTIVE",
-      "version" : null,
-      "buildId" : null,
-      "startTime" : 0,
-      "upTimeSec" : 0,
-      "activateTime" : 0
-    }, {
-      "id" : "server-2",
-      "serverEntities" : [ ],
-      "serverName" : "server-2",
-      "hostName" : "hostname-2",
-      "hostAddress" : null,
-      "bindAddress" : "0.0.0.0",
-      "bindPort" : 8881,
-      "groupPort" : 0,
-      "state" : "PASSIVE",
-      "version" : null,
-      "buildId" : null,
-      "startTime" : 0,
-      "upTimeSec" : 0,
-      "activateTime" : 0
-    } ]
-  }, {
-    "id" : "stripe-2",
-    "name" : "stripe-2",
-    "servers" : [ {
-      "id" : "server-1",
-      "serverEntities" : [ {
-        "id" : "ehcache-entity-name-1:org.ehcache.clustered.client.internal.EhcacheClientEntity",
-        "type" : "org.ehcache.clustered.client.internal.EhcacheClientEntity",
-        "name" : "ehcache-entity-name-1",
-        "consumerId" : 0,
-        "managementRegistry" : {
-          "contextContainer" : {
-            "entityName" : "ehcache-entity-name-1",
-            "subContexts" : [ ]
-          },
-          "capabilities" : [ {
-            "name" : "ActionCapability",
-            "context" : [ ],
-            "descriptors" : [ ]
-          } ]
+      ]
+    },
+    {
+      "id": "stripe-2",
+      "name": "stripe-2",
+      "servers": [
+        {
+          "id": "server-1",
+          "serverEntities": [
+            {
+              "id": "ehcache-entity-name-1:org.ehcache.clustered.client.internal.EhcacheClientEntity",
+              "type": "org.ehcache.clustered.client.internal.EhcacheClientEntity",
+              "name": "ehcache-entity-name-1",
+              "consumerId": 0,
+              "managementRegistry": {
+                "rootContext": {},
+                "contextContainer": {
+                  "entityName": "ehcache-entity-name-1",
+                  "subContexts": []
+                },
+                "capabilities": [
+                  {
+                    "name": "ActionCapability",
+                    "context": [],
+                    "descriptors": []
+                  }
+                ]
+              }
+            }
+          ],
+          "serverName": "server-1",
+          "hostName": "hostname-3",
+          "hostAddress": null,
+          "bindAddress": "0.0.0.0",
+          "bindPort": 8881,
+          "groupPort": 0,
+          "state": "ACTIVE",
+          "version": null,
+          "buildId": null,
+          "startTime": 0,
+          "upTimeSec": 0,
+          "activateTime": 0
+        },
+        {
+          "id": "server-2",
+          "serverEntities": [],
+          "serverName": "server-2",
+          "hostName": "hostname-4",
+          "hostAddress": null,
+          "bindAddress": "0.0.0.0",
+          "bindPort": 8881,
+          "groupPort": 0,
+          "state": "PASSIVE",
+          "version": null,
+          "buildId": null,
+          "startTime": 0,
+          "upTimeSec": 0,
+          "activateTime": 0
         }
-      } ],
-      "serverName" : "server-1",
-      "hostName" : "hostname-3",
-      "hostAddress" : null,
-      "bindAddress" : "0.0.0.0",
-      "bindPort" : 8881,
-      "groupPort" : 0,
-      "state" : "ACTIVE",
-      "version" : null,
-      "buildId" : null,
-      "startTime" : 0,
-      "upTimeSec" : 0,
-      "activateTime" : 0
-    }, {
-      "id" : "server-2",
-      "serverEntities" : [ ],
-      "serverName" : "server-2",
-      "hostName" : "hostname-4",
-      "hostAddress" : null,
-      "bindAddress" : "0.0.0.0",
-      "bindPort" : 8881,
-      "groupPort" : 0,
-      "state" : "PASSIVE",
-      "version" : null,
-      "buildId" : null,
-      "startTime" : 0,
-      "upTimeSec" : 0,
-      "activateTime" : 0
-    } ]
-  } ],
-  "clients" : [ {
-    "id" : "12345@127.0.0.1:ehcache:uid",
-    "pid" : 12345,
-    "hostAddress" : "127.0.0.1",
-    "name" : "ehcache",
-    "logicalConnectionUid" : "uid",
-    "vmId" : "12345@127.0.0.1",
-    "clientId" : "12345@127.0.0.1:ehcache:uid",
-    "hostName" : null,
-    "tags" : [ ],
-    "properties" : { },
-    "connections" : [ {
-      "id" : "uid:stripe-1:server-1:10.10.10.10:3456",
-      "logicalConnectionUid" : "uid",
-      "clientEndpoint" : {
-        "address" : "10.10.10.10",
-        "port" : 3456
-      },
-      "stripeId" : "stripe-1",
-      "serverId" : "server-1",
-      "serverEntityIds" : { }
-    }, {
-      "id" : "uid:stripe-2:server-1:10.10.10.10:3457",
-      "logicalConnectionUid" : "uid",
-      "clientEndpoint" : {
-        "address" : "10.10.10.10",
-        "port" : 3457
-      },
-      "stripeId" : "stripe-2",
-      "serverId" : "server-1",
-      "serverEntityIds" : { }
-    } ],
-    "managementRegistry" : {
-      "contextContainer" : {
-        "cacheManagerName" : "cache-manager-1",
-        "subContexts" : [ {
-          "cacheName" : "my-cache",
-          "subContexts" : [ ]
-        } ]
-      },
-      "capabilities" : [ {
-        "name" : "ActionCapability",
-        "context" : [ ],
-        "descriptors" : [ ]
-      } ]
+      ]
     }
-  } ]
+  ],
+  "clients": [
+    {
+      "id": "12345@127.0.0.1:ehcache:uid",
+      "pid": 12345,
+      "hostAddress": "127.0.0.1",
+      "name": "ehcache",
+      "logicalConnectionUid": "uid",
+      "vmId": "12345@127.0.0.1",
+      "clientId": "12345@127.0.0.1:ehcache:uid",
+      "hostName": null,
+      "tags": [],
+      "properties": {},
+      "connections": [
+        {
+          "id": "uid:stripe-1:server-1:10.10.10.10:3456",
+          "logicalConnectionUid": "uid",
+          "clientEndpoint": {
+            "address": "10.10.10.10",
+            "port": 3456
+          },
+          "stripeId": "stripe-1",
+          "serverId": "server-1",
+          "serverEntityIds": {}
+        },
+        {
+          "id": "uid:stripe-2:server-1:10.10.10.10:3457",
+          "logicalConnectionUid": "uid",
+          "clientEndpoint": {
+            "address": "10.10.10.10",
+            "port": 3457
+          },
+          "stripeId": "stripe-2",
+          "serverId": "server-1",
+          "serverEntityIds": {}
+        }
+      ],
+      "managementRegistry": {
+        "rootContext": {},
+        "contextContainer": {
+          "cacheManagerName": "cache-manager-1",
+          "subContexts": [
+            {
+              "cacheName": "my-cache",
+              "subContexts": []
+            }
+          ]
+        },
+        "capabilities": [
+          {
+            "name": "ActionCapability",
+            "context": [],
+            "descriptors": []
+          }
+        ]
+      }
+    }
+  ]
 }

--- a/management/management-model/src/main/java/org/terracotta/management/model/capabilities/context/CapabilityContext.java
+++ b/management/management-model/src/main/java/org/terracotta/management/model/capabilities/context/CapabilityContext.java
@@ -15,6 +15,10 @@
  */
 package org.terracotta.management.model.capabilities.context;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.terracotta.management.model.context.Context;
+
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -27,6 +31,8 @@ import java.util.Objects;
  * @author Mathieu Carbou
  */
 public final class CapabilityContext implements Serializable {
+
+  private static final Logger logger = LoggerFactory.getLogger(CapabilityContext.class);
 
   private static final long serialVersionUID = 1;
 
@@ -52,6 +58,22 @@ public final class CapabilityContext implements Serializable {
       }
     }
     return names;
+  }
+
+  /**
+   * Check if the context contains at least all required attributes
+   */
+  public boolean isValid(Context context) {
+    if (context == null) {
+      return false;
+    }
+    for (CapabilityContext.Attribute attribute : getRequiredAttributes()) {
+      if (context.get(attribute.getName()) == null) {
+        logger.debug("Required attribute: {} not found in context: {}", attribute.getName(), context);
+        return false;
+      }
+    }
+    return true;
   }
 
   public Collection<Attribute> getRequiredAttributes() {

--- a/management/management-model/src/main/java/org/terracotta/management/model/cluster/ClientIdentifier.java
+++ b/management/management-model/src/main/java/org/terracotta/management/model/cluster/ClientIdentifier.java
@@ -85,6 +85,10 @@ public final class ClientIdentifier implements Serializable {
     return getVmId() + ":" + name + ":" + connectionUid;
   }
 
+  public String getAppId() {
+    return getVmId() + ":" + name;
+  }
+
   @Override
   public String toString() {
     return getClientId();

--- a/management/management-model/src/main/java/org/terracotta/management/model/context/Context.java
+++ b/management/management-model/src/main/java/org/terracotta/management/model/context/Context.java
@@ -40,6 +40,12 @@ public class Context extends AbstractMap<String, String> implements Serializable
     return Collections.unmodifiableMap(back);
   }
 
+  public Context without(String key) {
+    Context context = new Context(back);
+    context.back.remove(key);
+    return context;
+  }
+
   public Context with(String key, String val) {
     if (val == null) {
       throw new NullPointerException();
@@ -68,7 +74,7 @@ public class Context extends AbstractMap<String, String> implements Serializable
     return back.size();
   }
 
-  public boolean isEmpty() { return back.isEmpty(); }
+  public boolean isEmpty() {return back.isEmpty();}
 
   @Override
   public Set<Entry<String, String>> entrySet() {

--- a/management/management-registry/src/main/java/org/terracotta/management/registry/AbstractManagementProvider.java
+++ b/management/management-registry/src/main/java/org/terracotta/management/registry/AbstractManagementProvider.java
@@ -167,7 +167,7 @@ public abstract class AbstractManagementProvider<T> implements ManagementProvide
   protected abstract ExposedObject<T> wrap(T managedObject);
 
   protected ExposedObject<T> findExposedObject(Context context) {
-    if (!contextValid(context)) {
+    if (!getCapabilityContext().isValid(context)) {
       return null;
     }
     for (ExposedObject<T> exposedObject : exposedObjects) {
@@ -187,17 +187,4 @@ public abstract class AbstractManagementProvider<T> implements ManagementProvide
     }
     return null;
   }
-
-  private boolean contextValid(Context context) {
-    if (context == null) {
-      return false;
-    }
-    for (CapabilityContext.Attribute attribute : getCapabilityContext().getAttributes()) {
-      if (context.get(attribute.getName()) == null) {
-        return false;
-      }
-    }
-    return true;
-  }
-
 }

--- a/management/management-registry/src/main/java/org/terracotta/management/registry/DefaultManagementRegistry.java
+++ b/management/management-registry/src/main/java/org/terracotta/management/registry/DefaultManagementRegistry.java
@@ -16,6 +16,7 @@
 package org.terracotta.management.registry;
 
 import org.terracotta.management.model.capabilities.Capability;
+import org.terracotta.management.model.context.Context;
 import org.terracotta.management.model.context.ContextContainer;
 
 import java.io.Closeable;
@@ -24,6 +25,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Objects;
 import java.util.TreeSet;
 import java.util.concurrent.CopyOnWriteArrayList;
 
@@ -33,6 +35,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
  */
 public class DefaultManagementRegistry implements ManagementRegistry, Closeable {
 
+  private final Context context;
   private final ContextContainer contextContainer;
 
   private static final Comparator<Capability> CAPABILITY_COMPARATOR = new Comparator<Capability>() {
@@ -44,8 +47,24 @@ public class DefaultManagementRegistry implements ManagementRegistry, Closeable 
 
   protected final List<ManagementProvider<?>> managementProviders = new CopyOnWriteArrayList<ManagementProvider<?>>();
 
+  public DefaultManagementRegistry() {
+    this.context = Context.empty();
+    this.contextContainer = null;
+  }
+
+  public DefaultManagementRegistry(Context context) {
+    this.context = Objects.requireNonNull(context);
+    this.contextContainer = null;
+  }
+
   public DefaultManagementRegistry(ContextContainer contextContainer) {
-    this.contextContainer = contextContainer; // accept null values - can be overridden
+    this.contextContainer = Objects.requireNonNull(contextContainer);
+    this.context = Context.create(contextContainer.getName(), contextContainer.getValue());
+  }
+
+  public DefaultManagementRegistry(Context context, ContextContainer contextContainer) {
+    this.contextContainer = Objects.requireNonNull(contextContainer);
+    this.context = Objects.requireNonNull(context).with(contextContainer.getName(), contextContainer.getValue());
   }
 
   @Override
@@ -122,6 +141,11 @@ public class DefaultManagementRegistry implements ManagementRegistry, Closeable 
   @Override
   public ContextContainer getContextContainer() {
     return contextContainer;
+  }
+
+  @Override
+  public Context getContext() {
+    return context;
   }
 
   @Override

--- a/management/management-registry/src/main/java/org/terracotta/management/registry/ManagementRegistry.java
+++ b/management/management-registry/src/main/java/org/terracotta/management/registry/ManagementRegistry.java
@@ -15,6 +15,7 @@
  */
 package org.terracotta.management.registry;
 
+import org.terracotta.management.model.context.Context;
 import org.terracotta.management.model.context.ContextContainer;
 
 /**
@@ -61,4 +62,8 @@ public interface ManagementRegistry extends CapabilityManagementSupport {
    */
   ContextContainer getContextContainer();
 
+  /**
+   * Will contain the context container, instance id or consumer id, and eventually other things
+   */
+  Context getContext();
 }

--- a/management/management-registry/src/test/java/org/terracotta/management/registry/ManagementRegistryTest.java
+++ b/management/management-registry/src/test/java/org/terracotta/management/registry/ManagementRegistryTest.java
@@ -66,6 +66,7 @@ public class ManagementRegistryTest {
     ContextualReturn<?> cr = registry.withCapability("TheActionProvider")
         .call("incr", int.class, new Parameter(Integer.MAX_VALUE, "int"))
         .on(Context.empty()
+            .with("instanceId", "instance-0")
             .with("cacheManagerName", "myCacheManagerName")
             .with("cacheName", "myCacheName1"))
         .build()

--- a/management/management-registry/src/test/java/org/terracotta/management/registry/action/ActionProviderTest.java
+++ b/management/management-registry/src/test/java/org/terracotta/management/registry/action/ActionProviderTest.java
@@ -68,10 +68,13 @@ public class ActionProviderTest {
 
     CapabilityContext capabilityContext = managementProvider.getCapabilityContext();
 
-    assertThat(capabilityContext.getAttributes().size(), is(2));
+    assertThat(capabilityContext.getAttributes().size(), is(3));
 
     Iterator<CapabilityContext.Attribute> iterator = capabilityContext.getAttributes().iterator();
     CapabilityContext.Attribute next = iterator.next();
+    assertThat(next.getName(), equalTo("instanceId"));
+    assertThat(next.isRequired(), is(true));
+    next = iterator.next();
     assertThat(next.getName(), equalTo("cacheManagerName"));
     assertThat(next.isRequired(), is(true));
     next = iterator.next();
@@ -94,6 +97,7 @@ public class ActionProviderTest {
     managementProvider.register(new MyObject("cache-manager-0", "cache-0"));
 
     Context context = Context.empty()
+        .with("instanceId", "instance-0")
         .with("cacheManagerName", "cache-manager-0")
         .with("cacheName", "cache-0");
 
@@ -107,6 +111,7 @@ public class ActionProviderTest {
     managementProvider.register(new MyObject("cache-manager-0", "cache-0"));
 
     Context context = Context.empty()
+        .with("instanceId", "instance-0")
         .with("cacheManagerName", "cache-manager-0")
         .with("cacheName", "cache-1");
 

--- a/management/management-registry/src/test/java/org/terracotta/management/registry/action/MyManagementProvider.java
+++ b/management/management-registry/src/test/java/org/terracotta/management/registry/action/MyManagementProvider.java
@@ -23,7 +23,7 @@ import org.terracotta.management.registry.RequiredContext;
  * @author Mathieu Carbou
  */
 @Named("TheActionProvider")
-@RequiredContext({@Named("cacheManagerName"), @Named("cacheName")})
+@RequiredContext({@Named("instanceId"), @Named("cacheManagerName"), @Named("cacheName")})
 public class MyManagementProvider extends AbstractActionManagementProvider<MyObject> {
   public MyManagementProvider() {
     super(MyObject.class);

--- a/management/management-registry/src/test/java/org/terracotta/management/registry/action/MyObject.java
+++ b/management/management-registry/src/test/java/org/terracotta/management/registry/action/MyObject.java
@@ -56,7 +56,7 @@ public class MyObject implements ExposedObject<MyObject> {
 
   @Override
   public Context getContext() {
-    return Context.empty().with("cacheManagerName", cmName).with("cacheName", cName);
+    return Context.empty().with("instanceId", "instance-0").with("cacheManagerName", cmName).with("cacheName", cName);
   }
 
   @Override

--- a/management/management-registry/src/test/resources/capabilities.json
+++ b/management/management-registry/src/test/resources/capabilities.json
@@ -10,6 +10,9 @@
   } ],
   "capabilityContext" : {
     "attributes" : [ {
+      "name" : "instanceId",
+      "required" : true
+    }, {
       "name" : "cacheManagerName",
       "required" : true
     }, {

--- a/management/monitoring-service-api/src/main/java/org/terracotta/management/service/monitoring/ClientMonitoringService.java
+++ b/management/monitoring-service-api/src/main/java/org/terracotta/management/service/monitoring/ClientMonitoringService.java
@@ -19,6 +19,7 @@ import org.terracotta.entity.ClientDescriptor;
 import org.terracotta.entity.CommonServerEntity;
 import org.terracotta.management.model.call.ContextualReturn;
 import org.terracotta.management.model.capabilities.Capability;
+import org.terracotta.management.model.context.Context;
 import org.terracotta.management.model.context.ContextContainer;
 import org.terracotta.management.model.notification.ContextualNotification;
 import org.terracotta.management.model.stats.ContextualStatistics;
@@ -58,7 +59,7 @@ public interface ClientMonitoringService extends Closeable {
    * <p>
    * Can be called from active entity only
    */
-  void exposeManagementRegistry(ClientDescriptor caller, ContextContainer contextContainer, Capability... capabilities);
+  void exposeManagementRegistry(ClientDescriptor caller, Context root, ContextContainer contextContainer, Capability... capabilities);
 
   /**
    * Answer a management call we received and executed

--- a/management/monitoring-service/src/main/java/org/terracotta/management/service/monitoring/DefaultClientMonitoringService.java
+++ b/management/monitoring-service/src/main/java/org/terracotta/management/service/monitoring/DefaultClientMonitoringService.java
@@ -84,12 +84,12 @@ class DefaultClientMonitoringService implements ClientMonitoringService, Topolog
   }
 
   @Override
-  public void exposeManagementRegistry(ClientDescriptor from, ContextContainer contextContainer, Capability... capabilities) {
+  public void exposeManagementRegistry(ClientDescriptor from, Context root, ContextContainer contextContainer, Capability... capabilities) {
     if (LOGGER.isTraceEnabled()) {
       List<String> names = Stream.of(capabilities).map(Capability::getName).collect(Collectors.toList());
       LOGGER.trace("[{}] exposeManagementRegistry({}, {})", consumerId, from, names);
     }
-    ManagementRegistry newRegistry = ManagementRegistry.create(contextContainer);
+    ManagementRegistry newRegistry = ManagementRegistry.create(root, contextContainer);
     newRegistry.addCapabilities(capabilities);
     topologyService.willSetClientManagementRegistry(consumerId, from, newRegistry);
     topologyService.getClientIdentifier(consumerId, from)

--- a/management/monitoring-service/src/main/java/org/terracotta/management/service/monitoring/DefaultEntityMonitoringService.java
+++ b/management/monitoring-service/src/main/java/org/terracotta/management/service/monitoring/DefaultEntityMonitoringService.java
@@ -22,6 +22,7 @@ import org.terracotta.management.model.call.ContextualReturn;
 import org.terracotta.management.model.capabilities.Capability;
 import org.terracotta.management.model.cluster.ClientIdentifier;
 import org.terracotta.management.model.cluster.ManagementRegistry;
+import org.terracotta.management.model.context.Context;
 import org.terracotta.management.model.context.ContextContainer;
 import org.terracotta.management.model.notification.ContextualNotification;
 import org.terracotta.management.model.stats.ContextualStatistics;
@@ -82,7 +83,7 @@ class DefaultEntityMonitoringService implements EntityMonitoringService {
       List<String> names = Stream.of(capabilities).map(Capability::getName).collect(Collectors.toList());
       LOGGER.trace("[{}] exposeManagementRegistry({})", getConsumerId(), names);
     }
-    ManagementRegistry registry = ManagementRegistry.create(contextContainer);
+    ManagementRegistry registry = ManagementRegistry.create(Context.empty(), contextContainer);
     registry.addCapabilities(capabilities);
     forwardToActiveServer(REGISTRY, registry);
   }

--- a/management/monitoring-service/src/test/java/org/terracotta/management/service/monitoring/MyManagementProvider.java
+++ b/management/monitoring-service/src/test/java/org/terracotta/management/service/monitoring/MyManagementProvider.java
@@ -24,7 +24,7 @@ import org.terracotta.management.registry.RequiredContext;
  * @author Mathieu Carbou
  */
 @Named("TheActionProvider")
-@RequiredContext({@Named("cacheManagerName"), @Named("cacheName")})
+@RequiredContext({@Named("instanceId"), @Named("cacheManagerName"), @Named("cacheName")})
 public class MyManagementProvider extends AbstractManagementProvider<MyObject> {
   public MyManagementProvider() {
     super(MyObject.class);

--- a/management/monitoring-service/src/test/java/org/terracotta/management/service/monitoring/VoltronMonitoringServiceTest.java
+++ b/management/monitoring-service/src/test/java/org/terracotta/management/service/monitoring/VoltronMonitoringServiceTest.java
@@ -304,6 +304,7 @@ public class VoltronMonitoringServiceTest {
     test_fetch_entity();
     clientMonitoringService.exposeManagementRegistry(
         new FakeDesc("1-1"),
+        Context.empty(),
         new ContextContainer("ctName", "ctValue"),
         new DefaultCapability("capabilityName", new CapabilityContext(), new CallDescriptor("myMethod", "java.lang.String")));
     assertTopologyEquals("cluster-7.json");
@@ -406,6 +407,7 @@ public class VoltronMonitoringServiceTest {
 
     clientMonitoringService.exposeManagementRegistry(
         new FakeDesc("2-1"),
+        Context.empty(),
         new ContextContainer("ctName", "ctValue"),
         new DefaultCapability("capabilityName", new CapabilityContext(), new CallDescriptor("myMethod", "java.lang.String")));
 
@@ -439,7 +441,7 @@ public class VoltronMonitoringServiceTest {
     });
     String expected = new String(Files.readAllBytes(new File("src/test/resources/" + file).toPath()), "UTF-8");
     String sampled = mapper.writeValueAsString(cluster.toMap());
-    JSONAssert.assertEquals(expected, sampled, true);
+    JSONAssert.assertEquals(sampled, expected, sampled, true);
   }
 
   private List<Message> messages() {

--- a/management/monitoring-service/src/test/resources/cluster-7.json
+++ b/management/monitoring-service/src/test/resources/cluster-7.json
@@ -1,71 +1,86 @@
 {
-  "stripes" : [ {
-    "id" : "stripe[0]",
-    "name" : "stripe[0]",
-    "servers" : [ {
-      "id" : "server-1",
-      "serverEntities" : [ {
-        "id" : "entityName-1:entityType",
-        "type" : "entityType",
-        "name" : "entityName-1",
-        "consumerId" : 1,
-        "managementRegistry" : null
-      } ],
-      "serverName" : "server-1",
-      "hostName" : "localhost",
-      "hostAddress" : "127.0.0.1",
-      "bindAddress" : "0.0.0.0",
-      "bindPort" : 9510,
-      "groupPort" : 9610,
-      "state" : "ACTIVE",
-      "version" : "v1",
-      "buildId" : "b1",
-      "startTime" : 1476304913984,
-      "upTimeSec" : 0,
-      "activateTime" : 1615832230246
-    } ]
-  } ],
-  "clients" : [ {
-    "id" : "111@127.0.0.1:name:uuid-1",
-    "pid" : 111,
-    "hostAddress" : "127.0.0.1",
-    "name" : "name",
-    "logicalConnectionUid" : "uuid-1",
-    "vmId" : "111@127.0.0.1",
-    "clientId" : "111@127.0.0.1:name:uuid-1",
-    "hostName" : "localhost",
-    "tags" : [ ],
-    "properties" : {
-        "clientReportedAddress" : "localhost:65432",
-        "version" : "1.2.0"
-    },
-    "connections" : [ {
-      "id" : "uuid-1:stripe[0]:server-1:127.0.0.1:5678",
-      "logicalConnectionUid" : "uuid-1",
-      "clientEndpoint" : {
-        "address" : "127.0.0.1",
-        "port" : 5678
-      },
-      "stripeId" : "stripe[0]",
-      "serverId" : "server-1",
-      "serverEntityIds" : {
-        "entityName-1:entityType" : 1
-      }
-    } ],
-    "managementRegistry" : {
-      "contextContainer" : {
-        "ctName" : "ctValue",
-        "subContexts" : [ ]
-      },
-      "capabilities" : [ {
-        "name" : "capabilityName",
-        "context" : [ ],
-        "descriptors" : [ {
-          "name" : "myMethod",
-          "returnType" : "java.lang.String",
-          "parameters" : [ ]
-        } ]
-      } ]
+  "stripes": [
+    {
+      "id": "stripe[0]",
+      "name": "stripe[0]",
+      "servers": [
+        {
+          "id": "server-1",
+          "serverEntities": [
+            {
+              "id": "entityName-1:entityType",
+              "type": "entityType",
+              "name": "entityName-1",
+              "consumerId": 1,
+              "managementRegistry": null
+            }
+          ],
+          "serverName": "server-1",
+          "hostName": "localhost",
+          "hostAddress": "127.0.0.1",
+          "bindAddress": "0.0.0.0",
+          "bindPort": 9510,
+          "groupPort": 9610,
+          "state": "ACTIVE",
+          "version": "v1",
+          "buildId": "b1",
+          "startTime": 1476304913984,
+          "upTimeSec": 0,
+          "activateTime": 1615832230246
+        }
+      ]
     }
-  } ]
+  ],
+  "clients": [
+    {
+      "id": "111@127.0.0.1:name:uuid-1",
+      "pid": 111,
+      "hostAddress": "127.0.0.1",
+      "name": "name",
+      "logicalConnectionUid": "uuid-1",
+      "vmId": "111@127.0.0.1",
+      "clientId": "111@127.0.0.1:name:uuid-1",
+      "hostName": "localhost",
+      "tags": [],
+      "properties": {
+        "version": "1.2.0",
+        "clientReportedAddress": "localhost:65432"
+      },
+      "connections": [
+        {
+          "id": "uuid-1:stripe[0]:server-1:127.0.0.1:5678",
+          "logicalConnectionUid": "uuid-1",
+          "clientEndpoint": {
+            "address": "127.0.0.1",
+            "port": 5678
+          },
+          "stripeId": "stripe[0]",
+          "serverId": "server-1",
+          "serverEntityIds": {
+            "entityName-1:entityType": 1
+          }
+        }
+      ],
+      "managementRegistry": {
+        "rootContext": {},
+        "contextContainer": {
+          "ctName": "ctValue",
+          "subContexts": []
+        },
+        "capabilities": [
+          {
+            "name": "capabilityName",
+            "context": [],
+            "descriptors": [
+              {
+                "name": "myMethod",
+                "returnType": "java.lang.String",
+                "parameters": []
+              }
+            ]
+          }
+        ]
+      }
+    }
+  ]
 }

--- a/management/monitoring-service/src/test/resources/cluster-8.json
+++ b/management/monitoring-service/src/test/resources/cluster-8.json
@@ -1,69 +1,84 @@
 {
-  "stripes" : [ {
-    "id" : "stripe[0]",
-    "name" : "stripe[0]",
-    "servers" : [ {
-      "id" : "server-1",
-      "serverEntities" : [ {
-        "id" : "entityName-1:entityType",
-        "type" : "entityType",
-        "name" : "entityName-1",
-        "consumerId" : 1,
-        "managementRegistry" : {
-          "contextContainer" : {
-            "ctName" : "ctValue",
-            "subContexts" : [ ]
-          },
-          "capabilities" : [ {
-            "name" : "capabilityName",
-            "context" : [ ],
-            "descriptors" : [ {
-              "name" : "myMethod",
-              "returnType" : "java.lang.String",
-              "parameters" : [ ]
-            } ]
-          } ]
+  "stripes": [
+    {
+      "id": "stripe[0]",
+      "name": "stripe[0]",
+      "servers": [
+        {
+          "id": "server-1",
+          "serverEntities": [
+            {
+              "id": "entityName-1:entityType",
+              "type": "entityType",
+              "name": "entityName-1",
+              "consumerId": 1,
+              "managementRegistry": {
+                "rootContext": {},
+                "contextContainer": {
+                  "ctName": "ctValue",
+                  "subContexts": []
+                },
+                "capabilities": [
+                  {
+                    "name": "capabilityName",
+                    "context": [],
+                    "descriptors": [
+                      {
+                        "name": "myMethod",
+                        "returnType": "java.lang.String",
+                        "parameters": []
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "serverName": "server-1",
+          "hostName": "localhost",
+          "hostAddress": "127.0.0.1",
+          "bindAddress": "0.0.0.0",
+          "bindPort": 9510,
+          "groupPort": 9610,
+          "state": "ACTIVE",
+          "version": "v1",
+          "buildId": "b1",
+          "startTime": 1476304913984,
+          "upTimeSec": 0,
+          "activateTime": 1615832230246
         }
-      } ],
-      "serverName" : "server-1",
-      "hostName" : "localhost",
-      "hostAddress" : "127.0.0.1",
-      "bindAddress" : "0.0.0.0",
-      "bindPort" : 9510,
-      "groupPort" : 9610,
-      "state" : "ACTIVE",
-      "version" : "v1",
-      "buildId" : "b1",
-      "startTime" : 1476304913984,
-      "upTimeSec" : 0,
-      "activateTime" : 1615832230246
-    } ]
-  } ],
-  "clients" : [ {
-    "id" : "111@127.0.0.1:name:uuid-1",
-    "pid" : 111,
-    "hostAddress" : "127.0.0.1",
-    "name" : "name",
-    "logicalConnectionUid" : "uuid-1",
-    "vmId" : "111@127.0.0.1",
-    "clientId" : "111@127.0.0.1:name:uuid-1",
-    "hostName" : "localhost",
-    "tags" : [ ],
-    "properties" : {
-        "clientReportedAddress" : "localhost:65432",
-        "version" : "1.2.0"
-    },
-    "connections" : [ {
-      "id" : "uuid-1:stripe[0]:server-1:127.0.0.1:5678",
-      "logicalConnectionUid" : "uuid-1",
-      "clientEndpoint" : {
-        "address" : "127.0.0.1",
-        "port" : 5678
+      ]
+    }
+  ],
+  "clients": [
+    {
+      "id": "111@127.0.0.1:name:uuid-1",
+      "pid": 111,
+      "hostAddress": "127.0.0.1",
+      "name": "name",
+      "logicalConnectionUid": "uuid-1",
+      "vmId": "111@127.0.0.1",
+      "clientId": "111@127.0.0.1:name:uuid-1",
+      "hostName": "localhost",
+      "tags": [],
+      "properties": {
+        "version": "1.2.0",
+        "clientReportedAddress": "localhost:65432"
       },
-      "stripeId" : "stripe[0]",
-      "serverId" : "server-1",
-      "serverEntityIds" : { }
-    } ],
-    "managementRegistry" : null
-  } ]
+      "connections": [
+        {
+          "id": "uuid-1:stripe[0]:server-1:127.0.0.1:5678",
+          "logicalConnectionUid": "uuid-1",
+          "clientEndpoint": {
+            "address": "127.0.0.1",
+            "port": 5678
+          },
+          "stripeId": "stripe[0]",
+          "serverId": "server-1",
+          "serverEntityIds": {}
+        }
+      ],
+      "managementRegistry": null
+    }
+  ]
 }

--- a/management/monitoring-service/src/test/resources/cluster-9.json
+++ b/management/monitoring-service/src/test/resources/cluster-9.json
@@ -1,90 +1,108 @@
 {
-  "stripes" : [ {
-    "id" : "stripe[0]",
-    "name" : "stripe[0]",
-    "servers" : [ {
-      "id" : "server-1",
-      "serverEntities" : [ {
-        "id" : "entityName-1:entityType",
-        "type" : "entityType",
-        "name" : "entityName-1",
-        "consumerId" : 1,
-        "managementRegistry" : null
-      } ],
-      "serverName" : "server-1",
-      "hostName" : "localhost",
-      "hostAddress" : "127.0.0.1",
-      "bindAddress" : "0.0.0.0",
-      "bindPort" : 9510,
-      "groupPort" : 9610,
-      "state" : "ACTIVE",
-      "version" : "v1",
-      "buildId" : "b1",
-      "startTime" : 1476304913984,
-      "upTimeSec" : 0,
-      "activateTime" : 1615832230246
-    }, {
-      "id" : "server-2",
-      "serverEntities" : [ {
-        "id" : "entityName-1:entityType",
-        "type" : "entityType",
-        "name" : "entityName-1",
-        "consumerId" : 3,
-        "managementRegistry" : {
-          "contextContainer" : {
-            "k" : "v",
-            "subContexts" : [ ]
-          },
-          "capabilities" : [ {
-            "name" : "capabilityName",
-            "context" : [ ],
-            "descriptors" : [ {
-              "name" : "myMethod",
-              "returnType" : "java.lang.String",
-              "parameters" : [ ]
-            } ]
-          } ]
+  "stripes": [
+    {
+      "id": "stripe[0]",
+      "name": "stripe[0]",
+      "servers": [
+        {
+          "id": "server-1",
+          "serverEntities": [
+            {
+              "id": "entityName-1:entityType",
+              "type": "entityType",
+              "name": "entityName-1",
+              "consumerId": 1,
+              "managementRegistry": null
+            }
+          ],
+          "serverName": "server-1",
+          "hostName": "localhost",
+          "hostAddress": "127.0.0.1",
+          "bindAddress": "0.0.0.0",
+          "bindPort": 9510,
+          "groupPort": 9610,
+          "state": "ACTIVE",
+          "version": "v1",
+          "buildId": "b1",
+          "startTime": 1476304913984,
+          "upTimeSec": 0,
+          "activateTime": 1615832230246
+        },
+        {
+          "id": "server-2",
+          "serverEntities": [
+            {
+              "id": "entityName-1:entityType",
+              "type": "entityType",
+              "name": "entityName-1",
+              "consumerId": 3,
+              "managementRegistry": {
+                "rootContext": {},
+                "contextContainer": {
+                  "k": "v",
+                  "subContexts": []
+                },
+                "capabilities": [
+                  {
+                    "name": "capabilityName",
+                    "context": [],
+                    "descriptors": [
+                      {
+                        "name": "myMethod",
+                        "returnType": "java.lang.String",
+                        "parameters": []
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "serverName": "server-2",
+          "hostName": "localhost",
+          "hostAddress": "127.0.0.1",
+          "bindAddress": "0.0.0.0",
+          "bindPort": 9511,
+          "groupPort": 9611,
+          "state": "PASSIVE",
+          "version": "v1",
+          "buildId": "b1",
+          "startTime": 1476304913984,
+          "upTimeSec": 0,
+          "activateTime": 0
         }
-      } ],
-      "serverName" : "server-2",
-      "hostName" : "localhost",
-      "hostAddress" : "127.0.0.1",
-      "bindAddress" : "0.0.0.0",
-      "bindPort" : 9511,
-      "groupPort" : 9611,
-      "state" : "PASSIVE",
-      "version" : "v1",
-      "buildId" : "b1",
-      "startTime" : 1476304913984,
-      "upTimeSec" : 0,
-      "activateTime" : 0
-    } ]
-  } ],
-  "clients" : [ {
-    "id" : "111@127.0.0.1:name:uuid-1",
-    "pid" : 111,
-    "hostAddress" : "127.0.0.1",
-    "name" : "name",
-    "logicalConnectionUid" : "uuid-1",
-    "vmId" : "111@127.0.0.1",
-    "clientId" : "111@127.0.0.1:name:uuid-1",
-    "hostName" : "localhost",
-    "tags" : [ ],
-    "properties" : {
-        "clientReportedAddress" : "localhost:65432",
-        "version" : "1.2.0"
-    },
-    "connections" : [ {
-      "id" : "uuid-1:stripe[0]:server-1:127.0.0.1:5678",
-      "logicalConnectionUid" : "uuid-1",
-      "clientEndpoint" : {
-        "address" : "127.0.0.1",
-        "port" : 5678
+      ]
+    }
+  ],
+  "clients": [
+    {
+      "id": "111@127.0.0.1:name:uuid-1",
+      "pid": 111,
+      "hostAddress": "127.0.0.1",
+      "name": "name",
+      "logicalConnectionUid": "uuid-1",
+      "vmId": "111@127.0.0.1",
+      "clientId": "111@127.0.0.1:name:uuid-1",
+      "hostName": "localhost",
+      "tags": [],
+      "properties": {
+        "version": "1.2.0",
+        "clientReportedAddress": "localhost:65432"
       },
-      "stripeId" : "stripe[0]",
-      "serverId" : "server-1",
-      "serverEntityIds" : { }
-    } ],
-    "managementRegistry" : null
-  } ]
+      "connections": [
+        {
+          "id": "uuid-1:stripe[0]:server-1:127.0.0.1:5678",
+          "logicalConnectionUid": "uuid-1",
+          "clientEndpoint": {
+            "address": "127.0.0.1",
+            "port": 5678
+          },
+          "stripeId": "stripe[0]",
+          "serverId": "server-1",
+          "serverEntityIds": {}
+        }
+      ],
+      "managementRegistry": null
+    }
+  ]
 }

--- a/management/nms-agent-entity/nms-agent-entity-common/src/main/java/org/terracotta/management/entity/nms/agent/NmsAgent.java
+++ b/management/nms-agent-entity/nms-agent-entity-common/src/main/java/org/terracotta/management/entity/nms/agent/NmsAgent.java
@@ -17,6 +17,7 @@ package org.terracotta.management.entity.nms.agent;
 
 import org.terracotta.management.model.call.ContextualReturn;
 import org.terracotta.management.model.capabilities.Capability;
+import org.terracotta.management.model.context.Context;
 import org.terracotta.management.model.context.ContextContainer;
 import org.terracotta.management.model.notification.ContextualNotification;
 import org.terracotta.management.model.stats.ContextualStatistics;
@@ -40,11 +41,27 @@ public interface NmsAgent {
    * @param contextContainer output from Management registry
    * @param capabilities     output from Management registry
    * @param clientDescriptor must be null, used only for implementation
+   * @deprecated Use instead: {@link #exposeManagementMetadata(Object, Context, ContextContainer, Capability...)}
    */
   @Async(Async.Ack.NONE)
   @ConcurrencyStrategy(key = ConcurrencyStrategy.UNIVERSAL_KEY)
   @ExecutionStrategy(location = ACTIVE)
-  Future<Void> exposeManagementMetadata(@ClientId Object clientDescriptor, ContextContainer contextContainer, Capability... capabilities);
+  @Deprecated
+  default Future<Void> exposeManagementMetadata(@ClientId Object clientDescriptor, ContextContainer contextContainer, Capability... capabilities) {
+    return exposeManagementMetadata(clientDescriptor, Context.empty(), contextContainer, capabilities);
+  }
+
+  /**
+   * Exposes this management registry output (context container and capabilities) over this connection.
+   *
+   * @param contextContainer output from Management registry
+   * @param capabilities     output from Management registry
+   * @param clientDescriptor must be null, used only for implementation
+   */
+  @Async(Async.Ack.NONE)
+  @ConcurrencyStrategy(key = ConcurrencyStrategy.UNIVERSAL_KEY)
+  @ExecutionStrategy(location = ACTIVE)
+  Future<Void> exposeManagementMetadata(@ClientId Object clientDescriptor, Context root, ContextContainer contextContainer, Capability... capabilities);
 
   /**
    * Exposes client tags
@@ -79,7 +96,7 @@ public interface NmsAgent {
   /**
    * Sends client's stats to the server
    *
-   * @param statistics     the client's stats
+   * @param statistics       the client's stats
    * @param clientDescriptor must be null, used only for implementation
    */
   @Async(Async.Ack.NONE)

--- a/management/nms-agent-entity/nms-agent-entity-common/src/main/java/org/terracotta/management/entity/nms/agent/ReconnectData.java
+++ b/management/nms-agent-entity/nms-agent-entity-common/src/main/java/org/terracotta/management/entity/nms/agent/ReconnectData.java
@@ -17,6 +17,7 @@ package org.terracotta.management.entity.nms.agent;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.terracotta.management.model.capabilities.Capability;
+import org.terracotta.management.model.context.Context;
 import org.terracotta.management.model.context.ContextContainer;
 import org.terracotta.management.model.notification.ContextualNotification;
 
@@ -28,16 +29,18 @@ import java.io.Serializable;
 @SuppressFBWarnings("SE_BAD_FIELD")
 public class ReconnectData implements Serializable {
 
-  private static final long serialVersionUID = 1L;
+  private static final long serialVersionUID = 2L;
 
+  public final Context root;
   public final String[] tags;
   public final ContextContainer contextContainer;
   public final Capability[] capabilities;
   public final ContextualNotification contextualNotification;
 
-  public ReconnectData(String[] tags, ContextContainer contextContainer, Capability[] capabilities, ContextualNotification contextualNotification) {
+  public ReconnectData(String[] tags, Context root, ContextContainer contextContainer, Capability[] capabilities, ContextualNotification contextualNotification) {
     this.tags = tags;
     this.contextContainer = contextContainer;
+    this.root = root;
     this.capabilities = capabilities;
     this.contextualNotification = contextualNotification;
   }

--- a/management/nms-agent-entity/nms-agent-entity-server/src/main/java/org/terracotta/management/entity/nms/agent/server/ActiveNmsAgentServerEntity.java
+++ b/management/nms-agent-entity/nms-agent-entity-server/src/main/java/org/terracotta/management/entity/nms/agent/server/ActiveNmsAgentServerEntity.java
@@ -22,6 +22,7 @@ import org.terracotta.management.entity.nms.agent.NmsAgent;
 import org.terracotta.management.entity.nms.agent.ReconnectData;
 import org.terracotta.management.model.call.ContextualReturn;
 import org.terracotta.management.model.capabilities.Capability;
+import org.terracotta.management.model.context.Context;
 import org.terracotta.management.model.context.ContextContainer;
 import org.terracotta.management.model.notification.ContextualNotification;
 import org.terracotta.management.model.stats.ContextualStatistics;
@@ -59,7 +60,7 @@ class ActiveNmsAgentServerEntity extends ActiveProxiedServerEntity<Void, Reconne
     if (reconnectData != null && clientMonitoringService != null) {
       LOGGER.info("Client reconnecting: {}", clientDescriptor);
       exposeTags(clientDescriptor, reconnectData.tags);
-      exposeManagementMetadata(clientDescriptor, reconnectData.contextContainer, reconnectData.capabilities);
+      exposeManagementMetadata(clientDescriptor, reconnectData.root == null ? Context.empty() : reconnectData.root, reconnectData.contextContainer, reconnectData.capabilities);
       pushNotification(clientDescriptor, reconnectData.contextualNotification);
     }
   }
@@ -81,9 +82,9 @@ class ActiveNmsAgentServerEntity extends ActiveProxiedServerEntity<Void, Reconne
   }
 
   @Override
-  public Future<Void> exposeManagementMetadata(@ClientId Object caller, ContextContainer contextContainer, Capability... capabilities) {
+  public Future<Void> exposeManagementMetadata(@ClientId Object caller, Context root, ContextContainer contextContainer, Capability... capabilities) {
     if (clientMonitoringService != null && contextContainer != null && capabilities != null) {
-      clientMonitoringService.exposeManagementRegistry((ClientDescriptor) caller, contextContainer, capabilities);
+      clientMonitoringService.exposeManagementRegistry((ClientDescriptor) caller, root, contextContainer, capabilities);
     }
     return CompletableFuture.completedFuture(null);
   }

--- a/management/nms-agent-entity/nms-agent-entity-server/src/main/java/org/terracotta/management/entity/nms/agent/server/PassiveNmsAgentServerEntity.java
+++ b/management/nms-agent-entity/nms-agent-entity-server/src/main/java/org/terracotta/management/entity/nms/agent/server/PassiveNmsAgentServerEntity.java
@@ -18,6 +18,7 @@ package org.terracotta.management.entity.nms.agent.server;
 import org.terracotta.management.entity.nms.agent.NmsAgent;
 import org.terracotta.management.model.call.ContextualReturn;
 import org.terracotta.management.model.capabilities.Capability;
+import org.terracotta.management.model.context.Context;
 import org.terracotta.management.model.context.ContextContainer;
 import org.terracotta.management.model.notification.ContextualNotification;
 import org.terracotta.management.model.stats.ContextualStatistics;
@@ -31,7 +32,7 @@ import java.util.concurrent.Future;
  */
 class PassiveNmsAgentServerEntity extends PassiveProxiedServerEntity implements NmsAgent {
   @Override
-  public Future<Void> exposeManagementMetadata(@ClientId Object clientDescriptor, ContextContainer contextContainer, Capability... capabilities) {
+  public Future<Void> exposeManagementMetadata(@ClientId Object clientDescriptor, Context root, ContextContainer contextContainer, Capability... capabilities) {
     throw new UnsupportedOperationException("Cannot be called on a passive server");
   }
 

--- a/management/nms-entity/nms-entity-client/src/main/java/org/terracotta/management/entity/nms/client/DefaultNmsService.java
+++ b/management/nms-entity/nms-entity-client/src/main/java/org/terracotta/management/entity/nms/client/DefaultNmsService.java
@@ -60,7 +60,7 @@ public class DefaultNmsService implements NmsService, Closeable {
   }
 
   public DefaultNmsService(final NmsEntity entity, BlockingQueue<Optional<Message>> incomingMessageQueue) {
-    this(entity, incomingMessageQueue, message -> LOGGER.warn("Queue is full - Message lost: ", message));
+    this(entity, incomingMessageQueue, message -> LOGGER.warn("Queue is full - Message lost: {}", message));
   }
 
   public DefaultNmsService(final NmsEntity entity, BlockingQueue<Optional<Message>> incomingMessageQueue, Consumer<Message> sink) {

--- a/management/testing/doc/src/main/java/org/terracotta/management/doc/StartSampleEntity.java
+++ b/management/testing/doc/src/main/java/org/terracotta/management/doc/StartSampleEntity.java
@@ -21,6 +21,7 @@ import org.terracotta.management.entity.sample.client.CacheFactory;
 
 import java.net.URI;
 import java.util.Random;
+import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 
@@ -29,7 +30,7 @@ import java.util.concurrent.TimeoutException;
  */
 public class StartSampleEntity {
   public static void main(String[] args) throws ConnectionException, ExecutionException, TimeoutException, InterruptedException {
-    CacheFactory cacheFactory = new CacheFactory(URI.create("terracotta://localhost:9510"), "pet-clinic");
+    CacheFactory cacheFactory = new CacheFactory(UUID.randomUUID().toString(), URI.create("terracotta://localhost:9510"), "pet-clinic");
 
     cacheFactory.init();
 

--- a/management/testing/integration-tests/pom.xml
+++ b/management/testing/integration-tests/pom.xml
@@ -182,6 +182,7 @@
           <reuseForks>false</reuseForks>
           <systemPropertyVariables>
             <kitInstallationPath>${project.build.directory}/platform-kit-${project.version}</kitInstallationPath>
+            <serverWorkingDir>${project.build.directory}</serverWorkingDir>
           </systemPropertyVariables>
           <argLine>-XX:+UseG1GC</argLine>
         </configuration>

--- a/management/testing/integration-tests/src/test/java/org/terracotta/management/integration/tests/AbstractTest.java
+++ b/management/testing/integration-tests/src/test/java/org/terracotta/management/integration/tests/AbstractTest.java
@@ -174,9 +174,13 @@ public abstract class AbstractTest {
   }
 
   protected void addWebappNode(URI uri, String path) throws Exception {
-    CacheFactory cacheFactory = new CacheFactory(uri, path);
+    CacheFactory cacheFactory = new CacheFactory(nextInstanceId(), uri, path);
     cacheFactory.init();
     webappNodes.add(cacheFactory);
+  }
+
+  protected final String nextInstanceId() {
+    return "instance-" + webappNodes.size();
   }
 
   private void connectManagementClient(URI uri) throws Exception {
@@ -242,6 +246,8 @@ public abstract class AbstractTest {
         .replaceAll("\"id\":\"[^\"]+:([\\w\\[\\]]+):[^\"]+:[^\"]+:[^\"]+\",\"logicalConnectionUid\":\"[^\"]*\"", "\"id\":\"<uuid>:$1:testServer0:127.0.0.1:0\",\"logicalConnectionUid\":\"<uuid>\"")
         .replaceAll("\"vmId\":\"[^\"]*\"", "\"vmId\":\"0@127.0.0.1\"")
         .replaceAll("-2", "")
+        .replaceAll("instance-0", "instance-?")
+        .replaceAll("instance-1", "instance-?")
         .replaceAll("testServer1", "testServer0")
         .replaceAll("\"(clientReportedAddress)\":\"[^\"]*\"", "\"$1\":\"<$1>\"")
         .replaceAll("\"clientRevision\":\"[^\"]*\"", "\"clientRevision\":\"<uuid>\"");
@@ -291,7 +297,7 @@ public abstract class AbstractTest {
         .clientStream()
         .filter(client -> client.getName().equals("pet-clinic"))
         .filter(AbstractManageableNode::isManageable)
-        .map(client -> client.getContext().with("appName", "pet-clinic"))
+        .map(AbstractManageableNode::getContext)
         .map(context -> {
           try {
             return nmsService.startStatisticCollector(context, interval, unit).asCompletionStage();
@@ -307,13 +313,13 @@ public abstract class AbstractTest {
     List<String> waitingFor = new ArrayList<>(Arrays.asList(notificationTypes));
     try {
       return nmsService.waitForMessage(message -> {
-        if (message.getType().equals("NOTIFICATION")) {
-          for (ContextualNotification notification : message.unwrap(ContextualNotification.class)) {
-            waitingFor.remove(notification.getType());
-          }
-        }
-        return waitingFor.isEmpty();
-      }).stream()
+            if (message.getType().equals("NOTIFICATION")) {
+              for (ContextualNotification notification : message.unwrap(ContextualNotification.class)) {
+                waitingFor.remove(notification.getType());
+              }
+            }
+            return waitingFor.isEmpty();
+          }).stream()
           .filter(message -> message.getType().equals("NOTIFICATION"))
           .flatMap(message -> message.unwrap(ContextualNotification.class).stream())
           .collect(Collectors.toList());

--- a/management/testing/integration-tests/src/test/java/org/terracotta/management/integration/tests/BadClientsIT.java
+++ b/management/testing/integration-tests/src/test/java/org/terracotta/management/integration/tests/BadClientsIT.java
@@ -36,7 +36,7 @@ public class BadClientsIT extends AbstractSingleTest {
     URI uri = cluster.getConnectionURI();
     String uuid = UUID.randomUUID().toString();
 
-    CacheFactory cacheFactory1 = new CacheFactory(uri, "bad-client");
+    CacheFactory cacheFactory1 = new CacheFactory(nextInstanceId(), uri, "bad-client");
     cacheFactory1.init(uuid);
     Cache foo1 = cacheFactory1.getCache("foo");
 
@@ -46,7 +46,7 @@ public class BadClientsIT extends AbstractSingleTest {
     assertThat(count, equalTo(1L));
 
     // create another client that will have the same client identifier
-    CacheFactory cacheFactory2 = new CacheFactory(uri, "bad-client");
+    CacheFactory cacheFactory2 = new CacheFactory(nextInstanceId(), uri, "bad-client");
     cacheFactory2.init(uuid);
     ClientCache foo2 = (ClientCache) cacheFactory1.getCache("foo");
 

--- a/management/testing/integration-tests/src/test/java/org/terracotta/management/integration/tests/ClientCacheRemoteManagementIT.java
+++ b/management/testing/integration-tests/src/test/java/org/terracotta/management/integration/tests/ClientCacheRemoteManagementIT.java
@@ -37,7 +37,7 @@ public class ClientCacheRemoteManagementIT extends AbstractSingleTest {
   public void can_access_remote_management_registry_of_client() throws Exception {
     ManagementRegistry registry = nmsService.readTopology()
         .clientStream()
-        .filter(cli -> cli.getName().equals("pet-clinic"))
+        .filter(cli -> cli.getName().equals("pet-clinic") && cli.getContext().get("instanceId").equals("instance-0"))
         .findAny()
         .flatMap(Client::getManagementRegistry)
         .get();
@@ -63,9 +63,7 @@ public class ClientCacheRemoteManagementIT extends AbstractSingleTest {
         .get();
 
     // similar to cacheManagerName and cacheName context
-    Context context = client.getContext()
-        .with("appName", "pet-clinic")
-        .with("cacheName", "pets");
+    Context context = client.getContext().with("cacheName", "pets");
 
     // put
     nmsService.call(context, "CacheCalls", "put", Void.TYPE, new Parameter("pet1"), new Parameter("Cat")).waitForReturn();

--- a/management/testing/integration-tests/src/test/java/org/terracotta/management/integration/tests/FailoverIT.java
+++ b/management/testing/integration-tests/src/test/java/org/terracotta/management/integration/tests/FailoverIT.java
@@ -82,7 +82,7 @@ public class FailoverIT extends AbstractHATest {
 
     // removes all random values
     JsonNode actual = removeRandomValues(toJson(cluster.toMap()));
-    JSONAssert.assertEquals(readJson("topology-after-failover.json").toString(), actual.toString(), true);
+    JSONAssert.assertEquals(actual.toString(), readJson("topology-after-failover.json").toString(), actual.toString(), true);
   }
 
   @Test

--- a/management/testing/integration-tests/src/test/java/org/terracotta/management/integration/tests/NmsAgentServiceIT.java
+++ b/management/testing/integration-tests/src/test/java/org/terracotta/management/integration/tests/NmsAgentServiceIT.java
@@ -99,7 +99,7 @@ public class NmsAgentServiceIT {
     clientConnection = createConnection();
 
     // note the supplier below, which is used to recycle the entity with a potentially new connection
-    nmsAgentService = new DefaultNmsAgentService(this::createAgentEntity);
+    nmsAgentService = new DefaultNmsAgentService(Context.empty(), this::createAgentEntity);
     nmsAgentService.setOperationTimeout(30, TimeUnit.SECONDS);
     nmsAgentService.setOnOperationError((operation, throwable) -> opErrors.incrementAndGet());
     nmsAgentService.setManagementRegistry(registry);

--- a/management/testing/integration-tests/src/test/java/org/terracotta/management/integration/tests/PassiveTopologyIT.java
+++ b/management/testing/integration-tests/src/test/java/org/terracotta/management/integration/tests/PassiveTopologyIT.java
@@ -47,7 +47,7 @@ public class PassiveTopologyIT extends AbstractHATest {
     // clear buffer
     nmsService.readMessages();
 
-    CacheFactory cacheFactory = new CacheFactory(cluster.getConnectionURI(), "random-1");
+    CacheFactory cacheFactory = new CacheFactory(nextInstanceId(), cluster.getConnectionURI(), "random-1");
     cacheFactory.init();
     Cache cache = cacheFactory.getCache("my-cache");
     cache.put("key", "val");

--- a/management/testing/integration-tests/src/test/java/org/terracotta/management/integration/tests/ReconfigureEntityIT.java
+++ b/management/testing/integration-tests/src/test/java/org/terracotta/management/integration/tests/ReconfigureEntityIT.java
@@ -79,7 +79,12 @@ public class ReconfigureEntityIT extends AbstractSingleTest {
 
   @Test
   public void topology_after_reconfigure() throws Exception {
-    Cluster cluster = nmsService.readTopology();
+    webappNodes.remove(1).close();
+    Cluster cluster;
+    do {
+      cluster = nmsService.readTopology();
+    } while (cluster.getClientCount() != 2);
+
     JsonNode actual = removeRandomValues(toJson(cluster.toMap()));
     JsonNode expected = readJson("topology-before-reconfigure.json");
     assertEquals(actual.toPrettyString(), expected, actual);

--- a/management/testing/integration-tests/src/test/java/org/terracotta/management/integration/tests/SimpleGalvanIT.java
+++ b/management/testing/integration-tests/src/test/java/org/terracotta/management/integration/tests/SimpleGalvanIT.java
@@ -65,7 +65,7 @@ public class SimpleGalvanIT {
   @Before
   public void setUp() throws Exception {
     URI uri = CLUSTER.getConnectionURI();
-    cacheFactory = new CacheFactory(uri, "pif");
+    cacheFactory = new CacheFactory("instance-0", uri, "pif");
   }
 
   @After

--- a/management/testing/integration-tests/src/test/java/org/terracotta/management/integration/tests/UserErrorsIT.java
+++ b/management/testing/integration-tests/src/test/java/org/terracotta/management/integration/tests/UserErrorsIT.java
@@ -83,7 +83,7 @@ public class UserErrorsIT extends AbstractSingleTest {
       fail();
     } catch (ExecutionException e) {
       assertThat(e.getCause(), is(instanceOf(EntityUserException.class)));
-      assertThat(e.getCause().getMessage(), equalTo("Entity: org.terracotta.management.entity.nms.server.ActiveNmsServerEntity: exception in user code: java.lang.IllegalArgumentException: Server Entity {stripeId=stripe[0], serverId=testServer0, serverName=INEXISTING, entityId=pet-clinic/pets:org.terracotta.management.entity.sample.client.CacheEntity, entityName=pet-clinic/pets, entityType=org.terracotta.management.entity.sample.client.CacheEntity, consumerId=7, cacheName=pet-clinic/pets} is either not found or not manageable"));
+      assertThat(e.getCause().getMessage(), equalTo("Entity: org.terracotta.management.entity.nms.server.ActiveNmsServerEntity: exception in user code: java.lang.IllegalArgumentException: Server Entity {stripeId=stripe[0], serverId=testServer0, serverName=INEXISTING, entityId=pet-clinic/pets:org.terracotta.management.entity.sample.client.CacheEntity, consumerId=7, entityName=pet-clinic/pets, entityType=org.terracotta.management.entity.sample.client.CacheEntity, cacheName=pet-clinic/pets} is either not found or not manageable"));
     }
   }
 

--- a/management/testing/integration-tests/src/test/resources/client-descriptors.json
+++ b/management/testing/integration-tests/src/test/resources/client-descriptors.json
@@ -3,6 +3,10 @@
     "capabilityContext": {
       "attributes": [
         {
+          "name": "instanceId",
+          "required": true
+        },
+        {
           "name": "appName",
           "required": true
         },
@@ -54,6 +58,10 @@
     "capabilityContext": {
       "attributes": [
         {
+          "name": "instanceId",
+          "required": true
+        },
+        {
           "name": "appName",
           "required": true
         },
@@ -66,11 +74,13 @@
     "descriptors": [
       {
         "appName": "pet-clinic",
+        "instanceId": "instance-0",
         "cacheName": "pets",
         "size": 0
       },
       {
         "appName": "pet-clinic",
+        "instanceId": "instance-0",
         "cacheName": "clients",
         "size": 0
       }
@@ -80,6 +90,10 @@
   {
     "capabilityContext": {
       "attributes": [
+        {
+          "name": "instanceId",
+          "required": true
+        },
         {
           "name": "appName",
           "required": true
@@ -133,6 +147,10 @@
   {
     "capabilityContext": {
       "attributes": [
+        {
+          "name": "instanceId",
+          "required": true
+        },
         {
           "name": "appName",
           "required": true

--- a/management/testing/integration-tests/src/test/resources/notifications.json
+++ b/management/testing/integration-tests/src/test/resources/notifications.json
@@ -10,9 +10,33 @@
     },
     "type": "CLIENT_CONNECTED"
   },
-  {"attributes":{"version":"<version>"},"context":{"clientId":"0@127.0.0.1:pet-clinic:<uuid>"},"type":"CLIENT_PROPERTY_ADDED"},
-  {"attributes":{"clientReportedAddress":"<clientReportedAddress>"},"context":{"clientId":"0@127.0.0.1:pet-clinic:<uuid>"},"type":"CLIENT_PROPERTY_ADDED"},
-  {"attributes":{"clientRevision":"<uuid>"},"context":{"clientId":"0@127.0.0.1:pet-clinic:<uuid>"},"type":"CLIENT_PROPERTY_ADDED"},
+  {
+    "attributes": {
+      "version": "<version>"
+    },
+    "context": {
+      "clientId": "0@127.0.0.1:pet-clinic:<uuid>"
+    },
+    "type": "CLIENT_PROPERTY_ADDED"
+  },
+  {
+    "attributes": {
+      "clientReportedAddress": "<clientReportedAddress>"
+    },
+    "context": {
+      "clientId": "0@127.0.0.1:pet-clinic:<uuid>"
+    },
+    "type": "CLIENT_PROPERTY_ADDED"
+  },
+  {
+    "attributes": {
+      "clientRevision": "<uuid>"
+    },
+    "context": {
+      "clientId": "0@127.0.0.1:pet-clinic:<uuid>"
+    },
+    "type": "CLIENT_PROPERTY_ADDED"
+  },
   {
     "attributes": {
       "clientId": "0@127.0.0.1:pet-clinic:<uuid>"
@@ -31,14 +55,18 @@
   {
     "attributes": {},
     "context": {
-      "clientId": "0@127.0.0.1:pet-clinic:<uuid>"
+      "clientId": "0@127.0.0.1:pet-clinic:<uuid>",
+      "appName": "pet-clinic",
+      "instanceId": "instance-?"
     },
     "type": "CLIENT_REGISTRY_AVAILABLE"
   },
   {
     "attributes": {},
     "context": {
-      "clientId": "0@127.0.0.1:pet-clinic:<uuid>"
+      "clientId": "0@127.0.0.1:pet-clinic:<uuid>",
+      "appName": "pet-clinic",
+      "instanceId": "instance-?"
     },
     "type": "CLIENT_TAGS_UPDATED"
   },
@@ -46,6 +74,7 @@
     "attributes": {},
     "context": {
       "appName": "pet-clinic",
+      "instanceId": "instance-?",
       "clientId": "0@127.0.0.1:pet-clinic:<uuid>"
     },
     "type": "CLIENT_INIT"
@@ -61,9 +90,33 @@
     },
     "type": "CLIENT_CONNECTED"
   },
-  {"attributes":{"version":"<version>"},"context":{"clientId":"0@127.0.0.1:pet-clinic:<uuid>"},"type":"CLIENT_PROPERTY_ADDED"},
-  {"attributes":{"clientReportedAddress":"<clientReportedAddress>"},"context":{"clientId":"0@127.0.0.1:pet-clinic:<uuid>"},"type":"CLIENT_PROPERTY_ADDED"},
-  {"attributes":{"clientRevision":"<uuid>"},"context":{"clientId":"0@127.0.0.1:pet-clinic:<uuid>"},"type":"CLIENT_PROPERTY_ADDED"},
+  {
+    "attributes": {
+      "version": "<version>"
+    },
+    "context": {
+      "clientId": "0@127.0.0.1:pet-clinic:<uuid>"
+    },
+    "type": "CLIENT_PROPERTY_ADDED"
+  },
+  {
+    "attributes": {
+      "clientReportedAddress": "<clientReportedAddress>"
+    },
+    "context": {
+      "clientId": "0@127.0.0.1:pet-clinic:<uuid>"
+    },
+    "type": "CLIENT_PROPERTY_ADDED"
+  },
+  {
+    "attributes": {
+      "clientRevision": "<uuid>"
+    },
+    "context": {
+      "clientId": "0@127.0.0.1:pet-clinic:<uuid>"
+    },
+    "type": "CLIENT_PROPERTY_ADDED"
+  },
   {
     "attributes": {
       "clientId": "0@127.0.0.1:pet-clinic:<uuid>"
@@ -82,14 +135,18 @@
   {
     "attributes": {},
     "context": {
-      "clientId": "0@127.0.0.1:pet-clinic:<uuid>"
+      "clientId": "0@127.0.0.1:pet-clinic:<uuid>",
+      "appName": "pet-clinic",
+      "instanceId": "instance-?"
     },
     "type": "CLIENT_REGISTRY_AVAILABLE"
   },
   {
     "attributes": {},
     "context": {
-      "clientId": "0@127.0.0.1:pet-clinic:<uuid>"
+      "clientId": "0@127.0.0.1:pet-clinic:<uuid>",
+      "appName": "pet-clinic",
+      "instanceId": "instance-?"
     },
     "type": "CLIENT_TAGS_UPDATED"
   },
@@ -97,6 +154,7 @@
     "attributes": {},
     "context": {
       "appName": "pet-clinic",
+      "instanceId": "instance-?",
       "clientId": "0@127.0.0.1:pet-clinic:<uuid>"
     },
     "type": "CLIENT_INIT"
@@ -121,9 +179,9 @@
       "serverId": "testServer0",
       "serverName": "testServer0",
       "entityId": "pet-clinic/pets:org.terracotta.management.entity.sample.client.CacheEntity",
+      "consumerId": "7",
       "entityName": "pet-clinic/pets",
-      "entityType": "org.terracotta.management.entity.sample.client.CacheEntity",
-      "consumerId": "7"
+      "entityType": "org.terracotta.management.entity.sample.client.CacheEntity"
     },
     "type": "ENTITY_REGISTRY_AVAILABLE"
   },
@@ -144,16 +202,18 @@
   },
   {
     "attributes": {
-      "clientId": "0@127.0.0.1:pet-clinic:<uuid>"
+      "clientId": "0@127.0.0.1:pet-clinic:<uuid>",
+      "instanceId": "instance-?",
+      "appName": "pet-clinic"
     },
     "context": {
       "stripeId": "stripe[0]",
       "serverId": "testServer0",
       "serverName": "testServer0",
       "entityId": "pet-clinic/pets:org.terracotta.management.entity.sample.client.CacheEntity",
+      "consumerId": "7",
       "entityName": "pet-clinic/pets",
-      "entityType": "org.terracotta.management.entity.sample.client.CacheEntity",
-      "consumerId": "7"
+      "entityType": "org.terracotta.management.entity.sample.client.CacheEntity"
     },
     "type": "SERVER_ENTITY_FETCHED"
   },
@@ -164,9 +224,9 @@
       "serverId": "testServer0",
       "serverName": "testServer0",
       "entityId": "pet-clinic/pets:org.terracotta.management.entity.sample.client.CacheEntity",
+      "consumerId": "7",
       "entityName": "pet-clinic/pets",
-      "entityType": "org.terracotta.management.entity.sample.client.CacheEntity",
-      "consumerId": "7"
+      "entityType": "org.terracotta.management.entity.sample.client.CacheEntity"
     },
     "type": "ENTITY_REGISTRY_AVAILABLE"
   },
@@ -188,7 +248,9 @@
   {
     "attributes": {},
     "context": {
-      "clientId": "0@127.0.0.1:pet-clinic:<uuid>"
+      "clientId": "0@127.0.0.1:pet-clinic:<uuid>",
+      "appName": "pet-clinic",
+      "instanceId": "instance-?"
     },
     "type": "CLIENT_REGISTRY_AVAILABLE"
   },
@@ -196,6 +258,7 @@
     "attributes": {},
     "context": {
       "appName": "pet-clinic",
+      "instanceId": "instance-?",
       "cacheName": "pets",
       "clientId": "0@127.0.0.1:pet-clinic:<uuid>"
     },
@@ -203,16 +266,18 @@
   },
   {
     "attributes": {
-      "clientId": "0@127.0.0.1:pet-clinic:<uuid>"
+      "clientId": "0@127.0.0.1:pet-clinic:<uuid>",
+      "instanceId": "instance-?",
+      "appName": "pet-clinic"
     },
     "context": {
       "stripeId": "stripe[0]",
       "serverId": "testServer0",
       "serverName": "testServer0",
       "entityId": "pet-clinic/pets:org.terracotta.management.entity.sample.client.CacheEntity",
+      "consumerId": "7",
       "entityName": "pet-clinic/pets",
-      "entityType": "org.terracotta.management.entity.sample.client.CacheEntity",
-      "consumerId": "7"
+      "entityType": "org.terracotta.management.entity.sample.client.CacheEntity"
     },
     "type": "SERVER_ENTITY_FETCHED"
   },
@@ -223,9 +288,9 @@
       "serverId": "testServer0",
       "serverName": "testServer0",
       "entityId": "pet-clinic/pets:org.terracotta.management.entity.sample.client.CacheEntity",
+      "consumerId": "7",
       "entityName": "pet-clinic/pets",
-      "entityType": "org.terracotta.management.entity.sample.client.CacheEntity",
-      "consumerId": "7"
+      "entityType": "org.terracotta.management.entity.sample.client.CacheEntity"
     },
     "type": "ENTITY_REGISTRY_AVAILABLE"
   },
@@ -247,7 +312,9 @@
   {
     "attributes": {},
     "context": {
-      "clientId": "0@127.0.0.1:pet-clinic:<uuid>"
+      "clientId": "0@127.0.0.1:pet-clinic:<uuid>",
+      "appName": "pet-clinic",
+      "instanceId": "instance-?"
     },
     "type": "CLIENT_REGISTRY_AVAILABLE"
   },
@@ -255,6 +322,7 @@
     "attributes": {},
     "context": {
       "appName": "pet-clinic",
+      "instanceId": "instance-?",
       "cacheName": "pets",
       "clientId": "0@127.0.0.1:pet-clinic:<uuid>"
     },
@@ -280,9 +348,9 @@
       "serverId": "testServer0",
       "serverName": "testServer0",
       "entityId": "pet-clinic/clients:org.terracotta.management.entity.sample.client.CacheEntity",
+      "consumerId": "8",
       "entityName": "pet-clinic/clients",
-      "entityType": "org.terracotta.management.entity.sample.client.CacheEntity",
-      "consumerId": "8"
+      "entityType": "org.terracotta.management.entity.sample.client.CacheEntity"
     },
     "type": "ENTITY_REGISTRY_AVAILABLE"
   },
@@ -303,16 +371,18 @@
   },
   {
     "attributes": {
-      "clientId": "0@127.0.0.1:pet-clinic:<uuid>"
+      "clientId": "0@127.0.0.1:pet-clinic:<uuid>",
+      "instanceId": "instance-?",
+      "appName": "pet-clinic"
     },
     "context": {
       "stripeId": "stripe[0]",
       "serverId": "testServer0",
       "serverName": "testServer0",
       "entityId": "pet-clinic/clients:org.terracotta.management.entity.sample.client.CacheEntity",
+      "consumerId": "8",
       "entityName": "pet-clinic/clients",
-      "entityType": "org.terracotta.management.entity.sample.client.CacheEntity",
-      "consumerId": "8"
+      "entityType": "org.terracotta.management.entity.sample.client.CacheEntity"
     },
     "type": "SERVER_ENTITY_FETCHED"
   },
@@ -323,9 +393,9 @@
       "serverId": "testServer0",
       "serverName": "testServer0",
       "entityId": "pet-clinic/clients:org.terracotta.management.entity.sample.client.CacheEntity",
+      "consumerId": "8",
       "entityName": "pet-clinic/clients",
-      "entityType": "org.terracotta.management.entity.sample.client.CacheEntity",
-      "consumerId": "8"
+      "entityType": "org.terracotta.management.entity.sample.client.CacheEntity"
     },
     "type": "ENTITY_REGISTRY_AVAILABLE"
   },
@@ -347,7 +417,9 @@
   {
     "attributes": {},
     "context": {
-      "clientId": "0@127.0.0.1:pet-clinic:<uuid>"
+      "clientId": "0@127.0.0.1:pet-clinic:<uuid>",
+      "appName": "pet-clinic",
+      "instanceId": "instance-?"
     },
     "type": "CLIENT_REGISTRY_AVAILABLE"
   },
@@ -355,6 +427,7 @@
     "attributes": {},
     "context": {
       "appName": "pet-clinic",
+      "instanceId": "instance-?",
       "cacheName": "clients",
       "clientId": "0@127.0.0.1:pet-clinic:<uuid>"
     },
@@ -362,16 +435,18 @@
   },
   {
     "attributes": {
-      "clientId": "0@127.0.0.1:pet-clinic:<uuid>"
+      "clientId": "0@127.0.0.1:pet-clinic:<uuid>",
+      "instanceId": "instance-?",
+      "appName": "pet-clinic"
     },
     "context": {
       "stripeId": "stripe[0]",
       "serverId": "testServer0",
       "serverName": "testServer0",
       "entityId": "pet-clinic/clients:org.terracotta.management.entity.sample.client.CacheEntity",
+      "consumerId": "8",
       "entityName": "pet-clinic/clients",
-      "entityType": "org.terracotta.management.entity.sample.client.CacheEntity",
-      "consumerId": "8"
+      "entityType": "org.terracotta.management.entity.sample.client.CacheEntity"
     },
     "type": "SERVER_ENTITY_FETCHED"
   },
@@ -382,9 +457,9 @@
       "serverId": "testServer0",
       "serverName": "testServer0",
       "entityId": "pet-clinic/clients:org.terracotta.management.entity.sample.client.CacheEntity",
+      "consumerId": "8",
       "entityName": "pet-clinic/clients",
-      "entityType": "org.terracotta.management.entity.sample.client.CacheEntity",
-      "consumerId": "8"
+      "entityType": "org.terracotta.management.entity.sample.client.CacheEntity"
     },
     "type": "ENTITY_REGISTRY_AVAILABLE"
   },
@@ -406,7 +481,9 @@
   {
     "attributes": {},
     "context": {
-      "clientId": "0@127.0.0.1:pet-clinic:<uuid>"
+      "clientId": "0@127.0.0.1:pet-clinic:<uuid>",
+      "appName": "pet-clinic",
+      "instanceId": "instance-?"
     },
     "type": "CLIENT_REGISTRY_AVAILABLE"
   },
@@ -414,6 +491,7 @@
     "attributes": {},
     "context": {
       "appName": "pet-clinic",
+      "instanceId": "instance-?",
       "cacheName": "clients",
       "clientId": "0@127.0.0.1:pet-clinic:<uuid>"
     },

--- a/management/testing/integration-tests/src/test/resources/passive.json
+++ b/management/testing/integration-tests/src/test/resources/passive.json
@@ -14,6 +14,7 @@
       "name": "PassiveTopologyIT",
       "consumerId": 6,
       "managementRegistry": {
+        "rootContext": {},
         "contextContainer": {
           "consumerId": "6",
           "subContexts": []
@@ -116,6 +117,7 @@
       "name": "dynamic-config-management-entity",
       "consumerId": 4,
       "managementRegistry": {
+        "rootContext": {},
         "contextContainer": {
           "consumerId": "4",
           "subContexts": []
@@ -129,6 +131,7 @@
       "name": "pet-clinic/clients",
       "consumerId": 8,
       "managementRegistry": {
+        "rootContext": {},
         "contextContainer": {
           "consumerId": "8",
           "subContexts": []
@@ -268,6 +271,7 @@
       "name": "pet-clinic/pets",
       "consumerId": 7,
       "managementRegistry": {
+        "rootContext": {},
         "contextContainer": {
           "consumerId": "7",
           "subContexts": []

--- a/management/testing/integration-tests/src/test/resources/topology-after-failover.json
+++ b/management/testing/integration-tests/src/test/resources/topology-after-failover.json
@@ -13,6 +13,7 @@
               "name": "FailoverIT",
               "consumerId": 6,
               "managementRegistry": {
+                "rootContext": {},
                 "contextContainer": {
                   "consumerId": "6",
                   "subContexts": []
@@ -122,6 +123,7 @@
               "name": "dynamic-config-management-entity",
               "consumerId": 4,
               "managementRegistry": {
+                "rootContext": {},
                 "contextContainer": {
                   "consumerId": "4",
                   "subContexts": []
@@ -135,6 +137,7 @@
               "name": "pet-clinic/clients",
               "consumerId": 8,
               "managementRegistry": {
+                "rootContext": {},
                 "contextContainer": {
                   "consumerId": "8",
                   "subContexts": []
@@ -305,6 +308,7 @@
               "name": "pet-clinic/pets",
               "consumerId": 7,
               "managementRegistry": {
+                "rootContext": {},
                 "contextContainer": {
                   "consumerId": "7",
                   "subContexts": []
@@ -533,9 +537,9 @@
         "pet-clinic"
       ],
       "properties": {
+        "version": "<version>",
         "clientReportedAddress": "<clientReportedAddress>",
-        "clientRevision": "<uuid>",
-        "version": "<version>"
+        "clientRevision": "<uuid>"
       },
       "connections": [
         {
@@ -555,6 +559,10 @@
         }
       ],
       "managementRegistry": {
+        "rootContext": {
+          "appName": "pet-clinic",
+          "instanceId": "instance-?"
+        },
         "contextContainer": {
           "appName": "pet-clinic",
           "subContexts": []
@@ -563,6 +571,10 @@
           {
             "name": "CacheCalls",
             "context": [
+              {
+                "name": "instanceId",
+                "required": true
+              },
               {
                 "name": "appName",
                 "required": true
@@ -613,6 +625,10 @@
             "name": "CacheSettings",
             "context": [
               {
+                "name": "instanceId",
+                "required": true
+              },
+              {
                 "name": "appName",
                 "required": true
               },
@@ -624,11 +640,13 @@
             "descriptors": [
               {
                 "appName": "pet-clinic",
+                "instanceId": "instance-?",
                 "cacheName": "pets",
                 "size": 0
               },
               {
                 "appName": "pet-clinic",
+                "instanceId": "instance-?",
                 "cacheName": "clients",
                 "size": 0
               }
@@ -637,6 +655,10 @@
           {
             "name": "CacheStatistics",
             "context": [
+              {
+                "name": "instanceId",
+                "required": true
+              },
               {
                 "name": "appName",
                 "required": true
@@ -684,6 +706,10 @@
           {
             "name": "StatisticCollectorCapability",
             "context": [
+              {
+                "name": "instanceId",
+                "required": true
+              },
               {
                 "name": "appName",
                 "required": true
@@ -733,9 +759,9 @@
         "pet-clinic"
       ],
       "properties": {
+        "version": "<version>",
         "clientReportedAddress": "<clientReportedAddress>",
-        "clientRevision": "<uuid>",
-        "version": "<version>"
+        "clientRevision": "<uuid>"
       },
       "connections": [
         {
@@ -755,6 +781,10 @@
         }
       ],
       "managementRegistry": {
+        "rootContext": {
+          "appName": "pet-clinic",
+          "instanceId": "instance-?"
+        },
         "contextContainer": {
           "appName": "pet-clinic",
           "subContexts": []
@@ -763,6 +793,10 @@
           {
             "name": "CacheCalls",
             "context": [
+              {
+                "name": "instanceId",
+                "required": true
+              },
               {
                 "name": "appName",
                 "required": true
@@ -813,6 +847,10 @@
             "name": "CacheSettings",
             "context": [
               {
+                "name": "instanceId",
+                "required": true
+              },
+              {
                 "name": "appName",
                 "required": true
               },
@@ -824,11 +862,13 @@
             "descriptors": [
               {
                 "appName": "pet-clinic",
+                "instanceId": "instance-?",
                 "cacheName": "pets",
                 "size": 0
               },
               {
                 "appName": "pet-clinic",
+                "instanceId": "instance-?",
                 "cacheName": "clients",
                 "size": 0
               }
@@ -837,6 +877,10 @@
           {
             "name": "CacheStatistics",
             "context": [
+              {
+                "name": "instanceId",
+                "required": true
+              },
               {
                 "name": "appName",
                 "required": true
@@ -884,6 +928,10 @@
           {
             "name": "StatisticCollectorCapability",
             "context": [
+              {
+                "name": "instanceId",
+                "required": true
+              },
               {
                 "name": "appName",
                 "required": true

--- a/management/testing/integration-tests/src/test/resources/topology-before-reconfigure.json
+++ b/management/testing/integration-tests/src/test/resources/topology-before-reconfigure.json
@@ -20,6 +20,7 @@
               "name": "ReconfigureEntityIT",
               "consumerId": 6,
               "managementRegistry": {
+                "rootContext": {},
                 "contextContainer": {
                   "consumerId": "6",
                   "subContexts": []
@@ -122,6 +123,7 @@
               "name": "dynamic-config-management-entity",
               "consumerId": 4,
               "managementRegistry": {
+                "rootContext": {},
                 "contextContainer": {
                   "consumerId": "4",
                   "subContexts": []
@@ -135,6 +137,7 @@
               "name": "pet-clinic/clients",
               "consumerId": 8,
               "managementRegistry": {
+                "rootContext": {},
                 "contextContainer": {
                   "consumerId": "8",
                   "subContexts": []
@@ -157,12 +160,6 @@
                       }
                     ],
                     "descriptors": [
-                      {
-                        "consumerId": "8",
-                        "alias": "0@127.0.0.1:pet-clinic:<uuid>",
-                        "type": "ClientState",
-                        "attached": true
-                      },
                       {
                         "consumerId": "8",
                         "alias": "0@127.0.0.1:pet-clinic:<uuid>",
@@ -305,6 +302,7 @@
               "name": "pet-clinic/pets",
               "consumerId": 7,
               "managementRegistry": {
+                "rootContext": {},
                 "contextContainer": {
                   "consumerId": "7",
                   "subContexts": []
@@ -327,12 +325,6 @@
                       }
                     ],
                     "descriptors": [
-                      {
-                        "consumerId": "7",
-                        "alias": "0@127.0.0.1:pet-clinic:<uuid>",
-                        "type": "ClientState",
-                        "attached": true
-                      },
                       {
                         "consumerId": "7",
                         "alias": "0@127.0.0.1:pet-clinic:<uuid>",
@@ -555,6 +547,10 @@
         }
       ],
       "managementRegistry": {
+        "rootContext": {
+          "appName": "pet-clinic",
+          "instanceId": "instance-?"
+        },
         "contextContainer": {
           "appName": "pet-clinic",
           "subContexts": []
@@ -563,6 +559,10 @@
           {
             "name": "CacheCalls",
             "context": [
+              {
+                "name": "instanceId",
+                "required": true
+              },
               {
                 "name": "appName",
                 "required": true
@@ -613,6 +613,10 @@
             "name": "CacheSettings",
             "context": [
               {
+                "name": "instanceId",
+                "required": true
+              },
+              {
                 "name": "appName",
                 "required": true
               },
@@ -624,11 +628,13 @@
             "descriptors": [
               {
                 "appName": "pet-clinic",
+                "instanceId": "instance-?",
                 "cacheName": "pets",
                 "size": 0
               },
               {
                 "appName": "pet-clinic",
+                "instanceId": "instance-?",
                 "cacheName": "clients",
                 "size": 0
               }
@@ -637,6 +643,10 @@
           {
             "name": "CacheStatistics",
             "context": [
+              {
+                "name": "instanceId",
+                "required": true
+              },
               {
                 "name": "appName",
                 "required": true
@@ -685,205 +695,9 @@
             "name": "StatisticCollectorCapability",
             "context": [
               {
-                "name": "appName",
-                "required": true
-              }
-            ],
-            "descriptors": [
-              {
-                "name": "isRunning",
-                "returnType": "boolean",
-                "parameters": []
-              },
-              {
-                "name": "startStatisticCollector",
-                "returnType": "void",
-                "parameters": [
-                  {
-                    "name": "interval",
-                    "type": "long"
-                  },
-                  {
-                    "name": "unit",
-                    "type": "java.util.concurrent.TimeUnit"
-                  }
-                ]
-              },
-              {
-                "name": "stopStatisticCollector",
-                "returnType": "void",
-                "parameters": []
-              }
-            ]
-          }
-        ]
-      }
-    },
-    {
-      "id": "0@127.0.0.1:pet-clinic:<uuid>",
-      "pid": 0,
-      "hostAddress": "127.0.0.1",
-      "name": "pet-clinic",
-      "logicalConnectionUid": "<uuid>",
-      "vmId": "0@127.0.0.1",
-      "clientId": "0@127.0.0.1:pet-clinic:<uuid>",
-      "hostName": "<hostname>",
-      "tags": [
-        "caches",
-        "pet-clinic"
-      ],
-      "properties": {
-        "version": "<version>",
-        "clientReportedAddress": "<clientReportedAddress>",
-        "clientRevision": "<uuid>"
-      },
-      "connections": [
-        {
-          "id": "<uuid>:stripe[0]:testServer0:127.0.0.1:0",
-          "logicalConnectionUid": "<uuid>",
-          "clientEndpoint": {
-            "address": "127.0.0.1",
-            "port": 0
-          },
-          "stripeId": "stripe[0]",
-          "serverId": "testServer0",
-          "serverEntityIds": {
-            "NmsAgent:org.terracotta.management.entity.nms.agent.client.NmsAgentEntity": 1,
-            "pet-clinic/clients:org.terracotta.management.entity.sample.client.CacheEntity": 1,
-            "pet-clinic/pets:org.terracotta.management.entity.sample.client.CacheEntity": 1
-          }
-        }
-      ],
-      "managementRegistry": {
-        "contextContainer": {
-          "appName": "pet-clinic",
-          "subContexts": []
-        },
-        "capabilities": [
-          {
-            "name": "CacheCalls",
-            "context": [
-              {
-                "name": "appName",
+                "name": "instanceId",
                 "required": true
               },
-              {
-                "name": "cacheName",
-                "required": true
-              }
-            ],
-            "descriptors": [
-              {
-                "name": "clear",
-                "returnType": "void",
-                "parameters": []
-              },
-              {
-                "name": "get",
-                "returnType": "java.lang.String",
-                "parameters": [
-                  {
-                    "name": "key",
-                    "type": "java.lang.String"
-                  }
-                ]
-              },
-              {
-                "name": "put",
-                "returnType": "void",
-                "parameters": [
-                  {
-                    "name": "key",
-                    "type": "java.lang.String"
-                  },
-                  {
-                    "name": "value",
-                    "type": "java.lang.String"
-                  }
-                ]
-              },
-              {
-                "name": "size",
-                "returnType": "int",
-                "parameters": []
-              }
-            ]
-          },
-          {
-            "name": "CacheSettings",
-            "context": [
-              {
-                "name": "appName",
-                "required": true
-              },
-              {
-                "name": "cacheName",
-                "required": true
-              }
-            ],
-            "descriptors": [
-              {
-                "appName": "pet-clinic",
-                "cacheName": "pets",
-                "size": 0
-              },
-              {
-                "appName": "pet-clinic",
-                "cacheName": "clients",
-                "size": 0
-              }
-            ]
-          },
-          {
-            "name": "CacheStatistics",
-            "context": [
-              {
-                "name": "appName",
-                "required": true
-              },
-              {
-                "name": "cacheName",
-                "required": true
-              }
-            ],
-            "descriptors": [
-              {
-                "name": "Cache:ClearCount",
-                "type": "COUNTER"
-              },
-              {
-                "name": "Cache:HitCount",
-                "type": "COUNTER"
-              },
-              {
-                "name": "Cache:MissCount",
-                "type": "COUNTER"
-              },
-              {
-                "name": "ClientCache:Size",
-                "type": "GAUGE"
-              }
-            ]
-          },
-          {
-            "name": "DiagnosticCalls",
-            "context": [],
-            "descriptors": [
-              {
-                "name": "getThreadDump",
-                "returnType": "java.lang.String",
-                "parameters": []
-              }
-            ]
-          },
-          {
-            "name": "NmsAgentService",
-            "context": [],
-            "descriptors": []
-          },
-          {
-            "name": "StatisticCollectorCapability",
-            "context": [
               {
                 "name": "appName",
                 "required": true

--- a/management/testing/integration-tests/src/test/resources/topology-reconfigured.json
+++ b/management/testing/integration-tests/src/test/resources/topology-reconfigured.json
@@ -20,6 +20,7 @@
               "name": "ReconfigureEntityIT",
               "consumerId": 6,
               "managementRegistry": {
+                "rootContext": {},
                 "contextContainer": {
                   "consumerId": "6",
                   "subContexts": []
@@ -122,6 +123,7 @@
               "name": "dynamic-config-management-entity",
               "consumerId": 4,
               "managementRegistry": {
+                "rootContext": {},
                 "contextContainer": {
                   "consumerId": "4",
                   "subContexts": []
@@ -135,6 +137,7 @@
               "name": "pet-clinic/clients",
               "consumerId": 8,
               "managementRegistry": {
+                "rootContext": {},
                 "contextContainer": {
                   "consumerId": "8",
                   "subContexts": []
@@ -157,12 +160,6 @@
                       }
                     ],
                     "descriptors": [
-                      {
-                        "consumerId": "8",
-                        "alias": "0@127.0.0.1:pet-clinic:<uuid>",
-                        "type": "ClientState",
-                        "attached": true
-                      },
                       {
                         "consumerId": "8",
                         "alias": "0@127.0.0.1:pet-clinic:<uuid>",
@@ -305,6 +302,7 @@
               "name": "pet-clinic/pets",
               "consumerId": 7,
               "managementRegistry": {
+                "rootContext": {},
                 "contextContainer": {
                   "consumerId": "7",
                   "subContexts": []
@@ -327,12 +325,6 @@
                       }
                     ],
                     "descriptors": [
-                      {
-                        "consumerId": "7",
-                        "alias": "0@127.0.0.1:pet-clinic:<uuid>",
-                        "type": "ClientState",
-                        "attached": true
-                      },
                       {
                         "consumerId": "7",
                         "alias": "0@127.0.0.1:pet-clinic:<uuid>",
@@ -555,6 +547,10 @@
         }
       ],
       "managementRegistry": {
+        "rootContext": {
+          "appName": "pet-clinic",
+          "instanceId": "instance-?"
+        },
         "contextContainer": {
           "appName": "pet-clinic",
           "subContexts": []
@@ -563,6 +559,10 @@
           {
             "name": "CacheCalls",
             "context": [
+              {
+                "name": "instanceId",
+                "required": true
+              },
               {
                 "name": "appName",
                 "required": true
@@ -613,6 +613,10 @@
             "name": "CacheSettings",
             "context": [
               {
+                "name": "instanceId",
+                "required": true
+              },
+              {
                 "name": "appName",
                 "required": true
               },
@@ -624,11 +628,13 @@
             "descriptors": [
               {
                 "appName": "pet-clinic",
+                "instanceId": "instance-?",
                 "cacheName": "pets",
                 "size": 0
               },
               {
                 "appName": "pet-clinic",
+                "instanceId": "instance-?",
                 "cacheName": "clients",
                 "size": 0
               }
@@ -637,6 +643,10 @@
           {
             "name": "CacheStatistics",
             "context": [
+              {
+                "name": "instanceId",
+                "required": true
+              },
               {
                 "name": "appName",
                 "required": true
@@ -685,205 +695,9 @@
             "name": "StatisticCollectorCapability",
             "context": [
               {
-                "name": "appName",
-                "required": true
-              }
-            ],
-            "descriptors": [
-              {
-                "name": "isRunning",
-                "returnType": "boolean",
-                "parameters": []
-              },
-              {
-                "name": "startStatisticCollector",
-                "returnType": "void",
-                "parameters": [
-                  {
-                    "name": "interval",
-                    "type": "long"
-                  },
-                  {
-                    "name": "unit",
-                    "type": "java.util.concurrent.TimeUnit"
-                  }
-                ]
-              },
-              {
-                "name": "stopStatisticCollector",
-                "returnType": "void",
-                "parameters": []
-              }
-            ]
-          }
-        ]
-      }
-    },
-    {
-      "id": "0@127.0.0.1:pet-clinic:<uuid>",
-      "pid": 0,
-      "hostAddress": "127.0.0.1",
-      "name": "pet-clinic",
-      "logicalConnectionUid": "<uuid>",
-      "vmId": "0@127.0.0.1",
-      "clientId": "0@127.0.0.1:pet-clinic:<uuid>",
-      "hostName": "<hostname>",
-      "tags": [
-        "caches",
-        "pet-clinic"
-      ],
-      "properties": {
-        "version": "<version>",
-        "clientReportedAddress": "<clientReportedAddress>",
-        "clientRevision": "<uuid>"
-      },
-      "connections": [
-        {
-          "id": "<uuid>:stripe[0]:testServer0:127.0.0.1:0",
-          "logicalConnectionUid": "<uuid>",
-          "clientEndpoint": {
-            "address": "127.0.0.1",
-            "port": 0
-          },
-          "stripeId": "stripe[0]",
-          "serverId": "testServer0",
-          "serverEntityIds": {
-            "NmsAgent:org.terracotta.management.entity.nms.agent.client.NmsAgentEntity": 1,
-            "pet-clinic/clients:org.terracotta.management.entity.sample.client.CacheEntity": 1,
-            "pet-clinic/pets:org.terracotta.management.entity.sample.client.CacheEntity": 1
-          }
-        }
-      ],
-      "managementRegistry": {
-        "contextContainer": {
-          "appName": "pet-clinic",
-          "subContexts": []
-        },
-        "capabilities": [
-          {
-            "name": "CacheCalls",
-            "context": [
-              {
-                "name": "appName",
+                "name": "instanceId",
                 "required": true
               },
-              {
-                "name": "cacheName",
-                "required": true
-              }
-            ],
-            "descriptors": [
-              {
-                "name": "clear",
-                "returnType": "void",
-                "parameters": []
-              },
-              {
-                "name": "get",
-                "returnType": "java.lang.String",
-                "parameters": [
-                  {
-                    "name": "key",
-                    "type": "java.lang.String"
-                  }
-                ]
-              },
-              {
-                "name": "put",
-                "returnType": "void",
-                "parameters": [
-                  {
-                    "name": "key",
-                    "type": "java.lang.String"
-                  },
-                  {
-                    "name": "value",
-                    "type": "java.lang.String"
-                  }
-                ]
-              },
-              {
-                "name": "size",
-                "returnType": "int",
-                "parameters": []
-              }
-            ]
-          },
-          {
-            "name": "CacheSettings",
-            "context": [
-              {
-                "name": "appName",
-                "required": true
-              },
-              {
-                "name": "cacheName",
-                "required": true
-              }
-            ],
-            "descriptors": [
-              {
-                "appName": "pet-clinic",
-                "cacheName": "pets",
-                "size": 0
-              },
-              {
-                "appName": "pet-clinic",
-                "cacheName": "clients",
-                "size": 0
-              }
-            ]
-          },
-          {
-            "name": "CacheStatistics",
-            "context": [
-              {
-                "name": "appName",
-                "required": true
-              },
-              {
-                "name": "cacheName",
-                "required": true
-              }
-            ],
-            "descriptors": [
-              {
-                "name": "Cache:ClearCount",
-                "type": "COUNTER"
-              },
-              {
-                "name": "Cache:HitCount",
-                "type": "COUNTER"
-              },
-              {
-                "name": "Cache:MissCount",
-                "type": "COUNTER"
-              },
-              {
-                "name": "ClientCache:Size",
-                "type": "GAUGE"
-              }
-            ]
-          },
-          {
-            "name": "DiagnosticCalls",
-            "context": [],
-            "descriptors": [
-              {
-                "name": "getThreadDump",
-                "returnType": "java.lang.String",
-                "parameters": []
-              }
-            ]
-          },
-          {
-            "name": "NmsAgentService",
-            "context": [],
-            "descriptors": []
-          },
-          {
-            "name": "StatisticCollectorCapability",
-            "context": [
               {
                 "name": "appName",
                 "required": true

--- a/management/testing/integration-tests/src/test/resources/topology.json
+++ b/management/testing/integration-tests/src/test/resources/topology.json
@@ -20,6 +20,7 @@
               "name": "TopologyIT",
               "consumerId": 6,
               "managementRegistry": {
+                "rootContext": {},
                 "contextContainer": {
                   "consumerId": "6",
                   "subContexts": []
@@ -122,6 +123,7 @@
               "name": "dynamic-config-management-entity",
               "consumerId": 4,
               "managementRegistry": {
+                "rootContext": {},
                 "contextContainer": {
                   "consumerId": "4",
                   "subContexts": []
@@ -135,6 +137,7 @@
               "name": "pet-clinic/clients",
               "consumerId": 8,
               "managementRegistry": {
+                "rootContext": {},
                 "contextContainer": {
                   "consumerId": "8",
                   "subContexts": []
@@ -305,6 +308,7 @@
               "name": "pet-clinic/pets",
               "consumerId": 7,
               "managementRegistry": {
+                "rootContext": {},
                 "contextContainer": {
                   "consumerId": "7",
                   "subContexts": []
@@ -555,6 +559,10 @@
         }
       ],
       "managementRegistry": {
+        "rootContext": {
+          "appName": "pet-clinic",
+          "instanceId": "instance-?"
+        },
         "contextContainer": {
           "appName": "pet-clinic",
           "subContexts": []
@@ -563,6 +571,10 @@
           {
             "name": "CacheCalls",
             "context": [
+              {
+                "name": "instanceId",
+                "required": true
+              },
               {
                 "name": "appName",
                 "required": true
@@ -613,6 +625,10 @@
             "name": "CacheSettings",
             "context": [
               {
+                "name": "instanceId",
+                "required": true
+              },
+              {
                 "name": "appName",
                 "required": true
               },
@@ -624,11 +640,13 @@
             "descriptors": [
               {
                 "appName": "pet-clinic",
+                "instanceId": "instance-?",
                 "cacheName": "pets",
                 "size": 0
               },
               {
                 "appName": "pet-clinic",
+                "instanceId": "instance-?",
                 "cacheName": "clients",
                 "size": 0
               }
@@ -637,6 +655,10 @@
           {
             "name": "CacheStatistics",
             "context": [
+              {
+                "name": "instanceId",
+                "required": true
+              },
               {
                 "name": "appName",
                 "required": true
@@ -684,6 +706,10 @@
           {
             "name": "StatisticCollectorCapability",
             "context": [
+              {
+                "name": "instanceId",
+                "required": true
+              },
               {
                 "name": "appName",
                 "required": true
@@ -755,6 +781,10 @@
         }
       ],
       "managementRegistry": {
+        "rootContext": {
+          "appName": "pet-clinic",
+          "instanceId": "instance-?"
+        },
         "contextContainer": {
           "appName": "pet-clinic",
           "subContexts": []
@@ -763,6 +793,10 @@
           {
             "name": "CacheCalls",
             "context": [
+              {
+                "name": "instanceId",
+                "required": true
+              },
               {
                 "name": "appName",
                 "required": true
@@ -813,6 +847,10 @@
             "name": "CacheSettings",
             "context": [
               {
+                "name": "instanceId",
+                "required": true
+              },
+              {
                 "name": "appName",
                 "required": true
               },
@@ -824,11 +862,13 @@
             "descriptors": [
               {
                 "appName": "pet-clinic",
+                "instanceId": "instance-?",
                 "cacheName": "pets",
                 "size": 0
               },
               {
                 "appName": "pet-clinic",
+                "instanceId": "instance-?",
                 "cacheName": "clients",
                 "size": 0
               }
@@ -837,6 +877,10 @@
           {
             "name": "CacheStatistics",
             "context": [
+              {
+                "name": "instanceId",
+                "required": true
+              },
               {
                 "name": "appName",
                 "required": true
@@ -884,6 +928,10 @@
           {
             "name": "StatisticCollectorCapability",
             "context": [
+              {
+                "name": "instanceId",
+                "required": true
+              },
               {
                 "name": "appName",
                 "required": true

--- a/management/testing/sample-entity/src/main/java/org/terracotta/management/entity/sample/client/CacheFactory.java
+++ b/management/testing/sample-entity/src/main/java/org/terracotta/management/entity/sample/client/CacheFactory.java
@@ -25,6 +25,7 @@ import org.terracotta.exception.EntityNotProvidedException;
 import org.terracotta.exception.PermanentEntityException;
 import org.terracotta.management.entity.sample.Cache;
 import org.terracotta.management.entity.sample.client.management.Management;
+import org.terracotta.management.model.context.Context;
 import org.terracotta.management.model.context.ContextContainer;
 import org.terracotta.management.registry.CapabilityManagementSupport;
 
@@ -49,15 +50,17 @@ public class CacheFactory implements Closeable {
   private Connection connection;
   private CacheEntityFactory cacheEntityFactory;
 
-  public CacheFactory(URI u, String path) {
+  public CacheFactory(String instanceId, URI u, String path) {
     this.uri = u;
     this.path = path;
-    this.management = new Management(new ContextContainer("appName", path));
+    this.management = new Management(instanceId, new ContextContainer("appName", path));
   }
 
   public CapabilityManagementSupport getManagementRegistry() {
     return management.getManagementRegistry();
   }
+
+  public Context getRootContext() {return management.getRootContext();}
 
   public void init() throws ConnectionException {
     init(null);

--- a/management/testing/sample-entity/src/main/java/org/terracotta/management/entity/sample/client/management/CacheCallManagementProvider.java
+++ b/management/testing/sample-entity/src/main/java/org/terracotta/management/entity/sample/client/management/CacheCallManagementProvider.java
@@ -31,7 +31,7 @@ import java.util.Collections;
  * @author Mathieu Carbou
  */
 @Named("CacheCalls")
-@RequiredContext({@Named("appName"), @Named("cacheName")})
+@RequiredContext({@Named("instanceId"), @Named("appName"), @Named("cacheName")})
 public class CacheCallManagementProvider extends AbstractActionManagementProvider<ClientCache> {
   private final Context parentContext;
 

--- a/management/testing/sample-entity/src/main/java/org/terracotta/management/entity/sample/client/management/CacheSettingsManagementProvider.java
+++ b/management/testing/sample-entity/src/main/java/org/terracotta/management/entity/sample/client/management/CacheSettingsManagementProvider.java
@@ -31,7 +31,7 @@ import java.util.Collections;
  * @author Mathieu Carbou
  */
 @Named("CacheSettings")
-@RequiredContext({@Named("appName"), @Named("cacheName")})
+@RequiredContext({@Named("instanceId"), @Named("appName"), @Named("cacheName")})
 class CacheSettingsManagementProvider extends AbstractManagementProvider<ClientCache> {
   private final Context parentContext;
 

--- a/management/testing/sample-entity/src/main/java/org/terracotta/management/entity/sample/client/management/CacheStatisticCollectorManagementProvider.java
+++ b/management/testing/sample-entity/src/main/java/org/terracotta/management/entity/sample/client/management/CacheStatisticCollectorManagementProvider.java
@@ -20,7 +20,7 @@ import org.terracotta.management.registry.Named;
 import org.terracotta.management.registry.RequiredContext;
 import org.terracotta.management.registry.collect.StatisticCollectorProvider;
 
-@RequiredContext({@Named("appName")})
+@RequiredContext({@Named("instanceId"), @Named("appName")})
 class CacheStatisticCollectorManagementProvider extends StatisticCollectorProvider {
   CacheStatisticCollectorManagementProvider(Context context) {
     super(context);

--- a/management/testing/sample-entity/src/main/java/org/terracotta/management/entity/sample/client/management/CacheStatisticsManagementProvider.java
+++ b/management/testing/sample-entity/src/main/java/org/terracotta/management/entity/sample/client/management/CacheStatisticsManagementProvider.java
@@ -35,7 +35,7 @@ import static java.util.EnumSet.of;
  * @author Mathieu Carbou
  */
 @Named("CacheStatistics")
-@RequiredContext({@Named("appName"), @Named("cacheName")})
+@RequiredContext({@Named("instanceId"), @Named("appName"), @Named("cacheName")})
 class CacheStatisticsManagementProvider extends DefaultStatisticsManagementProvider<ClientCache> {
 
   private final Context parentContext;

--- a/management/testing/sample-entity/src/main/java/org/terracotta/management/entity/sample/client/management/Management.java
+++ b/management/testing/sample-entity/src/main/java/org/terracotta/management/entity/sample/client/management/Management.java
@@ -49,8 +49,8 @@ public class Management {
 
   private NmsAgentService nmsAgentService;
 
-  public Management(ContextContainer contextContainer) {
-    this.parentContext = Context.create(contextContainer.getName(), contextContainer.getValue());
+  public Management(String instanceId, ContextContainer contextContainer) {
+    this.parentContext = Context.create(contextContainer.getName(), contextContainer.getValue()).with("instanceId", instanceId);
 
     // create a client-side management registry and add some providers for stats, calls and settings
     this.managementRegistry = new DefaultManagementRegistry(contextContainer);
@@ -72,6 +72,10 @@ public class Management {
 
   public ManagementRegistry getManagementRegistry() {
     return managementRegistry;
+  }
+
+  public Context getRootContext() {
+    return parentContext;
   }
 
   public void init(Connection connection) {
@@ -112,7 +116,7 @@ public class Management {
   }
 
   private NmsAgentService createNmsAgentService(Connection connection) {
-    DefaultNmsAgentService nmsAgentService = new DefaultNmsAgentService(new NmsAgentEntityFactory(connection).retrieve());
+    DefaultNmsAgentService nmsAgentService = new DefaultNmsAgentService(parentContext, new NmsAgentEntityFactory(connection).retrieve());
     nmsAgentService.setManagementCallExecutor(executorService);
     nmsAgentService.setOperationTimeout(5, TimeUnit.SECONDS);
     nmsAgentService.setManagementRegistry(managementRegistry);

--- a/management/testing/sample-entity/src/test/java/org/terracotta/management/entity/sample/AbstractTest.java
+++ b/management/testing/sample-entity/src/test/java/org/terracotta/management/entity/sample/AbstractTest.java
@@ -201,9 +201,13 @@ public abstract class AbstractTest {
   }
 
   protected void addWebappNode() throws Exception {
-    CacheFactory cacheFactory = new CacheFactory(URI.create("passthrough://stripe-1:9510"), "pet-clinic");
+    CacheFactory cacheFactory = new CacheFactory(nextInstanceId(), URI.create("passthrough://stripe-1:9510"), "pet-clinic");
     cacheFactory.init();
     webappNodes.add(cacheFactory);
+  }
+
+  protected final String nextInstanceId() {
+    return "instance-" + webappNodes.size();
   }
 
   public static abstract class CapabilityContextMixin {

--- a/management/testing/sample-entity/src/test/java/org/terracotta/management/entity/sample/CacheEntityFeaturesTest.java
+++ b/management/testing/sample-entity/src/test/java/org/terracotta/management/entity/sample/CacheEntityFeaturesTest.java
@@ -32,13 +32,13 @@ public class CacheEntityFeaturesTest extends AbstractTest {
 
   @Test
   public void cache_remains_active_on_server_on_client_close() throws Exception {
-    CacheFactory cacheFactory = new CacheFactory(URI.create("passthrough://stripe-1:9510"), "cat-clinic");
+    CacheFactory cacheFactory = new CacheFactory(nextInstanceId(), URI.create("passthrough://stripe-1:9510"), "cat-clinic");
     cacheFactory.init();
     Cache cache = cacheFactory.getCache("cache");
     cache.put("client1", "Mat");
     cacheFactory.close();
 
-    cacheFactory = new CacheFactory(URI.create("passthrough://stripe-1:9510"), "cat-clinic");
+    cacheFactory = new CacheFactory(nextInstanceId(), URI.create("passthrough://stripe-1:9510"), "cat-clinic");
     cacheFactory.init();
     cache = cacheFactory.getCache("cache");
     try {

--- a/management/testing/sample-entity/src/test/java/org/terracotta/management/entity/sample/ClientCacheLocalManagementTest.java
+++ b/management/testing/sample-entity/src/test/java/org/terracotta/management/entity/sample/ClientCacheLocalManagementTest.java
@@ -59,14 +59,13 @@ public class ClientCacheLocalManagementTest extends AbstractTest {
 
   @Test
   public void can_do_local_management_calls() throws Exception {
+    Context rootContext = webappNodes.get(0).getRootContext();
     CapabilityManagementSupport registry = webappNodes.get(0).getManagementRegistry();
 
     // put
     ContextualReturn<?> put = registry.withCapability("CacheCalls")
         .call("put", new Parameter("pet1"), new Parameter("Cat"))
-        .on(Context.empty()
-            .with("appName", "pet-clinic")
-            .with("cacheName", "pets"))
+        .on(rootContext.with("cacheName", "pets"))
         .build()
         .execute()
         .getSingleResult();
@@ -77,9 +76,7 @@ public class ClientCacheLocalManagementTest extends AbstractTest {
     // get
     ContextualReturn<String> get = registry.withCapability("CacheCalls")
         .call("get", String.class, new Parameter("pet1"))
-        .on(Context.empty()
-            .with("appName", "pet-clinic")
-            .with("cacheName", "pets"))
+        .on(rootContext.with("cacheName", "pets"))
         .build()
         .execute()
         .getSingleResult();
@@ -91,9 +88,7 @@ public class ClientCacheLocalManagementTest extends AbstractTest {
     // size
     ContextualReturn<Integer> size = registry.withCapability("CacheCalls")
         .call("size", int.class)
-        .on(Context.empty()
-            .with("appName", "pet-clinic")
-            .with("cacheName", "pets"))
+        .on(rootContext.with("cacheName", "pets"))
         .build()
         .execute()
         .getSingleResult();
@@ -105,9 +100,7 @@ public class ClientCacheLocalManagementTest extends AbstractTest {
     // clear
     ContextualReturn<?> result = registry.withCapability("CacheCalls")
         .call("clear")
-        .on(Context.empty()
-            .with("appName", "pet-clinic")
-            .with("cacheName", "pets"))
+        .on(rootContext.with("cacheName", "pets"))
         .build()
         .execute()
         .getSingleResult();
@@ -164,6 +157,7 @@ public class ClientCacheLocalManagementTest extends AbstractTest {
   }
 
   private Stream<? extends ContextualStatistics> queryAllStats(int node) {
+    Context rootContext = webappNodes.get(node).getRootContext();
     CapabilityManagementSupport registry = webappNodes.get(node).getManagementRegistry();
     // get all possible stat names
     List<String> statNames = registry.getCapabilities()
@@ -179,9 +173,7 @@ public class ClientCacheLocalManagementTest extends AbstractTest {
         .filter(capability -> capability.getName().equals("CacheSettings"))
         .flatMap(capability -> capability.getDescriptors().stream())
         .map(descriptor -> ((Settings) descriptor).getString("cacheName"))
-        .map(c -> Context.empty()
-            .with("appName", "pet-clinic")
-            .with("cacheName", c))
+        .map(c -> rootContext.with("cacheName", c))
         .collect(Collectors.toList());
 
     // do a management call to activate all stats from all contexts

--- a/management/testing/sample-entity/src/test/resources/client-descriptors.json
+++ b/management/testing/sample-entity/src/test/resources/client-descriptors.json
@@ -40,6 +40,10 @@
     "capabilityContext": {
       "attributes": [
         {
+          "name": "instanceId",
+          "required": true
+        },
+        {
           "name": "appName",
           "required": true
         },
@@ -55,17 +59,23 @@
     "descriptors": [
       {
         "appName": "pet-clinic",
+        "instanceId": "instance-0",
         "cacheName": "pets",
         "size": 0
       },
       {
         "appName": "pet-clinic",
+        "instanceId": "instance-0",
         "cacheName": "clients",
         "size": 0
       }
     ],
     "capabilityContext": {
       "attributes": [
+        {
+          "name": "instanceId",
+          "required": true
+        },
         {
           "name": "appName",
           "required": true
@@ -99,6 +109,10 @@
     ],
     "capabilityContext": {
       "attributes": [
+        {
+          "name": "instanceId",
+          "required": true
+        },
         {
           "name": "appName",
           "required": true
@@ -160,6 +174,10 @@
     ],
     "capabilityContext": {
       "attributes": [
+        {
+          "name": "instanceId",
+          "required": true
+        },
         {
           "name": "appName",
           "required": true


### PR DESCRIPTION
Management: Allow more routing information to be passed in the client context.

Backward-compatible refactoring in management code to allow a client to add more routing information in its context used to identify pushed statistics and notifications. This will allow a client context to contain the previously missing "instanceId" routing information plus the manager name