### PR TITLE
TDB-5601 - move voter tool cli from core into platform

### DIFF
--- a/client-message-tracker/pom.xml
+++ b/client-message-tracker/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>platform-root</artifactId>
     <groupId>org.terracotta</groupId>
-    <version>5.8-SNAPSHOT</version>
+    <version>5.9-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/common/inet-support/pom.xml
+++ b/common/inet-support/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.terracotta.common</groupId>
     <artifactId>common</artifactId>
-    <version>5.8-SNAPSHOT</version>
+    <version>5.9-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/common/json-support/pom.xml
+++ b/common/json-support/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.terracotta.common</groupId>
     <artifactId>common</artifactId>
-    <version>5.8-SNAPSHOT</version>
+    <version>5.9-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/common/nomad/pom.xml
+++ b/common/nomad/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.terracotta.common</groupId>
     <artifactId>common</artifactId>
-    <version>5.8-SNAPSHOT</version>
+    <version>5.9-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/common/output-service/pom.xml
+++ b/common/output-service/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.terracotta.common</groupId>
     <artifactId>common</artifactId>
-    <version>5.8-SNAPSHOT</version>
+    <version>5.9-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.terracotta</groupId>
     <artifactId>platform-root</artifactId>
-    <version>5.8-SNAPSHOT</version>
+    <version>5.9-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/common/sanskrit/pom.xml
+++ b/common/sanskrit/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.terracotta.common</groupId>
     <artifactId>common</artifactId>
-    <version>5.8-SNAPSHOT</version>
+    <version>5.9-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/common/structures/pom.xml
+++ b/common/structures/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.terracotta.common</groupId>
     <artifactId>common</artifactId>
-    <version>5.8-SNAPSHOT</version>
+    <version>5.9-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/common/test-utilities/pom.xml
+++ b/common/test-utilities/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.terracotta.common</groupId>
     <artifactId>common</artifactId>
-    <version>5.8-SNAPSHOT</version>
+    <version>5.9-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/communicator-support/communicator-support-client/pom.xml
+++ b/communicator-support/communicator-support-client/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>communicator-support</artifactId>
     <groupId>org.terracotta.voltron.communicator</groupId>
-    <version>5.8-SNAPSHOT</version>
+    <version>5.9-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/communicator-support/communicator-support-common/pom.xml
+++ b/communicator-support/communicator-support-common/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>communicator-support</artifactId>
     <groupId>org.terracotta.voltron.communicator</groupId>
-    <version>5.8-SNAPSHOT</version>
+    <version>5.9-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/communicator-support/communicator-support-server/pom.xml
+++ b/communicator-support/communicator-support-server/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>communicator-support</artifactId>
     <groupId>org.terracotta.voltron.communicator</groupId>
-    <version>5.8-SNAPSHOT</version>
+    <version>5.9-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/communicator-support/pom.xml
+++ b/communicator-support/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>platform-root</artifactId>
     <groupId>org.terracotta</groupId>
-    <version>5.8-SNAPSHOT</version>
+    <version>5.9-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <packaging>pom</packaging>

--- a/concurrent-map-entity/client/pom.xml
+++ b/concurrent-map-entity/client/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.terracotta</groupId>
     <artifactId>platform-root</artifactId>
-    <version>5.8-SNAPSHOT</version>
+    <version>5.9-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
 

--- a/concurrent-map-entity/common/pom.xml
+++ b/concurrent-map-entity/common/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.terracotta</groupId>
     <artifactId>platform-root</artifactId>
-    <version>5.8-SNAPSHOT</version>
+    <version>5.9-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
 

--- a/concurrent-map-entity/integration-tests/pom.xml
+++ b/concurrent-map-entity/integration-tests/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.terracotta</groupId>
     <artifactId>platform-root</artifactId>
-    <version>5.8-SNAPSHOT</version>
+    <version>5.9-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
 

--- a/concurrent-map-entity/server/pom.xml
+++ b/concurrent-map-entity/server/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.terracotta</groupId>
     <artifactId>platform-root</artifactId>
-    <version>5.8-SNAPSHOT</version>
+    <version>5.9-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
 

--- a/data-root-resource/pom.xml
+++ b/data-root-resource/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.terracotta</groupId>
     <artifactId>platform-root</artifactId>
-    <version>5.8-SNAPSHOT</version>
+    <version>5.9-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/diagnostic/client/pom.xml
+++ b/diagnostic/client/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.terracotta.diagnostic</groupId>
     <artifactId>diagnostic</artifactId>
-    <version>5.8-SNAPSHOT</version>
+    <version>5.9-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/diagnostic/common/pom.xml
+++ b/diagnostic/common/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.terracotta.diagnostic</groupId>
     <artifactId>diagnostic</artifactId>
-    <version>5.8-SNAPSHOT</version>
+    <version>5.9-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/diagnostic/model/pom.xml
+++ b/diagnostic/model/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.terracotta.diagnostic</groupId>
     <artifactId>diagnostic</artifactId>
-    <version>5.8-SNAPSHOT</version>
+    <version>5.9-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/diagnostic/pom.xml
+++ b/diagnostic/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.terracotta</groupId>
     <artifactId>platform-root</artifactId>
-    <version>5.8-SNAPSHOT</version>
+    <version>5.9-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/diagnostic/service-api/pom.xml
+++ b/diagnostic/service-api/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.terracotta.diagnostic</groupId>
     <artifactId>diagnostic</artifactId>
-    <version>5.8-SNAPSHOT</version>
+    <version>5.9-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/diagnostic/service/pom.xml
+++ b/diagnostic/service/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.terracotta.diagnostic</groupId>
     <artifactId>diagnostic</artifactId>
-    <version>5.8-SNAPSHOT</version>
+    <version>5.9-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.terracotta</groupId>
     <artifactId>platform-root</artifactId>
-    <version>5.8-SNAPSHOT</version>
+    <version>5.9-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/dynamic-config/api/pom.xml
+++ b/dynamic-config/api/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.terracotta.dynamic-config</groupId>
     <artifactId>dynamic-config</artifactId>
-    <version>5.8-SNAPSHOT</version>
+    <version>5.9-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/dynamic-config/cli/cli-support/pom.xml
+++ b/dynamic-config/cli/cli-support/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.terracotta.dynamic-config.cli</groupId>
     <artifactId>dynamic-config-cli</artifactId>
-    <version>5.8-SNAPSHOT</version>
+    <version>5.9-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/dynamic-config/cli/config-tool/pom.xml
+++ b/dynamic-config/cli/config-tool/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.terracotta.dynamic-config.cli</groupId>
     <artifactId>dynamic-config-cli</artifactId>
-    <version>5.8-SNAPSHOT</version>
+    <version>5.9-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/dynamic-config/cli/dynamic-config-cli-api/pom.xml
+++ b/dynamic-config/cli/dynamic-config-cli-api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>dynamic-config-cli</artifactId>
         <groupId>org.terracotta.dynamic-config.cli</groupId>
-        <version>5.8-SNAPSHOT</version>
+        <version>5.9-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/dynamic-config/cli/pom.xml
+++ b/dynamic-config/cli/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.terracotta.dynamic-config</groupId>
     <artifactId>dynamic-config</artifactId>
-    <version>5.8-SNAPSHOT</version>
+    <version>5.9-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/dynamic-config/cli/upgrade-tools-oss/pom.xml
+++ b/dynamic-config/cli/upgrade-tools-oss/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.terracotta.dynamic-config.cli</groupId>
     <artifactId>dynamic-config-cli</artifactId>
-    <version>5.8-SNAPSHOT</version>
+    <version>5.9-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/dynamic-config/cli/upgrade-tools/pom.xml
+++ b/dynamic-config/cli/upgrade-tools/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.terracotta.dynamic-config.cli</groupId>
     <artifactId>dynamic-config-cli</artifactId>
-    <version>5.8-SNAPSHOT</version>
+    <version>5.9-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/dynamic-config/entities/management-entity/server/pom.xml
+++ b/dynamic-config/entities/management-entity/server/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.terracotta.dynamic-config.entities</groupId>
     <artifactId>dynamic-config-entities</artifactId>
-    <version>5.8-SNAPSHOT</version>
+    <version>5.9-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/dynamic-config/entities/nomad-entity/client/pom.xml
+++ b/dynamic-config/entities/nomad-entity/client/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.terracotta.dynamic-config.entities</groupId>
     <artifactId>dynamic-config-entities</artifactId>
-    <version>5.8-SNAPSHOT</version>
+    <version>5.9-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/dynamic-config/entities/nomad-entity/common/pom.xml
+++ b/dynamic-config/entities/nomad-entity/common/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.terracotta.dynamic-config.entities</groupId>
     <artifactId>dynamic-config-entities</artifactId>
-    <version>5.8-SNAPSHOT</version>
+    <version>5.9-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/dynamic-config/entities/nomad-entity/server/pom.xml
+++ b/dynamic-config/entities/nomad-entity/server/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.terracotta.dynamic-config.entities</groupId>
     <artifactId>dynamic-config-entities</artifactId>
-    <version>5.8-SNAPSHOT</version>
+    <version>5.9-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/dynamic-config/entities/pom.xml
+++ b/dynamic-config/entities/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.terracotta.dynamic-config</groupId>
     <artifactId>dynamic-config</artifactId>
-    <version>5.8-SNAPSHOT</version>
+    <version>5.9-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/dynamic-config/entities/topology-entity/client/pom.xml
+++ b/dynamic-config/entities/topology-entity/client/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.terracotta.dynamic-config.entities</groupId>
     <artifactId>dynamic-config-entities</artifactId>
-    <version>5.8-SNAPSHOT</version>
+    <version>5.9-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/dynamic-config/entities/topology-entity/common/pom.xml
+++ b/dynamic-config/entities/topology-entity/common/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.terracotta.dynamic-config.entities</groupId>
     <artifactId>dynamic-config-entities</artifactId>
-    <version>5.8-SNAPSHOT</version>
+    <version>5.9-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/dynamic-config/entities/topology-entity/server/pom.xml
+++ b/dynamic-config/entities/topology-entity/server/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.terracotta.dynamic-config.entities</groupId>
     <artifactId>dynamic-config-entities</artifactId>
-    <version>5.8-SNAPSHOT</version>
+    <version>5.9-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/dynamic-config/model/pom.xml
+++ b/dynamic-config/model/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.terracotta.dynamic-config</groupId>
     <artifactId>dynamic-config</artifactId>
-    <version>5.8-SNAPSHOT</version>
+    <version>5.9-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/dynamic-config/pom.xml
+++ b/dynamic-config/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.terracotta</groupId>
     <artifactId>platform-root</artifactId>
-    <version>5.8-SNAPSHOT</version>
+    <version>5.9-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/dynamic-config/server/configuration-provider/pom.xml
+++ b/dynamic-config/server/configuration-provider/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.terracotta.dynamic-config.server</groupId>
     <artifactId>dynamic-config-server</artifactId>
-    <version>5.8-SNAPSHOT</version>
+    <version>5.9-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/dynamic-config/server/configuration-repository/pom.xml
+++ b/dynamic-config/server/configuration-repository/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.terracotta.dynamic-config.server</groupId>
     <artifactId>dynamic-config-server</artifactId>
-    <version>5.8-SNAPSHOT</version>
+    <version>5.9-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/dynamic-config/server/pom.xml
+++ b/dynamic-config/server/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.terracotta.dynamic-config</groupId>
     <artifactId>dynamic-config</artifactId>
-    <version>5.8-SNAPSHOT</version>
+    <version>5.9-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/dynamic-config/server/server-api/pom.xml
+++ b/dynamic-config/server/server-api/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.terracotta.dynamic-config.server</groupId>
     <artifactId>dynamic-config-server</artifactId>
-    <version>5.8-SNAPSHOT</version>
+    <version>5.9-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/dynamic-config/server/services/pom.xml
+++ b/dynamic-config/server/services/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.terracotta.dynamic-config.server</groupId>
     <artifactId>dynamic-config-server</artifactId>
-    <version>5.8-SNAPSHOT</version>
+    <version>5.9-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/dynamic-config/testing/entity/pom.xml
+++ b/dynamic-config/testing/entity/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.terracotta.dynamic-config.testing</groupId>
     <artifactId>dynamic-config-testing</artifactId>
-    <version>5.8-SNAPSHOT</version>
+    <version>5.9-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/dynamic-config/testing/pom.xml
+++ b/dynamic-config/testing/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.terracotta.dynamic-config</groupId>
     <artifactId>dynamic-config</artifactId>
-    <version>5.8-SNAPSHOT</version>
+    <version>5.9-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/dynamic-config/testing/support/pom.xml
+++ b/dynamic-config/testing/support/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.terracotta.dynamic-config.testing</groupId>
     <artifactId>dynamic-config-testing</artifactId>
-    <version>5.8-SNAPSHOT</version>
+    <version>5.9-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/dynamic-config/testing/support/pom.xml
+++ b/dynamic-config/testing/support/pom.xml
@@ -52,8 +52,9 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
-      <groupId>org.terracotta.internal</groupId>
+      <groupId>org.terracotta</groupId>
       <artifactId>voter</artifactId>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.terracotta.internal</groupId>

--- a/dynamic-config/testing/support/src/main/java/org/terracotta/dynamic_config/test_support/DcActiveVoter.java
+++ b/dynamic-config/testing/support/src/main/java/org/terracotta/dynamic_config/test_support/DcActiveVoter.java
@@ -26,6 +26,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
@@ -121,6 +122,10 @@ public class DcActiveVoter implements Closeable {
 
   public int getKnownHosts() {
     return activeVoter.getHeartbeatFutures().size();
+  }
+
+  public Set<String> getTopology() {
+    return activeVoter.getExistingTopology();
   }
 
   @Override

--- a/dynamic-config/testing/system-tests/pom.xml
+++ b/dynamic-config/testing/system-tests/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.terracotta.dynamic-config.testing</groupId>
     <artifactId>dynamic-config-testing</artifactId>
-    <version>5.8-SNAPSHOT</version>
+    <version>5.9-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/dynamic-config/testing/system-tests/pom.xml
+++ b/dynamic-config/testing/system-tests/pom.xml
@@ -79,8 +79,9 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.terracotta.internal</groupId>
+      <groupId>org.terracotta</groupId>
       <artifactId>voter</artifactId>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/Voter1x2IT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/Voter1x2IT.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.terracotta.dynamic_config.system_tests.activated;
+
+import org.hamcrest.CoreMatchers;
+import org.junit.Test;
+import org.terracotta.dynamic_config.api.model.FailoverPriority;
+import org.terracotta.dynamic_config.test_support.ClusterDefinition;
+import org.terracotta.dynamic_config.test_support.DcActiveVoter;
+import org.terracotta.dynamic_config.test_support.DynamicConfigIT;
+import org.terracotta.voter.TCVoter;
+import org.terracotta.voter.TCVoterImpl;
+import org.terracotta.voter.VoterStatus;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.terracotta.angela.client.support.hamcrest.AngelaMatchers.successful;
+
+@ClusterDefinition(nodesPerStripe = 2, autoActivate = true)
+public class Voter1x2IT extends DynamicConfigIT {
+
+  @Override
+  protected FailoverPriority getFailoverPriority() {
+    return FailoverPriority.consistency(1);
+  }
+
+  @Test
+  public void testDirectConnection() throws Exception {
+    int activeId = waitForActive(1);
+    int passiveId = waitForNPassives(1, 1)[0];
+
+    TCVoter voter = new TCVoterImpl();
+    Future<VoterStatus> voterStatusFuture = voter.register("MyCluster", getNode(1, activeId).getHostPort(), getNode(1, passiveId).getHostPort());
+    VoterStatus voterStatus = voterStatusFuture.get();
+    voterStatus.awaitRegistrationWithAll(10, TimeUnit.SECONDS);
+
+    stopNode(1, activeId);
+    CompletableFuture<Void> connectionFuture = CompletableFuture.runAsync(() -> {
+      try {
+        waitForActive(1);
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    });
+    connectionFuture.get(10, TimeUnit.SECONDS);
+  }
+
+  @Test
+  public void testTopologyUpdateAfterPassiveRemoval() throws Exception {
+    int activeId = waitForActive(1);
+    int passiveId = waitForNPassives(1, 1)[0];
+    String active = getNode(1, activeId).getHostPort();
+    String passive = getNode(1, passiveId).getHostPort();
+
+    try (DcActiveVoter activeVoter = new DcActiveVoter("voter1", active, passive)) {
+      activeVoter.startAndAwaitRegistration();
+
+      String[] hostPorts = {getNode(1, activeId).getHostPort(), getNode(1, passiveId).getHostPort()};
+      Set<String> expectedTopology = new HashSet<>(Arrays.asList(hostPorts));
+
+      assertThat(activeVoter.getTopology(), CoreMatchers.is(expectedTopology));
+      assertThat(activeVoter.getKnownHosts(), CoreMatchers.is(hostPorts.length));
+
+      stopNode(1, passiveId);
+      activeVoter.waitForVote(active);
+      assertThat(configTool("detach", "-f", "-d", "localhost:" + getNodePort(1, activeId), "-s", "localhost:" + getNodePort(1, passiveId)), is(successful()));
+
+      expectedTopology.remove(hostPorts[1]);
+      waitUntil(activeVoter::getTopology, is(expectedTopology));
+      waitUntil(activeVoter::getKnownHosts, is(1));
+    }
+  }
+}

--- a/galvan-platform-support/pom.xml
+++ b/galvan-platform-support/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.terracotta</groupId>
     <artifactId>platform-root</artifactId>
-    <version>5.8-SNAPSHOT</version>
+    <version>5.9-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/healthchecker-entity/api/pom.xml
+++ b/healthchecker-entity/api/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.terracotta</groupId>
     <artifactId>healthchecker-entity</artifactId>
-    <version>5.8-SNAPSHOT</version>
+    <version>5.9-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/healthchecker-entity/client-impl/pom.xml
+++ b/healthchecker-entity/client-impl/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.terracotta</groupId>
     <artifactId>healthchecker-entity</artifactId>
-    <version>5.8-SNAPSHOT</version>
+    <version>5.9-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/healthchecker-entity/common/pom.xml
+++ b/healthchecker-entity/common/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.terracotta</groupId>
     <artifactId>healthchecker-entity</artifactId>
-    <version>5.8-SNAPSHOT</version>
+    <version>5.9-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/healthchecker-entity/pom.xml
+++ b/healthchecker-entity/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.terracotta</groupId>
     <artifactId>platform-root</artifactId>
-    <version>5.8-SNAPSHOT</version>
+    <version>5.9-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/healthchecker-entity/server-impl/pom.xml
+++ b/healthchecker-entity/server-impl/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.terracotta</groupId>
     <artifactId>healthchecker-entity</artifactId>
-    <version>5.8-SNAPSHOT</version>
+    <version>5.9-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/kit/pom.xml
+++ b/kit/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.terracotta</groupId>
     <artifactId>platform-root</artifactId>
-    <version>5.8-SNAPSHOT</version>
+    <version>5.9-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/kit/pom.xml
+++ b/kit/pom.xml
@@ -32,6 +32,13 @@
 
   <dependencies>
 
+    <dependency>
+      <groupId>org.terracotta.test</groupId>
+      <artifactId>test-common</artifactId>
+      <version>${terracotta-core.version}</version>
+      <scope>test</scope>
+    </dependency>
+
     <!--
       server/plugins/api
     -->
@@ -160,6 +167,16 @@
     <dependency>
       <groupId>org.terracotta.dynamic-config.cli</groupId>
       <artifactId>upgrade-tools-oss</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <!--
+      tools/voter/lib
+    -->
+
+    <dependency>
+      <groupId>org.terracotta</groupId>
+      <artifactId>voter</artifactId>
       <version>${project.version}</version>
     </dependency>
 

--- a/kit/src/main/assembly/platform-kit.xml
+++ b/kit/src/main/assembly/platform-kit.xml
@@ -170,6 +170,13 @@
     </dependencySet>
 
     <dependencySet>
+      <outputDirectory>tools/voter/lib</outputDirectory>
+      <includes>
+        <include>org.terracotta:voter</include>
+      </includes>
+    </dependencySet>
+
+    <dependencySet>
       <outputDirectory>tools/lib</outputDirectory>
       <includes>
         <include>org.terracotta.internal:client-runtime</include>

--- a/kit/src/main/kit/tools/voter/bin/start-tc-voter.bat
+++ b/kit/src/main/kit/tools/voter/bin/start-tc-voter.bat
@@ -1,0 +1,50 @@
+@REM
+@REM Copyright Terracotta, Inc.
+@REM
+@REM Licensed under the Apache License, Version 2.0 (the "License");
+@REM you may not use this file except in compliance with the License.
+@REM You may obtain a copy of the License at
+@REM
+@REM     http://www.apache.org/licenses/LICENSE-2.0
+@REM
+@REM Unless required by applicable law or agreed to in writing, software
+@REM distributed under the License is distributed on an "AS IS" BASIS,
+@REM WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+@REM See the License for the specific language governing permissions and
+@REM limitations under the License.
+@REM
+
+@echo off
+setlocal EnableExtensions EnableDelayedExpansion
+set TC_VOTER_MAIN=org.terracotta.voter.cli.TCVoterMain
+
+pushd "%~dp0.."
+set "TC_VOTER_DIR=%CD%"
+popd
+
+if exist "!TC_VOTER_DIR!\bin\setenv.bat" (
+  pushd "!TC_VOTER_DIR!\bin" && (
+    call .\setenv.bat
+    popd
+  )
+)
+
+if not defined JAVA_HOME (
+  echo Environment variable JAVA_HOME needs to be set
+  exit /b 1
+)
+
+pushd "%TC_VOTER_DIR%\..\.."
+set "TC_KIT_ROOT=%CD%"
+popd
+set "TC_LOGGING_ROOT=%TC_KIT_ROOT%\client\logging"
+set "TC_CLIENT_ROOT=%TC_KIT_ROOT%\client\lib"
+
+set "CLASSPATH=%TC_VOTER_DIR%\lib\*;%TC_CLIENT_ROOT%\*;%TC_LOGGING_ROOT%\*;%TC_LOGGING_ROOT%\impl\*;%TC_LOGGING_ROOT%\impl"
+set "JAVA=%JAVA_HOME%\bin\java.exe"
+
+"%JAVA%" %JAVA_OPTS% -cp "%CLASSPATH%" %TC_VOTER_MAIN% %*
+
+exit /b %ERRORLEVEL%
+
+endlocal

--- a/kit/src/main/kit/tools/voter/bin/start-tc-voter.sh
+++ b/kit/src/main/kit/tools/voter/bin/start-tc-voter.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+#
+# Copyright Terracotta, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+TC_VOTER_DIR="$(dirname "$(cd "$(dirname "$0")";pwd)")"
+TC_VOTER_MAIN=org.terracotta.voter.cli.TCVoterMain
+
+# this will only happen if using sag installer
+if [ -r "${TC_VOTER_DIR}/bin/setenv.sh" ] ; then
+  . "${TC_VOTER_DIR}/bin/setenv.sh"
+fi
+
+if ! [ -d "${JAVA_HOME}" ]; then
+  echo "$0: the JAVA_HOME environment variable is not defined correctly"
+  exit 2
+fi
+
+TC_KIT_ROOT="$(dirname "$(dirname "$TC_VOTER_DIR")")"
+TC_LOGGING_ROOT="$TC_KIT_ROOT/client/logging"
+TC_CLIENT_ROOT="$TC_KIT_ROOT/client/lib"
+
+CLASS_PATH="${TC_VOTER_DIR}/lib/*:${TC_CLIENT_ROOT}/*:${TC_LOGGING_ROOT}/*:${TC_LOGGING_ROOT}/impl/*:${TC_LOGGING_ROOT}/impl/"
+
+"$JAVA_HOME/bin/java" ${JAVA_OPTS} -cp "$CLASS_PATH" $TC_VOTER_MAIN "$@"

--- a/lease/api/pom.xml
+++ b/lease/api/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.terracotta</groupId>
     <artifactId>lease</artifactId>
-    <version>5.8-SNAPSHOT</version>
+    <version>5.9-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/lease/common/pom.xml
+++ b/lease/common/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.terracotta</groupId>
     <artifactId>lease</artifactId>
-    <version>5.8-SNAPSHOT</version>
+    <version>5.9-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/lease/entity-api/pom.xml
+++ b/lease/entity-api/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.terracotta</groupId>
     <artifactId>lease</artifactId>
-    <version>5.8-SNAPSHOT</version>
+    <version>5.9-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/lease/entity-client/pom.xml
+++ b/lease/entity-client/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.terracotta</groupId>
     <artifactId>lease</artifactId>
-    <version>5.8-SNAPSHOT</version>
+    <version>5.9-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/lease/entity-common/pom.xml
+++ b/lease/entity-common/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.terracotta</groupId>
     <artifactId>lease</artifactId>
-    <version>5.8-SNAPSHOT</version>
+    <version>5.9-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/lease/entity-server/pom.xml
+++ b/lease/entity-server/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.terracotta</groupId>
     <artifactId>lease</artifactId>
-    <version>5.8-SNAPSHOT</version>
+    <version>5.9-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/lease/passthrough-leased-connection-api/pom.xml
+++ b/lease/passthrough-leased-connection-api/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.terracotta</groupId>
     <artifactId>lease</artifactId>
-    <version>5.8-SNAPSHOT</version>
+    <version>5.9-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/lease/pom.xml
+++ b/lease/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.terracotta</groupId>
     <artifactId>platform-root</artifactId>
-    <version>5.8-SNAPSHOT</version>
+    <version>5.9-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/lease/system-test/pom.xml
+++ b/lease/system-test/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.terracotta</groupId>
     <artifactId>lease</artifactId>
-    <version>5.8-SNAPSHOT</version>
+    <version>5.9-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/management/cluster-topology/pom.xml
+++ b/management/cluster-topology/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>terracotta-management</artifactId>
     <groupId>org.terracotta.management</groupId>
-    <version>5.8-SNAPSHOT</version>
+    <version>5.9-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/management/management-model/pom.xml
+++ b/management/management-model/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.terracotta.management</groupId>
     <artifactId>terracotta-management</artifactId>
-    <version>5.8-SNAPSHOT</version>
+    <version>5.9-SNAPSHOT</version>
   </parent>
 
   <artifactId>management-model</artifactId>

--- a/management/management-registry/pom.xml
+++ b/management/management-registry/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.terracotta.management</groupId>
     <artifactId>terracotta-management</artifactId>
-    <version>5.8-SNAPSHOT</version>
+    <version>5.9-SNAPSHOT</version>
   </parent>
 
   <artifactId>management-registry</artifactId>

--- a/management/monitoring-service-api/pom.xml
+++ b/management/monitoring-service-api/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>terracotta-management</artifactId>
     <groupId>org.terracotta.management</groupId>
-    <version>5.8-SNAPSHOT</version>
+    <version>5.9-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/management/monitoring-service/pom.xml
+++ b/management/monitoring-service/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>terracotta-management</artifactId>
     <groupId>org.terracotta.management</groupId>
-    <version>5.8-SNAPSHOT</version>
+    <version>5.9-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/management/nms-agent-entity/nms-agent-entity-client/pom.xml
+++ b/management/nms-agent-entity/nms-agent-entity-client/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>nms-agent-entity</artifactId>
     <groupId>org.terracotta.management</groupId>
-    <version>5.8-SNAPSHOT</version>
+    <version>5.9-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/management/nms-agent-entity/nms-agent-entity-common/pom.xml
+++ b/management/nms-agent-entity/nms-agent-entity-common/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>nms-agent-entity</artifactId>
     <groupId>org.terracotta.management</groupId>
-    <version>5.8-SNAPSHOT</version>
+    <version>5.9-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/management/nms-agent-entity/nms-agent-entity-server/pom.xml
+++ b/management/nms-agent-entity/nms-agent-entity-server/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>nms-agent-entity</artifactId>
     <groupId>org.terracotta.management</groupId>
-    <version>5.8-SNAPSHOT</version>
+    <version>5.9-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/management/nms-agent-entity/pom.xml
+++ b/management/nms-agent-entity/pom.xml
@@ -31,7 +31,7 @@
   <parent>
     <groupId>org.terracotta.management</groupId>
     <artifactId>terracotta-management</artifactId>
-    <version>5.8-SNAPSHOT</version>
+    <version>5.9-SNAPSHOT</version>
   </parent>
 
   <artifactId>nms-agent-entity</artifactId>

--- a/management/nms-entity/nms-entity-client/pom.xml
+++ b/management/nms-entity/nms-entity-client/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>nms-entity</artifactId>
     <groupId>org.terracotta.management</groupId>
-    <version>5.8-SNAPSHOT</version>
+    <version>5.9-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/management/nms-entity/nms-entity-common/pom.xml
+++ b/management/nms-entity/nms-entity-common/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>nms-entity</artifactId>
     <groupId>org.terracotta.management</groupId>
-    <version>5.8-SNAPSHOT</version>
+    <version>5.9-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/management/nms-entity/nms-entity-server/pom.xml
+++ b/management/nms-entity/nms-entity-server/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>nms-entity</artifactId>
     <groupId>org.terracotta.management</groupId>
-    <version>5.8-SNAPSHOT</version>
+    <version>5.9-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/management/nms-entity/pom.xml
+++ b/management/nms-entity/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>terracotta-management</artifactId>
     <groupId>org.terracotta.management</groupId>
-    <version>5.8-SNAPSHOT</version>
+    <version>5.9-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/management/pom.xml
+++ b/management/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.terracotta</groupId>
     <artifactId>platform-root</artifactId>
-    <version>5.8-SNAPSHOT</version>
+    <version>5.9-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/management/sequence-generator/pom.xml
+++ b/management/sequence-generator/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>terracotta-management</artifactId>
     <groupId>org.terracotta.management</groupId>
-    <version>5.8-SNAPSHOT</version>
+    <version>5.9-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/management/testing/doc/pom.xml
+++ b/management/testing/doc/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>terracotta-management</artifactId>
     <groupId>org.terracotta.management</groupId>
-    <version>5.8-SNAPSHOT</version>
+    <version>5.9-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/management/testing/integration-tests/pom.xml
+++ b/management/testing/integration-tests/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>terracotta-management</artifactId>
     <groupId>org.terracotta.management</groupId>
-    <version>5.8-SNAPSHOT</version>
+    <version>5.9-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/management/testing/sample-entity/pom.xml
+++ b/management/testing/sample-entity/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>terracotta-management</artifactId>
     <groupId>org.terracotta.management</groupId>
-    <version>5.8-SNAPSHOT</version>
+    <version>5.9-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/offheap-resource/pom.xml
+++ b/offheap-resource/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.terracotta</groupId>
     <artifactId>platform-root</artifactId>
-    <version>5.8-SNAPSHOT</version>
+    <version>5.9-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/platform-base/pom.xml
+++ b/platform-base/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.terracotta</groupId>
     <artifactId>platform-root</artifactId>
-    <version>5.8-SNAPSHOT</version>
+    <version>5.9-SNAPSHOT</version>
   </parent>
 
   <artifactId>platform-base</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
   </parent>
 
   <artifactId>platform-root</artifactId>
-  <version>5.8-SNAPSHOT</version>
+  <version>5.9-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -36,13 +36,13 @@
     <terracotta-apis.version>1.8.1</terracotta-apis.version>
     <terracotta-configuration.version>10.7.1</terracotta-configuration.version>
     <passthrough-testing.version>1.8.2</passthrough-testing.version>
-    <terracotta-core.version>5.8.7</terracotta-core.version>
+    <terracotta-core.version>5.9.0</terracotta-core.version>
     <tripwire.version>1.0.2</tripwire.version>
     <galvan.version>1.6.3</galvan.version>
     <angela.version>3.3.17</angela.version>
     <statistics.version>2.1</statistics.version>
     <jackson.version>2.13.2.20220328</jackson.version>
-    <terracotta-utilities.version>0.0.10</terracotta-utilities.version>
+    <terracotta-utilities.version>0.0.11</terracotta-utilities.version>
     <test.parallel.forks>4</test.parallel.forks>
     <jna.version>5.9.0</jna.version>
   </properties>
@@ -68,6 +68,7 @@
     <module>galvan-platform-support</module>
     <module>kit</module>
     <module>docs</module>
+    <module>voter</module>
   </modules>
 
   <dependencyManagement>
@@ -157,11 +158,6 @@
         <artifactId>client-runtime</artifactId>
         <version>${terracotta-core.version}</version>
         <scope>runtime</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.terracotta.internal</groupId>
-        <artifactId>voter</artifactId>
-        <version>${terracotta-core.version}</version>
       </dependency>
       <dependency>
         <groupId>org.terracotta.internal</groupId>

--- a/runnel/pom.xml
+++ b/runnel/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.terracotta</groupId>
     <artifactId>platform-root</artifactId>
-    <version>5.8-SNAPSHOT</version>
+    <version>5.9-SNAPSHOT</version>
   </parent>
 
   <artifactId>runnel</artifactId>

--- a/voltron-proxy/pom.xml
+++ b/voltron-proxy/pom.xml
@@ -29,7 +29,7 @@
   <parent>
     <groupId>org.terracotta</groupId>
     <artifactId>platform-root</artifactId>
-    <version>5.8-SNAPSHOT</version>
+    <version>5.9-SNAPSHOT</version>
   </parent>
 
   <groupId>org.terracotta.voltron.proxy</groupId>

--- a/voltron-proxy/voltron-proxy-client/pom.xml
+++ b/voltron-proxy/voltron-proxy-client/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>voltron-proxy</artifactId>
     <groupId>org.terracotta.voltron.proxy</groupId>
-    <version>5.8-SNAPSHOT</version>
+    <version>5.9-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/voltron-proxy/voltron-proxy-common/pom.xml
+++ b/voltron-proxy/voltron-proxy-common/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>voltron-proxy</artifactId>
     <groupId>org.terracotta.voltron.proxy</groupId>
-    <version>5.8-SNAPSHOT</version>
+    <version>5.9-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/voltron-proxy/voltron-proxy-server/pom.xml
+++ b/voltron-proxy/voltron-proxy-server/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>voltron-proxy</artifactId>
     <groupId>org.terracotta.voltron.proxy</groupId>
-    <version>5.8-SNAPSHOT</version>
+    <version>5.9-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/voter/pom.xml
+++ b/voter/pom.xml
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright Terracotta, Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.terracotta</groupId>
+    <artifactId>platform-root</artifactId>
+    <version>5.9-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>voter</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.terracotta.internal</groupId>
+      <artifactId>client-runtime</artifactId>
+      <version>${terracotta-core.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.beust</groupId>
+      <artifactId>jcommander</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-all</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.terracotta</groupId>
+      <artifactId>terracotta-utilities-test-tools</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.terracotta.internal</groupId>
+      <artifactId>connection-impl</artifactId>
+      <version>${terracotta-core.version}</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.terracotta.internal</groupId>
+      <artifactId>common</artifactId>
+      <version>${terracotta-core.version}</version>
+      <scope>compile</scope>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>2.4</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <promoteTransitiveDependencies>false</promoteTransitiveDependencies>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/voter/src/main/java/org/terracotta/voter/ActiveVoter.java
+++ b/voter/src/main/java/org/terracotta/voter/ActiveVoter.java
@@ -1,0 +1,484 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.voter;
+
+import com.tc.voter.VoterManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static java.util.Arrays.asList;
+import static java.util.stream.Collectors.toCollection;
+
+/**
+ * ActiveVoter votes only for the active it originally connects to.  If the active disconnects,
+ * vote for the next server requesting vote.  If the server with the new vote becomes the new active,
+ * continue voting for that active.  If the server with the new vote does not become active
+ * in a reasonable amount of time, disconnect from all server and hunt for the new active until found.
+ */
+public class ActiveVoter implements AutoCloseable {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(ActiveVoter.class);
+
+  private final static String ACTIVE_COORDINATOR = "ACTIVE-COORDINATOR";
+
+  private static final long HEARTBEAT_INTERVAL = 1000L;
+  private static final long REG_RETRY_INTERVAL = 5000L;
+  private static final long DEFAULT_TOPOLOGY_FETCH_TIME = 300000L;
+  public static final String TOPOLOGY_FETCH_TIME_PROPERTY = "org.terracotta.voter.topology.fetch.interval";
+  private static final long topologyFetchInterval = Long.getLong(TOPOLOGY_FETCH_TIME_PROPERTY, DEFAULT_TOPOLOGY_FETCH_TIME);
+
+  private final Thread voter;
+  private final String id;
+  private final Function<String, ClientVoterManager> clientVoterManagerFactory;
+  private volatile boolean active = false;
+  private volatile Future<?> topologyFetchingFuture = null;
+  private final Set<String> existingTopology = new HashSet<>();
+  private final List<ClientVoterManager> voterManagers = new CopyOnWriteArrayList<>();
+  private final Set<String> registrationLatch = new HashSet<>();
+  private final Map<String, Future<?>> heartbeatFutures = new ConcurrentHashMap<>();
+
+  public ActiveVoter(String id, CompletableFuture<VoterStatus> voterStatus, Optional<Properties> connectionProps, String... hostPorts) {
+    this(id, voterStatus, connectionProps, ClientVoterManagerImpl::new, hostPorts);
+  }
+
+  public ActiveVoter(String id, CompletableFuture<VoterStatus> voterStatus, Optional<Properties> connectionProps,
+                     Function<String, ClientVoterManager> clientVoterManagerFactory, String... hostPorts) {
+    this.voter = voterThread(voterStatus, connectionProps, hostPorts);
+    this.id = id;
+    this.clientVoterManagerFactory = clientVoterManagerFactory;
+  }
+
+  public ActiveVoter start() {
+    this.voter.start();
+    return this;
+  }
+
+  private Thread voterThread(CompletableFuture<VoterStatus> voterStatus, Optional<Properties> connectionProps, String... hostPorts) {
+    return new Thread(() -> {
+      ExecutorService executorService = Executors.newCachedThreadPool();
+      Stream.of(hostPorts).map(clientVoterManagerFactory).collect(toCollection(() -> voterManagers));
+      existingTopology.addAll(new HashSet<>(asList(hostPorts)));
+      registrationLatch.addAll(new HashSet<>(asList(hostPorts)));
+      try {
+        while (!Thread.currentThread().isInterrupted()) {
+          ClientVoterManager currentActive = registerWithActive(id, voterManagers, connectionProps);
+          active = true;
+          LOGGER.info("{} registered with the active: {}", this, currentActive.getTargetHostPort());
+          voterStatus.complete(new VoterStatus() {
+            @Override
+            public boolean isActive() {
+              return active;
+            }
+
+            @Override
+            public void awaitRegistrationWithAll() throws InterruptedException {
+              synchronized (registrationLatch) {
+                while (!registrationLatch.isEmpty()) {
+                  registrationLatch.wait();
+                }
+              }
+            }
+
+            @Override
+            public void awaitRegistrationWithAll(long timeout, TimeUnit unit) throws InterruptedException, TimeoutException {
+              long current = System.currentTimeMillis();
+              long finish = current + unit.toMillis(timeout);
+              synchronized (registrationLatch) {
+                while (!registrationLatch.isEmpty()) {
+                  current = System.currentTimeMillis();
+                  if (System.currentTimeMillis() >= finish) {
+                    throw new TimeoutException("Registration timed out");
+                  }
+                  registrationLatch.wait(finish - current);
+                }
+              }
+            }
+          });
+
+          registerAndHeartbeat(executorService, currentActive, connectionProps);
+          active = false;
+        }
+      } catch (InterruptedException e) {
+        LOGGER.warn("{} interrupted", this);
+      }
+      active = false;
+      cleanHeartBeatingAndPollingFutures();
+      executorService.shutdownNow();
+      try {
+        executorService.awaitTermination(5, TimeUnit.SECONDS);
+      } catch (InterruptedException ie) {
+        LOGGER.warn("{} interrupted", this);
+      }
+    });
+  }
+
+  ClientVoterManager registerWithActive(String id,
+                                        List<ClientVoterManager> voterManagers, Optional<Properties> connectionProps) throws InterruptedException {
+    CompletableFuture<ClientVoterManager> registrationLatch = new CompletableFuture<>();
+    ScheduledExecutorService executorService = Executors.newScheduledThreadPool(voterManagers.size());
+
+    List<ScheduledFuture<?>> futures = voterManagers.stream().map(voterManager -> executorService.scheduleAtFixedRate(() -> {
+      if (!voterManager.isConnected()) {
+        voterManager.connect(connectionProps);
+      }
+
+      if (!registrationLatch.isDone()) {
+        try {
+          String serverState = voterManager.getServerState();
+          if (serverState.equals(ACTIVE_COORDINATOR)) {
+            long response = voterManager.registerVoter(id);
+            if (response >= 0) {
+              registrationLatch.complete(voterManager);
+            } else {
+              StringBuilder message = new StringBuilder();
+              message.append(String.format("Registration with %s in state %s failed. ",
+                  voterManager.getTargetHostPort(), voterManager.getServerState()));
+              long voterLimit = Math.max(0, voterManager.getRegisteredVoterLimit());
+              if (voterManager.getRegisteredVoterCount() >= voterLimit) {
+                message.append(String.format("Configured voter limit (%d) has already been reached. ", voterLimit));
+              }
+              message.append("Retrying...");
+              LOGGER.warn(message.toString());
+            }
+          } else {
+            LOGGER.info("State of {}: {}. Continuing the search for an active server.", voterManager.getTargetHostPort(), serverState);
+          }
+        } catch (TimeoutException e) {
+          voterManager.close();
+        }
+      }
+    }, 0, REG_RETRY_INTERVAL, TimeUnit.MILLISECONDS)).collect(Collectors.toList());
+
+    LOGGER.info("{} waiting to get registered with the active", this);
+    try {
+      return registrationLatch.get();
+    } catch (ExecutionException e) {
+      throw new RuntimeException(e);
+    } finally {
+      futures.forEach(f -> f.cancel(true));
+      executorService.shutdownNow();
+      try {
+        executorService.awaitTermination(5, TimeUnit.SECONDS);
+      } catch (InterruptedException ie) {
+        LOGGER.warn("{} interrupted", this);
+      }
+    }
+  }
+
+  private Runnable heartbeat(ExecutorService executorService, ClientVoterManager voterManager, Optional<Properties> connectionProps, AtomicReference<ClientVoterManager> voteOwner) {
+    return () -> {
+      try {
+        ClientVoterManager owner = voteOwner.get();
+        while (owner != null && !executorService.isShutdown()) {
+          try {
+            // Need to break out if the voterManager pointing to node is detached from the cluster
+            if (!existingTopology.contains(voterManager.getTargetHostPort())) {
+              break;
+            }
+            voterManager.connect(connectionProps);
+            long lastVotedElection = 0;
+            // if the current vote owner is the active, allowed to reconnect
+            long registration = voterManager.registerVoter(id);
+            LOGGER.debug("Registration {} for {}", registration, voterManager);
+            if (registration > 0) {
+              if (voterManager == owner) {
+                // the vote was re-registered on the active, this is not allowed, voting cycle
+                // must start over
+                if (voteOwner.compareAndSet(owner, null)) {
+                  voterManager.deregisterVoter(id);
+                }
+                voterManager.close();
+              } else {
+                if (owner.isVoting()) {
+                  voterManager.deregisterVoter(id);
+                  voterManager.close();
+                } else {
+                  synchronized (registrationLatch) {
+                    registrationLatch.remove(voterManager.getTargetHostPort());
+                    if (registrationLatch.isEmpty()) {
+                      registrationLatch.notifyAll();
+                    }
+                  }
+                }
+              }
+            } else if (registration == 0) {
+              synchronized (registrationLatch) {
+                registrationLatch.remove(voterManager.getTargetHostPort());
+                if (registrationLatch.isEmpty()) {
+                  registrationLatch.notifyAll();
+                }
+              }
+              //  everything is good, continue to operate  
+            } else {
+              //  unable to register
+              if (voterManager == owner) {
+                // the vote was re-registered on the active, this is not allowed, voting cycle
+                // must start over
+                if (voteOwner.compareAndSet(owner, null)) {
+                  voterManager.deregisterVoter(id);
+                }
+              }
+              voterManager.close();
+              sleepFor10();
+            }
+
+            // heartbeat with the server until a vote is requested
+            while (voterManager.isConnected()) {
+              long election = heartbeat(voterManager);
+              if (election < 0) {
+                voterManager.close();
+              } else if (owner == voterManager) {
+                // owner of the vote, go ahead and vote
+                if (lastVotedElection > election) {
+                  LOGGER.warn("{} term revoted last voted: {} current: {}", voterManager.getTargetHostPort(), lastVotedElection, election);
+                }
+                lastVotedElection = election;
+                long result = voterManager.vote(id, election);
+                LOGGER.info("Own the vote, voting for {} for term: {}, result: {}", voterManager.getTargetHostPort(), election, result);
+              } else if (owner.isConnected()) {
+                // ignore, back to heartbeating
+                LOGGER.info("Not the vote owner and the owner is still connected, rejecting the vote request from {} for election term {}", voterManager.getTargetHostPort(), election);
+                if (owner.isVoting()) {
+                  // if the owner is voting, this voter must zombie, cannot vote in this generation
+                  voterManager.zombie();
+                }
+                // can never steal the vote back having voted in a previous vote tally
+              } else if (lastVotedElection < election && voteOwner.compareAndSet(owner, voterManager)) {
+                // stole ownership of the vote
+                owner.zombie();
+                long result = voterManager.vote(id, election);
+                LOGGER.info("Stole the vote from {}, voting for {} for term: {}, result: {}", owner.getTargetHostPort(), voterManager.getTargetHostPort(), election, result);
+                break;
+              } else {
+                LOGGER.info("Failed to steal the vote from {}, rejecting the vote request from {} for term {}, last voted election: {}", owner.getTargetHostPort(), voterManager.getTargetHostPort(), election, lastVotedElection);
+                break;
+                // failed to steal, back to heartbeating
+              }
+            }
+          } catch (TimeoutException to) {
+            LOGGER.warn("Heart-beating with {} timed-out", voterManager.getTargetHostPort());
+            voterManager.close();
+          } catch (InterruptedException e) {
+            LOGGER.warn("Heart-beating with {} stopped", voterManager.getTargetHostPort());
+            voterManager.close();
+          } catch (RuntimeException run) {
+            LOGGER.warn("Heart-beating with {} not connected", voterManager.getTargetHostPort());
+            voterManager.close();
+            sleepFor10();  // sleep for 10 here because the cause of the error is unknown
+          }
+          owner = voteOwner.get();
+          LOGGER.info("owner is " + owner);
+        }
+      } finally {
+        voterManager.close();
+      }
+    };
+  }
+
+  public void registerAndHeartbeat(ExecutorService executorService, ClientVoterManager currentActive,
+                                   Optional<Properties> connectionProps) throws InterruptedException {
+    AtomicReference<ClientVoterManager> voteOwner = new AtomicReference<>();
+    //Try to connect and register with all the servers
+    voteOwner.set(currentActive);
+    voterManagers.forEach(voterManager ->
+        heartbeatFutures.put(voterManager.getTargetHostPort(), executorService.submit(heartbeat(executorService, voterManager, connectionProps, voteOwner))));
+    startTopologyPolling(executorService, connectionProps, voteOwner); // Adding the polling job
+    int tryCount = 0;
+    String state;
+    while (tryCount < 10) {
+      ClientVoterManager vm = voteOwner.get();
+      if (vm == null) {
+        break;
+      }
+      try {
+        state = vm.isConnected() ? voteOwner.get().getServerState() : "Not Connected";
+      } catch (TimeoutException to) {
+        state = "Timeout";
+      }
+      LOGGER.info("{} Vote owner state: {}, Try count: {}", this, state, tryCount);
+      if (state.equals(ACTIVE_COORDINATOR)) {
+        // expected that the vote owner is active
+        TimeUnit.SECONDS.sleep(5);
+        tryCount = 0;
+      } else if (state.equals("PASSIVE-STANDBY")) {
+        // expected that the vote owner will be active soon
+        TimeUnit.SECONDS.sleep(1);
+      } else if (state.startsWith("PASSIVE-SYNCING")) {
+        // expected that the vote owner will never be active because active is somewhere else
+        break;
+      } else {
+        // unknown state, try again shortly, vote should be stolen soon
+        Optional<ClientVoterManager> om = voterManagers.stream().filter(ActiveVoter::isActive).findFirst();
+        om.ifPresent(target -> voteOwner.compareAndSet(vm, target));
+        if (!om.isPresent()) {
+          sleepFor10();
+        }
+        tryCount++;
+      }
+    }
+//  by here, the server being voted for seems to not have won the election.  
+//  reset everything and start over
+    voteOwner.set(null);
+    heartbeatFutures.forEach((server, f) -> f.cancel(true));
+    topologyFetchingFuture.cancel(true);
+    cleanHeartBeatingAndPollingFutures();
+    voterManagers.stream().forEach(ClientVoterManager::close);
+    LOGGER.warn("Rejected by all servers. Attempting to re-register");
+  }
+
+  private static void sleepFor10() {
+    try {
+      TimeUnit.SECONDS.sleep(10);
+    } catch (InterruptedException ie) {
+      Thread.currentThread().interrupt();
+    }
+  }
+
+  private static boolean isActive(ClientVoterManager vm) {
+    try {
+      return vm.isConnected() && vm.getServerState().equals(ACTIVE_COORDINATOR);
+    } catch (TimeoutException to) {
+      return false;
+    }
+  }
+
+  private long heartbeat(ClientVoterManager voter) throws TimeoutException, InterruptedException {
+    long beatResponse = VoterManager.HEARTBEAT_RESPONSE;
+    while (voter.isConnected() && beatResponse == VoterManager.HEARTBEAT_RESPONSE) {
+      TimeUnit.MILLISECONDS.sleep(HEARTBEAT_INTERVAL);
+      LOGGER.debug("Heartbeating with {}", voter.getTargetHostPort());
+      beatResponse = voter.heartbeat(id);
+    }
+    LOGGER.info("Heartbeat broken. Response: {}", beatResponse);
+    return beatResponse;
+  }
+
+  public void stop() {
+    LOGGER.info("Stopping {}", this);
+    this.voter.interrupt();
+  }
+
+  private void startTopologyPolling(ExecutorService executorService, Optional<Properties> connectionProps,
+                                    AtomicReference<ClientVoterManager> voteOwner) {
+    topologyFetchingFuture = executorService.submit(() -> {
+      ClientVoterManager activeVoter = voteOwner.get();
+      while (activeVoter != null && !executorService.isShutdown()) {
+        try {
+          Set<String> newTopology = activeVoter.getTopology();
+          LOGGER.info("Topology is {}.", newTopology);
+          if (!existingTopology.equals(newTopology)) {
+            LOGGER.info("New Topology detected {}.", newTopology);
+            // Start heartbeating with new servers
+            Set<String> addedServers = getAddedServers(newTopology);
+            synchronized (registrationLatch) {
+              registrationLatch.addAll(addedServers);
+            }
+            addedServers.forEach(server -> {
+              existingTopology.add(server);
+              ClientVoterManager clientVoterManager = clientVoterManagerFactory.apply(server);
+              voterManagers.add(clientVoterManager);
+              heartbeatFutures.put(clientVoterManager.getTargetHostPort(),
+                  executorService.submit(heartbeat(executorService, clientVoterManager, connectionProps, voteOwner)));
+            });
+
+            // Do removal of old servers from topology
+            Set<String> removedServers = getRemovedServers(newTopology);
+            synchronized (registrationLatch) {
+              registrationLatch.removeAll(removedServers);
+              if (registrationLatch.isEmpty()) {
+                registrationLatch.notifyAll();
+              }
+            }
+            removedServers.forEach(server -> {
+              existingTopology.remove(server);
+              heartbeatFutures.remove(server).cancel(true);
+            });
+          }
+          sleepForTopologyFetchInterval();
+        } catch (TimeoutException | RuntimeException e) {
+          sleepFor10();
+        }
+        activeVoter = voteOwner.get();
+      }
+    });
+  }
+
+  private Set<String> getRemovedServers(Set<String> newTopology) {
+    Set<String> res = new HashSet<>(existingTopology);
+    res.removeAll(newTopology);
+    return res;
+  }
+
+  private Set<String> getAddedServers(Set<String> newTopology) {
+    Set<String> res = new HashSet<>(newTopology);
+    res.removeAll(existingTopology);
+    return res;
+  }
+
+  private void sleepForTopologyFetchInterval() {
+    try {
+      Thread.sleep(topologyFetchInterval);
+    } catch (InterruptedException ie) {
+      Thread.currentThread().interrupt();
+    }
+  }
+
+  private void cleanHeartBeatingAndPollingFutures() {
+    heartbeatFutures.clear();
+    topologyFetchingFuture = null;
+  }
+
+  @Override
+  public void close() {
+    stop();
+  }
+
+  @Override
+  public String toString() {
+    return "ActiveVoter{" + existingTopology + "}";
+  }
+
+  // For testing purposes
+  public Set<String> getExistingTopology() {
+    return existingTopology;
+  }
+
+  public Map<String, Future<?>> getHeartbeatFutures() {
+    return heartbeatFutures;
+  }
+}

--- a/voter/src/main/java/org/terracotta/voter/ClientVoterManager.java
+++ b/voter/src/main/java/org/terracotta/voter/ClientVoterManager.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.voter;
+
+import com.tc.voter.VoterManager;
+
+import java.util.Optional;
+import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.TimeoutException;
+
+public interface ClientVoterManager extends VoterManager {
+
+  /**
+   * The host and port information of the server that this client is connected to.
+   *
+   * @return host and port of the server separated by a ":"
+   */
+  String getTargetHostPort();
+
+  /**
+   * Establish a connection with the server at the given host and port
+   */
+  void connect(Optional<Properties> connectionProps);
+
+  /**
+   * @return the current state of the server that this voter is connected to.
+   */
+  String getServerState() throws TimeoutException;
+
+  /**
+   * @return the configuration of the server that this voter is connected to.
+   * @throws TimeoutException
+   */
+  String getServerConfig() throws TimeoutException;
+
+  Set<String> getTopology() throws TimeoutException;
+
+  /**
+   * Close the connection with the server.
+   */
+  void close();
+
+  boolean isVoting();
+
+  void zombie();
+
+  boolean isConnected();
+
+  /**
+   * @return the number of voters that have been registered with the server.
+   */
+  long getRegisteredVoterCount() throws TimeoutException;
+
+  /**
+   * @return the maximum number of voters that can be registered with the server.
+   */
+  long getRegisteredVoterLimit() throws TimeoutException;
+}

--- a/voter/src/main/java/org/terracotta/voter/ClientVoterManagerImpl.java
+++ b/voter/src/main/java/org/terracotta/voter/ClientVoterManagerImpl.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.voter;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.terracotta.connection.ConnectionException;
+import org.terracotta.connection.Diagnostics;
+import org.terracotta.connection.DiagnosticsFactory;
+
+import java.net.InetSocketAddress;
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.TimeoutException;
+
+import static com.tc.voter.VoterManagerMBean.MBEAN_NAME;
+
+public class ClientVoterManagerImpl implements ClientVoterManager {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(ClientVoterManagerImpl.class);
+
+  public static final String REQUEST_TIMEOUT = "Request Timeout";
+
+  private final String hostPort;
+  public Diagnostics diagnostics;
+
+  private volatile boolean voting = false;
+  private volatile long generation = 0;
+
+  public ClientVoterManagerImpl(String hostPort) {
+    this.hostPort = hostPort;
+  }
+
+  @Override
+  public String getTargetHostPort() {
+    return this.hostPort;
+  }
+
+  @Override
+  public void connect(Optional<Properties> connectionProps) {
+    String[] split = this.hostPort.split(":");
+    InetSocketAddress addr = InetSocketAddress.createUnresolved(split[0], Integer.parseInt(split[1]));
+    Properties properties = connectionProps.orElse(new Properties());
+    try {
+      Diagnostics temp = DiagnosticsFactory.connect(addr, properties);
+      synchronized (this) {
+        if (diagnostics != null) {
+          diagnostics.close();
+        }
+        diagnostics = temp;
+      }
+      LOGGER.info("Connected to {}", hostPort);
+    } catch (ConnectionException e) {
+      throw new RuntimeException("Unable to connect to " + hostPort, e);
+    }
+  }
+
+  @Override
+  public long registerVoter(String id) throws TimeoutException {
+    String result = processInvocation(diagnostics.invokeWithArg(MBEAN_NAME, "registerVoter", id));
+    try {
+      return Long.parseLong(result);
+    } catch (NumberFormatException ne) {
+      LOGGER.info("unexpected value returned for register voter: {}", result);
+      throw new RuntimeException("register voter error");
+    }
+  }
+
+  @Override
+  public long heartbeat(String id) throws TimeoutException {
+    long time = System.currentTimeMillis();
+    String result = processInvocation(diagnostics.invokeWithArg(MBEAN_NAME, "heartbeat", id));
+    LOGGER.debug("voting result {} time {} id {} host {} thread {}", result, System.currentTimeMillis() - time, id, hostPort, Thread.currentThread().getName());
+    long nr = Long.parseLong(result);
+    if (nr <= 0) {
+      voting = false;
+      generation = 0;
+    } else {
+      if (!voting && generation == nr) {
+        //  already zombied for this generation, cannot vote, just heartbeat
+        return 0;
+      } else {
+        voting = true;
+        generation = nr;
+      }
+    }
+    return nr;
+  }
+
+  @Override
+  public long vote(String id, long term) throws TimeoutException {
+    if (!voting) {
+      return -1;
+    }
+    String result = processInvocation(diagnostics.invokeWithArg(MBEAN_NAME, "vote", id + ":" + term));
+    return Long.parseLong(result);
+  }
+
+  @Override
+  public boolean overrideVote(String id) {
+    String result = diagnostics.invokeWithArg(MBEAN_NAME, "overrideVote", id);
+    return Boolean.parseBoolean(result);
+  }
+
+  @Override
+  public boolean deregisterVoter(String id) throws TimeoutException {
+    String result = processInvocation(diagnostics.invokeWithArg(MBEAN_NAME, "deregisterVoter", id));
+    return Boolean.parseBoolean(result);
+  }
+
+  @Override
+  public String getServerState() throws TimeoutException {
+    return processInvocation(diagnostics.getState());
+  }
+
+  @Override
+  public String getServerConfig() throws TimeoutException {
+    return processInvocation(diagnostics.getConfig());
+  }
+
+  @Override
+  public Set<String> getTopology() throws TimeoutException {
+    Set<String> resServers = new HashSet<>();
+    String res = processInvocation(diagnostics.invoke("TopologyMBean", "getTopology"));
+    String[] resHostPorts = res.split(",");
+    for (int i = 0; i < resHostPorts.length; ++i) {
+      resServers.add(resHostPorts[i]);
+    }
+    return resServers;
+  }
+
+  String processInvocation(String invocation) throws TimeoutException {
+    if (invocation == null) {
+      return "UNKNOWN";
+    }
+    if (invocation.equals(REQUEST_TIMEOUT)) {
+      throw new TimeoutException("Request timed out");
+    }
+    return invocation;
+  }
+
+  @Override
+  public synchronized void close() {
+    try {
+      if (this.diagnostics != null) {
+        this.diagnostics.close();
+        LOGGER.info("Connection closed to {}", hostPort);
+      }
+    } catch (Throwable t) {
+      LOGGER.info("Connection trouble closing", t);
+    } finally {
+      this.diagnostics = null;
+    }
+  }
+
+  @Override
+  public synchronized boolean isConnected() {
+    return this.diagnostics != null;
+  }
+
+  @Override
+  public boolean isVoting() {
+    return voting;
+  }
+
+  @Override
+  public void zombie() {
+    LOGGER.debug("Zombied {} for generation {}", getTargetHostPort(), generation);
+    voting = false;
+  }
+
+  @Override
+  public String toString() {
+    return "ClientVoterManagerImpl{" + "hostPort=" + hostPort + ", connection=" + diagnostics + '}';
+  }
+
+  @Override
+  public long getRegisteredVoterCount() throws TimeoutException {
+    String result = processInvocation(diagnostics.invoke(MBEAN_NAME, "getRegisteredVoters"));
+    return Long.parseLong(result);
+  }
+
+  @Override
+  public long getRegisteredVoterLimit() throws TimeoutException {
+    String result = processInvocation(diagnostics.invoke(MBEAN_NAME, "getVoterLimit"));
+    return Long.parseLong(result);
+  }
+}

--- a/voter/src/main/java/org/terracotta/voter/TCVoter.java
+++ b/voter/src/main/java/org/terracotta/voter/TCVoter.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.voter;
+
+import java.util.concurrent.Future;
+
+public interface TCVoter {
+
+  /**
+   * Register this voter instance with a cluster.
+   *
+   * @param clusterName an identifier for the target cluster
+   * @param hostPorts   the host:port combination of all the servers in that stripe
+   * @return A Future that holds the registration status of the voter.
+   * This Future will complete once the registration succeeds.
+   */
+  Future<VoterStatus> register(String clusterName, String... hostPorts);
+
+  /**
+   * Send an override vote to the server at the given host:port to force promote it to be an active.
+   * The server will accept this vote if and only if it's trying to get promoted.
+   * Else this vote will be ignored.
+   *
+   * @param hostPort The host:port combination of the target server
+   * @return true if the override vote was accepted by the server. Else false.
+   */
+  boolean overrideVote(String hostPort);
+
+  /**
+   * De-register this voter instance from a cluster that it was previously registered with.
+   *
+   * @param clusterName the cluster name that was used to register this voter with a cluster
+   */
+  void deregister(String clusterName);
+
+}

--- a/voter/src/main/java/org/terracotta/voter/TCVoterImpl.java
+++ b/voter/src/main/java/org/terracotta/voter/TCVoterImpl.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.voter;
+
+import com.tc.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeoutException;
+
+public class TCVoterImpl implements TCVoter {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(TCVoterImpl.class);
+
+  protected final String id = UUID.getUUID().toString();
+  private final Map<String, ActiveVoter> registeredClusters = new ConcurrentHashMap<>();
+
+  public TCVoterImpl() {
+    LOGGER.info("Voter ID: {}", id);
+  }
+
+  protected Optional<Properties> getConnectionProperties() {
+    return Optional.empty();
+  }
+
+  @Override
+  public boolean overrideVote(String hostPort) {
+    ClientVoterManager voterManager = new ClientVoterManagerImpl(hostPort);
+    voterManager.connect(getConnectionProperties());
+    boolean override;
+    try {
+      override = voterManager.overrideVote(id);
+    } catch (TimeoutException e) {
+      LOGGER.error("Override vote to {} timed-out", hostPort);
+      return false;
+    }
+
+    if (override) {
+      LOGGER.info("Successfully cast an override vote to {}", hostPort);
+    } else {
+      LOGGER.info("Override vote rejected by {}", hostPort);
+    }
+    return override;
+  }
+
+  @Override
+  public Future<VoterStatus> register(String clusterName, String... hostPorts) {
+    CompletableFuture<VoterStatus> voterStatusFuture = new CompletableFuture<>();
+    ActiveVoter activeVoter = new ActiveVoter(id, voterStatusFuture, getConnectionProperties(), hostPorts);
+    if (registeredClusters.putIfAbsent(clusterName, activeVoter) != null) {
+      throw new RuntimeException("Another cluster is already registered with the name: " + clusterName);
+    }
+    activeVoter.start();
+    return voterStatusFuture;
+  }
+
+  @Override
+  public void deregister(String clusterName) {
+    ActiveVoter voter = registeredClusters.remove(clusterName);
+    if (voter != null) {
+      try {
+        voter.close();
+      } catch (Exception exp) {
+        throw new RuntimeException(exp);
+      }
+    } else {
+      throw new RuntimeException("A cluster with the given name: " + clusterName + " is not registered with this voter");
+    }
+  }
+
+}

--- a/voter/src/main/java/org/terracotta/voter/VoterStatus.java
+++ b/voter/src/main/java/org/terracotta/voter/VoterStatus.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.voter;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+public interface VoterStatus {
+
+  /**
+   * @return true if this voter is registered with all stripes in the cluster at the moment.
+   */
+  boolean isActive();
+
+  void awaitRegistrationWithAll() throws InterruptedException;
+
+  void awaitRegistrationWithAll(long timeout, TimeUnit unit) throws InterruptedException, TimeoutException;
+
+}

--- a/voter/src/main/java/org/terracotta/voter/cli/CustomJCommander.java
+++ b/voter/src/main/java/org/terracotta/voter/cli/CustomJCommander.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.voter.cli;
+
+import com.beust.jcommander.DefaultUsageFormatter;
+import com.beust.jcommander.JCommander;
+import com.beust.jcommander.ParameterDescription;
+import com.beust.jcommander.WrappedParameter;
+import com.beust.jcommander.internal.Lists;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+import static java.lang.System.lineSeparator;
+
+public class CustomJCommander extends JCommander {
+
+  public CustomJCommander(OptionsParsing object) {
+    super(object);
+    setUsageFormatter(new UsageFormatter(this, object));
+  }
+
+  @Override
+  public Map<String, JCommander> getCommands() {
+    // force an ordering of commands by name
+    return new TreeMap<>(super.getCommands());
+  }
+
+  private static class UsageFormatter extends DefaultUsageFormatter {
+    private final JCommander commander;
+    private final OptionsParsing object;
+
+    private UsageFormatter(JCommander commander, OptionsParsing object) {
+      super(commander);
+      this.commander = commander;
+      this.object = object;
+    }
+
+    @Override
+    public void usage(StringBuilder out, String indent) {
+      appendOptions(commander, out, indent);
+    }
+
+    private void appendOptions(JCommander jCommander, StringBuilder out, String indent) {
+      out.append("Usage: ");
+      String usage = object.getClass().getAnnotation(Usage.class).value();
+      out.append(usage.replace(lineSeparator(), lineSeparator() + "    " + indent)).append(lineSeparator());
+      // Align the descriptions at the "longestName" column
+      List<ParameterDescription> sorted = Lists.newArrayList();
+      int colSize = Integer.MIN_VALUE;
+      for (ParameterDescription pd : jCommander.getParameters()) {
+        if (!pd.getParameter().hidden()) {
+          sorted.add(pd);
+          int length = pd.getParameterAnnotation().names()[0].length();
+          if (length > colSize) {
+            colSize = length;
+          }
+        }
+      }
+
+      // Display all the names and descriptions
+      if (sorted.size() > 0) {
+
+        // Sort the options by only considering the first displayed option
+        // which will be the one with 1 dash (i.e. -help).
+        sorted.sort(Comparator.comparing(pd -> pd.getParameterAnnotation().names()[0]));
+
+        out.append(indent).append("Options:").append(lineSeparator());
+
+        for (ParameterDescription pd : sorted) {
+          WrappedParameter parameter = pd.getParameter();
+          out.append(indent)
+              .append("    ")
+              .append(pad(pd.getParameterAnnotation().names()[0], colSize))
+              .append(parameter.required() ? " (required)    " : " (optional)    ")
+              .append(pd.getDescription())
+              .append(lineSeparator());
+        }
+      }
+    }
+  }
+
+  @SuppressFBWarnings("SBSC_USE_STRINGBUFFER_CONCATENATION")
+  @SuppressWarnings("StringConcatenationInLoop")
+  private static String pad(String str, int colSize) {
+    while (str.length() < colSize) {
+      str += " ";
+    }
+    return str;
+  }
+}

--- a/voter/src/main/java/org/terracotta/voter/cli/NoCommaSplitter.java
+++ b/voter/src/main/java/org/terracotta/voter/cli/NoCommaSplitter.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.voter.cli;
+
+import com.beust.jcommander.converters.IParameterSplitter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class NoCommaSplitter implements IParameterSplitter {
+  @Override
+  public List<String> split(String s) {
+    List<String> res = new ArrayList<>();
+    res.add(s);
+    return res;
+  }
+}

--- a/voter/src/main/java/org/terracotta/voter/cli/Options.java
+++ b/voter/src/main/java/org/terracotta/voter/cli/Options.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.voter.cli;
+
+import java.util.List;
+
+public class Options {
+
+  private boolean help;
+  private String overrideHostPort;
+  private List<String> serversHostPort;
+
+  public void setHelp(boolean help) {
+    this.help = help;
+  }
+
+  public void setOverrideHostPort(String overrideHostPort) {
+    this.overrideHostPort = overrideHostPort;
+  }
+
+  public void setServerHostPort(List<String> serversHostPort) {
+    this.serversHostPort = serversHostPort;
+  }
+
+  public boolean isHelp() {
+    return help;
+  }
+
+  public String getOverrideHostPort() {
+    return overrideHostPort;
+  }
+
+  public List<String> getServersHostPort() {
+    return serversHostPort;
+  }
+
+}

--- a/voter/src/main/java/org/terracotta/voter/cli/OptionsParsing.java
+++ b/voter/src/main/java/org/terracotta/voter/cli/OptionsParsing.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.voter.cli;
+
+public interface OptionsParsing {
+  Options process();
+}

--- a/voter/src/main/java/org/terracotta/voter/cli/OptionsParsingImpl.java
+++ b/voter/src/main/java/org/terracotta/voter/cli/OptionsParsingImpl.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.voter.cli;
+
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.Parameters;
+
+import java.util.List;
+
+@Parameters
+@Usage("(-connect-to <hostname:port>,<hostname:port>... -connect-to <hostname:port>,<hostname:port> ... | -vote-for <hostname:port>))")
+public class OptionsParsingImpl implements OptionsParsing {
+
+  @Parameter(names = {"-help", "-h"}, description = "Help", help = true)
+  private boolean help;
+
+  @Parameter(names = {"-vote-for", "-o"}, description = "Override vote to host:port")
+  private String overrideHostPort;
+
+  @Parameter(names = {"-connect-to", "-s"}, description = "Comma separated host:port to connect to (one per stripe)", splitter = NoCommaSplitter.class)
+  private List<String> serversHostPort;
+
+  @Override
+  public Options process() {
+    validateOptions();
+    Options options = new Options();
+    options.setHelp(help);
+    options.setOverrideHostPort(overrideHostPort);
+    options.setServerHostPort(serversHostPort);
+    return options;
+  }
+
+  private void validateOptions() {
+    if (!help) {
+      if (overrideHostPort == null && serversHostPort == null) {
+        throw new RuntimeException("Neither the -vote-for option nor the regular -connect-to option provided");
+      } else if (overrideHostPort != null && serversHostPort != null) {
+        throw new RuntimeException("Either the -vote-for or the regular -connect-to option can be provided");
+      }
+    }
+  }
+}

--- a/voter/src/main/java/org/terracotta/voter/cli/TCVoterMain.java
+++ b/voter/src/main/java/org/terracotta/voter/cli/TCVoterMain.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.voter.cli;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.terracotta.voter.ActiveVoter;
+import org.terracotta.voter.TCVoter;
+import org.terracotta.voter.TCVoterImpl;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+
+public class TCVoterMain {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(TCVoterMain.class);
+
+  private static final String ID = UUID.randomUUID().toString();
+
+  public static void main(String[] args) {
+    TCVoterMain main = new TCVoterMain();
+    main.processArgs(args);
+  }
+
+  public void processArgs(String[] args) {
+    OptionsParsing optionsParsing = getParsingObject();
+    CustomJCommander jCommander = new CustomJCommander(optionsParsing);
+    jCommander.parse(args);
+    Options options = optionsParsing.process();
+
+    if (options.isHelp()) {
+      jCommander.usage();
+      return;
+    }
+
+    writePID();
+    Optional<Properties> connectionProps = getConnectionProperties(options);
+    if (options.getServersHostPort() != null) {
+      processServerArg(connectionProps, options.getServersHostPort().toArray(new String[0]));
+    } else if (options.getOverrideHostPort() != null) {
+      String hostPort = options.getOverrideHostPort();
+      validateHostPort(hostPort);
+      getVoter(connectionProps).overrideVote(hostPort);
+    } else {
+      throw new AssertionError("This should not happen");
+    }
+  }
+
+  protected OptionsParsing getParsingObject() {
+    return new OptionsParsingImpl();
+  }
+
+  protected Optional<Properties> getConnectionProperties(Options option) {
+    return Optional.empty();
+  }
+
+  protected void processServerArg(Optional<Properties> connectionProps, String[] stripes) {
+    validateStripesLimit(stripes);
+    String[] hostPorts = stripes[0].split(",");
+    for (String hostPort : hostPorts) {
+      validateHostPort(hostPort);
+    }
+    startVoter(connectionProps, hostPorts);
+  }
+
+  protected TCVoter getVoter(Optional<Properties> connectionProps) {
+    return new TCVoterImpl();
+  }
+
+  protected void startVoter(Optional<Properties> connectionProps, String... hostPorts) {
+    new ActiveVoter(ID, new CompletableFuture<>(), connectionProps, hostPorts).start();
+  }
+
+  protected void validateStripesLimit(String[] args) {
+    if (args.length > 1) {
+      throw new RuntimeException("Usage of multiple -connect-to options not supported");
+    }
+  }
+
+  protected void validateHostPort(String hostPort) {
+    URI uri;
+    try {
+      uri = new URI("tc://" + hostPort);
+    } catch (URISyntaxException e) {
+      throw new RuntimeException(e);
+    }
+    if (uri.getHost() == null || uri.getPort() == -1) {
+      throw new RuntimeException("Invalid host:port combination provided: " + hostPort);
+    }
+  }
+
+  private static void writePID() {
+    try {
+      String processName = java.lang.management.ManagementFactory.getRuntimeMXBean().getName();
+      long pid = Long.parseLong(processName.split("@")[0]);
+      LOGGER.info("PID is {}", pid);
+    } catch (Throwable t) {
+      LOGGER.warn("Unable to fetch the PID of this process.");
+    }
+  }
+}

--- a/voter/src/main/java/org/terracotta/voter/cli/Usage.java
+++ b/voter/src/main/java/org/terracotta/voter/cli/Usage.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.voter.cli;
+
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.TYPE;
+
+@Retention(java.lang.annotation.RetentionPolicy.RUNTIME)
+@Target({TYPE})
+@Inherited
+public @interface Usage {
+  String value();
+}
+

--- a/voter/src/main/resources/logback.xml
+++ b/voter/src/main/resources/logback.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright Terracotta, Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<configuration>
+
+  <statusListener class="ch.qos.logback.core.status.NopStatusListener"/>
+  <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d %p - %m%n</pattern>
+      <charset>utf8</charset>
+    </encoder>
+  </appender>
+
+  <root level="INFO">
+    <appender-ref ref="CONSOLE"/>
+  </root>
+</configuration>

--- a/voter/src/test/java/org/terracotta/voter/ActiveVoterTest.java
+++ b/voter/src/test/java/org/terracotta/voter/ActiveVoterTest.java
@@ -1,0 +1,409 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.terracotta.voter;
+
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import org.hamcrest.CoreMatchers;
+import org.hamcrest.MatcherAssert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.slf4j.LoggerFactory;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Function;
+
+import static java.util.Optional.empty;
+import static java.util.function.UnaryOperator.identity;
+import static java.util.stream.Collectors.toMap;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.Matchers.hasProperty;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.terracotta.utilities.test.matchers.Eventually.within;
+
+public class ActiveVoterTest {
+
+  private static final String VOTER_ID = UUID.randomUUID().toString();
+  private static final long TOPOLOGY_FETCH_INTERVAL = 10000L;
+
+  private static final String HOST1 = "localhost:1111";
+  private static final String HOST2 = "localhost:2222";
+  private static final String HOST3 = "localhost:3333";
+  private static final String HOST4 = "localhost:4444";
+
+  @BeforeClass
+  public static void beforeClass() {
+    System.setProperty("org.terracotta.voter.topology.fetch.interval", "5000");
+  }
+
+  @Test
+  public void testTopologyUpdate() throws TimeoutException, InterruptedException {
+    Set<String> expectedTopology = new HashSet<>();
+    expectedTopology.add(HOST1);
+    expectedTopology.add(HOST2);
+
+    ClientVoterManager firstClientVoterManager = mock(ClientVoterManager.class);
+    ClientVoterManager otherClientVoterManager = mock(ClientVoterManager.class);
+    when(firstClientVoterManager.isConnected()).thenReturn(true);
+    when(otherClientVoterManager.isConnected()).thenReturn(true);
+    when(firstClientVoterManager.getServerState()).thenReturn("ACTIVE-COORDINATOR");
+    when(otherClientVoterManager.getServerState()).thenReturn("PASSIVE-STANDBY");
+    when(firstClientVoterManager.registerVoter(VOTER_ID)).thenReturn(0L);
+    when(otherClientVoterManager.registerVoter(VOTER_ID)).thenReturn(0L);
+    when(firstClientVoterManager.getTopology()).thenReturn(expectedTopology);
+    when(firstClientVoterManager.heartbeat(VOTER_ID)).thenReturn(0L);
+    when(otherClientVoterManager.heartbeat(VOTER_ID)).thenReturn(0L);
+    when(firstClientVoterManager.getTargetHostPort()).thenReturn(HOST1);
+    when(otherClientVoterManager.getTargetHostPort()).thenReturn(HOST2);
+
+    Function<String, ClientVoterManager> factory = hostPort -> {
+      if (hostPort.equals(HOST1)) {
+        return firstClientVoterManager;
+      } else if (hostPort.equals(HOST2)) {
+        return otherClientVoterManager;
+      } else {
+        ClientVoterManager mockClientVoterManager = mock(ClientVoterManager.class);
+        when(mockClientVoterManager.getTargetHostPort()).thenReturn(hostPort);
+        when(mockClientVoterManager.isConnected()).thenReturn(true);
+        return mockClientVoterManager;
+      }
+    };
+    try (ActiveVoter activeVoter = new ActiveVoter(VOTER_ID, new CompletableFuture<>(), empty(), factory, HOST1, HOST2)) {
+      activeVoter.start();
+      Thread.sleep(TOPOLOGY_FETCH_INTERVAL);
+      MatcherAssert.assertThat(activeVoter.getExistingTopology(), CoreMatchers.is(expectedTopology));
+      MatcherAssert.assertThat(activeVoter.getHeartbeatFutures().size(), CoreMatchers.is(2));
+
+      // Update Topology To Add Passive
+      expectedTopology.add(HOST3);
+      Thread.sleep(TOPOLOGY_FETCH_INTERVAL);
+      MatcherAssert.assertThat(activeVoter.getExistingTopology(), CoreMatchers.is(expectedTopology));
+      MatcherAssert.assertThat(activeVoter.getHeartbeatFutures().size(), CoreMatchers.is(3));
+
+      //Update Topology To Remove Passive
+      expectedTopology.remove(HOST2);
+      Thread.sleep(TOPOLOGY_FETCH_INTERVAL);
+      MatcherAssert.assertThat(activeVoter.getExistingTopology(), CoreMatchers.is(expectedTopology));
+      MatcherAssert.assertThat(activeVoter.getHeartbeatFutures().size(), CoreMatchers.is(2));
+    }
+  }
+
+  @Test
+  public void testOverLappingHostPortsWhileAddingServers() throws TimeoutException, InterruptedException {
+    Set<String> expectedTopology = new HashSet<>();
+    expectedTopology.add(HOST1);
+
+    ClientVoterManager firstClientVoterManager = mock(ClientVoterManager.class);
+    when(firstClientVoterManager.isConnected()).thenReturn(true);
+    when(firstClientVoterManager.getServerState()).thenReturn("ACTIVE-COORDINATOR");
+    when(firstClientVoterManager.registerVoter(VOTER_ID)).thenReturn(0L);
+    when(firstClientVoterManager.getTopology()).thenReturn(expectedTopology);
+    when(firstClientVoterManager.heartbeat(VOTER_ID)).thenReturn(0L);
+    when(firstClientVoterManager.getTargetHostPort()).thenReturn(HOST1);
+
+    Function<String, ClientVoterManager> factory = hostPort -> {
+      if (hostPort.equals(HOST1)) {
+        return firstClientVoterManager;
+      } else {
+        ClientVoterManager mockClientVoterManager = mock(ClientVoterManager.class);
+        when(mockClientVoterManager.getTargetHostPort()).thenReturn(hostPort);
+        when(mockClientVoterManager.isConnected()).thenReturn(true);
+        return mockClientVoterManager;
+      }
+    };
+    try (ActiveVoter activeVoter = new ActiveVoter(VOTER_ID, new CompletableFuture<>(), empty(), factory, HOST1)) {
+      activeVoter.start();
+      Thread.sleep(TOPOLOGY_FETCH_INTERVAL);
+      MatcherAssert.assertThat(activeVoter.getExistingTopology(), CoreMatchers.is(expectedTopology));
+      MatcherAssert.assertThat(activeVoter.getHeartbeatFutures().size(), CoreMatchers.is(1));
+
+      // Update Topology To Add Passive
+      expectedTopology.add(HOST2);
+      Thread.sleep(TOPOLOGY_FETCH_INTERVAL);
+      MatcherAssert.assertThat(activeVoter.getExistingTopology(), CoreMatchers.is(expectedTopology));
+      MatcherAssert.assertThat(activeVoter.getHeartbeatFutures().size(), CoreMatchers.is(2));
+    }
+  }
+
+  @Test
+  public void testOverLappingHostPortsWhileRemovingServers() throws TimeoutException, InterruptedException {
+    Set<String> expectedTopology = new HashSet<>();
+    expectedTopology.add(HOST1);
+    expectedTopology.add(HOST2);
+
+    ClientVoterManager firstClientVoterManager = mock(ClientVoterManager.class);
+    ClientVoterManager otherClientVoterManager = mock(ClientVoterManager.class);
+    when(firstClientVoterManager.isConnected()).thenReturn(true);
+    when(otherClientVoterManager.isConnected()).thenReturn(true);
+    when(firstClientVoterManager.getServerState()).thenReturn("ACTIVE-COORDINATOR");
+    when(otherClientVoterManager.getServerState()).thenReturn("PASSIVE-STANDBY");
+    when(firstClientVoterManager.registerVoter(VOTER_ID)).thenReturn(0L);
+    when(otherClientVoterManager.registerVoter(VOTER_ID)).thenReturn(0L);
+    when(firstClientVoterManager.getTopology()).thenReturn(expectedTopology);
+    when(firstClientVoterManager.heartbeat(VOTER_ID)).thenReturn(0L);
+    when(otherClientVoterManager.heartbeat(VOTER_ID)).thenReturn(0L);
+    when(firstClientVoterManager.getTargetHostPort()).thenReturn(HOST1);
+    when(otherClientVoterManager.getTargetHostPort()).thenReturn(HOST2);
+
+    Function<String, ClientVoterManager> factory = hostPort -> {
+      if (hostPort.equals(HOST1)) {
+        return firstClientVoterManager;
+      } else if (hostPort.equals(HOST2)) {
+        return otherClientVoterManager;
+      } else {
+        ClientVoterManager mockClientVoterManager = mock(ClientVoterManager.class);
+        when(mockClientVoterManager.getTargetHostPort()).thenReturn(hostPort);
+        when(mockClientVoterManager.isConnected()).thenReturn(true);
+        return mockClientVoterManager;
+      }
+    };
+    try (ActiveVoter activeVoter = new ActiveVoter(VOTER_ID, new CompletableFuture<>(), empty(), factory, HOST1, HOST2)) {
+      activeVoter.start();
+
+      Thread.sleep(TOPOLOGY_FETCH_INTERVAL);
+      MatcherAssert.assertThat(activeVoter.getExistingTopology(), CoreMatchers.is(expectedTopology));
+      MatcherAssert.assertThat(activeVoter.getHeartbeatFutures().size(), CoreMatchers.is(2));
+
+      // Update Topology To Remove Passive
+      expectedTopology.remove(HOST2);
+      Thread.sleep(TOPOLOGY_FETCH_INTERVAL);
+      MatcherAssert.assertThat(activeVoter.getExistingTopology(), CoreMatchers.is(expectedTopology));
+      MatcherAssert.assertThat(activeVoter.getHeartbeatFutures().size(), CoreMatchers.is(1));
+    }
+  }
+
+  @Test
+  public void testWhenStaticPassivePortsRemoved() throws TimeoutException, InterruptedException {
+    Set<String> expectedTopology = new HashSet<>();
+    expectedTopology.add(HOST1);
+    expectedTopology.add(HOST3);
+    expectedTopology.add(HOST4);
+
+    ClientVoterManager firstClientVoterManager = mock(ClientVoterManager.class);
+    ClientVoterManager otherClientVoterManager = mock(ClientVoterManager.class);
+    when(firstClientVoterManager.isConnected()).thenReturn(true);
+    when(otherClientVoterManager.isConnected()).thenReturn(true);
+    when(firstClientVoterManager.getServerState()).thenReturn("ACTIVE-COORDINATOR");
+    when(otherClientVoterManager.getServerState()).thenReturn("PASSIVE-STANDBY");
+    when(firstClientVoterManager.registerVoter(VOTER_ID)).thenReturn(0L);
+    when(otherClientVoterManager.registerVoter(VOTER_ID)).thenReturn(0L);
+    when(firstClientVoterManager.getTopology()).thenReturn(expectedTopology);
+    when(firstClientVoterManager.heartbeat(VOTER_ID)).thenReturn(0L);
+    when(otherClientVoterManager.heartbeat(VOTER_ID)).thenReturn(0L);
+    when(firstClientVoterManager.getTargetHostPort()).thenReturn(HOST1);
+    when(otherClientVoterManager.getTargetHostPort()).thenReturn(HOST2);
+
+    Function<String, ClientVoterManager> factory = hostPort -> {
+      if (hostPort.equals(HOST1)) {
+        return firstClientVoterManager;
+      } else if (hostPort.equals(HOST2)) {
+        return otherClientVoterManager;
+      } else {
+        ClientVoterManager mockClientVoterManager = mock(ClientVoterManager.class);
+        when(mockClientVoterManager.getTargetHostPort()).thenReturn(hostPort);
+        when(mockClientVoterManager.isConnected()).thenReturn(true);
+        return mockClientVoterManager;
+      }
+    };
+    try (ActiveVoter activeVoter = new ActiveVoter(VOTER_ID, new CompletableFuture<>(), empty(), factory, HOST1, HOST2)) {
+      activeVoter.start();
+      Thread.sleep(TOPOLOGY_FETCH_INTERVAL);
+      MatcherAssert.assertThat(activeVoter.getExistingTopology(), CoreMatchers.is(expectedTopology));
+      MatcherAssert.assertThat(activeVoter.getHeartbeatFutures().size(), CoreMatchers.is(3));
+    }
+  }
+
+  @Test
+  @SuppressWarnings("serial")
+  public void testReregistrationWhenAllStaticHostPortsNotAvailable() throws InterruptedException, NoSuchFieldException {
+    Map<String, String> servers = new HashMap<String, String>() {
+      {
+        put("ACTIVE-COORDINATOR", HOST1);
+        put("PASSIVE-STANDBY", HOST2);
+      }
+    };
+    Map<String, MockedClientVoterManager> managers = Collections.synchronizedMap(
+        servers.entrySet()
+            .stream()
+            .map((e) -> manager(e.getKey(), e.getValue(), new HashSet<>(servers.values())))
+            .collect(toMap(ClientVoterManager::getTargetHostPort, identity())));
+
+    ListAppender<ILoggingEvent> listAppender = new ListAppender<>();
+    listAppender.setContext((LoggerContext) LoggerFactory.getILoggerFactory());
+    listAppender.start();
+    Logger logger = (Logger) LoggerFactory.getLogger(ActiveVoter.class);
+    logger.addAppender(listAppender);
+
+    try (ActiveVoter voter = new ActiveVoter(VOTER_ID, new CompletableFuture<>(), empty(), managers::get, servers.get("ACTIVE-COORDINATOR"))) {
+      voter.start();
+      Thread.sleep(10000L);
+      waitForLogMessage(listAppender, "New Topology detected");
+      disconnectManagers(managers.values());
+      waitForLogMessage(listAppender, "Attempting to re-register");
+      synchronized (listAppender) {
+        listAppender.list.clear();
+      }
+      MockedClientVoterManager passiveManager = managers.get(servers.get("PASSIVE-STANDBY"));
+      passiveManager.promote();
+      waitForLogMessage(listAppender, "Vote owner state: ACTIVE-COORDINATOR");
+      Thread.sleep(5000L); // wait for reg retry
+      verify(passiveManager, atLeastOnce()).registerVoter(eq(VOTER_ID));
+    } finally {
+      logger.detachAppender(listAppender);
+      listAppender.stop();
+    }
+  }
+
+  private void waitForLogMessage(ListAppender<ILoggingEvent> appender, String message) {
+    MatcherAssert.assertThat(() -> getLogs(appender), within(Duration.ofSeconds(10))
+        .matches(CoreMatchers.<ILoggingEvent>hasItem(hasProperty("formattedMessage", containsString(message)))));
+  }
+
+  private List<ILoggingEvent> getLogs(ListAppender<ILoggingEvent> appender) {
+    synchronized (appender) {
+      return new ArrayList<>(appender.list);
+    }
+  }
+
+  private void disconnectManagers(Collection<MockedClientVoterManager> managers) {
+    for (MockedClientVoterManager manager : managers) {
+      manager.connected = false;
+    }
+  }
+
+  private MockedClientVoterManager manager(String state, String serverAddress, Set<String> topology) {
+    return spy(new MockedClientVoterManager(state, serverAddress, topology));
+  }
+
+  private static class MockedClientVoterManager implements ClientVoterManager {
+
+    private final String serverAddress;
+    private volatile String state;
+    private final Set<String> topology;
+    volatile boolean connected = true;
+
+    public MockedClientVoterManager(String initialState, String serverAddress, Set<String> topology) {
+      this.state = initialState;
+      this.serverAddress = serverAddress;
+      this.topology = topology;
+    }
+
+    void promote() {
+      state = "ACTIVE-COORDINATOR";
+      connected = true;
+    }
+
+    @Override
+    public String getTargetHostPort() {
+      return serverAddress;
+    }
+
+    @Override
+    public void connect(Optional<Properties> connectionProps) {
+    }
+
+    @Override
+    public String getServerState() {
+      return state;
+    }
+
+    @Override
+    public String getServerConfig() {
+      return null;
+    }
+
+    @Override
+    public Set<String> getTopology() {
+      return topology;
+    }
+
+    @Override
+    public void close() {
+      connected = false;
+    }
+
+    @Override
+    public boolean isVoting() {
+      return false;
+    }
+
+    @Override
+    public void zombie() {
+
+    }
+
+    @Override
+    public boolean isConnected() {
+      return connected;
+    }
+
+    @Override
+    public long registerVoter(String id) {
+      return connected ? HEARTBEAT_RESPONSE : INVALID_VOTER_RESPONSE;
+    }
+
+    @Override
+    public long heartbeat(String id) {
+      return connected ? HEARTBEAT_RESPONSE : INVALID_VOTER_RESPONSE;
+    }
+
+    @Override
+    public long vote(String id, long electionTerm) {
+      return connected ? HEARTBEAT_RESPONSE : INVALID_VOTER_RESPONSE;
+    }
+
+    @Override
+    public boolean overrideVote(String id) {
+      return false;
+    }
+
+    @Override
+    public boolean deregisterVoter(String id) {
+      return false;
+    }
+
+    @Override
+    public long getRegisteredVoterCount() {
+      return 0;
+    }
+
+    @Override
+    public long getRegisteredVoterLimit() {
+      return 0;
+    }
+  }
+}

--- a/voter/src/test/java/org/terracotta/voter/ClientVoterManagerImplTest.java
+++ b/voter/src/test/java/org/terracotta/voter/ClientVoterManagerImplTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.voter;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.terracotta.connection.Diagnostics;
+
+import java.util.concurrent.TimeoutException;
+
+import static com.tc.voter.VoterManager.INVALID_VOTER_RESPONSE;
+import static com.tc.voter.VoterManagerMBean.MBEAN_NAME;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.terracotta.voter.ClientVoterManagerImpl.REQUEST_TIMEOUT;
+
+public class ClientVoterManagerImplTest {
+
+  private ClientVoterManagerImpl manager = new ClientVoterManagerImpl("foo:6543");
+  private Diagnostics diagnostics = mock(Diagnostics.class);
+
+  @Before
+  public void setUp() throws Exception {
+    manager.diagnostics = diagnostics;
+  }
+
+  @Test
+  public void testRegister() throws TimeoutException {
+    when(diagnostics.invokeWithArg(MBEAN_NAME, "registerVoter", "foo")).thenReturn("123");
+    assertThat(manager.registerVoter("foo"), is(123L));
+  }
+
+  @Test
+  public void testRegisterFailure() throws TimeoutException {
+    when(diagnostics.invokeWithArg(MBEAN_NAME, "registerVoter", "foo")).thenReturn("-1");
+    assertThat(manager.registerVoter("foo"), is(INVALID_VOTER_RESPONSE));
+  }
+
+  @Test(expected = TimeoutException.class)
+  public void testRegisterTimeout() throws TimeoutException {
+    when(diagnostics.invokeWithArg(MBEAN_NAME, "registerVoter", "foo")).thenReturn(REQUEST_TIMEOUT);
+    manager.registerVoter("foo");
+  }
+
+  @Test
+  public void testHeartbeat() throws TimeoutException {
+    when(diagnostics.invokeWithArg(MBEAN_NAME, "heartbeat", "foo")).thenReturn("123");
+    assertThat(manager.heartbeat("foo"), is(123L));
+  }
+
+  @Test
+  public void testHeartbeatInvalidVoter() throws TimeoutException {
+    when(diagnostics.invokeWithArg(MBEAN_NAME, "heartbeat", "foo")).thenReturn("-1");
+    assertThat(manager.heartbeat("foo"), is(INVALID_VOTER_RESPONSE));
+  }
+
+  @Test(expected = TimeoutException.class)
+  public void testHeartbeatTimeout() throws TimeoutException {
+    when(diagnostics.invokeWithArg(MBEAN_NAME, "heartbeat", "foo")).thenReturn(REQUEST_TIMEOUT);
+    manager.heartbeat("foo");
+  }
+
+  @Test
+  public void testVote() throws TimeoutException {
+    when(diagnostics.invokeWithArg(MBEAN_NAME, "vote", "foo:123")).thenReturn("123");
+    when(diagnostics.invokeWithArg(MBEAN_NAME, "heartbeat", "foo:123")).thenReturn("123");
+    manager.heartbeat("foo:123");
+    assertThat(manager.vote("foo", 123L), is(123L));
+  }
+
+  @Test
+  public void testVoteInvalidVoter() throws TimeoutException {
+    when(diagnostics.invokeWithArg(MBEAN_NAME, "vote", "foo:123")).thenReturn("-1");
+    manager.vote("foo", 123L);
+  }
+
+  @Test(expected = TimeoutException.class)
+  public void testVoteTimeout() throws TimeoutException {
+    when(diagnostics.invokeWithArg(MBEAN_NAME, "vote", "foo:123")).thenReturn(REQUEST_TIMEOUT);
+    when(diagnostics.invokeWithArg(MBEAN_NAME, "heartbeat", "foo:123")).thenReturn("123");
+    manager.heartbeat("foo:123");
+    manager.vote("foo", 123L);
+  }
+
+  @Test
+  public void testOverrideVote() {
+    when(diagnostics.invokeWithArg(MBEAN_NAME, "overrideVote", "foo")).thenReturn("true");
+    assertThat(manager.overrideVote("foo"), is(true));
+  }
+
+  @Test
+  public void testOverrideVoteFailure() {
+    when(diagnostics.invokeWithArg(MBEAN_NAME, "overrideVote", "foo")).thenReturn("false");
+    manager.overrideVote("foo");
+  }
+
+  @Test
+  public void testOverrideVoteTimeout() {
+    when(diagnostics.invokeWithArg(MBEAN_NAME, "overrideVote", "foo")).thenReturn(REQUEST_TIMEOUT);
+    assertThat(manager.overrideVote("foo"), is(false));
+  }
+
+  @Test
+  public void testDeregisterVoter() throws TimeoutException {
+    when(diagnostics.invokeWithArg(MBEAN_NAME, "deregisterVoter", "foo")).thenReturn("true");
+    assertThat(manager.deregisterVoter("foo"), is(true));
+  }
+
+  @Test(expected = TimeoutException.class)
+  public void testDeregisterVoterTimeout() throws TimeoutException {
+    when(diagnostics.invokeWithArg(MBEAN_NAME, "deregisterVoter", "foo")).thenReturn(REQUEST_TIMEOUT);
+    manager.deregisterVoter("foo");
+  }
+}

--- a/voter/src/test/java/org/terracotta/voter/TCVoterMainTest.java
+++ b/voter/src/test/java/org/terracotta/voter/TCVoterMainTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.voter;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.terracotta.voter.cli.TCVoterMain;
+
+import java.util.Optional;
+import java.util.Properties;
+
+import static org.hamcrest.Matchers.arrayContaining;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+public class TCVoterMainTest {
+
+  @Rule
+  public ExpectedException expectedException = ExpectedException.none();
+
+  @Test
+  public void testOverrideVote() {
+    TCVoter voter = mock(TCVoter.class);
+    TCVoterMain voterMain = new TCVoterMain() {
+      @Override
+      protected TCVoter getVoter(Optional<Properties> connectionProps) {
+        return voter;
+      }
+    };
+
+    String overrideTarget = "foo:1234";
+    String[] args = new String[]{"-o", overrideTarget};
+    voterMain.processArgs(args);
+
+    verify(voter).overrideVote(overrideTarget);
+  }
+
+  @Test
+  public void testServerOpt() {
+    String hostPort = "foo:1234";
+    TCVoterMain voterMain = new TCVoterMain() {
+      @Override
+      protected void startVoter(Optional<Properties> connectionProps, String... hostPorts) {
+        assertThat(hostPorts, arrayContaining(hostPort));
+      }
+    };
+
+    String[] args = new String[]{"-s", hostPort};
+    voterMain.processArgs(args);
+  }
+
+  @Test
+  public void testMultipleServerOptArgs() {
+    String hostPort1 = "foo:1234";
+    String hostPort2 = "bar:2345";
+    TCVoterMain voterMain = new TCVoterMain() {
+      @Override
+      protected void startVoter(Optional<Properties> connectionProps, String... hostPorts) {
+        assertThat(hostPorts, arrayContaining(hostPort1, hostPort2));
+      }
+    };
+
+    String[] args = new String[]{"-s", hostPort1 + "," + hostPort2};
+    voterMain.processArgs(args);
+  }
+
+  @Test
+  public void testMultipleServerOpts() {
+    TCVoterMain voterMain = new TCVoterMain();
+
+    String[] args = new String[]{"-s", "foo:1234", "-s", "bar:2345"};
+
+    expectedException.expect(RuntimeException.class);
+    expectedException.expectMessage("Usage of multiple -connect-to options not supported");
+    voterMain.processArgs(args);
+  }
+
+  @Test
+  public void testZeroArguments() {
+    TCVoterMain voterMain = new TCVoterMain();
+    String[] args = new String[0];
+
+    expectedException.expect(RuntimeException.class);
+    expectedException.expectMessage("Neither the -vote-for option nor the regular -connect-to option provided");
+    voterMain.processArgs(args);
+  }
+
+  @Test
+  public void testInvalidTargetHostPort() {
+    TCVoterMain voterMain = new TCVoterMain();
+    String[] args = new String[]{"-s", "bar:baz"};
+
+    expectedException.expect(RuntimeException.class);
+    expectedException.expectMessage("Invalid host:port combination provided");
+    voterMain.processArgs(args);
+  }
+}


### PR DESCRIPTION
- Voter Tool script and client/cli classes were moved from core to platform, including their tests.  
- Some unused classes from core were not added to this platform implementation.
- Some slight refactoring of the code was performed.
- Added a commit to move platform to version 5.9.  This keeps platform in sync with core which moved to 5.9 following the removal of the voter tool.