### PR TITLE
Fixing generics in interface to remove node key as a class parameter.

### DIFF
--- a/diagnostic/client/src/main/java/org/terracotta/diagnostic/client/connection/ConcurrentDiagnosticServiceProvider.java
+++ b/diagnostic/client/src/main/java/org/terracotta/diagnostic/client/connection/ConcurrentDiagnosticServiceProvider.java
@@ -35,7 +35,7 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.terracotta.common.struct.Tuple3.tuple3;
 
-public class ConcurrentDiagnosticServiceProvider<K> implements MultiDiagnosticServiceProvider<K> {
+public class ConcurrentDiagnosticServiceProvider implements MultiDiagnosticServiceProvider {
 
   private final DiagnosticServiceProvider diagnosticServiceProvider;
   private final Duration connectionTimeout;
@@ -49,23 +49,23 @@ public class ConcurrentDiagnosticServiceProvider<K> implements MultiDiagnosticSe
   }
 
   @Override
-  public DiagnosticServices<K> fetchDiagnosticServices(Map<K, InetSocketAddress> addresses) {
+  public <K> DiagnosticServices<K> fetchDiagnosticServices(Map<K, InetSocketAddress> addresses) {
     return _fetchOnlineDiagnosticService(addresses, false);
   }
 
   @Override
-  public DiagnosticServices<K> fetchAnyOnlineDiagnosticService(Map<K, InetSocketAddress> addresses) {
+  public <K> DiagnosticServices<K> fetchAnyOnlineDiagnosticService(Map<K, InetSocketAddress> addresses) {
     return _fetchOnlineDiagnosticService(addresses, true);
   }
 
-  private DiagnosticServices<K> _fetchOnlineDiagnosticService(Map<K, InetSocketAddress> addresses, boolean firstAvailable) {
+  private <K> DiagnosticServices<K> _fetchOnlineDiagnosticService(Map<K, InetSocketAddress> addresses, boolean firstAvailable) {
     if (addresses.isEmpty()) {
       return new DiagnosticServices<>(emptyMap(), emptyMap());
     }
 
     ExecutorService executor = Executors.newFixedThreadPool(
-      concurrencySizing.getThreadCount(addresses.size()),
-      r -> new Thread(r, "diagnostics-connect"));
+        concurrencySizing.getThreadCount(addresses.size()),
+        r -> new Thread(r, "diagnostics-connect"));
 
     try {
       CompletionService<Tuple3<K, DiagnosticService, DiagnosticServiceProviderException>> completionService = new ExecutorCompletionService<>(executor);

--- a/diagnostic/client/src/main/java/org/terracotta/diagnostic/client/connection/MultiDiagnosticServiceProvider.java
+++ b/diagnostic/client/src/main/java/org/terracotta/diagnostic/client/connection/MultiDiagnosticServiceProvider.java
@@ -21,10 +21,9 @@ import java.util.Map;
 import java.util.Objects;
 
 /**
- * @param <K> a node identifier
  * @author Mathieu Carbou
  */
-public interface MultiDiagnosticServiceProvider<K> {
+public interface MultiDiagnosticServiceProvider {
   /**
    * Concurrently fetch the diagnostic service of all the nodes.
    * These nodes are expected to be online.
@@ -32,10 +31,11 @@ public interface MultiDiagnosticServiceProvider<K> {
    * <p>
    * The returned {@link DiagnosticServices} will only have online nodes and no offline nodes.
    *
+   * @param <K> a node identifier
    * @throws DiagnosticServiceProviderException If one of the node is unreachable,
    *                                            or if all the nodes cannot be reached within a specific duration (timeout)
    */
-  default DiagnosticServices<K> fetchOnlineDiagnosticServices(Map<K, InetSocketAddress> expectedOnlineNodes) throws DiagnosticServiceProviderException {
+  default <K> DiagnosticServices<K> fetchOnlineDiagnosticServices(Map<K, InetSocketAddress> expectedOnlineNodes) throws DiagnosticServiceProviderException {
     DiagnosticServices<K> diagnosticServices = fetchDiagnosticServices(expectedOnlineNodes);
     Collection<K> offlineEndpoints = diagnosticServices.getOfflineEndpoints().keySet();
     if (!offlineEndpoints.isEmpty()) {
@@ -61,8 +61,10 @@ public interface MultiDiagnosticServiceProvider<K> {
    * If some nodes are offline, they will be reported in {@link DiagnosticServices#getOfflineEndpoints()}.
    * <p>
    * The returned {@link DiagnosticServices} will have a list of online nodes and a list of offline nodes.
+   *
+   * @param <K> a node identifier
    */
-  DiagnosticServices<K> fetchDiagnosticServices(Map<K, InetSocketAddress> addresses);
+  <K> DiagnosticServices<K> fetchDiagnosticServices(Map<K, InetSocketAddress> addresses);
 
   /**
    * Concurrently fetch any single online diagnostic service of all the provided nodes.
@@ -70,6 +72,8 @@ public interface MultiDiagnosticServiceProvider<K> {
    * Offline nodes are ignored.
    * <p>
    * If successful, the returned {@link DiagnosticServices} will have a single online node.
+   *
+   * @param <K> a node identifier
    */
-  DiagnosticServices<K> fetchAnyOnlineDiagnosticService(Map<K, InetSocketAddress> addresses);
+  <K> DiagnosticServices<K> fetchAnyOnlineDiagnosticService(Map<K, InetSocketAddress> addresses);
 }

--- a/diagnostic/client/src/test/java/org/terracotta/diagnostic/client/connection/MultiDiagnosticServiceConnectionTest.java
+++ b/diagnostic/client/src/test/java/org/terracotta/diagnostic/client/connection/MultiDiagnosticServiceConnectionTest.java
@@ -42,7 +42,7 @@ public class MultiDiagnosticServiceConnectionTest {
   @Mock
   private DiagnosticService diagnosticService;
 
-  private MultiDiagnosticServiceProvider<InetSocketAddress> multiDiagnosticServiceProvider;
+  private MultiDiagnosticServiceProvider multiDiagnosticServiceProvider;
 
   private Map<InetSocketAddress, InetSocketAddress> nodes = Stream.of(
       InetSocketAddress.createUnresolved("host1", 1234),
@@ -59,7 +59,7 @@ public class MultiDiagnosticServiceConnectionTest {
         return diagnosticService;
       }
     };
-    multiDiagnosticServiceProvider = new ConcurrentDiagnosticServiceProvider<>(diagnosticServiceProvider, timeout, new ConcurrencySizing());
+    multiDiagnosticServiceProvider = new ConcurrentDiagnosticServiceProvider(diagnosticServiceProvider, timeout, new ConcurrencySizing());
   }
 
   @Test

--- a/dynamic-config/cli/dynamic-config-cli-api/src/main/java/org/terracotta/dynamic_config/cli/api/command/OssServiceProvider.java
+++ b/dynamic-config/cli/dynamic-config-cli-api/src/main/java/org/terracotta/dynamic_config/cli/api/command/OssServiceProvider.java
@@ -25,7 +25,6 @@ import org.terracotta.diagnostic.client.connection.DiagnosticServiceProvider;
 import org.terracotta.diagnostic.model.KitInformation;
 import org.terracotta.dynamic_config.api.json.DynamicConfigApiJsonModule;
 import org.terracotta.dynamic_config.api.model.NodeContext;
-import org.terracotta.dynamic_config.api.model.UID;
 import org.terracotta.dynamic_config.cli.api.nomad.DefaultNomadManager;
 import org.terracotta.dynamic_config.cli.api.nomad.LockAwareNomadManager;
 import org.terracotta.dynamic_config.cli.api.nomad.NomadManager;
@@ -91,8 +90,8 @@ public class OssServiceProvider implements ServiceProvider {
         config.getSecurityRootDirectory());
   }
 
-  protected ConcurrentDiagnosticServiceProvider<UID> createMultiDiagnosticServiceProvider(Configuration config) {
-    return new ConcurrentDiagnosticServiceProvider<>(
+  protected ConcurrentDiagnosticServiceProvider createMultiDiagnosticServiceProvider(Configuration config) {
+    return new ConcurrentDiagnosticServiceProvider(
         createDiagnosticServiceProvider(config),
         getConnectionTimeout(config),
         getConcurrencySizing(config));

--- a/dynamic-config/cli/dynamic-config-cli-api/src/main/java/org/terracotta/dynamic_config/cli/api/command/RemoteAction.java
+++ b/dynamic-config/cli/dynamic-config-cli-api/src/main/java/org/terracotta/dynamic_config/cli/api/command/RemoteAction.java
@@ -95,7 +95,7 @@ public abstract class RemoteAction implements Runnable {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(RemoteAction.class);
 
-  @Inject public MultiDiagnosticServiceProvider<UID> multiDiagnosticServiceProvider;
+  @Inject public MultiDiagnosticServiceProvider multiDiagnosticServiceProvider;
   @Inject public DiagnosticServiceProvider diagnosticServiceProvider;
   @Inject public NomadManager<NodeContext> nomadManager;
   @Inject public RestartService restartService;

--- a/dynamic-config/cli/dynamic-config-cli-api/src/main/java/org/terracotta/dynamic_config/cli/api/nomad/DefaultNomadManager.java
+++ b/dynamic-config/cli/dynamic-config-cli-api/src/main/java/org/terracotta/dynamic_config/cli/api/nomad/DefaultNomadManager.java
@@ -83,10 +83,10 @@ public class DefaultNomadManager<T> implements NomadManager<T> {
   );
 
   private final NomadEnvironment environment;
-  private final MultiDiagnosticServiceProvider<UID> multiDiagnosticServiceProvider;
+  private final MultiDiagnosticServiceProvider multiDiagnosticServiceProvider;
   private final NomadEntityProvider nomadEntityProvider;
 
-  public DefaultNomadManager(NomadEnvironment environment, MultiDiagnosticServiceProvider<UID> multiDiagnosticServiceProvider, NomadEntityProvider nomadEntityProvider) {
+  public DefaultNomadManager(NomadEnvironment environment, MultiDiagnosticServiceProvider multiDiagnosticServiceProvider, NomadEntityProvider nomadEntityProvider) {
     this.environment = environment;
     this.multiDiagnosticServiceProvider = multiDiagnosticServiceProvider;
     this.nomadEntityProvider = nomadEntityProvider;

--- a/dynamic-config/cli/dynamic-config-cli-api/src/test/java/org/terracotta/dynamic_config/cli/api/BaseTest.java
+++ b/dynamic-config/cli/dynamic-config-cli-api/src/test/java/org/terracotta/dynamic_config/cli/api/BaseTest.java
@@ -28,7 +28,6 @@ import org.terracotta.diagnostic.client.connection.DiagnosticServiceProvider;
 import org.terracotta.diagnostic.client.connection.MultiDiagnosticServiceProvider;
 import org.terracotta.dynamic_config.api.json.DynamicConfigApiJsonModule;
 import org.terracotta.dynamic_config.api.model.NodeContext;
-import org.terracotta.dynamic_config.api.model.UID;
 import org.terracotta.dynamic_config.api.service.DynamicConfigService;
 import org.terracotta.dynamic_config.api.service.TopologyService;
 import org.terracotta.dynamic_config.cli.api.nomad.DefaultNomadManager;
@@ -64,7 +63,7 @@ import static org.mockito.Mockito.mock;
 public abstract class BaseTest {
 
   protected DiagnosticServiceProvider diagnosticServiceProvider;
-  protected MultiDiagnosticServiceProvider<UID> multiDiagnosticServiceProvider;
+  protected MultiDiagnosticServiceProvider multiDiagnosticServiceProvider;
   protected NomadEntityProvider nomadEntityProvider;
   protected NomadManager<NodeContext> nomadManager;
   protected RestartService restartService;
@@ -115,7 +114,7 @@ public abstract class BaseTest {
         return (NomadEntity<T>) nomadEntities.get(addresses);
       }
     };
-    multiDiagnosticServiceProvider = new ConcurrentDiagnosticServiceProvider<>(diagnosticServiceProvider, timeout, new ConcurrencySizing());
+    multiDiagnosticServiceProvider = new ConcurrentDiagnosticServiceProvider(diagnosticServiceProvider, timeout, new ConcurrencySizing());
     nomadManager = new DefaultNomadManager<>(new NomadEnvironment(), multiDiagnosticServiceProvider, nomadEntityProvider);
     restartService = new RestartService(diagnosticServiceProvider, concurrencySizing);
     stopService = new StopService(diagnosticServiceProvider, concurrencySizing);


### PR DESCRIPTION
Node key is only relevant when the map parameter is used.