### PR TITLE
log license details on server startup

### DIFF
--- a/dynamic-config/model/src/main/java/org/terracotta/dynamic_config/api/model/License.java
+++ b/dynamic-config/model/src/main/java/org/terracotta/dynamic_config/api/model/License.java
@@ -21,6 +21,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
+import static java.lang.System.lineSeparator;
+
 public class License {
 
   // Mapping between capability name and corresponding limit value
@@ -67,6 +69,13 @@ public class License {
     return capabilityLimitMap.get(capability);
   }
 
+  /***
+   * Returns first 'true' value of SubscriptionLicense, PerpetualLicense or DatahubLicense
+   */
+  public String getType() {
+    return flagsMap.entrySet().stream().filter(Map.Entry::getValue).findFirst().get().getKey();
+  }
+
   @Override
   public String toString() {
     return "License{" +
@@ -74,6 +83,18 @@ public class License {
         ", expiryDate=" + expiryDate +
         ", flagsMap=" + flagsMap +
         "}";
+  }
+
+  public String toLoggingString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("Type: ").append(getType()).append(lineSeparator());
+    sb.append("Expiration: ").append(expiryDate == LocalDate.MAX ? "Never" : expiryDate).append(lineSeparator());
+    sb.append("Capabilities:").append(lineSeparator());
+    Map<String, Long> capabilities = new HashMap<>(capabilityLimitMap);
+    capabilities.remove("OffHeap"); // handle this separately
+    capabilities.forEach((k,v) -> sb.append(k + ": ").append(hasCapability(k)).append(lineSeparator()));
+    sb.append("OffHeap: ").append(getLimit("OffHeap"));
+    return sb.toString();
   }
 
   @Override

--- a/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/service/Licensing.java
+++ b/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/service/Licensing.java
@@ -41,7 +41,7 @@ class Licensing {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(Licensing.class);
   private static final String LICENSE_FILE_NAME = "license.xml";
-
+  private static final String DATAHUB_LICENSE_FLAG = "DatahubLicense";
   // guard access to the installed license
   private final ReadWriteLock licenseLock = new ReentrantReadWriteLock();
 
@@ -149,8 +149,14 @@ class Licensing {
             final Path tempFile = Files.createTempFile("terracotta-license-", ".xml");
             try {
               Files.write(tempFile, licenseContent.getBytes(StandardCharsets.UTF_8));
+              License license = licenseService.parse(tempFile);
+              LOGGER.info("Validating license");
+              LOGGER.info(license.toLoggingString());
               licenseService.validate(tempFile, cluster);
               LOGGER.info("License validated");
+              if (license.getType().equals(DATAHUB_LICENSE_FLAG)) {
+                LOGGER.info("This Terracotta cluster is licensed for use only with webMethods DataHub");
+              }
               LOGGER.debug("Moving license file: {} to: {}", tempFile, licenseFile);
               org.terracotta.utilities.io.Files.relocate(tempFile, licenseFile, StandardCopyOption.REPLACE_EXISTING);
               LOGGER.info("License installed");


### PR DESCRIPTION
Log all relevant details for the installed license whenever the server starts and whenever the license is updated via config-tool set command.  Logged details include: 'type' of license (subscription, perpetual or datahub (*new*), expiration date, supported capabilities and available offheap.