### PR TITLE
Updated Jackson BOM to 2.13.2.20220328

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
     <galvan.version>1.6.3</galvan.version>
     <angela.version>3.3.12</angela.version>
     <statistics.version>2.1</statistics.version>
-    <jackson.version>2.13.2.20220324</jackson.version>
+    <jackson.version>2.13.2.20220328</jackson.version>
     <terracotta-utilities.version>0.0.9</terracotta-utilities.version>
     <test.parallel.forks>4</test.parallel.forks>
     <jna.version>5.9.0</jna.version>


### PR DESCRIPTION
Release notes: https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.13
Same as before but correct Gradle Module Metadata (2.13.2.1 had invalid reference to parent, jackson-bom)