### PR TITLE
[master] Core already has some default connection and operation timeouts for diagnostic port, so use them if we set null

### DIFF
--- a/diagnostic/client/src/main/java/org/terracotta/diagnostic/client/DiagnosticServiceFactory.java
+++ b/diagnostic/client/src/main/java/org/terracotta/diagnostic/client/DiagnosticServiceFactory.java
@@ -102,7 +102,9 @@ public class DiagnosticServiceFactory {
       throws EntityNotProvidedException, EntityVersionMismatchException, EntityNotFoundException {
     EntityRef<Diagnostics, Object, Properties> ref = connection.getEntityRef(Diagnostics.class, 1, "root");
     Properties properties = new Properties();
-    properties.setProperty(DiagnosticsFactory.REQUEST_TIMEOUT, String.valueOf(diagnosticInvokeTimeout.toMillis()));
+    if (diagnosticInvokeTimeout != null) {
+      properties.setProperty(DiagnosticsFactory.REQUEST_TIMEOUT, String.valueOf(diagnosticInvokeTimeout.toMillis()));
+    }
     Diagnostics delegate = ref.fetchEntity(properties);
     return getDiagnosticService(connection, delegate, objectMapperFactory);
   }

--- a/diagnostic/client/src/main/java/org/terracotta/diagnostic/client/connection/DefaultDiagnosticServiceProvider.java
+++ b/diagnostic/client/src/main/java/org/terracotta/diagnostic/client/connection/DefaultDiagnosticServiceProvider.java
@@ -38,8 +38,8 @@ public class DefaultDiagnosticServiceProvider implements DiagnosticServiceProvid
 
   public DefaultDiagnosticServiceProvider(String connectionName, Duration connectTimeout, Duration diagnosticInvokeTimeout, String securityRootDirectory, ObjectMapperFactory objectMapperFactory) {
     this.connectionName = requireNonNull(connectionName);
-    this.diagnosticInvokeTimeout = requireNonNull(diagnosticInvokeTimeout);
-    this.connectTimeout = requireNonNull(connectTimeout);
+    this.diagnosticInvokeTimeout = diagnosticInvokeTimeout;
+    this.connectTimeout = connectTimeout;
     this.securityRootDirectory = securityRootDirectory;
     this.objectMapperFactory = objectMapperFactory;
   }


### PR DESCRIPTION
Fixing inconsistencies regarding timeouts in API:
- connection timeout can be null, so no need to null-check in the ctor
- request timeout can actually be null because core provides a default one (2 sec) if not set