### PR TITLE
[cloud] Enable DC to return null to core when log dir is not configured and we run into containers with the system property "terracotta.config.logDir.noDefault"

### DIFF
--- a/dynamic-config/model/src/test/java/org/terracotta/dynamic_config/api/model/ConfigurationTest.java
+++ b/dynamic-config/model/src/test/java/org/terracotta/dynamic_config/api/model/ConfigurationTest.java
@@ -327,7 +327,6 @@ public class ConfigurationTest {
           tuple2(NODE_GROUP_PORT, "9410"),
           tuple2(NODE_BIND_ADDRESS, "0.0.0.0"),
           tuple2(NODE_GROUP_BIND_ADDRESS, "0.0.0.0"),
-          tuple2(NODE_LOG_DIR, "foo/bar"),
           tuple2(NODE_METADATA_DIR, "foo/bar")
       ).forEach(tuple -> {
         allowInput(tuple.t1.toString(), tuple.t1, CLUSTER, null, null, null, null);
@@ -349,6 +348,7 @@ public class ConfigurationTest {
       Stream.of(
           tuple2(NODE_BACKUP_DIR, "foo/bar"),
           tuple2(SECURITY_DIR, "foo/bar"),
+          tuple2(NODE_LOG_DIR, "foo/bar"),
           tuple2(SECURITY_AUDIT_LOG_DIR, "foo/bar")
       ).forEach(tuple -> {
         allowInput(tuple.t1.toString(), tuple.t1, CLUSTER, null, null, null, null);
@@ -754,7 +754,7 @@ public class ConfigurationTest {
       reject(state, op, "log-dir=foo");
       reject(state, op, "stripe.1.log-dir=foo");
       allow(state, op, "stripe.1.node.1.log-dir=foo");
-      reject(state, op, "stripe.1.node.1.log-dir=");
+      allow(state, op, "stripe.1.node.1.log-dir=");
     }));
 
     // cluster-name, offheap-resources, failover-priority

--- a/dynamic-config/model/src/test/java/org/terracotta/dynamic_config/api/model/SettingValidatorTest.java
+++ b/dynamic-config/model/src/test/java/org/terracotta/dynamic_config/api/model/SettingValidatorTest.java
@@ -145,7 +145,7 @@ public class SettingValidatorTest {
 
   @Test
   public void test_paths() {
-    Stream.of(NODE_LOG_DIR, NODE_METADATA_DIR).forEach(setting -> {
+    Stream.of(NODE_METADATA_DIR).forEach(setting -> {
       validateRequired(setting);
       assertThat(
           () -> setting.validate("/\u0000/"),
@@ -157,7 +157,7 @@ public class SettingValidatorTest {
       setting.validate(null); // unset - switch back to default value
     });
 
-    Stream.of(NODE_BACKUP_DIR, SECURITY_DIR, SECURITY_AUDIT_LOG_DIR).forEach(setting -> {
+    Stream.of(NODE_BACKUP_DIR, SECURITY_DIR, SECURITY_AUDIT_LOG_DIR, NODE_LOG_DIR).forEach(setting -> {
       validateOptional(setting);
       assertThat(
           () -> setting.validate("/\u0000/"),

--- a/dynamic-config/model/src/test/java/org/terracotta/dynamic_config/api/service/ClusterFactoryTest.java
+++ b/dynamic-config/model/src/test/java/org/terracotta/dynamic_config/api/service/ClusterFactoryTest.java
@@ -143,6 +143,7 @@ public class ClusterFactoryTest {
 
   @Test
   public void test_create_cli() {
+    assertCliEquals(cli("failover-priority=availability", "hostname=foo", "log-dir="), Testing.newTestCluster(new Stripe().addNodes(Testing.newTestNode("<GENERATED>", "foo").setLogDir(null))));
     assertCliEquals(cli("failover-priority=availability"), Testing.newTestCluster(new Stripe().addNodes(Testing.newTestNode("<GENERATED>", "localhost"))));
     assertCliEquals(cli("failover-priority=availability", "hostname=%c"), Testing.newTestCluster(new Stripe().addNodes(Testing.newTestNode("<GENERATED>", "localhost.home"))));
     assertCliEquals(cli("failover-priority=availability", "hostname=foo"), Testing.newTestCluster(new Stripe().addNodes(Testing.newTestNode("<GENERATED>", "foo"))));
@@ -469,7 +470,7 @@ public class ClusterFactoryTest {
   private static Map<Setting, String> cli(String... params) {
     return Stream.of(params)
         .map(p -> p.split("="))
-        .map(kv -> new AbstractMap.SimpleEntry<>(Setting.fromName(kv[0]), kv[1]))
+        .map(kv -> new AbstractMap.SimpleEntry<>(Setting.fromName(kv[0]), kv.length == 2 ? kv[1] : ""))
         .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
   }
 

--- a/dynamic-config/model/src/test/java/org/terracotta/dynamic_config/api/service/ConfigurationParserTest.java
+++ b/dynamic-config/model/src/test/java/org/terracotta/dynamic_config/api/service/ConfigurationParserTest.java
@@ -97,6 +97,22 @@ public class ConfigurationParserTest {
   }
 
   @Test
+  public void test_cli_no_logDir() {
+    // node hostname should be resolved from default value (%h) if not given
+    assertCliEquals(
+        cli("failover-priority=availability", "log-dir="),
+        Testing.newTestCluster(new Stripe().addNodes(Testing.newTestNode("<GENERATED>", "localhost").setLogDir(null)))
+            .setFailoverPriority(availability()),
+        "stripe.1.node.1.name=<GENERATED>",
+        "stripe.1.stripe-name=<GENERATED>",
+        "stripe.1.node.1.node-uid=<GENERATED>",
+        "stripe.1.stripe-uid=<GENERATED>",
+        "cluster-uid=<GENERATED>",
+        "stripe.1.node.1.hostname=localhost"
+    );
+  }
+
+  @Test
   public void test_cliToProperties_2() {
     // placeholder in node hostname should be resolved eagerly
     assertCliEquals(
@@ -282,6 +298,24 @@ public class ConfigurationParserTest {
   }
 
   @Test
+  public void test_parsing_no_log_dir() {
+    // minimal config is to only have hostname, but to facilitate testing we add name
+    assertConfigEquals(
+        config(
+            "stripe.1.stripe-name=<GENERATED>",
+            "stripe.1.node.1.name=node1",
+            "stripe.1.node.1.hostname=localhost",
+            "stripe.1.node.1.log-dir=",
+            "cluster-name=foo"
+        ),
+        Testing.newTestCluster("foo", new Stripe().addNodes(Testing.newTestNode("node1", "localhost").setLogDir(null))).setFailoverPriority(null),
+        "cluster-uid=<GENERATED>",
+        "stripe.1.stripe-uid=<GENERATED>",
+        "stripe.1.node.1.node-uid=<GENERATED>"
+    );
+  }
+
+  @Test
   public void test_parsing_complete_1x1() {
     // minimal config is to only have hostname, but to facilitate testing we add name
     assertConfigEquals(
@@ -416,7 +450,7 @@ public class ConfigurationParserTest {
   private static Map<Setting, String> cli(String... params) {
     return Stream.of(params)
         .map(p -> p.split("="))
-        .map(kv -> new AbstractMap.SimpleEntry<>(Setting.fromName(kv[0]), kv[1]))
+        .map(kv -> new AbstractMap.SimpleEntry<>(Setting.fromName(kv[0]), kv.length == 2 ? kv[1] : ""))
         .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
   }
 

--- a/dynamic-config/server/configuration-provider/src/test/java/org/terracotta/dynamic_config/server/configuration/startup/DynamicConfigServerConfigurationTest.java
+++ b/dynamic-config/server/configuration-provider/src/test/java/org/terracotta/dynamic_config/server/configuration/startup/DynamicConfigServerConfigurationTest.java
@@ -1,0 +1,361 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.dynamic_config.server.configuration.startup;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.terracotta.configuration.ServerConfiguration;
+import org.terracotta.dynamic_config.api.model.Cluster;
+import org.terracotta.dynamic_config.api.model.Node;
+import org.terracotta.dynamic_config.api.model.NodeContext;
+import org.terracotta.dynamic_config.api.model.Setting;
+import org.terracotta.dynamic_config.api.service.ClusterFactory;
+import org.terracotta.dynamic_config.server.api.GroupPortMapper;
+import org.terracotta.dynamic_config.server.api.PathResolver;
+
+import java.nio.file.Paths;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+import java.util.function.BiConsumer;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.terracotta.dynamic_config.api.service.IParameterSubstitutor.identity;
+
+/**
+ * @author Mathieu Carbou
+ */
+@RunWith(Parameterized.class)
+public class DynamicConfigServerConfigurationTest {
+
+  @Parameterized.Parameters(name = "{index}: unconfigured={0},terracotta.config.logDir.noDefault={1},cluster={3}")
+  public static Collection<Object[]> data() {
+    return asList(new Object[][]{
+        // default config
+        {
+            true, // unconfigured ?
+            false, // terracotta.config.logDir.noDefault
+            (Supplier<Cluster>) () -> makeFromConfig(),
+            (BiConsumer<Cluster, ServerConfiguration>) (cluster, configuration) -> {
+              assertFalse(cluster.getSingleNode().get().getLogDir().isConfigured());
+              assertNotNull(cluster.getSingleNode().get().getLogDir().orDefault());
+              assertNull(configuration.getLogsLocation());
+            },
+        },
+        {
+            false, // unconfigured ?
+            false, // terracotta.config.logDir.noDefault
+            (Supplier<Cluster>) () -> makeFromConfig(),
+            (BiConsumer<Cluster, ServerConfiguration>) (cluster, configuration) -> {
+              assertFalse(cluster.getSingleNode().get().getLogDir().isConfigured());
+              assertNotNull(cluster.getSingleNode().get().getLogDir().orDefault());
+              assertNotNull(configuration.getLogsLocation());
+            },
+        },
+        {
+            true, // unconfigured ?
+            true, // terracotta.config.logDir.noDefault
+            (Supplier<Cluster>) () -> makeFromConfig(),
+            (BiConsumer<Cluster, ServerConfiguration>) (cluster, configuration) -> {
+              assertFalse(cluster.getSingleNode().get().getLogDir().isConfigured());
+              assertNull(cluster.getSingleNode().get().getLogDir().orDefault());
+              assertNull(configuration.getLogsLocation());
+            },
+        },
+        {
+            false, // unconfigured ?
+            true, // terracotta.config.logDir.noDefault
+            (Supplier<Cluster>) () -> makeFromConfig(),
+            (BiConsumer<Cluster, ServerConfiguration>) (cluster, configuration) -> {
+              assertFalse(cluster.getSingleNode().get().getLogDir().isConfigured());
+              assertNull(cluster.getSingleNode().get().getLogDir().orDefault());
+              assertNull(configuration.getLogsLocation());
+            },
+        },
+        // config: log-dir=
+        {
+            true, // unconfigured ?
+            false, // terracotta.config.logDir.noDefault
+            (Supplier<Cluster>) () -> makeFromConfig("stripe.1.node.1.log-dir="),
+            (BiConsumer<Cluster, ServerConfiguration>) (cluster, configuration) -> {
+              assertFalse(cluster.getSingleNode().get().getLogDir().isConfigured());
+              assertNotNull(cluster.getSingleNode().get().getLogDir().orDefault());
+              assertNull(configuration.getLogsLocation());
+            },
+        },
+        {
+            false, // unconfigured ?
+            false, // terracotta.config.logDir.noDefault
+            (Supplier<Cluster>) () -> makeFromConfig("stripe.1.node.1.log-dir="),
+            (BiConsumer<Cluster, ServerConfiguration>) (cluster, configuration) -> {
+              assertFalse(cluster.getSingleNode().get().getLogDir().isConfigured());
+              assertNotNull(cluster.getSingleNode().get().getLogDir().orDefault());
+              assertNotNull(configuration.getLogsLocation());
+            },
+        },
+        {
+            true, // unconfigured ?
+            true, // terracotta.config.logDir.noDefault
+            (Supplier<Cluster>) () -> makeFromConfig("stripe.1.node.1.log-dir="),
+            (BiConsumer<Cluster, ServerConfiguration>) (cluster, configuration) -> {
+              assertFalse(cluster.getSingleNode().get().getLogDir().isConfigured());
+              assertNull(cluster.getSingleNode().get().getLogDir().orDefault());
+              assertNull(configuration.getLogsLocation());
+            },
+        },
+        {
+            false, // unconfigured ?
+            true, // terracotta.config.logDir.noDefault
+            (Supplier<Cluster>) () -> makeFromConfig("stripe.1.node.1.log-dir="),
+            (BiConsumer<Cluster, ServerConfiguration>) (cluster, configuration) -> {
+              assertFalse(cluster.getSingleNode().get().getLogDir().isConfigured());
+              assertNull(cluster.getSingleNode().get().getLogDir().orDefault());
+              assertNull(configuration.getLogsLocation());
+            },
+        },
+        // config: log-dir=foo
+        {
+            true, // unconfigured ?
+            false, // terracotta.config.logDir.noDefault
+            (Supplier<Cluster>) () -> makeFromConfig("stripe.1.node.1.log-dir=foo"),
+            (BiConsumer<Cluster, ServerConfiguration>) (cluster, configuration) -> {
+              assertTrue(cluster.getSingleNode().get().getLogDir().isConfigured());
+              assertNotNull(cluster.getSingleNode().get().getLogDir().orDefault());
+              assertNull(configuration.getLogsLocation());
+            },
+        },
+        {
+            false, // unconfigured ?
+            false, // terracotta.config.logDir.noDefault
+            (Supplier<Cluster>) () -> makeFromConfig("stripe.1.node.1.log-dir=foo"),
+            (BiConsumer<Cluster, ServerConfiguration>) (cluster, configuration) -> {
+              assertTrue(cluster.getSingleNode().get().getLogDir().isConfigured());
+              assertNotNull(cluster.getSingleNode().get().getLogDir().orDefault());
+              assertNotNull(configuration.getLogsLocation());
+            },
+        },
+        {
+            true, // unconfigured ?
+            true, // terracotta.config.logDir.noDefault
+            (Supplier<Cluster>) () -> makeFromConfig("stripe.1.node.1.log-dir=foo"),
+            (BiConsumer<Cluster, ServerConfiguration>) (cluster, configuration) -> {
+              assertTrue(cluster.getSingleNode().get().getLogDir().isConfigured());
+              assertNotNull(cluster.getSingleNode().get().getLogDir().orDefault());
+              assertNull(configuration.getLogsLocation());
+            },
+        },
+        {
+            false, // unconfigured ?
+            true, // terracotta.config.logDir.noDefault
+            (Supplier<Cluster>) () -> makeFromConfig("stripe.1.node.1.log-dir=foo"),
+            (BiConsumer<Cluster, ServerConfiguration>) (cluster, configuration) -> {
+              assertTrue(cluster.getSingleNode().get().getLogDir().isConfigured());
+              assertNotNull(cluster.getSingleNode().get().getLogDir().orDefault());
+              assertNotNull(configuration.getLogsLocation());
+            },
+        },
+        // default CLI
+        {
+            true, // unconfigured ?
+            false, // terracotta.config.logDir.noDefault
+            (Supplier<Cluster>) () -> makeFromCLI(),
+            (BiConsumer<Cluster, ServerConfiguration>) (cluster, configuration) -> {
+              assertFalse(cluster.getSingleNode().get().getLogDir().isConfigured());
+              assertNotNull(cluster.getSingleNode().get().getLogDir().orDefault());
+              assertNull(configuration.getLogsLocation());
+            },
+        },
+        {
+            false, // unconfigured ?
+            false, // terracotta.config.logDir.noDefault
+            (Supplier<Cluster>) () -> makeFromCLI(),
+            (BiConsumer<Cluster, ServerConfiguration>) (cluster, configuration) -> {
+              assertFalse(cluster.getSingleNode().get().getLogDir().isConfigured());
+              assertNotNull(cluster.getSingleNode().get().getLogDir().orDefault());
+              assertNotNull(configuration.getLogsLocation());
+            },
+        },
+        {
+            true, // unconfigured ?
+            true, // terracotta.config.logDir.noDefault
+            (Supplier<Cluster>) () -> makeFromCLI(),
+            (BiConsumer<Cluster, ServerConfiguration>) (cluster, configuration) -> {
+              assertFalse(cluster.getSingleNode().get().getLogDir().isConfigured());
+              assertNull(cluster.getSingleNode().get().getLogDir().orDefault());
+              assertNull(configuration.getLogsLocation());
+            },
+        },
+        {
+            false, // unconfigured ?
+            true, // terracotta.config.logDir.noDefault
+            (Supplier<Cluster>) () -> makeFromCLI(),
+            (BiConsumer<Cluster, ServerConfiguration>) (cluster, configuration) -> {
+              assertFalse(cluster.getSingleNode().get().getLogDir().isConfigured());
+              assertNull(cluster.getSingleNode().get().getLogDir().orDefault());
+              assertNull(configuration.getLogsLocation());
+            },
+        },
+        // CLI: log-dir=
+        {
+            true, // unconfigured ?
+            false, // terracotta.config.logDir.noDefault
+            (Supplier<Cluster>) () -> makeFromCLI("log-dir="),
+            (BiConsumer<Cluster, ServerConfiguration>) (cluster, configuration) -> {
+              assertFalse(cluster.getSingleNode().get().getLogDir().isConfigured());
+              assertNotNull(cluster.getSingleNode().get().getLogDir().orDefault());
+              assertNull(configuration.getLogsLocation());
+            },
+        },
+        {
+            false, // unconfigured ?
+            false, // terracotta.config.logDir.noDefault
+            (Supplier<Cluster>) () -> makeFromCLI("log-dir="),
+            (BiConsumer<Cluster, ServerConfiguration>) (cluster, configuration) -> {
+              assertFalse(cluster.getSingleNode().get().getLogDir().isConfigured());
+              assertNotNull(cluster.getSingleNode().get().getLogDir().orDefault());
+              assertNotNull(configuration.getLogsLocation());
+            },
+        },
+        {
+            true, // unconfigured ?
+            true, // terracotta.config.logDir.noDefault
+            (Supplier<Cluster>) () -> makeFromCLI("log-dir="),
+            (BiConsumer<Cluster, ServerConfiguration>) (cluster, configuration) -> {
+              assertFalse(cluster.getSingleNode().get().getLogDir().isConfigured());
+              assertNull(cluster.getSingleNode().get().getLogDir().orDefault());
+              assertNull(configuration.getLogsLocation());
+            },
+        },
+        {
+            false, // unconfigured ?
+            true, // terracotta.config.logDir.noDefault
+            (Supplier<Cluster>) () -> makeFromCLI("log-dir="),
+            (BiConsumer<Cluster, ServerConfiguration>) (cluster, configuration) -> {
+              assertFalse(cluster.getSingleNode().get().getLogDir().isConfigured());
+              assertNull(cluster.getSingleNode().get().getLogDir().orDefault());
+              assertNull(configuration.getLogsLocation());
+            },
+        },
+        // CLI: log-dir=foo
+        {
+            true, // unconfigured ?
+            false, // terracotta.config.logDir.noDefault
+            (Supplier<Cluster>) () -> makeFromCLI("log-dir=foo"),
+            (BiConsumer<Cluster, ServerConfiguration>) (cluster, configuration) -> {
+              assertTrue(cluster.getSingleNode().get().getLogDir().isConfigured());
+              assertNotNull(cluster.getSingleNode().get().getLogDir().orDefault());
+              assertNull(configuration.getLogsLocation());
+            },
+        },
+        {
+            false, // unconfigured ?
+            false, // terracotta.config.logDir.noDefault
+            (Supplier<Cluster>) () -> makeFromCLI("log-dir=foo"),
+            (BiConsumer<Cluster, ServerConfiguration>) (cluster, configuration) -> {
+              assertTrue(cluster.getSingleNode().get().getLogDir().isConfigured());
+              assertNotNull(cluster.getSingleNode().get().getLogDir().orDefault());
+              assertNotNull(configuration.getLogsLocation());
+            },
+        },
+        {
+            true, // unconfigured ?
+            true, // terracotta.config.logDir.noDefault
+            (Supplier<Cluster>) () -> makeFromCLI("log-dir=foo"),
+            (BiConsumer<Cluster, ServerConfiguration>) (cluster, configuration) -> {
+              assertTrue(cluster.getSingleNode().get().getLogDir().isConfigured());
+              assertNotNull(cluster.getSingleNode().get().getLogDir().orDefault());
+              assertNull(configuration.getLogsLocation());
+            },
+        },
+        {
+            false, // unconfigured ?
+            true, // terracotta.config.logDir.noDefault
+            (Supplier<Cluster>) () -> makeFromCLI("log-dir=foo"),
+            (BiConsumer<Cluster, ServerConfiguration>) (cluster, configuration) -> {
+              assertTrue(cluster.getSingleNode().get().getLogDir().isConfigured());
+              assertNotNull(cluster.getSingleNode().get().getLogDir().orDefault());
+              assertNotNull(configuration.getLogsLocation());
+            },
+        },
+    });
+  }
+
+
+  @Parameter(0)
+  public boolean unconfigured;
+  @Parameter(1)
+  public boolean sysprop;
+  @Parameter(2)
+  public Supplier<Cluster> clusterSupplier;
+  @Parameter(3)
+  public BiConsumer<Cluster, ServerConfiguration> assertions;
+
+  private final PathResolver pathResolver = new PathResolver(Paths.get(""));
+
+  @Test
+  public void test_getLogsLocation_default() {
+    try {
+      System.setProperty("terracotta.config.logDir.noDefault", String.valueOf(sysprop));
+
+      Cluster cluster = clusterSupplier.get();
+      Node node = cluster.getSingleNode().get();
+      DynamicConfigServerConfiguration configuration = new DynamicConfigServerConfiguration(node, () -> new NodeContext(cluster, node.getUID()), identity(), mock(GroupPortMapper.class), pathResolver, unconfigured);
+
+      assertions.accept(cluster, configuration);
+    } finally {
+      System.clearProperty("terracotta.config.logDir.noDefault");
+    }
+  }
+
+  private static Cluster makeFromConfig(String... lines) {
+    Properties cfg = Stream.concat(
+            Stream.of("failover-priority=availability", "stripe.1.node.1.hostname=localhost", "stripe.1.node.1.name=node-1-1"),
+            Stream.of(lines))
+        .map(s -> s.split("="))
+        .reduce(new Properties(), (configFile, kv) -> {
+          configFile.setProperty(kv[0], kv.length == 1 ? "" : kv[1]);
+          return configFile;
+        }, (cfg1, cfg2) -> {
+          throw new UnsupportedOperationException();
+        });
+    cfg.setProperty("failover-priority", "availability");
+    return new ClusterFactory().create(cfg);
+  }
+
+  private static Cluster makeFromCLI(String... args) {
+    Map<Setting, String> cli = Stream.concat(
+            Stream.of("failover-priority=availability", "hostname=localhost", "name=node-1-1"),
+            Stream.of(args))
+        .map(s -> s.split("="))
+        .reduce(new HashMap<>(), (map, kv) -> {
+          map.put(Setting.fromName(kv[0]), kv.length == 1 ? "" : kv[1]);
+          return map;
+        }, (cli1, cli2) -> {
+          throw new UnsupportedOperationException();
+        });
+    return new ClusterFactory().create(cli, identity());
+  }
+}


### PR DESCRIPTION
### Examples

- **Starting in diagnostic mode will always log to stdout and not to a log file**

```bash
rm -f -r ~/terracotta/ && ./kit/target/platform-kit-5.9-SNAPSHOT/platform-kit-5.9-SNAPSHOT/server/bin/start-tc-server.sh
```

outputs:

```
2022-07-22 10:28:21,644 INFO - Logging directory is not set. Logging only to the console
```

- **Starting an active node with default log dir value**

```bash
rm -f -r ~/terracotta/ && ./kit/target/platform-kit-5.9-SNAPSHOT/platform-kit-5.9-SNAPSHOT/server/bin/start-tc-server.sh -auto-activate -cluster-name=foo
```

outputs:

```
2022-07-22 10:29:41,158 INFO - Created logging directory /Users/matc/terracotta/logs/node-NEGJzh3-S0OoGMWUj8rU0A
2022-07-22 10:29:41,158 INFO - Log file: /Users/matc/terracotta/logs/node-NEGJzh3-S0OoGMWUj8rU0A/terracotta.server.log
```

- **Starting an active node with a custom log dir value**

```bash
rm -f -r ~/terracotta/ && ./kit/target/platform-kit-5.9-SNAPSHOT/platform-kit-5.9-SNAPSHOT/server/bin/start-tc-server.sh -auto-activate -cluster-name=foo -log-dir=foo
```

outputs:

```
2022-07-22 10:30:32,082 INFO - Created logging directory /Users/matc/workspace/terracotta/terracotta-platform/foo/node-nbR3fz6xS1uxpCahCn2f_Q
2022-07-22 10:30:32,082 INFO - Log file: /Users/matc/workspace/terracotta/terracotta-platform/foo/node-nbR3fz6xS1uxpCahCn2f_Q/terracotta.server.log
```

- **Starting an active node on a container with a default log dir value**

```bash
rm -f -r ~/terracotta/ && JAVA_OPTS=-Dterracotta.config.logDir.noDefault=true ./kit/target/platform-kit-5.9-SNAPSHOT/platform-kit-5.9-SNAPSHOT/server/bin/start-tc-server.sh -auto-activate -cluster-name=foo
```

outputs:

```
2022-07-22 10:31:45,515 INFO - Logging directory is not set. Logging only to the console
```

- **Starting an active node on a container with a custom log dir value**

```bash
rm -f -r ~/terracotta/ && JAVA_OPTS=-Dterracotta.config.logDir.noDefault=true ./kit/target/platform-kit-5.9-SNAPSHOT/platform-kit-5.9-SNAPSHOT/server/bin/start-tc-server.sh -auto-activate -cluster-name=foo -log-dir=foo
```

outputs:

```
2022-07-22 10:32:51,463 INFO - Created logging directory /Users/matc/workspace/terracotta/terracotta-platform/foo/node-jyy1ATrCSQGMC-FSZ2QF1w
2022-07-22 10:32:51,463 INFO - Log file: /Users/matc/workspace/terracotta/terracotta-platform/foo/node-jyy1ATrCSQGMC-FSZ2QF1w/terracotta.server.log

```