### PR TITLE
TDB-5488 - fix set/unset license-file when unconfigured

### DIFF
--- a/dynamic-config/cli/dynamic-config-cli-api/src/main/java/org/terracotta/dynamic_config/cli/api/command/RemoteAction.java
+++ b/dynamic-config/cli/dynamic-config-cli-api/src/main/java/org/terracotta/dynamic_config/cli/api/command/RemoteAction.java
@@ -125,7 +125,7 @@ public abstract class RemoteAction implements Runnable {
           .map(Tuple2::getT2)
           .forEach(service -> service.activate(cluster, licenseContent));
       if (licenseContent == null) {
-        output.info("No license installed. If you are attaching a node, the license will be synced.");
+        output.info("No license specified for activation. If a license was previously configured, it will take effect. If you are attaching a node, the license will be synced.");
       } else {
         output.info("License installation successful");
       }

--- a/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/service/DynamicConfigServiceImpl.java
+++ b/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/service/DynamicConfigServiceImpl.java
@@ -79,8 +79,8 @@ public class DynamicConfigServiceImpl implements TopologyService, DynamicConfigS
 
   public DynamicConfigServiceImpl(NodeContext nodeContext, LicenseService licenseService, NomadServerManager nomadServerManager, ObjectMapperFactory objectMapperFactory, Server server) {
     this.topologies = new Topologies(nodeContext);
-    this.licensing = new Licensing(licenseService, nomadServerManager.getConfigurationManager().getLicensePath());
     this.nomadServerManager = requireNonNull(nomadServerManager);
+    this.licensing = new Licensing(licenseService, nomadServerManager);
     this.objectMapper = objectMapperFactory.create();
     this.server = requireNonNull(server);
 
@@ -91,7 +91,7 @@ public class DynamicConfigServiceImpl implements TopologyService, DynamicConfigS
 
   @Override
   public Optional<String> getLicenseContent() {
-    return licensing.read();
+    return licensing.getLicenseContent();
   }
 
   @Override
@@ -350,7 +350,11 @@ public class DynamicConfigServiceImpl implements TopologyService, DynamicConfigS
 
   @Override
   public void upgradeLicense(String licenseContent) {
-    licensing.install(licenseContent, getUpcomingNodeContext().getCluster());
+    if (licenseContent == null) {
+      licensing.uninstall();
+    } else {
+      licensing.install(licenseContent, getUpcomingNodeContext().getCluster());
+    }
   }
 
   @Override

--- a/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/service/Licensing.java
+++ b/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/service/Licensing.java
@@ -47,10 +47,13 @@ class Licensing {
 
   private final LicenseService licenseService;
   private final Path licenseFile;
+  private volatile String unconfiguredLicenseContent; // set only when the server is unconfigured (RO mode)
+  private final NomadServerManager nomadServerManager;
 
-  public Licensing(LicenseService licenseService, Path licenseDir) {
+  public Licensing(LicenseService licenseService, NomadServerManager nomadServerManager) {
     this.licenseService = requireNonNull(licenseService);
-    this.licenseFile = requireNonNull(licenseDir).resolve(LICENSE_FILE_NAME);
+    this.nomadServerManager = nomadServerManager;
+    this.licenseFile = requireNonNull(nomadServerManager.getConfigurationManager().getLicensePath()).resolve(LICENSE_FILE_NAME);
   }
 
   public Path getLicenseFile() {
@@ -66,7 +69,19 @@ class Licensing {
     }
   }
 
-  public Optional<String> read() throws UncheckedIOException, IllegalStateException {
+  public Optional<String> getLicenseContent() {
+    return Optional.ofNullable(read().orElseGet(() -> getUnconfiguredLicenseContent().orElse(null)));
+  }
+
+  /**
+   * Only return the unconfiguredLicenseContent if the server is unconfigured (i.e. RO mode).
+   */
+  private Optional<String> getUnconfiguredLicenseContent() {
+    return nomadServerManager.getNomadMode() == NomadMode.RO && unconfiguredLicenseContent != null ?
+        Optional.of(unconfiguredLicenseContent) : Optional.empty();
+  }
+
+  private Optional<String> read() throws UncheckedIOException, IllegalStateException {
     licenseLock.readLock().lock();
     try {
       return licenseFile.toFile().exists() ?
@@ -106,30 +121,61 @@ class Licensing {
     }
   }
 
+  /**
+   * Licenses can be configured (set/unset) when the server is ACTIVE or UNCONFIGURED.
+   * Since the config folder does not yet exist when the server is UNCONFIGURED, we only 'install' the license
+   * (i.e. copy the specified file to the config folder) when the server is ACTIVE.
+   * If install is called when the server is UNCONFIGURED (RO mode), we simply update the unconfiguredLicenseContent
+   * member with the supplied licenseContent.
+   * If install is called when the server is CONFIGURED (RW mode), we use the license that was supplied during activation.
+   * If a license was not specified during activation, we use the unconfiguredLicenseContent that was set when the
+   * server was UNCONFIGURED (if one was specified).
+   */
   public void install(String licenseContent, Cluster cluster) {
     licenseLock.writeLock().lock();
     try {
-      if (licenseContent != null) {
-        try {
-          final Path tempFile = Files.createTempFile("terracotta-license-", ".xml");
-          try {
-            Files.write(tempFile, licenseContent.getBytes(StandardCharsets.UTF_8));
-            licenseService.validate(tempFile, cluster);
-            LOGGER.info("License validated");
-            LOGGER.debug("Moving license file: {} to: {}", tempFile, licenseFile);
-            org.terracotta.utilities.io.Files.relocate(tempFile, licenseFile, StandardCopyOption.REPLACE_EXISTING);
-            LOGGER.info("License installed");
-          } finally {
-            try {
-              org.terracotta.utilities.io.Files.deleteIfExists(tempFile);
-            } catch (IOException ignored) {
-            }
-          }
-        } catch (IOException e) {
-          throw new UncheckedIOException(e);
+      if (nomadServerManager.getNomadMode() == NomadMode.RO) {
+        // server is unconfigured (or in Repair)
+        unconfiguredLicenseContent = licenseContent;
+      } else {
+        // server is configured
+        if (licenseContent == null && unconfiguredLicenseContent != null) {
+          // no license specified; if available, use the license set when unconfigured
+          licenseContent = unconfiguredLicenseContent;
         }
-        LOGGER.info("License installation successful");
-      } else if (isInstalled()) {
+        if (licenseContent != null) {
+          // only perform file operations on activated servers (config folders do not exist when unconfigured)
+          try {
+            final Path tempFile = Files.createTempFile("terracotta-license-", ".xml");
+            try {
+              Files.write(tempFile, licenseContent.getBytes(StandardCharsets.UTF_8));
+              licenseService.validate(tempFile, cluster);
+              LOGGER.info("License validated");
+              LOGGER.debug("Moving license file: {} to: {}", tempFile, licenseFile);
+              org.terracotta.utilities.io.Files.relocate(tempFile, licenseFile, StandardCopyOption.REPLACE_EXISTING);
+              LOGGER.info("License installed");
+            } finally {
+              try {
+                org.terracotta.utilities.io.Files.deleteIfExists(tempFile);
+              } catch (IOException ignored) {
+              }
+            }
+          } catch (IOException e) {
+            throw new UncheckedIOException(e);
+          }
+          LOGGER.info("License installation successful");
+        }
+      }
+    } finally {
+      licenseLock.writeLock().unlock();
+    }
+  }
+
+  public void uninstall() {
+    licenseLock.writeLock().lock();
+    try {
+      unconfiguredLicenseContent = null;
+      if (isInstalled()) {
         try {
           org.terracotta.utilities.io.Files.deleteIfExists(licenseFile);
         } catch (IOException e) {

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/AttachInConsistency1x4IT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/AttachInConsistency1x4IT.java
@@ -178,7 +178,7 @@ public class AttachInConsistency1x4IT extends DynamicConfigIT {
     assertThat(configTool("export", "-s", "localhost:" + getNodePort(1, activeId), "-f", tmpDir.getRoot().resolve("cluster.properties").toAbsolutePath().toString(), "-t", "properties"), is(successful()));
     assertThat(
         configTool("activate", "-R", "-s", "localhost:" + getNodePort(1, 4), "-f", tmpDir.getRoot().resolve("cluster.properties").toAbsolutePath().toString()),
-        allOf(containsOutput("No license installed"), containsOutput("came back up")));
+        allOf(containsOutput("No license specified for activation"), containsOutput("came back up")));
 
     // we finally verify that the added node became passive, activated with the right topology
     waitForPassive(1, 4);

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/LockConfigIT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/LockConfigIT.java
@@ -119,7 +119,7 @@ public class LockConfigIT extends DynamicConfigIT {
 
     assertThat(
         configTool("activate", "-R", "-s", "localhost:" + getNodePort(1, 2), "-f", exportedConfigPath.toString()),
-        allOf(containsOutput("No license installed"), containsOutput("came back up")));
+        allOf(containsOutput("No license specified for activation"), containsOutput("came back up")));
   }
 
   @Test

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/RepairCommand1x2IT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/RepairCommand1x2IT.java
@@ -315,13 +315,13 @@ public class RepairCommand1x2IT extends DynamicConfigIT {
     // restricted activation
     assertThat(
         configTool("activate", "-restrict", "-connect-to", "localhost:" + getNodePort(1, passiveId), "-config-file", exportPath),
-        allOf(containsOutput("No license installed"), containsOutput("came back up")));
+        allOf(containsOutput("No license specified for activation"), containsOutput("came back up")));
     waitForPassive(1, passiveId);
   }
 
   private void activate1x2Cluster() {
     assertThat(configTool("attach", "-d", "localhost:" + getNodePort(), "-s", "localhost:" + getNodePort(1, 2)), is(successful()));
-    assertThat(activateCluster(), allOf(is(successful()), containsOutput("No license installed"), containsOutput("came back up")));
+    assertThat(activateCluster(), allOf(is(successful()), containsOutput("No license specified for activation"), containsOutput("came back up")));
 
     waitForActive(1);
     waitForPassives(1);

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activation/ActivateCommand1x2IT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activation/ActivateCommand1x2IT.java
@@ -35,7 +35,7 @@ public class ActivateCommand1x2IT extends DynamicConfigIT {
   @Test
   public void testSingleNodeActivation() {
     assertThat(activateCluster(),
-        allOf(is(successful()), containsOutput("No license installed"), containsOutput("came back up")));
+        allOf(is(successful()), containsOutput("No license specified for activation"), containsOutput("came back up")));
     waitForActive(1, 1);
   }
 
@@ -43,7 +43,7 @@ public class ActivateCommand1x2IT extends DynamicConfigIT {
   public void testMultiNodeSingleStripeActivation() {
     assertThat(configTool("attach", "-d", "localhost:" + getNodePort(), "-s", "localhost:" + getNodePort(1, 2)), is(successful()));
 
-    assertThat(activateCluster(), allOf(is(successful()), containsOutput("No license installed"), containsOutput("came back up")));
+    assertThat(activateCluster(), allOf(is(successful()), containsOutput("No license specified for activation"), containsOutput("came back up")));
     waitForActive(1);
     waitForPassives(1);
   }
@@ -61,7 +61,7 @@ public class ActivateCommand1x2IT extends DynamicConfigIT {
   public void testSingleNodeActivationWithConfigFile() throws Exception {
     assertThat(
         configTool("activate", "-f", copyConfigProperty("/config-property-files/single-stripe.properties").toString(), "-n", "my-cluster"),
-        allOf(containsOutput("No license installed"), containsOutput("came back up")));
+        allOf(containsOutput("No license specified for activation"), containsOutput("came back up")));
 
     waitForActive(1, 1);
 
@@ -75,7 +75,7 @@ public class ActivateCommand1x2IT extends DynamicConfigIT {
   public void testSingleNodeActivationWithConfigFileNoFailover() throws Exception {
     assertThat(
         configTool("activate", "-f", copyConfigProperty("/config-property-files/single-stripe-no-fo.properties").toString(), "-n", "my-cluster"),
-        allOf(containsOutput("No license installed"), containsOutput("came back up")));
+        allOf(containsOutput("No license specified for activation"), containsOutput("came back up")));
 
     waitForActive(1, 1);
 
@@ -89,7 +89,7 @@ public class ActivateCommand1x2IT extends DynamicConfigIT {
   public void testMultiNodeSingleStripeActivationWithConfigFile() {
     assertThat(
         configTool("activate", "-f", copyConfigProperty("/config-property-files/single-stripe_multi-node.properties").toString()),
-        allOf(containsOutput("No license installed"), containsOutput("came back up")));
+        allOf(containsOutput("No license specified for activation"), containsOutput("came back up")));
 
     waitForActive(1);
     waitForPassives(1);
@@ -106,7 +106,7 @@ public class ActivateCommand1x2IT extends DynamicConfigIT {
   public void testRestrictedActivationToActivateNodesAtDifferentTime() throws Exception {
     assertThat(
         configTool("activate", "-R", "-s", "localhost:" + getNodePort(1, 1), "-f", copyConfigProperty("/config-property-files/single-stripe_multi-node.properties").toString()),
-        allOf(containsOutput("No license installed"), containsOutput("came back up")));
+        allOf(containsOutput("No license specified for activation"), containsOutput("came back up")));
     waitForActive(1, 1);
 
     withTopologyService(1, 1, topologyService -> assertTrue(topologyService.isActivated()));
@@ -120,7 +120,7 @@ public class ActivateCommand1x2IT extends DynamicConfigIT {
 
     assertThat(
         configTool("activate", "-R", "-s", "localhost:" + getNodePort(1, 2), "-f", exportPath),
-        allOf(containsOutput("No license installed"), containsOutput("came back up")));
+        allOf(containsOutput("No license specified for activation"), containsOutput("came back up")));
     waitForPassive(1, 2);
 
     withTopologyService(1, 1, topologyService -> assertTrue(topologyService.isActivated()));
@@ -140,7 +140,7 @@ public class ActivateCommand1x2IT extends DynamicConfigIT {
     // restrict activation to only node 1
     assertThat(
         configTool("activate", "-R", "-n", "my-cluster", "-s", "localhost:" + getNodePort(1, 1)),
-        allOf(containsOutput("No license installed"), containsOutput("came back up")));
+        allOf(containsOutput("No license specified for activation"), containsOutput("came back up")));
 
     waitForActive(1, 1);
     waitForDiagnostic(1, 2);
@@ -151,7 +151,7 @@ public class ActivateCommand1x2IT extends DynamicConfigIT {
     // restrict activation to only node 2, which will become passive as node 1
     assertThat(
         configTool("activate", "-R", "-n", "my-cluster", "-s", "localhost:" + getNodePort(1, 2)),
-        allOf(containsOutput("No license installed"), containsOutput("came back up")));
+        allOf(containsOutput("No license specified for activation"), containsOutput("came back up")));
 
     waitForPassive(1, 2);
 

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activation/AutoActivateNewPassive1x2IT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activation/AutoActivateNewPassive1x2IT.java
@@ -131,6 +131,6 @@ public class AutoActivateNewPassive1x2IT extends DynamicConfigIT {
 
     assertThat(
         configTool("activate", "-R", "-s", "localhost:" + getNodePort(1, 2), "-f", exportedConfigPath.toString()),
-        allOf(containsOutput("No license installed"), containsOutput("came back up")));
+        allOf(containsOutput("No license specified for activation"), containsOutput("came back up")));
   }
 }


### PR DESCRIPTION
Fix for defect: https://itrac.eur.ad.sag/browse/TDB-5488.
This problem started after 10.7 fix 3, resulting from a change to when a server's config folders get created on disk (698072a0).  With 10.7 fix 3 and earlier, config folders were created when the node was unconfigured .  But this behavior was changed to only create the config folder structure as part of activation.  This problem revealed itself when setting a license file on an unconfigured node with the server attempting to install the license into a non-existent folder throwing an exception (see TDB-5488).

The solution here holds the supplied 'licenseContent' string in memory, if set when unconfigured, until the node is activated.  Upon activation, the existing licenseContent is then used to create the license on disk.  Or, that in-memory license is superseded if the license is optionally supplied with the activate call.

Corresponding system tests will appear in a subsequent Enterprise PR.