### PR TITLE
[5.9] Add official support for `-security-dir` in config-tool. The official  param name used by DC and server is called `security-dir`

### DIFF
--- a/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/RemoteMainCommand.java
+++ b/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/RemoteMainCommand.java
@@ -33,7 +33,7 @@ public class RemoteMainCommand extends LocalMainCommand {
   @Parameter(names = {"-connect-timeout", "-connection-timeout", "-t", "--connection-timeout"}, description = "Connection timeout. Default: 30s", converter = TimeUnitConverter.class)
   private Measure<TimeUnit> connectionTimeout = Measure.of(30, TimeUnit.SECONDS);
 
-  @Parameter(names = {"-security-root-directory", "-srd", "--security-root-directory"}, description = "Security root directory")
+  @Parameter(names = {"-security-dir", "-security-root-directory", "-srd", "--security-root-directory"}, description = "Security root directory")
   private String securityRootDirectory;
 
   @Parameter(names = {"-lock-token", "--lock-token"}, hidden = true, description = "Lock token")


### PR DESCRIPTION
(cherry picked from commit 531c6b7ce79ab17351dac0523c65e0b6895a46ee)

This commit needed to be in 5.9 since this is the platform version used downstream...