### PR TITLE
`config-tool` updates

### DIFF
--- a/diagnostic/client/src/main/java/org/terracotta/diagnostic/client/connection/ConcurrentDiagnosticServiceProvider.java
+++ b/diagnostic/client/src/main/java/org/terracotta/diagnostic/client/connection/ConcurrentDiagnosticServiceProvider.java
@@ -69,6 +69,10 @@ public class ConcurrentDiagnosticServiceProvider implements MultiDiagnosticServi
   }
 
   private <K> DiagnosticServices<K> _fetchOnlineDiagnosticService(Map<K, InetSocketAddress> addresses, boolean firstAvailable, Duration connTimeout) {
+    if (addresses.isEmpty() && firstAvailable) {
+      throw new IllegalArgumentException("Unable to find any online node: no address provided");
+    }
+
     if (addresses.isEmpty()) {
       return new DiagnosticServices<>(emptyMap(), emptyMap());
     }
@@ -121,6 +125,10 @@ public class ConcurrentDiagnosticServiceProvider implements MultiDiagnosticServi
       } catch (ExecutionException e) {
         // impossible since we catch Throwable in the submitted task
         throw new AssertionError(e);
+      }
+
+      if (online.isEmpty() && firstAvailable) {
+        throw new IllegalArgumentException("Unable to find any reachable node amongst: " + addresses);
       }
 
       return new DiagnosticServices<>(online, offline);

--- a/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/ActivateCommand.java
+++ b/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/ActivateCommand.java
@@ -38,7 +38,7 @@ import java.util.Map;
 public class ActivateCommand extends RestartCommand {
 
   @Parameter(names = {"-connect-to"}, description = "Node to connect to", converter = HostPortConverter.class)
-  private HostPort node;
+  private List<HostPort> nodes = Collections.emptyList();
 
   @Parameter(names = {"-config-file"}, description = "Configuration properties file containing nodes to be activated", converter = PathConverter.class)
   private Path configPropertiesFile;
@@ -57,7 +57,7 @@ public class ActivateCommand extends RestartCommand {
   @Parameter(names = {"-license-file"}, description = "License file", converter = PathConverter.class)
   private Path licenseFile;
 
-  @Parameter(names = {"-restrict"}, description = "Restrict the activation process to the node only")
+  @Parameter(names = {"-restrict"}, description = "Restrict the activation process to the specified nodes only")
   protected boolean restrictedActivation = false;
 
   @Inject
@@ -75,25 +75,25 @@ public class ActivateCommand extends RestartCommand {
   public void run() {
     // basic validations first
 
-    if (!shape.isEmpty() && (node != null || configPropertiesFile != null)) {
+    if (!shape.isEmpty() && (!nodes.isEmpty() || configPropertiesFile != null)) {
       throw new IllegalArgumentException("Fast activation with '-stripe' cannot be used with '-config-file' and '-connect-to'");
     }
     if (!shape.isEmpty() && clusterName == null) {
       throw new IllegalArgumentException("Fast activation with '-stripe' requires '-cluster-name' to be used");
     }
 
-    if (!restrictedActivation && node != null && configPropertiesFile != null) {
+    if (!restrictedActivation && !nodes.isEmpty() && configPropertiesFile != null) {
       throw new IllegalArgumentException("Either node or config properties file should be specified, not both");
     }
 
-    if (restrictedActivation && node == null) {
+    if (restrictedActivation && nodes.isEmpty()) {
       throw new IllegalArgumentException("A node must be supplied for a restricted activation");
     }
 
     if (licenseFile != null && !licenseFile.toFile().exists()) {
       throw new ParameterException("License file not found: " + licenseFile);
     }
-    action.setNode(node);
+    action.setNodess(nodes);
     action.setConfigPropertiesFile(configPropertiesFile);
     action.setClusterName(clusterName);
     action.setLicenseFile(licenseFile);

--- a/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/DiagnosticCommand.java
+++ b/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/DiagnosticCommand.java
@@ -24,12 +24,15 @@ import org.terracotta.dynamic_config.cli.command.Usage;
 import org.terracotta.dynamic_config.cli.converter.HostPortConverter;
 import org.terracotta.inet.HostPort;
 
+import java.util.Collections;
+import java.util.List;
+
 @Parameters(commandDescription = "Diagnose a cluster configuration")
-@Usage("-connect-to <hostname[:port]> [-output-format <text|json>]")
+@Usage("-connect-to <hostname[:port]>")
 public class DiagnosticCommand extends Command {
 
   @Parameter(names = {"-connect-to"}, description = "Node to connect to", required = true, converter = HostPortConverter.class)
-  private HostPort node;
+  private List<HostPort> nodes = Collections.emptyList();
 
   @Inject
   public final DiagnosticAction action;
@@ -44,7 +47,7 @@ public class DiagnosticCommand extends Command {
 
   @Override
   public void run() {
-    action.setNode(node);
+    action.setNodes(nodes);
 
     action.run();
   }

--- a/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/DiagnosticCommand.java
+++ b/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/DiagnosticCommand.java
@@ -28,11 +28,14 @@ import java.util.Collections;
 import java.util.List;
 
 @Parameters(commandDescription = "Diagnose a cluster configuration")
-@Usage("-connect-to <hostname[:port]>")
+@Usage("-connect-to <hostname[:port]> [-output-format <text|json>]")
 public class DiagnosticCommand extends Command {
 
   @Parameter(names = {"-connect-to"}, description = "Node to connect to", required = true, converter = HostPortConverter.class)
   private List<HostPort> nodes = Collections.emptyList();
+
+  @Parameter(names = {"-output-format"}, description = "Output format for the diagnostic")
+  private String outputFormat = "text";
 
   @Inject
   public final DiagnosticAction action;
@@ -48,6 +51,7 @@ public class DiagnosticCommand extends Command {
   @Override
   public void run() {
     action.setNodes(nodes);
+    action.setOutputFormat(outputFormat);
 
     action.run();
   }

--- a/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/DiagnosticCommand.java
+++ b/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/DiagnosticCommand.java
@@ -25,7 +25,7 @@ import org.terracotta.dynamic_config.cli.converter.HostPortConverter;
 import org.terracotta.inet.HostPort;
 
 @Parameters(commandDescription = "Diagnose a cluster configuration")
-@Usage("-connect-to <hostname[:port]>")
+@Usage("-connect-to <hostname[:port]> [-output-format <text|json>]")
 public class DiagnosticCommand extends Command {
 
   @Parameter(names = {"-connect-to"}, description = "Node to connect to", required = true, converter = HostPortConverter.class)

--- a/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/GetCommand.java
+++ b/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/GetCommand.java
@@ -30,6 +30,7 @@ import org.terracotta.dynamic_config.cli.converter.HostPortConverter;
 import org.terracotta.dynamic_config.cli.converter.MultiConfigCommaSplitter;
 import org.terracotta.inet.HostPort;
 
+import java.util.Collections;
 import java.util.List;
 
 @Parameters(commandDescription = "Read configuration properties")
@@ -37,7 +38,7 @@ import java.util.List;
 public class GetCommand extends Command {
 
   @Parameter(names = {"-connect-to"}, description = "Node to connect to", required = true, converter = HostPortConverter.class)
-  HostPort node;
+  List<HostPort> nodes = Collections.emptyList();
 
   @Parameter(names = {"-setting"}, description = "Configuration properties", splitter = MultiConfigCommaSplitter.class, required = true, converter = ConfigurationInputConverter.class)
   List<ConfigurationInput> inputs;
@@ -61,7 +62,7 @@ public class GetCommand extends Command {
 
   @Override
   public void run() {
-    action.setNode(node);
+    action.setNodes(nodes);
     action.setConfigurationInputs(inputs);
     action.setRuntimeConfig(wantsRuntimeConfig);
     action.setOutputFormat(outputFormat);

--- a/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/ImportCommand.java
+++ b/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/ImportCommand.java
@@ -26,13 +26,15 @@ import org.terracotta.dynamic_config.cli.converter.HostPortConverter;
 import org.terracotta.inet.HostPort;
 
 import java.nio.file.Path;
+import java.util.Collections;
+import java.util.List;
 
 @Parameters(commandDescription = "Import a cluster configuration")
 @Usage("-config-file <config.cfg|config.properties> [-connect-to <hostname[:port]>]")
 public class ImportCommand extends Command {
 
   @Parameter(names = {"-connect-to"}, description = "Node to connect to", converter = HostPortConverter.class)
-  private HostPort node;
+  private List<HostPort> nodes = Collections.emptyList();
 
   @Parameter(names = {"-config-file"}, description = "Config file", required = true, converter = PathConverter.class)
   private Path configFile;
@@ -50,7 +52,7 @@ public class ImportCommand extends Command {
 
   @Override
   public void run() {
-    action.setNode(node);
+    action.setNodes(nodes);
     action.setConfigFile(configFile);
 
     action.run();

--- a/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/SetCommand.java
+++ b/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/SetCommand.java
@@ -27,6 +27,7 @@ import org.terracotta.dynamic_config.cli.converter.HostPortConverter;
 import org.terracotta.dynamic_config.cli.converter.MultiConfigCommaSplitter;
 import org.terracotta.inet.HostPort;
 
+import java.util.Collections;
 import java.util.List;
 
 @Parameters(commandDescription = "Set configuration properties")
@@ -34,7 +35,7 @@ import java.util.List;
 public class SetCommand extends RestartCommand {
 
   @Parameter(names = {"-connect-to"}, description = "Node to connect to", required = true, converter = HostPortConverter.class)
-  HostPort node;
+  List<HostPort> nodes = Collections.emptyList();
 
   @Parameter(names = {"-setting"}, description = "Configuration properties", splitter = MultiConfigCommaSplitter.class, required = true, converter = ConfigurationInputConverter.class)
   List<ConfigurationInput> inputs;
@@ -55,7 +56,7 @@ public class SetCommand extends RestartCommand {
 
   @Override
   public void run() {
-    action.setNode(node);
+    action.setNodes(nodes);
     action.setConfigurationInputs(inputs);
     action.setAutoRestart(autoRestart);
     action.setRestartWaitTime(getRestartWaitTime());

--- a/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/UnsetCommand.java
+++ b/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/UnsetCommand.java
@@ -27,6 +27,7 @@ import org.terracotta.dynamic_config.cli.converter.HostPortConverter;
 import org.terracotta.dynamic_config.cli.converter.MultiConfigCommaSplitter;
 import org.terracotta.inet.HostPort;
 
+import java.util.Collections;
 import java.util.List;
 
 @Parameters(commandDescription = "Unset configuration properties")
@@ -34,7 +35,7 @@ import java.util.List;
 public class UnsetCommand extends RestartCommand {
 
   @Parameter(names = {"-connect-to"}, description = "Node to connect to", required = true, converter = HostPortConverter.class)
-  HostPort node;
+  List<HostPort> nodes = Collections.emptyList();
 
   @Parameter(names = {"-setting"}, description = "Configuration properties", splitter = MultiConfigCommaSplitter.class, required = true, converter = ConfigurationInputConverter.class)
   List<ConfigurationInput> inputs;
@@ -55,7 +56,7 @@ public class UnsetCommand extends RestartCommand {
 
   @Override
   public void run() {
-    action.setNode(node);
+    action.setNodes(nodes);
     action.setConfigurationInputs(inputs);
     action.setAutoRestart(autoRestart);
     action.setRestartWaitTime(getRestartWaitTime());

--- a/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/deprecated/DeprecatedActivateCommand.java
+++ b/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/deprecated/DeprecatedActivateCommand.java
@@ -31,6 +31,8 @@ import org.terracotta.inet.HostPort;
 
 import java.nio.file.Path;
 
+import static java.util.Collections.singletonList;
+
 @Parameters(commandDescription = "Activate a cluster")
 @Usage("(-s <hostname[:port]> | -f <config.cfg|config.properties>) [-n <cluster-name>] [-R] [-l <license-file>] [-W <restart-wait-time>] [-D <restart-delay>]")
 public class DeprecatedActivateCommand extends Command {
@@ -80,7 +82,7 @@ public class DeprecatedActivateCommand extends Command {
     if (licenseFile != null && !licenseFile.toFile().exists()) {
       throw new ParameterException("License file not found: " + licenseFile);
     }
-    action.setNode(node);
+    action.setNodess(singletonList(node));
     action.setConfigPropertiesFile(configPropertiesFile);
     action.setClusterName(clusterName);
     action.setLicenseFile(licenseFile);

--- a/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/deprecated/DeprecatedDiagnosticCommand.java
+++ b/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/deprecated/DeprecatedDiagnosticCommand.java
@@ -24,6 +24,9 @@ import org.terracotta.dynamic_config.cli.command.Usage;
 import org.terracotta.dynamic_config.cli.converter.HostPortConverter;
 import org.terracotta.inet.HostPort;
 
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+
 @Parameters(commandDescription = "Diagnose a cluster configuration")
 @Usage("-s <hostname[:port]>")
 public class DeprecatedDiagnosticCommand extends Command {
@@ -43,7 +46,7 @@ public class DeprecatedDiagnosticCommand extends Command {
 
   @Override
   public void run() {
-    action.setNode(node);
+    action.setNodes(node == null ? emptyList() : singletonList(node));
 
     action.run();
   }

--- a/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/deprecated/DeprecatedGetCommand.java
+++ b/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/deprecated/DeprecatedGetCommand.java
@@ -32,6 +32,9 @@ import org.terracotta.inet.HostPort;
 
 import java.util.List;
 
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+
 @Parameters(commandDescription = "Read configuration properties")
 @Usage("-s <hostname[:port]> [-r] [-t cfg|properties] -c <[namespace:]property> -c <[namespace:]property> ...")
 public class DeprecatedGetCommand extends Command {
@@ -61,7 +64,7 @@ public class DeprecatedGetCommand extends Command {
 
   @Override
   public void run() {
-    action.setNode(node);
+    action.setNodes(node == null ? emptyList() : singletonList(node));
     action.setConfigurationInputs(inputs);
     action.setRuntimeConfig(wantsRuntimeConfig);
     action.setOutputFormat(outputFormat);

--- a/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/deprecated/DeprecatedImportCommand.java
+++ b/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/deprecated/DeprecatedImportCommand.java
@@ -27,6 +27,9 @@ import org.terracotta.inet.HostPort;
 
 import java.nio.file.Path;
 
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+
 @Parameters(commandDescription = "Import a cluster configuration")
 @Usage("-f <config.cfg|config.properties> [-s <hostname[:port]>]")
 public class DeprecatedImportCommand extends Command {
@@ -50,7 +53,7 @@ public class DeprecatedImportCommand extends Command {
 
   @Override
   public void run() {
-    action.setNode(node);
+    action.setNodes(node == null ? emptyList() : singletonList(node));
     action.setConfigFile(configFile);
 
     action.run();

--- a/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/deprecated/DeprecatedSetCommand.java
+++ b/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/deprecated/DeprecatedSetCommand.java
@@ -32,6 +32,9 @@ import org.terracotta.inet.HostPort;
 
 import java.util.List;
 
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+
 @Parameters(commandDescription = "Set configuration properties")
 @Usage("-s <hostname[:port]> -c <[namespace:]property=value> -c <[namespace:]property=value> ...")
 public class DeprecatedSetCommand extends Command {
@@ -61,7 +64,7 @@ public class DeprecatedSetCommand extends Command {
 
   @Override
   public void run() {
-    action.setNode(node);
+    action.setNodes(node == null ? emptyList() : singletonList(node));
     action.setConfigurationInputs(inputs);
     action.setRestartDelay(restartDelay);
     action.setRestartWaitTime(restartWaitTime);

--- a/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/deprecated/DeprecatedUnsetCommand.java
+++ b/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/deprecated/DeprecatedUnsetCommand.java
@@ -32,6 +32,9 @@ import org.terracotta.inet.HostPort;
 
 import java.util.List;
 
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+
 @Parameters(commandDescription = "Unset configuration properties")
 @Usage("-s <hostname[:port]> -c <[namespace:]property> -c <[namespace:]property> ...")
 public class DeprecatedUnsetCommand extends Command {
@@ -61,7 +64,7 @@ public class DeprecatedUnsetCommand extends Command {
 
   @Override
   public void run() {
-    action.setNode(node);
+    action.setNodes(node == null ? emptyList() : singletonList(node));
     action.setConfigurationInputs(inputs);
     action.setRestartDelay(restartDelay);
     action.setRestartWaitTime(restartWaitTime);

--- a/dynamic-config/cli/dynamic-config-cli-api/src/main/java/org/terracotta/dynamic_config/cli/api/command/ConfigurationAction.java
+++ b/dynamic-config/cli/dynamic-config-cli-api/src/main/java/org/terracotta/dynamic_config/cli/api/command/ConfigurationAction.java
@@ -24,6 +24,7 @@ import org.terracotta.dynamic_config.api.model.Setting;
 import org.terracotta.inet.HostPort;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
@@ -36,6 +37,7 @@ import static org.terracotta.dynamic_config.api.model.ClusterState.CONFIGURING;
 public abstract class ConfigurationAction extends RemoteAction {
 
   protected HostPort node;
+  protected List<HostPort> nodes = Collections.emptyList();
   protected List<Configuration> configurations;
   protected List<ConfigurationInput> inputs;
 
@@ -46,12 +48,13 @@ public abstract class ConfigurationAction extends RemoteAction {
   protected boolean isActivated;
   protected ClusterState clusterState;
 
+
   protected ConfigurationAction(Operation operation) {
     this.operation = operation;
   }
 
-  public void setNode(HostPort node) {
-    this.node = node;
+  public void setNodes(List<HostPort> nodes) {
+    this.nodes = nodes;
   }
 
   public void setConfigurationInputs(List<ConfigurationInput> inputs) {
@@ -59,6 +62,7 @@ public abstract class ConfigurationAction extends RemoteAction {
   }
 
   protected void validate() {
+    node = findAnyOnlineNode(nodes).getHostPort();
 
     Cluster cluster = getRuntimeCluster(node);
 

--- a/dynamic-config/cli/dynamic-config-cli-api/src/main/java/org/terracotta/dynamic_config/cli/api/command/DiagnosticAction.java
+++ b/dynamic-config/cli/dynamic-config-cli-api/src/main/java/org/terracotta/dynamic_config/cli/api/command/DiagnosticAction.java
@@ -27,7 +27,9 @@ import java.time.Clock;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Comparator;
+import java.util.List;
 import java.util.Map;
 import java.util.TreeSet;
 
@@ -39,16 +41,16 @@ import static java.util.stream.Collectors.toSet;
  */
 public class DiagnosticAction extends RemoteAction {
 
-  private HostPort node;
+  private List<HostPort> nodes = Collections.emptyList();
 
-  public void setNode(HostPort node) {
-    this.node = node;
+  public void setNodes(List<HostPort> nodes) {
+    this.nodes = nodes;
   }
 
   @Override
   public final void run() {
     // this call can take some time and we can have some timeout
-    Map<Node.Endpoint, LogicalServerState> allNodes = findRuntimePeersStatus(node);
+    Map<Node.Endpoint, LogicalServerState> allNodes = findRuntimePeersStatus(nodes);
 
     ConfigurationConsistencyAnalyzer configurationConsistencyAnalyzer = analyzeNomadConsistency(allNodes);
     Collection<HostPort> onlineNodes = sort(configurationConsistencyAnalyzer.getOnlineNodes().keySet());

--- a/dynamic-config/cli/dynamic-config-cli-api/src/main/java/org/terracotta/dynamic_config/cli/api/command/ExportAction.java
+++ b/dynamic-config/cli/dynamic-config-cli-api/src/main/java/org/terracotta/dynamic_config/cli/api/command/ExportAction.java
@@ -15,18 +15,14 @@
  */
 package org.terracotta.dynamic_config.cli.api.command;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terracotta.dynamic_config.api.model.Cluster;
 import org.terracotta.dynamic_config.api.model.ConfigFormat;
 import org.terracotta.dynamic_config.api.service.ConfigPropertiesTranslator;
 import org.terracotta.dynamic_config.api.service.Props;
-import org.terracotta.dynamic_config.cli.api.command.Injector.Inject;
 import org.terracotta.dynamic_config.cli.api.output.FileOutputService;
 import org.terracotta.inet.HostPort;
-import org.terracotta.json.ObjectMapperFactory;
 
 import java.io.IOException;
 import java.io.StringWriter;
@@ -45,8 +41,6 @@ public class ExportAction extends RemoteAction {
   private boolean includeDefaultValues;
   private boolean wantsRuntimeConfig;
   private ConfigFormat outputFormat = ConfigFormat.CONFIG;
-
-  @Inject public ObjectMapperFactory objectMapperFactory;
 
   public void setNode(HostPort node) {
     this.node = node;
@@ -108,15 +102,7 @@ public class ExportAction extends RemoteAction {
     ConfigFormat outputFormat = outputFile == null ? this.outputFormat : ConfigFormat.from(outputFile);
     switch (outputFormat) {
       case JSON:
-        try {
-          return objectMapperFactory.pretty().create()
-              // shows optional values that are unset
-              .setSerializationInclusion(JsonInclude.Include.ALWAYS)
-              .setDefaultPropertyInclusion(JsonInclude.Include.ALWAYS)
-              .writeValueAsString(cluster);
-        } catch (JsonProcessingException e) {
-          throw new AssertionError(e);
-        }
+        return toJson(cluster);
       case CONFIG:
       case PROPERTIES:
         // user-defined

--- a/dynamic-config/cli/dynamic-config-cli-api/src/main/java/org/terracotta/dynamic_config/cli/api/command/RepairAction.java
+++ b/dynamic-config/cli/dynamic-config-cli-api/src/main/java/org/terracotta/dynamic_config/cli/api/command/RepairAction.java
@@ -111,7 +111,7 @@ public class RepairAction extends RemoteAction {
         break;
 
       case DISCOVERY_FAILURE:
-        LOGGER.error(description, configurationConsistencyAnalyzer.getDiscoverFailure());
+        LOGGER.error(description, configurationConsistencyAnalyzer.getDiscoverFailure().get());
         break;
 
       case INCONSISTENT:

--- a/dynamic-config/cli/dynamic-config-cli-api/src/main/java/org/terracotta/dynamic_config/cli/api/command/TopologyAction.java
+++ b/dynamic-config/cli/dynamic-config-cli-api/src/main/java/org/terracotta/dynamic_config/cli/api/command/TopologyAction.java
@@ -15,7 +15,6 @@
  */
 package org.terracotta.dynamic_config.cli.api.command;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terracotta.diagnostic.model.LogicalServerState;
@@ -23,12 +22,9 @@ import org.terracotta.dynamic_config.api.model.Cluster;
 import org.terracotta.dynamic_config.api.model.Node.Endpoint;
 import org.terracotta.dynamic_config.api.model.nomad.TopologyNomadChange;
 import org.terracotta.dynamic_config.api.service.ClusterValidator;
-import org.terracotta.dynamic_config.cli.api.command.Injector.Inject;
 import org.terracotta.dynamic_config.cli.api.converter.OperationType;
 import org.terracotta.inet.HostPort;
-import org.terracotta.json.ObjectMapperFactory;
 
-import java.io.UncheckedIOException;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Map;
@@ -48,8 +44,6 @@ public abstract class TopologyAction extends RemoteAction {
   protected OperationType operationType = OperationType.NODE;
   protected HostPort destinationHostPort;
   protected boolean force;
-
-  @Inject public ObjectMapperFactory objectMapperFactory;
 
   protected Endpoint destination;
 
@@ -99,11 +93,7 @@ public abstract class TopologyAction extends RemoteAction {
     new ClusterValidator(result).validate(destinationClusterActivated ? ACTIVATED : CONFIGURING);
 
     if (LOGGER.isDebugEnabled()) {
-      try {
-        LOGGER.debug("Updated topology:{}{}.", lineSeparator(), objectMapperFactory.create().writerWithDefaultPrettyPrinter().writeValueAsString(result));
-      } catch (JsonProcessingException e) {
-        throw new UncheckedIOException(e);
-      }
+      LOGGER.debug("Updated topology:{}{}.", lineSeparator(), toJson(result));
     }
 
     // push the updated topology to all the addresses

--- a/dynamic-config/cli/dynamic-config-cli-api/src/main/java/org/terracotta/dynamic_config/cli/api/nomad/DefaultNomadManager.java
+++ b/dynamic-config/cli/dynamic-config-cli-api/src/main/java/org/terracotta/dynamic_config/cli/api/nomad/DefaultNomadManager.java
@@ -75,7 +75,7 @@ import static org.terracotta.diagnostic.model.LogicalServerState.PASSIVE;
 public class DefaultNomadManager<T> implements NomadManager<T> {
   private static final Logger LOGGER = LoggerFactory.getLogger(NomadManager.class);
 
-  private static final EnumSet<LogicalServerState> ALLOWED = EnumSet.of(
+  public static final EnumSet<LogicalServerState> ALLOWED = EnumSet.of(
       ACTIVE,
       PASSIVE,
       ACTIVE_RECONNECTING,

--- a/dynamic-config/cli/dynamic-config-cli-api/src/test/java/org/terracotta/dynamic_config/cli/api/command/ActivateActionTest.java
+++ b/dynamic-config/cli/dynamic-config-cli-api/src/test/java/org/terracotta/dynamic_config/cli/api/command/ActivateActionTest.java
@@ -280,7 +280,7 @@ public class ActivateActionTest extends BaseTest {
 
   private ActivateAction command() {
     ActivateAction command = new ActivateAction();
-    inject(command, asList(diagnosticServiceProvider, multiDiagnosticServiceProvider, nomadManager, restartService, stopService, nomadEntityProvider, outputService));
+    inject(command, asList(diagnosticServiceProvider, multiDiagnosticServiceProvider, nomadManager, restartService, stopService, nomadEntityProvider, outputService, objectMapperFactory));
     return command;
   }
 

--- a/dynamic-config/cli/dynamic-config-cli-api/src/test/java/org/terracotta/dynamic_config/cli/api/command/ActivateActionTest.java
+++ b/dynamic-config/cli/dynamic-config-cli-api/src/test/java/org/terracotta/dynamic_config/cli/api/command/ActivateActionTest.java
@@ -244,7 +244,7 @@ public class ActivateActionTest extends BaseTest {
   @Test
   public void test_activate_from_node_and_cluster_name() {
     ActivateAction command = command();
-    command.setNode(HostPort.create("localhost", 9411));
+    command.setNodess(asList(HostPort.create("localhost", 9411)));
     command.setClusterName("foo");
     doRunAndVerify("foo", command);
   }

--- a/dynamic-config/cli/dynamic-config-cli-api/src/test/java/org/terracotta/dynamic_config/cli/api/command/ImportActionTest.java
+++ b/dynamic-config/cli/dynamic-config-cli-api/src/test/java/org/terracotta/dynamic_config/cli/api/command/ImportActionTest.java
@@ -37,7 +37,7 @@ public class ImportActionTest extends BaseTest {
   public void test_import() throws Exception {
 
     ImportAction command = new ImportAction();
-    inject(command, asList(diagnosticServiceProvider, multiDiagnosticServiceProvider, nomadManager, restartService, stopService, nomadEntityProvider, outputService));
+    inject(command, asList(diagnosticServiceProvider, multiDiagnosticServiceProvider, nomadManager, restartService, stopService, nomadEntityProvider, outputService, objectMapperFactory));
     command.setConfigFile(Paths.get(getClass().getResource("/my-cluster.cfg").toURI()));
     command.run();
 

--- a/dynamic-config/model/src/main/java/org/terracotta/dynamic_config/api/model/Cluster.java
+++ b/dynamic-config/model/src/main/java/org/terracotta/dynamic_config/api/model/Cluster.java
@@ -507,7 +507,7 @@ public class Cluster implements Cloneable, PropertyHolder {
    * Search all endpoints of all nodes matching this address. A result can contain several endpoints of the same node
    */
   public Collection<? extends Endpoint> search(Collection<? extends HostPort> hostPorts) {
-    return hostPorts.stream()
+    return hostPorts == null ? Collections.emptyList() : hostPorts.stream()
         .flatMap(addr -> getNodes().stream().flatMap(node -> node.findEndpoints(addr).stream()))
         .collect(toList());
   }


### PR DESCRIPTION
## `config-tool` support for multiple `-connect-to` parameters for get|set|unset|import|diagnostic|activate

### For activate:

Supporting multiple `-connect-to` parameters is useful in the case of a repair when force-pushing and force-activating a topology to some nodes, instead of doing node by node.

### For get|set|unset:

Supporting multiple `-connect-to` parameters allows the caller to pass all the known nodes of the cluster, and config-tool will pick one to fetch the topology. These commands can be run with some nodes down so supporting multiple values allows to pass all known pods in the CLI in a cloud env.

### For import:

Same for activate: allows tp import a cluster config to several nodes at once

### For diagnostic:

Same as get|set : diag command can be run over a cluster where some nodes are down, so it needs to support a complete set of pods and will detect the ones reachable

All these use cases are not only for cloud but for normal deployments, but they are really valuable on a cloud env.

## `config-tool.sh diagnostic -connect-to localhost -output-format json`

Enables an easier processing of diagnotic output.

For Kube Operator, these fields are relevant:

- `manualInterventionRequired`
- `readyForTopologyChange`

### Example for a node in diagnostic mode

- manualInterventionRequired: false
- readyForTopologyChange: false

```json
{
  "configChangeCommittedAll" : false,
  "configChangeCommittedOnline" : false,
  "configChangeInProgress" : false,
  "configChangePartiallyCommitted" : false,
  "configChangePartiallyPrepared" : false,
  "configChangePartiallyRolledBack" : false,
  "configChangePreparedAll" : false,
  "configChangePreparedOnline" : false,
  "configDiscoveryFailed" : false,
  "configDiscoveryFailure" : null,
  "configInconsistent" : false,
  "configLocked" : false,
  "configLockedToken" : null,
  "configPartitioned" : false,
  "manualInterventionRequired" : false,
  "nodeStates" : {
    "DIAGNOSTIC" : 1
  },
  "nodes" : 1,
  "nodesInActiveMode" : 0,
  "nodesInConfigMode" : 1,
  "nodesInRepairMode" : 0,
  "nodesOnline" : 1,
  "nodesRequiringRestart" : 0,
  "nodesUnreachable" : 0,
  "readyForTopologyChange" : false,
  "stripes" : 1
}
```

### Example for an activated node

- manualInterventionRequired: false
- readyForTopologyChange: true

```json
{
  "configChangeCommittedAll" : true,
  "configChangeCommittedOnline" : false,
  "configChangeInProgress" : false,
  "configChangePartiallyCommitted" : false,
  "configChangePartiallyPrepared" : false,
  "configChangePartiallyRolledBack" : false,
  "configChangePreparedAll" : false,
  "configChangePreparedOnline" : false,
  "configDiscoveryFailed" : false,
  "configDiscoveryFailure" : null,
  "configInconsistent" : false,
  "configLocked" : false,
  "configLockedToken" : null,
  "configPartitioned" : false,
  "manualInterventionRequired" : false,
  "nodeStates" : {
    "ACTIVE" : 1
  },
  "nodes" : 1,
  "nodesInActiveMode" : 1,
  "nodesInConfigMode" : 0,
  "nodesInRepairMode" : 0,
  "nodesOnline" : 1,
  "nodesRequiringRestart" : 0,
  "nodesUnreachable" : 0,
  "readyForTopologyChange" : true,
  "stripes" : 1
}
```

### Example for a node in repair mode

- manualInterventionRequired: false
- readyForTopologyChange: false

```json
{
  "configChangeCommittedAll" : true,
  "configChangeCommittedOnline" : false,
  "configChangeInProgress" : false,
  "configChangePartiallyCommitted" : false,
  "configChangePartiallyPrepared" : false,
  "configChangePartiallyRolledBack" : false,
  "configChangePreparedAll" : false,
  "configChangePreparedOnline" : false,
  "configDiscoveryFailed" : false,
  "configDiscoveryFailure" : null,
  "configInconsistent" : false,
  "configLocked" : false,
  "configLockedToken" : null,
  "configPartitioned" : false,
  "manualInterventionRequired" : false,
  "nodeStates" : {
    "DIAGNOSTIC" : 1
  },
  "nodes" : 1,
  "nodesInActiveMode" : 0,
  "nodesInConfigMode" : 0,
  "nodesInRepairMode" : 1,
  "nodesOnline" : 1,
  "nodesRequiringRestart" : 0,
  "nodesUnreachable" : 0,
  "readyForTopologyChange" : false,
  "stripes" : 1
}
```

### Example when restart is required

- manualInterventionRequired: true
- readyForTopologyChange: false

```json
{
  "configChangeCommittedAll" : true,
  "configChangeCommittedOnline" : false,
  "configChangeInProgress" : false,
  "configChangePartiallyCommitted" : false,
  "configChangePartiallyPrepared" : false,
  "configChangePartiallyRolledBack" : false,
  "configChangePreparedAll" : false,
  "configChangePreparedOnline" : false,
  "configDiscoveryFailed" : false,
  "configDiscoveryFailure" : null,
  "configInconsistent" : false,
  "configLocked" : false,
  "configLockedToken" : null,
  "configPartitioned" : false,
  "manualInterventionRequired" : true,
  "nodeStates" : {
    "PASSIVE" : 1,
    "ACTIVE" : 1
  },
  "nodes" : 2,
  "nodesInActiveMode" : 2,
  "nodesInConfigMode" : 0,
  "nodesInRepairMode" : 0,
  "nodesOnline" : 2,
  "nodesRequiringRestart" : 1,
  "nodesUnreachable" : 0,
  "readyForTopologyChange" : false,
  "stripes" : 1
}
```

### Examples when config is locked

- manualInterventionRequired: false
- readyForTopologyChange: false


```json
{
  "configChangeCommittedAll" : true,
  "configChangeCommittedOnline" : false,
  "configChangeInProgress" : false,
  "configChangePartiallyCommitted" : false,
  "configChangePartiallyPrepared" : false,
  "configChangePartiallyRolledBack" : false,
  "configChangePreparedAll" : false,
  "configChangePreparedOnline" : false,
  "configDiscoveryFailed" : false,
  "configDiscoveryFailure" : null,
  "configInconsistent" : false,
  "configLocked" : true,
  "configLockedToken" : "some-uuid",
  "configPartitioned" : false,
  "manualInterventionRequired" : false,
  "nodeStates" : {
    "ACTIVE" : 1
  },
  "nodes" : 1,
  "nodesInActiveMode" : 1,
  "nodesInConfigMode" : 0,
  "nodesInRepairMode" : 0,
  "nodesOnline" : 1,
  "nodesRequiringRestart" : 0,
  "nodesUnreachable" : 0,
  "readyForTopologyChange" : false,
  "stripes" : 1
}
```

### Example commit failure:

```json
{
  "configChangeCommittedAll" : false,
  "configChangeCommittedOnline" : false,
  "configChangeInProgress" : false,
  "configChangePartiallyCommitted" : false,
  "configChangePartiallyPrepared" : false,
  "configChangePartiallyRolledBack" : false,
  "configChangePreparedAll" : true,
  "configChangePreparedOnline" : false,
  "configDiscoveryFailed" : false,
  "configDiscoveryFailure" : null,
  "configInconsistent" : false,
  "configLocked" : false,
  "configLockedToken" : null,
  "configPartitioned" : false,
  "manualInterventionRequired" : true,
  "nodeStates" : {
    "ACTIVE" : 1
  },
  "nodes" : 1,
  "nodesInActiveMode" : 1,
  "nodesInConfigMode" : 0,
  "nodesInRepairMode" : 0,
  "nodesOnline" : 1,
  "nodesRequiringRestart" : 0,
  "nodesUnreachable" : 0,
  "readyForTopologyChange" : false,
  "stripes" : 1
}
```