### PR TITLE
Fix server plugins packaging:

### DIFF
--- a/client-message-tracker/pom.xml
+++ b/client-message-tracker/pom.xml
@@ -28,6 +28,22 @@
 
   <artifactId>client-message-tracker</artifactId>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifest>
+              <addClasspath>true</addClasspath>
+            </manifest>
+          </archive>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
   <dependencies>
     <dependency>
       <groupId>org.terracotta</groupId>

--- a/communicator-support/communicator-support-server/pom.xml
+++ b/communicator-support/communicator-support-server/pom.xml
@@ -28,6 +28,22 @@
 
   <artifactId>communicator-support-server</artifactId>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifest>
+              <addClasspath>true</addClasspath>
+            </manifest>
+          </archive>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
   <dependencies>
     <dependency>
       <groupId>org.terracotta.voltron.communicator</groupId>

--- a/concurrent-map-entity/server/pom.xml
+++ b/concurrent-map-entity/server/pom.xml
@@ -31,6 +31,22 @@
   <groupId>org.terracotta.entities</groupId>
   <artifactId>clustered-map-server</artifactId>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifest>
+              <addClasspath>true</addClasspath>
+            </manifest>
+          </archive>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
   <dependencies>
     <dependency>
       <groupId>org.terracotta.entities</groupId>

--- a/data-root-resource/pom.xml
+++ b/data-root-resource/pom.xml
@@ -145,6 +145,17 @@
           </episodes>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifest>
+              <addClasspath>true</addClasspath>
+            </manifest>
+          </archive>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 

--- a/diagnostic/service/pom.xml
+++ b/diagnostic/service/pom.xml
@@ -29,6 +29,22 @@
   <artifactId>diagnostic-service</artifactId>
   <name>Diagnostic :: Service</name>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifest>
+              <addClasspath>true</addClasspath>
+            </manifest>
+          </archive>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
   <dependencies>
     <dependency>
       <groupId>org.terracotta.diagnostic</groupId>
@@ -37,6 +53,11 @@
     </dependency>
 
     <!-- provided on server -->
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
     <dependency>
       <groupId>org.terracotta</groupId>
       <artifactId>standard-cluster-services</artifactId>

--- a/dynamic-config/entities/management-entity/server/pom.xml
+++ b/dynamic-config/entities/management-entity/server/pom.xml
@@ -29,6 +29,22 @@
   <artifactId>dynamic-config-management-entity-server</artifactId>
   <name>Dynamic Config :: Entities :: Management :: Server</name>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifest>
+              <addClasspath>true</addClasspath>
+            </manifest>
+          </archive>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
   <dependencies>
     <dependency>
       <groupId>org.terracotta.dynamic-config.server</groupId>
@@ -52,6 +68,11 @@
     <dependency>
       <groupId>org.terracotta</groupId>
       <artifactId>standard-cluster-services</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
       <scope>provided</scope>
     </dependency>
   </dependencies>

--- a/dynamic-config/entities/nomad-entity/server/pom.xml
+++ b/dynamic-config/entities/nomad-entity/server/pom.xml
@@ -29,6 +29,22 @@
   <artifactId>dynamic-config-nomad-entity-server</artifactId>
   <name>Dynamic Config :: Entities :: Nomad :: Server</name>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifest>
+              <addClasspath>true</addClasspath>
+            </manifest>
+          </archive>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
   <dependencies>
     <dependency>
       <groupId>org.terracotta.dynamic-config.entities</groupId>
@@ -52,6 +68,11 @@
     <dependency>
       <groupId>org.terracotta</groupId>
       <artifactId>standard-cluster-services</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
       <scope>provided</scope>
     </dependency>
   </dependencies>

--- a/dynamic-config/entities/topology-entity/server/pom.xml
+++ b/dynamic-config/entities/topology-entity/server/pom.xml
@@ -29,6 +29,22 @@
   <artifactId>dynamic-config-topology-entity-server</artifactId>
   <name>Dynamic Config :: Entities :: Topology :: Server</name>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifest>
+              <addClasspath>true</addClasspath>
+            </manifest>
+          </archive>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
   <dependencies>
     <dependency>
       <groupId>org.terracotta.dynamic-config.entities</groupId>
@@ -51,6 +67,11 @@
     <dependency>
       <groupId>org.terracotta</groupId>
       <artifactId>standard-cluster-services</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
       <scope>provided</scope>
     </dependency>
   </dependencies>

--- a/dynamic-config/server/configuration-provider/pom.xml
+++ b/dynamic-config/server/configuration-provider/pom.xml
@@ -29,6 +29,22 @@
   <artifactId>dynamic-config-configuration-provider</artifactId>
   <name>Dynamic Config :: Server :: Configuration Provider</name>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifest>
+              <addClasspath>true</addClasspath>
+            </manifest>
+          </archive>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
   <dependencies>
     <dependency>
       <groupId>org.terracotta.dynamic-config.server</groupId>
@@ -66,6 +82,11 @@
     <dependency>
       <groupId>org.terracotta</groupId>
       <artifactId>packaging-support</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
       <scope>provided</scope>
     </dependency>
 

--- a/dynamic-config/server/services/pom.xml
+++ b/dynamic-config/server/services/pom.xml
@@ -29,6 +29,22 @@
   <artifactId>dynamic-config-services</artifactId>
   <name>Dynamic Config :: Server :: Services</name>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifest>
+              <addClasspath>true</addClasspath>
+            </manifest>
+          </archive>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
   <dependencies>
     <dependency>
       <groupId>org.terracotta.dynamic-config.server</groupId>
@@ -47,6 +63,11 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
       <scope>provided</scope>
     </dependency>
 

--- a/dynamic-config/testing/entity/pom.xml
+++ b/dynamic-config/testing/entity/pom.xml
@@ -29,6 +29,22 @@
   <artifactId>dynamic-config-testing-entity</artifactId>
   <name>Dynamic Config :: Testing :: Entity</name>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifest>
+              <addClasspath>true</addClasspath>
+            </manifest>
+          </archive>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
   <dependencies>
     <dependency>
       <groupId>org.terracotta.dynamic-config.server</groupId>
@@ -66,6 +82,11 @@
     <dependency>
       <groupId>org.terracotta</groupId>
       <artifactId>standard-cluster-services</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
       <scope>provided</scope>
     </dependency>
   </dependencies>

--- a/healthchecker-entity/server-impl/pom.xml
+++ b/healthchecker-entity/server-impl/pom.xml
@@ -28,6 +28,22 @@
 
   <artifactId>healthchecker-server</artifactId>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifest>
+              <addClasspath>true</addClasspath>
+            </manifest>
+          </archive>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
   <dependencies>
     <dependency>
       <groupId>org.terracotta</groupId>

--- a/lease/entity-server/pom.xml
+++ b/lease/entity-server/pom.xml
@@ -28,6 +28,22 @@
 
   <artifactId>lease-entity-server</artifactId>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifest>
+              <addClasspath>true</addClasspath>
+            </manifest>
+          </archive>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
   <dependencies>
     <dependency>
       <groupId>org.terracotta</groupId>

--- a/management/monitoring-service/pom.xml
+++ b/management/monitoring-service/pom.xml
@@ -29,6 +29,22 @@
   <artifactId>monitoring-service</artifactId>
   <name>Terracotta Management :: Monitoring Service</name>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifest>
+              <addClasspath>true</addClasspath>
+            </manifest>
+          </archive>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
   <dependencies>
     <!-- will be inside service jar -->
     <dependency>

--- a/management/nms-agent-entity/nms-agent-entity-server/pom.xml
+++ b/management/nms-agent-entity/nms-agent-entity-server/pom.xml
@@ -29,6 +29,22 @@
   <artifactId>nms-agent-entity-server</artifactId>
   <name>Terracotta Management :: NMS Agent Entity :: Server</name>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifest>
+              <addClasspath>true</addClasspath>
+            </manifest>
+          </archive>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
   <dependencies>
     <!-- in common server classpath -->
     <dependency>

--- a/management/nms-entity/nms-entity-server/pom.xml
+++ b/management/nms-entity/nms-entity-server/pom.xml
@@ -29,6 +29,22 @@
   <artifactId>nms-entity-server</artifactId>
   <name>Terracotta Management :: NMS Entity :: Server</name>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifest>
+              <addClasspath>true</addClasspath>
+            </manifest>
+          </archive>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
   <dependencies>
     <!-- common server classpath -->
     <dependency>

--- a/offheap-resource/pom.xml
+++ b/offheap-resource/pom.xml
@@ -145,6 +145,17 @@
           </episodes>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifest>
+              <addClasspath>true</addClasspath>
+            </manifest>
+          </archive>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/platform-base/pom.xml
+++ b/platform-base/pom.xml
@@ -27,6 +27,22 @@
 
   <artifactId>platform-base</artifactId>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifest>
+              <addClasspath>true</addClasspath>
+            </manifest>
+          </archive>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
   <dependencies>
     <dependency>
       <groupId>org.terracotta</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -361,13 +361,6 @@
           <groupId>org.apache.felix</groupId>
           <artifactId>maven-bundle-plugin</artifactId>
           <version>2.5.4</version>
-          <configuration>
-            <archive>
-              <manifest>
-                <addClasspath>true</addClasspath>
-              </manifest>
-            </archive>
-          </configuration>
           <executions>
             <execution>
               <phase>process-classes</phase>

--- a/voltron-proxy/voltron-proxy-server/pom.xml
+++ b/voltron-proxy/voltron-proxy-server/pom.xml
@@ -28,6 +28,22 @@
 
   <artifactId>voltron-proxy-server</artifactId>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifest>
+              <addClasspath>true</addClasspath>
+            </manifest>
+          </archive>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
   <dependencies>
     <dependency>
       <groupId>org.terracotta.voltron.proxy</groupId>
@@ -48,6 +64,11 @@
     <dependency>
       <groupId>org.terracotta</groupId>
       <artifactId>connection-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
       <scope>provided</scope>
     </dependency>
 


### PR DESCRIPTION
- Only add Class-Path in plugin jars, not all jars
- Fix missing provided scopes on some server provided jars (i.e. SLF4J) in plugins POM

I have verified with the following that we do not have nay ref to logback or slf4j inside class-path entries of jars on the server/plugins path:

```bash
for jar in `find kit/target/platform-kit-5.9-SNAPSHOT/platform-kit-5.9-SNAPSHOT/server/plugins -name "*.jar"`; do echo $jar; unzip -p $jar META-INF/MANIFEST.MF | grep -A 8 -i Class-Path | grep -i slf4j; done;

for jar in `find kit/target/platform-kit-5.9-SNAPSHOT/platform-kit-5.9-SNAPSHOT/server/plugins -name "*.jar"`; do echo $jar; unzip -p $jar META-INF/MANIFEST.MF | grep -A 8 -i Class-Path | grep -i logback; done;
```