### PR TITLE
Improving test stability

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -28,25 +28,25 @@ jobs:
     parameters:
       jobName: Linux_Java_8
       timeoutInMinutes: 180
-      options: -B -Djava.test.version=1.8 -Dtest.parallel.forks=2
+      options: -B -Djava.test.version=1.8 -Dtest.parallel.forks=3
       mavenGoals: 'clean verify'
   - template: build-templates/maven-common.yml@templates
     parameters:
       jobName: Linux_Java_11
       timeoutInMinutes: 180
-      options: -B -Djava.test.version=1.11 -Dtest.parallel.forks=2
+      options: -B -Djava.test.version=1.11 -Dtest.parallel.forks=3
       mavenGoals: 'clean verify'
   - template: build-templates/maven-common.yml@templates
     parameters:
       jobName: Windows_Java_8
       timeoutInMinutes: 180
       vmImage: 'windows-latest'
-      options: -B -Djava.test.version=1.8 -Dtest.parallel.forks=2
+      options: -B -Djava.test.version=1.8 -Dtest.parallel.forks=3
       mavenGoals: 'clean verify'
   - template: build-templates/maven-common.yml@templates
     parameters:
       jobName: Windows_Java_11
       timeoutInMinutes: 180
       vmImage: 'windows-latest'
-      options: -B -Djava.test.version=1.11 -Dtest.parallel.forks=2
+      options: -B -Djava.test.version=1.11 -Dtest.parallel.forks=3
       mavenGoals: 'clean verify'

--- a/common/test-utilities/src/main/java/org/terracotta/testing/JavaTool.java
+++ b/common/test-utilities/src/main/java/org/terracotta/testing/JavaTool.java
@@ -82,7 +82,7 @@ public class JavaTool {
     } catch (IOException e) {
       throw new UncheckedIOException(e);
     }
-    threadDumps(timeout).forEach(dump -> dump.writeTo(outputDir.resolve("thread-dump-" + dump.process.pid + "-" + dump.process.processName.replaceAll("\\W", "_") + ".txt")));
+    threadDumps(timeout).forEach(dump -> dump.writeTo(outputDir.resolve("thread-dump-" + dump.process.pid + "-" + dump.process.processName.replaceAll("\\W", "_") + ".log")));
   }
 
   public static void memoryDump(Process process, Path output, Duration timeout) {

--- a/dynamic-config/testing/system-tests/pom.xml
+++ b/dynamic-config/testing/system-tests/pom.xml
@@ -139,28 +139,38 @@
             <goals>
               <goal>execute</goal>
             </goals>
-          </execution>
-        </executions>
-        <configuration>
-
-          <scripts>
-            <script><![CDATA[
+            <configuration>
+              <scripts>
+                <script><![CDATA[
 new File(project.build.directory, "fake-hosts.txt").text = "127.0.0.1 localhost ${"hostname".execute().text.trim()} ${"hostname".execute().text.trim().split('[.]')[0]} testhostname"
 println(new File(project.build.directory, "fake-hosts.txt").text)
-          ]]></script>
-            <script><![CDATA[
+]]>
+                </script>
+              </scripts>
+            </configuration>
+          </execution>
+          <execution>
+            <id>tc.properties</id>
+            <phase>pre-integration-test</phase>
+            <goals>
+              <goal>execute</goal>
+            </goals>
+            <configuration>
+              <scripts>
+                <script><![CDATA[
 new File(project.build.directory, "angela/platform-kit-${project.version}/server/lib/tc.properties").text = """
 com.tc.server.entity.processor.threads=4
 com.tc.l2.tccom.workerthreads=4
 com.tc.tc.messages.packup.enabled=false
 com.tc.l2.seda.stage.stall.warning=1000
-net.core.tcpnodelay=true
-net.core.keepalive=true
 """
 println(new File(project.build.directory, "angela/platform-kit-${project.version}/server/lib/tc.properties").text)
-          ]]></script>
-          </scripts>
-        </configuration>
+]]>
+                </script>
+              </scripts>
+            </configuration>
+          </execution>
+        </executions>
         <dependencies>
           <dependency>
             <groupId>org.codehaus.groovy</groupId>
@@ -176,6 +186,7 @@ println(new File(project.build.directory, "angela/platform-kit-${project.version
         <configuration>
           <forkCount>${test.parallel.forks}</forkCount>
           <reuseForks>false</reuseForks>
+          <rerunFailingTestsCount>2</rerunFailingTestsCount>
           <systemPropertyVariables>
             <angela.rootDir>${project.build.directory}/angela</angela.rootDir>
             <angela.skipUninstall>true</angela.skipUninstall>

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/AttachCommand1x2IT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/AttachCommand1x2IT.java
@@ -85,7 +85,7 @@ public class AttachCommand1x2IT extends DynamicConfigIT {
         Collections.singletonList(InetSocketAddress.createUnresolved("localhost", getNodePort())),
         "dynamic-config-topology-entity",
         getConnectionTimeout(),
-        new DynamicTopologyEntity.Settings().setRequestTimeout(getConnectionTimeout()),
+        new DynamicTopologyEntity.Settings().setRequestTimeout(getRequestTimeout()),
         null)) {
 
       CountDownLatch called = new CountDownLatch(1);

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/AttachCommand1x3IT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/AttachCommand1x3IT.java
@@ -41,6 +41,16 @@ public class AttachCommand1x3IT extends DynamicConfigIT {
     super(Duration.ofSeconds(180));
   }
 
+  @Override
+  protected Duration getConnectionTimeout() {
+    return Duration.ofSeconds(30);
+  }
+
+  @Override
+  protected Duration getRequestTimeout() {
+    return Duration.ofSeconds(30);
+  }
+
   @Before
   public void setup() throws Exception {
     startNode(1, 1);
@@ -161,7 +171,7 @@ public class AttachCommand1x3IT extends DynamicConfigIT {
     assertThat(getUpcomingCluster("localhost", getNodePort(1, 3)).getNodeCount(), is(equalTo(1)));
 
     //setup for failover in commit phase on active
-    assertThat(configTool("set", "-s", "localhost:" + getNodePort(1, 1), "-c", propertySettingString), is(successful()));
+    assertThat(configTool("set", "-s", "localhost:" + getNodePort(1, activeId), "-c", propertySettingString), is(successful()));
     assertThat(configTool("attach", "-f", "-d", "localhost:" + getNodePort(1, activeId), "-s", "localhost:" + getNodePort(1, 3)), is(successful()));
 
     waitForPassive(1, 3);

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/AttachInConsistency1x2IT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/AttachInConsistency1x2IT.java
@@ -77,6 +77,7 @@ public class AttachInConsistency1x2IT extends DynamicConfigIT {
 
     // activate a 1x1 cluster
     startNode(1, 1);
+    waitForDiagnostic(1, 1);
     activateCluster();
 
     // do a change requiring a restart

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/AttachStripeIT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/AttachStripeIT.java
@@ -113,7 +113,7 @@ public class AttachStripeIT extends DynamicConfigIT {
         Collections.singletonList(InetSocketAddress.createUnresolved("localhost", getNodePort(1, activeId))),
         "dynamic-config-topology-entity",
         getConnectionTimeout(),
-        new DynamicTopologyEntity.Settings(),
+        new DynamicTopologyEntity.Settings().setRequestTimeout(getRequestTimeout()),
         null)) {
 
       CountDownLatch called = new CountDownLatch(1);

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/ConfigSyncIT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/ConfigSyncIT.java
@@ -66,6 +66,9 @@ public class ConfigSyncIT extends DynamicConfigIT {
 
   @Before
   public void before() {
+    waitForActive(1);
+    waitForPassives(1);
+
     if (angela.tsa().getActive() == getNode(1, 1)) {
       activeNodeId = 1;
       passiveNodeId = 2;

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/DetachCommand1x2IT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/DetachCommand1x2IT.java
@@ -86,7 +86,7 @@ public class DetachCommand1x2IT extends DynamicConfigIT {
         Collections.singletonList(InetSocketAddress.createUnresolved("localhost", getNodePort(1, activeId))),
         "dynamic-config-topology-entity",
         getConnectionTimeout(),
-        new DynamicTopologyEntity.Settings().setRequestTimeout(getConnectionTimeout()),
+        new DynamicTopologyEntity.Settings().setRequestTimeout(getRequestTimeout()),
         null)) {
 
       CountDownLatch called = new CountDownLatch(1);

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/DetachInConsistency1x2IT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/DetachInConsistency1x2IT.java
@@ -35,7 +35,7 @@ import static org.terracotta.angela.client.support.hamcrest.AngelaMatchers.succe
 public class DetachInConsistency1x2IT extends DynamicConfigIT {
 
   public DetachInConsistency1x2IT() {
-    super(Duration.ofSeconds(180));
+    super(Duration.ofSeconds(240));
   }
 
   @Override

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/DetachInConsistency1x3IT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/DetachInConsistency1x3IT.java
@@ -156,7 +156,6 @@ public class DetachInConsistency1x3IT extends DynamicConfigIT {
 
     // To ensure that passiveId don't become active during failover since that is what we will remove
     stopNode(1, passiveId);
-    waitForStopped(1, passiveId);
 
     assertThat(
         configTool("-er", "40s", "detach", "-f", "-d", "localhost:" + getNodePort(1, activeId), "-s", "localhost:" + getNodePort(1, passiveId)),

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/DetachStripeIT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/DetachStripeIT.java
@@ -96,7 +96,7 @@ public class DetachStripeIT extends DynamicConfigIT {
         Collections.singletonList(InetSocketAddress.createUnresolved("localhost", getNodePort(1, 1))),
         "dynamic-config-topology-entity",
         getConnectionTimeout(),
-        new DynamicTopologyEntity.Settings().setRequestTimeout(getConnectionTimeout()),
+        new DynamicTopologyEntity.Settings().setRequestTimeout(getRequestTimeout()),
         null)) {
 
       CountDownLatch called = new CountDownLatch(1);

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/DiagnosticCommand1x2IT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/DiagnosticCommand1x2IT.java
@@ -66,6 +66,7 @@ public class DiagnosticCommand1x2IT extends DynamicConfigIT {
     stopNode(1, 1);
 
     startNode(1, 1, "--repair-mode", "--name", nodeName, "-r", repo);
+    waitForDiagnostic(1, 1);
     assertThat(
         configTool("diagnostic", "-s", "localhost:" + getNodePort(1, 1)),
         containsLinesInOrderStartingWith(Files.lines(Paths.get(getClass().getResource("/diagnostic-output/diagnostic3.txt").toURI())).collect(toList())));
@@ -110,8 +111,6 @@ public class DiagnosticCommand1x2IT extends DynamicConfigIT {
     // The restart status should be cleared upon restart
     stopNode(1, 1);
     stopNode(1, 2);
-    waitForStopped(1, 1);
-    waitForStopped(1, 2);
     startNode(1, 1, "--config-dir", "config/stripe1/node-1-1");
     startNode(1, 2, "--config-dir", "config/stripe1/node-1-2");
     waitForActive(1);

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/RepairCommand1x2IT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/RepairCommand1x2IT.java
@@ -52,6 +52,8 @@ public class RepairCommand1x2IT extends DynamicConfigIT {
   public void test_repair_partial_commit_when_passive_down() throws Exception {
     startNode(1, 1);
     startNode(1, 2);
+    waitForDiagnostic(1, 1);
+    waitForDiagnostic(1, 2);
     activate1x2Cluster();
 
     final int activeId = findActive(1).getAsInt();

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/SetCommand1x1IT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/SetCommand1x1IT.java
@@ -26,6 +26,7 @@ import org.terracotta.dynamic_config.test_support.DynamicConfigIT;
 
 import java.io.File;
 import java.net.InetSocketAddress;
+import java.time.Duration;
 import java.util.Collections;
 import java.util.concurrent.CountDownLatch;
 
@@ -38,6 +39,17 @@ import static org.terracotta.angela.client.support.hamcrest.AngelaMatchers.succe
 
 @ClusterDefinition(autoActivate = true, failoverPriority = "")
 public class SetCommand1x1IT extends DynamicConfigIT {
+
+  @Override
+  protected Duration getConnectionTimeout() {
+    return Duration.ofSeconds(30);
+  }
+
+  @Override
+  protected Duration getRequestTimeout() {
+    return Duration.ofSeconds(30);
+  }
+
   @Test
   public void setOffheapResource_decreaseSize() {
     assertThat(
@@ -159,6 +171,7 @@ public class SetCommand1x1IT extends DynamicConfigIT {
     // Restart node and verify that the change has taken effect
     stopNode(1, 1);
     startNode(1, 1);
+    waitForActive(1);
 
     assertThat(
         configTool("get", "-s", "localhost:" + getNodePort(), "-r", "-c", "log-dir", "-t", "index"),
@@ -276,7 +289,7 @@ public class SetCommand1x1IT extends DynamicConfigIT {
         Collections.singletonList(InetSocketAddress.createUnresolved("localhost", getNodePort())),
         "dynamic-config-topology-entity",
         getConnectionTimeout(),
-        new DynamicTopologyEntity.Settings().setRequestTimeout(getConnectionTimeout()),
+        new DynamicTopologyEntity.Settings().setRequestTimeout(getRequestTimeout()),
         null)) {
 
       CountDownLatch called = new CountDownLatch(1);

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/diagnostic/GetCommand1x1IT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/diagnostic/GetCommand1x1IT.java
@@ -77,7 +77,7 @@ public class GetCommand1x1IT extends DynamicConfigIT {
   public void testNode_getClientReconnectWindow() {
     assertThat(
         configTool("get", "-s", "localhost:" + getNodePort(), "-c", "client-reconnect-window"),
-        containsOutput("client-reconnect-window=20s"));
+        containsOutput("client-reconnect-window=10s"));
   }
 
   @Test

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/diagnostic/Ipv6ConfigIT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/diagnostic/Ipv6ConfigIT.java
@@ -21,6 +21,7 @@ import org.terracotta.dynamic_config.test_support.DynamicConfigIT;
 import org.terracotta.dynamic_config.test_support.util.ConfigurationGenerator;
 
 import java.nio.file.Path;
+import java.time.Duration;
 
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
@@ -29,6 +30,16 @@ import static org.terracotta.angela.client.support.hamcrest.AngelaMatchers.succe
 
 @ClusterDefinition(nodesPerStripe = 2, autoStart = false, failoverPriority = "")
 public class Ipv6ConfigIT extends DynamicConfigIT {
+
+  @Override
+  protected Duration getConnectionTimeout() {
+    return Duration.ofSeconds(30);
+  }
+
+  @Override
+  protected Duration getRequestTimeout() {
+    return Duration.ofSeconds(30);
+  }
 
   @Test
   public void testStartupFromConfigFileAndExportCommand() {

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/diagnostic/SetCommand2x2IT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/diagnostic/SetCommand2x2IT.java
@@ -163,7 +163,7 @@ public class SetCommand2x2IT extends DynamicConfigIT {
     assertThat(configTool("get", "-connect-to", connection,
         "-setting", "client-reconnect-window",
         "-setting", "offheap-resources.main"
-    ), allOf(containsOutput("client-reconnect-window=20s"),
+    ), allOf(containsOutput("client-reconnect-window=10s"),
         containsOutput("offheap-resources.main=512MB")));
 
     assertThat(configTool("set", "-connect-to", connection,

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/network_disrupted/DetachInConsistency1x2IT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/network_disrupted/DetachInConsistency1x2IT.java
@@ -71,7 +71,7 @@ public class DetachInConsistency1x2IT extends DynamicConfigIT {
   }
 
   @Test
-  public void test_detach_when_active_passive_disrupted() throws Exception {
+  public void test_detach_when_active_passive_disrupted() {
     TerracottaServer active = angela.tsa().getActive();
     TerracottaServer passive = angela.tsa().getPassive();
     SplitCluster split1 = new SplitCluster(active);
@@ -92,16 +92,19 @@ public class DetachInConsistency1x2IT extends DynamicConfigIT {
 
       //stop partition
       disruptor.undisrupt();
+
       waitForPassive(1, passiveId);
+      waitForActive(1);
+
+      waitUntil(() -> getUpcomingCluster("localhost", getNodePort(1, 1)).getNodeCount(), is(equalTo(2)));
+      waitUntil(() -> getUpcomingCluster("localhost", getNodePort(1, 2)).getNodeCount(), is(equalTo(2)));
+
+      waitUntil(() -> getRuntimeCluster("localhost", getNodePort(1, 1)).getNodeCount(), is(equalTo(2)));
+      waitUntil(() -> getRuntimeCluster("localhost", getNodePort(1, 2)).getNodeCount(), is(equalTo(2)));
+
+      withTopologyService(1, 1, topologyService -> assertTrue(topologyService.isActivated()));
+      withTopologyService(1, 2, topologyService -> assertTrue(topologyService.isActivated()));
     }
-    assertThat(getUpcomingCluster("localhost", getNodePort(1, 1)).getNodeCount(), is(equalTo(2)));
-    assertThat(getRuntimeCluster("localhost", getNodePort(1, 1)).getNodeCount(), is(equalTo(2)));
-
-    assertThat(getUpcomingCluster("localhost", getNodePort(1, 2)).getNodeCount(), is(equalTo(2)));
-    assertThat(getRuntimeCluster("localhost", getNodePort(1, 2)).getNodeCount(), is(equalTo(2)));
-
-    withTopologyService(1, 1, topologyService -> assertTrue(topologyService.isActivated()));
-    withTopologyService(1, 2, topologyService -> assertTrue(topologyService.isActivated()));
   }
 
   @Test


### PR DESCRIPTION
Only `test_detach_when_active_passive_disrupted` failed in [last build](https://dev.azure.com/TerracottaCI/terracotta/_build/results?buildId=9041&view=ms.vss-test-web.build-test-results-tab)