### PR TITLE
Add settings.xml per project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ nbactions.xml
 target/
 dependency-reduced-pom.xml
 .fbExcludeFilterFile
+.mvn/repository
 
 .checkstyle
 *~

--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 ## For Developers
 
+### IMPORTANT: settings.xml
+
+You can run all the Maven commands with `-s settings.xml` to use the project's settings.xml 
+and isolate downloaded libraries inside. Change the repo location to point to your default m2 home if needed.
+
+Example: `./mvnw -s settings.xml clean install`
+
 ### License Headers
 
 Check for missing licenses:

--- a/settings.xml
+++ b/settings.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright Terracotta, Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
+
+  <!--
+    Use it with:
+    ./mvnw -s settings.xml clean install -Dmaven.test.skip.exec=true
+
+    The goal is to *optionally* isolate the project repositories from any cache, mirror or global setting
+    from ~/.m2/settings.xml that could impact the resolving of libraries (false positives for example),
+    and then consequently make sure the project will work on any system regardless of the existence or
+    not of a global settings.xml or global cache.
+  -->
+
+  <localRepository>.mvn/repository</localRepository>
+  <!--<localRepository>{user.home}/.m2/repository</localRepository>-->
+
+</settings>


### PR DESCRIPTION
I'd like that we have such things per project (`./mvn -s settings.xml ...`), that could be optionally used to:

1. make sure we don't miss any repo for the project
2. isolate the Maven repository per project, which makes sure no library will be found locally and coming from elsewhere not defined in the pom/settings.
3. not be impacted by a global settings.xml that could contain overrides, mirrors, etc
4. avoid us to having to deal with all the troubles coming from settings.xml files  repo and mirrors

In this specific case for platform, the settings is blank because the project runs fine with declared repos in the parent pom.