### PR TITLE
Remove POM repositories elements & bump terracotta-utilities version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.terracotta</groupId>
     <artifactId>terracotta-parent</artifactId>
-    <version>5.20</version>
+    <version>5.21</version>
   </parent>
 
   <artifactId>platform-root</artifactId>
@@ -33,16 +33,16 @@
     <maven.version>3.6.3</maven.version>
     <slf4j.version>1.7.25</slf4j.version>
     <logback.version>1.2.3</logback.version>
-    <terracotta-apis.version>1.8.1</terracotta-apis.version>
-    <terracotta-configuration.version>10.7.1</terracotta-configuration.version>
-    <passthrough-testing.version>1.8.2</passthrough-testing.version>
-    <terracotta-core.version>5.9.2</terracotta-core.version>
-    <tripwire.version>1.0.2</tripwire.version>
-    <galvan.version>1.6.3</galvan.version>
+    <terracotta-apis.version>1.8.2</terracotta-apis.version>
+    <terracotta-configuration.version>10.7.2</terracotta-configuration.version>
+    <passthrough-testing.version>1.8.3</passthrough-testing.version>
+    <terracotta-core.version>5.9.3</terracotta-core.version>
+    <tripwire.version>1.0.3</tripwire.version>
+    <galvan.version>1.6.4</galvan.version>
     <angela.version>3.3.23</angela.version>
     <statistics.version>2.1</statistics.version>
     <jackson.version>2.13.2.20220328</jackson.version>
-    <terracotta-utilities.version>0.0.11</terracotta-utilities.version>
+    <terracotta-utilities.version>0.0.13</terracotta-utilities.version>
     <test.parallel.forks>4</test.parallel.forks>
     <jna.version>5.9.0</jna.version>
   </properties>


### PR DESCRIPTION
This commit bumps the terracotta-parent (and other dependency) versions
to reduce the repositories and pluginRepositories element to those
required to locate direct dependencies of this project.  More
specifically, SNAPSHOT repositories are removed -- inclusion of
SNAPSHOT repositories interferes with the use of range-based version
specifications.  Should a developer want to include a SNAPSHOT release
in a build, local addition of the SNAPSHOT repositories can be employed.

This commit also bumps the version of terracotta-utilities used.