### PR TITLE
relieve stress on inline servers

### DIFF
--- a/dynamic-config/testing/support/src/main/java/org/terracotta/dynamic_config/test_support/DynamicConfigIT.java
+++ b/dynamic-config/testing/support/src/main/java/org/terracotta/dynamic_config/test_support/DynamicConfigIT.java
@@ -137,6 +137,7 @@ public class DynamicConfigIT {
           System.setProperty("com.tc.server.entity.processor.threads", "4");
           System.setProperty("com.tc.l2.tccom.workerthreads", "4");
           System.setProperty("com.tc.l2.seda.stage.stall.warning", "1000");
+          System.setProperty("com.tc.tc.messages.packup.enabled", "false");
         }
       });
 


### PR DESCRIPTION
new core uses direct memory for comms.  let's turn that back off for inline tests that churn servers.  I may be causing problems with direct memory GC.