### PR TITLE
[daggy] NEVER ZAP a node when stopping it

### DIFF
--- a/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/service/DynamicConfigServiceImpl.java
+++ b/dynamic-config/server/configuration-provider/src/main/java/org/terracotta/dynamic_config/server/configuration/service/DynamicConfigServiceImpl.java
@@ -61,7 +61,6 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import static java.util.Objects.requireNonNull;
 import org.terracotta.server.ServerEnv;
 import static org.terracotta.server.StopAction.RESTART;
-import static org.terracotta.server.StopAction.ZAP;
 
 public class DynamicConfigServiceImpl implements TopologyService, DynamicConfigService, DynamicConfigEventService, DynamicConfigListener, StateDumpable {
 
@@ -343,7 +342,7 @@ public class DynamicConfigServiceImpl implements TopologyService, DynamicConfigS
     LOGGER.info("Will stop node in {} seconds", delayInSeconds.getSeconds());
     runAfterDelay(delayInSeconds, () -> {
       LOGGER.info("Stopping node");
-      ServerEnv.getServer().stop(ZAP);
+      ServerEnv.getServer().stop();
     });
   }
 


### PR DESCRIPTION
This bug has been introduced 30 April 2020.

When a node is stopped through DC API, it is also zapped.

The stop method is used:

1. From the repair command in the cluster-tool
2. From the detach command