### PR TITLE
`config-tool activate -stripe <[name/]hostname[:port]|hostname[:port]|…>`

### DIFF
--- a/dynamic-config/cli/cli-support/src/main/java/org/terracotta/dynamic_config/cli/converter/ShapeConverter.java
+++ b/dynamic-config/cli/cli-support/src/main/java/org/terracotta/dynamic_config/cli/converter/ShapeConverter.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.dynamic_config.cli.converter;
+
+import com.beust.jcommander.IStringConverter;
+import com.beust.jcommander.ParameterException;
+import org.terracotta.inet.HostPort;
+
+import java.util.AbstractMap;
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.Map;
+
+/**
+ * @author Mathieu Carbou
+ */
+public class ShapeConverter implements IStringConverter<Map.Entry<Collection<HostPort>, String>> {
+  @Override
+  public Map.Entry<Collection<HostPort>, String> convert(String stripe) {
+    // -stripe <[name/]hostname[:port]|hostname[:port]|...>
+    // LinkedHashMap: to keep stripe ordering as user defined them
+    // Set: node ordering within a stripe is not important
+    final String[] split = stripe.split("/");
+    switch (split.length) {
+      case 1:
+        return new AbstractMap.SimpleEntry<>(new LinkedHashSet<>(HostPort.parse(split[0].split("\\|"), 9410)), null);
+      case 2:
+        return new AbstractMap.SimpleEntry<>(new LinkedHashSet<>(HostPort.parse(split[1].split("\\|"), 9410)), split[0]);
+      default:
+        throw new ParameterException("Wrong stripe format");
+    }
+  }
+}

--- a/dynamic-config/cli/cli-support/src/test/java/org/terracotta/dynamic_config/cli/converter/ShapeConverterTest.java
+++ b/dynamic-config/cli/cli-support/src/test/java/org/terracotta/dynamic_config/cli/converter/ShapeConverterTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.dynamic_config.cli.converter;
+
+import org.junit.Test;
+
+import java.util.AbstractMap;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.terracotta.inet.HostPort.create;
+
+/**
+ * @author Mathieu Carbou
+ */
+public class ShapeConverterTest {
+
+  ShapeConverter converter = new ShapeConverter();
+
+  @Test
+  public void convert_hostports() {
+    assertThat(converter.convert("bar"), is(equalTo(entry(set(create("bar", 9410)), null))));
+    assertThat(converter.convert("bar:123"), is(equalTo(entry(set(create("bar", 123)), null))));
+    assertThat(converter.convert("bar|baz"), is(equalTo(entry(set(create("bar", 9410), create("baz", 9410)), null))));
+    assertThat(converter.convert("bar:123|baz"), is(equalTo(entry(set(create("bar", 123), create("baz", 9410)), null))));
+    assertThat(converter.convert("bar|baz:456"), is(equalTo(entry(set(create("bar", 9410), create("baz", 456)), null))));
+  }
+
+  @Test
+  public void convert_name_hostports() {
+    assertThat(converter.convert("foo/bar"), is(equalTo(entry(set(create("bar", 9410)), "foo"))));
+    assertThat(converter.convert("foo/bar:123"), is(equalTo(entry(set(create("bar", 123)), "foo"))));
+    assertThat(converter.convert("foo/bar|baz"), is(equalTo(entry(set(create("bar", 9410), create("baz", 9410)), "foo"))));
+    assertThat(converter.convert("foo/bar:123|baz"), is(equalTo(entry(set(create("bar", 123), create("baz", 9410)), "foo"))));
+    assertThat(converter.convert("foo/bar|baz:456"), is(equalTo(entry(set(create("bar", 9410), create("baz", 456)), "foo"))));
+  }
+
+  @SafeVarargs
+  @SuppressWarnings("varargs")
+  private static <E> Set<E> set(E... els) {
+    return new HashSet<>(Arrays.asList(els));
+  }
+
+  private static <K, V> Map.Entry<K, V> entry(K k1, V v1) {
+    return new AbstractMap.SimpleEntry<>(k1, v1);
+  }
+}

--- a/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/ActivateCommand.java
+++ b/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/ActivateCommand.java
@@ -24,12 +24,17 @@ import org.terracotta.dynamic_config.cli.api.command.Injector.Inject;
 import org.terracotta.dynamic_config.cli.command.RestartCommand;
 import org.terracotta.dynamic_config.cli.command.Usage;
 import org.terracotta.dynamic_config.cli.converter.HostPortConverter;
+import org.terracotta.dynamic_config.cli.converter.ShapeConverter;
 import org.terracotta.inet.HostPort;
 
 import java.nio.file.Path;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 
 @Parameters(commandDescription = "Activate a cluster")
-@Usage("(-connect-to <hostname[:port]> | -config-file <config.cfg|config.properties>) [-cluster-name <cluster-name>] [-restrict] [-license-file <license-file>] [-restart-wait-time <restart-wait-time>] [-restart-delay <restart-delay>]")
+@Usage("(-connect-to <hostname[:port]> | -config-file <config.cfg|config.properties> | -stripe <[name/]hostname[:port]|hostname[:port]|...>) [-cluster-name <cluster-name>] [-restrict] [-license-file <license-file>] [-restart-wait-time <restart-wait-time>] [-restart-delay <restart-delay>]")
 public class ActivateCommand extends RestartCommand {
 
   @Parameter(names = {"-connect-to"}, description = "Node to connect to", converter = HostPortConverter.class)
@@ -40,6 +45,14 @@ public class ActivateCommand extends RestartCommand {
 
   @Parameter(names = {"-cluster-name"}, description = "Cluster name")
   private String clusterName;
+
+  // Allows to quickly activate a cluster when all nodes are already started with the right parameters
+  // Examples:
+  // config-tool -cluster-name tc-cluster -stripe node-1-1:9410|node-1-2,node-2-1:9410|node-2-2
+  // config-tool -cluster-name tc-cluster -stripe node-1-1:9410|node-1-2 -stripe node-2-1:9410|node-2-2
+  // config-tool -cluster-name tc-cluster -stripe stripe1/node-1-1:9410|node-1-2,stripe2/node-2-1:9410|node-2-2
+  @Parameter(names = {"-stripe"}, description = "Stripe", converter = ShapeConverter.class)
+  private List<Map.Entry<Collection<HostPort>, String>> shape = Collections.emptyList();
 
   @Parameter(names = {"-license-file"}, description = "License file", converter = PathConverter.class)
   private Path licenseFile;
@@ -62,6 +75,13 @@ public class ActivateCommand extends RestartCommand {
   public void run() {
     // basic validations first
 
+    if (!shape.isEmpty() && (node != null || configPropertiesFile != null)) {
+      throw new IllegalArgumentException("Fast activation with '-stripe' cannot be used with '-config-file' and '-connect-to'");
+    }
+    if (!shape.isEmpty() && clusterName == null) {
+      throw new IllegalArgumentException("Fast activation with '-stripe' requires '-cluster-name' to be used");
+    }
+
     if (!restrictedActivation && node != null && configPropertiesFile != null) {
       throw new IllegalArgumentException("Either node or config properties file should be specified, not both");
     }
@@ -80,6 +100,7 @@ public class ActivateCommand extends RestartCommand {
     action.setRestartWaitTime(getRestartWaitTime());
     action.setRestartDelay(getRestartDelay());
     action.setRestrictedActivation(restrictedActivation);
+    action.setShape(shape);
 
     action.run();
   }

--- a/dynamic-config/model/src/main/java/org/terracotta/dynamic_config/api/model/Node.java
+++ b/dynamic-config/model/src/main/java/org/terracotta/dynamic_config/api/model/Node.java
@@ -575,6 +575,9 @@ public class Node implements Cloneable, PropertyHolder {
     return getInternalEndpoint().toString();
   }
 
+  public Node setHostPort(HostPort hostPort) {
+    return setHostname(hostPort.getHost()).setPort(hostPort.getPort());
+  }
 
   /**
    * This class represents an endpoint to use when connecting to a node.

--- a/dynamic-config/model/src/main/java/org/terracotta/dynamic_config/api/model/Stripe.java
+++ b/dynamic-config/model/src/main/java/org/terracotta/dynamic_config/api/model/Stripe.java
@@ -54,7 +54,7 @@ public class Stripe implements Cloneable, PropertyHolder {
   }
 
   public Stripe setName(String name) {
-    this.name = requireNonNull(name);
+    this.name = name;
     return this;
   }
 

--- a/dynamic-config/testing/support/src/main/java/org/terracotta/dynamic_config/test_support/DynamicConfigIT.java
+++ b/dynamic-config/testing/support/src/main/java/org/terracotta/dynamic_config/test_support/DynamicConfigIT.java
@@ -50,8 +50,8 @@ import org.terracotta.dynamic_config.api.json.DynamicConfigApiJsonModule;
 import org.terracotta.dynamic_config.api.model.Cluster;
 import org.terracotta.dynamic_config.api.model.FailoverPriority;
 import org.terracotta.dynamic_config.api.service.TopologyService;
-import org.terracotta.dynamic_config.cli.api.output.ConsoleOutputService;
 import org.terracotta.dynamic_config.cli.api.output.InMemoryOutputService;
+import org.terracotta.dynamic_config.cli.api.output.LoggingOutputService;
 import org.terracotta.dynamic_config.cli.api.output.OutputService;
 import org.terracotta.dynamic_config.cli.config_tool.ConfigTool;
 import org.terracotta.dynamic_config.test_support.util.ConfigurationGenerator;
@@ -462,13 +462,13 @@ public class DynamicConfigIT {
     {
       LOGGER.info("config-tool {}", String.join(" ", newCli));
       InlineToolExecutionResult result = new InlineToolExecutionResult();
-      OutputService out = new ConsoleOutputService().then(result);
+      OutputService out = new LoggingOutputService().then(result);
       try {
         new ConfigTool(out).run(newCli.toArray(new String[0]));
         result.setExitStatus(0);
       } catch (Exception e) {
         result.setExitStatus(1);
-        out.warn("Error: {}", e.getMessage());
+        out.warn("Error: {}", e.getMessage(), e);
       }
       return result;
     }

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activation/ActivateCommand2x2IT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activation/ActivateCommand2x2IT.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.dynamic_config.system_tests.activation;
+
+import org.junit.Test;
+import org.terracotta.dynamic_config.api.model.Cluster;
+import org.terracotta.dynamic_config.test_support.ClusterDefinition;
+import org.terracotta.dynamic_config.test_support.DynamicConfigIT;
+
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.terracotta.angela.client.support.hamcrest.AngelaMatchers.containsOutput;
+import static org.terracotta.angela.client.support.hamcrest.AngelaMatchers.successful;
+
+@ClusterDefinition(stripes = 2, nodesPerStripe = 2)
+public class ActivateCommand2x2IT extends DynamicConfigIT {
+
+  @Test
+  public void test_fast_activation_2x2() {
+    assertThat(
+        configTool("activate", "-cluster-name", "my-cluster",
+            "-stripe", getNodeHostPort(1, 1) + "|" + getNodeHostPort(1, 2),
+            "-stripe", getNodeHostPort(2, 1) + "|" + getNodeHostPort(2, 2)),
+        allOf(successful(), containsOutput("No license specified for activation"), containsOutput("came back up")));
+
+    waitForActive(1);
+    waitForActive(2);
+    waitForPassives(1);
+    waitForPassives(2);
+
+    withTopologyService("localhost", getNodePort(), topologyService -> {
+      Cluster cluster = topologyService.getRuntimeNodeContext().getCluster();
+      assertThat(cluster.getName(), is(equalTo("my-cluster")));
+      assertThat(cluster.getStripeCount(), is(equalTo(2)));
+      assertThat(cluster.getNodeCount(), is(equalTo(4)));
+    });
+  }
+
+  @Test
+  public void test_fast_activation_2x2_comma() {
+    assertThat(
+        configTool("activate", "-cluster-name", "my-cluster", "-stripe", getNodeHostPort(1, 1) + "|" + getNodeHostPort(1, 2) + "," + getNodeHostPort(2, 1) + "|" + getNodeHostPort(2, 2)),
+        allOf(successful(), containsOutput("No license specified for activation"), containsOutput("came back up")));
+
+    waitForActive(1);
+    waitForActive(2);
+    waitForPassives(1);
+    waitForPassives(2);
+
+    withTopologyService("localhost", getNodePort(), topologyService -> {
+      Cluster cluster = topologyService.getRuntimeNodeContext().getCluster();
+      assertThat(cluster.getName(), is(equalTo("my-cluster")));
+      assertThat(cluster.getStripeCount(), is(equalTo(2)));
+      assertThat(cluster.getNodeCount(), is(equalTo(4)));
+    });
+  }
+
+  @Test
+  public void test_fast_activation_2x2_with_stripe_name() {
+    assertThat(
+        configTool("activate", "-cluster-name", "my-cluster",
+            "-stripe", "foo/" + getNodeHostPort(1, 1) + "|" + getNodeHostPort(1, 2),
+            "-stripe", "bar/" + getNodeHostPort(2, 1) + "|" + getNodeHostPort(2, 2)),
+        allOf(successful(), containsOutput("No license specified for activation"), containsOutput("came back up")));
+
+    waitForActive(1);
+    waitForActive(2);
+    waitForPassives(1);
+    waitForPassives(2);
+
+    withTopologyService("localhost", getNodePort(), topologyService -> {
+      Cluster cluster = topologyService.getRuntimeNodeContext().getCluster();
+      assertThat(cluster.getName(), is(equalTo("my-cluster")));
+      assertThat(cluster.getStripeCount(), is(equalTo(2)));
+      assertThat(cluster.getNodeCount(), is(equalTo(4)));
+      assertTrue(cluster.getStripeByName("foo").isPresent());
+      assertTrue(cluster.getStripeByName("bar").isPresent());
+    });
+  }
+
+  @Test
+  public void test_fast_activation_2x2_with_duplicate_stripe_name() {
+    assertThat(
+        configTool("activate", "-cluster-name", "my-cluster",
+            "-stripe", "foo/" + getNodeHostPort(1, 1) + "|" + getNodeHostPort(1, 2),
+            "-stripe", "foo/" + getNodeHostPort(2, 1) + "|" + getNodeHostPort(2, 2)),
+        allOf(not(successful()), containsOutput("Found duplicate stripe name: foo")));
+  }
+}


### PR DESCRIPTION
Allows to quickly activate a cluster when all nodes are already started with the right parameters

**Examples:**

`config-tool -cluster-name tc-cluster -stripe node-1-1:9410|node-1-2,node-2-1:9410|node-2-2`

`config-tool -cluster-name tc-cluster -stripe node-1-1:9410|node-1-2 -stripe node-2-1:9410|node-2-2`

`config-tool -cluster-name tc-cluster -stripe stripe1/node-1-1:9410|node-1-2,stripe2/node-2-1:9410|node-2-2`

**Notes:**

- the separator characters used (`/` and `|`) are not a choice but more constrained coming from the [set of characters that we do not allow to have in both hostnames and stripe names](https://github.com/Terracotta-OSS/terracotta-platform/blob/master/dynamic-config/model/src/main/java/org/terracotta/dynamic_config/api/service/ClusterValidator.java#L58-L68). Also `,` is already taken by JCommander to split parameter values.
- Nodes are expected to have the exact same cluster-wide settings , otherwise validation failure. It means the nodes have to be started, like in a cloud env, with similar cluster-wide settings but can have each one different node-specific settings
- Nodes have to be started with an empty topology (they should be alone)