### PR TITLE
Update dependency versions -- logging component update

### DIFF
--- a/healthchecker-entity/api/pom.xml
+++ b/healthchecker-entity/api/pom.xml
@@ -32,7 +32,6 @@
     <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-api</artifactId>
-        <version>${slf4j.version}</version>
         <scope>provided</scope>
     </dependency>
     <dependency>

--- a/kit/pom.xml
+++ b/kit/pom.xml
@@ -183,7 +183,7 @@
     <!--
       KIT
     -->
-    
+
     <dependency>
       <groupId>org.terracotta.internal</groupId>
       <artifactId>terracotta-kit</artifactId>

--- a/lease/api/pom.xml
+++ b/lease/api/pom.xml
@@ -32,7 +32,6 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-      <version>${slf4j.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/lease/entity-server/pom.xml
+++ b/lease/entity-server/pom.xml
@@ -66,7 +66,6 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-      <version>${slf4j.version}</version>
       <scope>provided</scope>
     </dependency>
 

--- a/management/monitoring-service-api/pom.xml
+++ b/management/monitoring-service-api/pom.xml
@@ -61,7 +61,6 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-      <version>${slf4j.version}</version>
       <scope>provided</scope>
     </dependency>
 

--- a/management/nms-agent-entity/nms-agent-entity-client/pom.xml
+++ b/management/nms-agent-entity/nms-agent-entity-client/pom.xml
@@ -48,7 +48,6 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-      <version>${slf4j.version}</version>
     </dependency>
 
     <!-- provided by voltron-management module (client) -->

--- a/management/nms-agent-entity/nms-agent-entity-server/pom.xml
+++ b/management/nms-agent-entity/nms-agent-entity-server/pom.xml
@@ -46,7 +46,6 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-      <version>${slf4j.version}</version>
       <scope>provided</scope>
     </dependency>
 

--- a/management/nms-entity/nms-entity-server/pom.xml
+++ b/management/nms-entity/nms-entity-server/pom.xml
@@ -52,7 +52,6 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-      <version>${slf4j.version}</version>
       <scope>provided</scope>
     </dependency>
 

--- a/offheap-resource/pom.xml
+++ b/offheap-resource/pom.xml
@@ -101,7 +101,7 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-simple</artifactId>
-      <version>${slf4j.version}</version>
+      <version>${slf4j.range.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -31,18 +31,21 @@
 
   <properties>
     <maven.version>3.6.3</maven.version>
-    <slf4j.version>1.7.32</slf4j.version>
-    <logback.version>1.2.11</logback.version>
+    <slf4j.base.version>1.7.32</slf4j.base.version>
+    <slf4j.range.version>[${slf4j.base.version},1.7.9999)</slf4j.range.version>
+    <logback.base.version>1.2.11</logback.base.version>
+    <logback.range.version>[${logback.base.version},1.2.9999)</logback.range.version>
     <terracotta-apis.version>1.8.2</terracotta-apis.version>
-    <terracotta-configuration.version>10.7.2</terracotta-configuration.version>
-    <passthrough-testing.version>1.8.3</passthrough-testing.version>
-    <terracotta-core.version>5.9.4</terracotta-core.version>
-    <tripwire.version>1.0.3</tripwire.version>
-    <galvan.version>1.6.4</galvan.version>
-    <angela.version>3.3.24</angela.version>
-    <statistics.version>2.1.1</statistics.version>
+    <terracotta-configuration.version>10.7.3</terracotta-configuration.version>
+    <passthrough-testing.version>1.8.4</passthrough-testing.version>
+    <terracotta-core.version>5.9.5</terracotta-core.version>
+    <tripwire.version>1.0.4</tripwire.version>
+    <galvan.version>1.6.5</galvan.version>
+    <angela.version>3.3.25</angela.version>
+    <statistics.version>2.1.2</statistics.version>
     <jackson.version>2.13.2.20220328</jackson.version>
-    <terracotta-utilities.version>0.0.14</terracotta-utilities.version>
+    <terracotta-utilities.base.version>0.0.14</terracotta-utilities.base.version>
+    <terracotta-utilities.range.version>[${terracotta-utilities.base.version},)</terracotta-utilities.range.version>
     <test.parallel.forks>4</test.parallel.forks>
     <jna.version>5.9.0</jna.version>
   </properties>
@@ -96,12 +99,12 @@
       <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-api</artifactId>
-        <version>${slf4j.version}</version>
+        <version>${slf4j.range.version}</version>
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-simple</artifactId>
-        <version>${slf4j.version}</version>
+        <version>${slf4j.range.version}</version>
       </dependency>
       <dependency>
         <groupId>org.terracotta</groupId>
@@ -111,17 +114,17 @@
       <dependency>
         <groupId>org.terracotta</groupId>
         <artifactId>terracotta-utilities-test-tools</artifactId>
-        <version>${terracotta-utilities.version}</version>
+        <version>${terracotta-utilities.range.version}</version>
       </dependency>
       <dependency>
         <groupId>org.terracotta</groupId>
         <artifactId>terracotta-utilities-tools</artifactId>
-        <version>${terracotta-utilities.version}</version>
+        <version>${terracotta-utilities.range.version}</version>
       </dependency>
       <dependency>
         <groupId>org.terracotta</groupId>
         <artifactId>terracotta-utilities-port-chooser</artifactId>
-        <version>${terracotta-utilities.version}</version>
+        <version>${terracotta-utilities.range.version}</version>
       </dependency>
       <dependency>
         <groupId>org.terracotta.internal</groupId>
@@ -270,7 +273,17 @@
       <dependency>
         <groupId>ch.qos.logback</groupId>
         <artifactId>logback-classic</artifactId>
-        <version>${logback.version}</version>
+        <version>${logback.range.version}</version>
+        <exclusions>
+          <!--
+            Excluding slf4j-api to upgrade the version of slf4j-api used -
+            logback 1.2.11 pins slf4j-api to 1.7.32 but we want 1.7.36+.
+            -->
+          <exclusion>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>net.java.dev.jna</groupId>
@@ -424,31 +437,25 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-enforcer-plugin</artifactId>
-            <executions>
-              <execution>
-                <goals>
-                  <goal>enforce</goal>
-                </goals>
-                <configuration>
-                  <rules>
-                    <dependencyConvergence>
-                      <uniqueVersions>true</uniqueVersions>
-                    </dependencyConvergence>
-                    <requireJavaVersion>
-                      <version>[${java.build.version},)</version>
-                    </requireJavaVersion>
-                    <requireMavenVersion>
-                      <version>[${maven.version},)</version>
-                    </requireMavenVersion>
-                    <bannedDependencies>
-                      <excludes>
-                        <exclude>com.github.stefanbirkner:system-rules</exclude>
-                      </excludes>
-                    </bannedDependencies>
-                  </rules>
-                </configuration>
-              </execution>
-            </executions>
+            <version>3.0.0-M3</version>
+            <configuration>
+              <rules>
+                <dependencyConvergence>
+                  <uniqueVersions>true</uniqueVersions>
+                </dependencyConvergence>
+                <requireJavaVersion>
+                  <version>[${java.build.version},)</version>
+                </requireJavaVersion>
+                <requireMavenVersion>
+                  <version>[${maven.version},)</version>
+                </requireMavenVersion>
+                <bannedDependencies>
+                  <excludes>
+                    <exclude>com.github.stefanbirkner:system-rules</exclude>
+                  </excludes>
+                </bannedDependencies>
+              </rules>
+            </configuration>
           </plugin>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
This commit updates dependencies to consolidate the SLF4J and Logback
dependencies in upstream dependencies and this project.

* The versions of the following are updated:
** terracotta-configuration
** terracotta-core
** tc-passthrough-testins
** tc-tripwire
** galvan
** angela
** statistics
** terracotta-utilities
** logback
  The logback "base" version is set to 1.2.11
** slf4j
  The SLF4J "base" version is set to 1.7.32 (the minimum needed by
  logback 1.2.11

* Version ranges
  Version ranges are introduced for logback, slf4j, and
  terracotta-utilities.  The version of Logback is capped at
  1.2.9999 to avoid the early versions of 1.3.x.  The version of
  SLF4J is capped at 1.7.9999 to  avoid picking up 1.8.0-betaX
  releases which will not work with released versions of Logback
  before 1.3.x.