### PR TITLE
config-tool attach -stripe-shape [name/]hostname[:port]|hostname[:port] -to-cluster <hostname[:port]>

### DIFF
--- a/common/structures/src/main/java/org/terracotta/common/struct/Tuple2.java
+++ b/common/structures/src/main/java/org/terracotta/common/struct/Tuple2.java
@@ -17,6 +17,7 @@ package org.terracotta.common.struct;
 
 import java.util.Objects;
 import java.util.Optional;
+import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
@@ -61,6 +62,10 @@ public class Tuple2<T1, T2> {
       c.accept(this);
     }
     return this;
+  }
+
+  public void accept(BiConsumer<T1, T2> consumer) {
+    consumer.accept(t1, t2);
   }
 
   public boolean allNulls() {

--- a/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/ActivateCommand.java
+++ b/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/ActivateCommand.java
@@ -34,7 +34,7 @@ import java.util.List;
 import java.util.Map;
 
 @Parameters(commandDescription = "Activate a cluster")
-@Usage("(-connect-to <hostname[:port]> | -config-file <config.cfg|config.properties> | -stripe <[name/]hostname[:port]|hostname[:port]|...>) [-cluster-name <cluster-name>] [-restrict] [-license-file <license-file>] [-restart-wait-time <restart-wait-time>] [-restart-delay <restart-delay>]")
+@Usage("(-connect-to <hostname[:port]> | -config-file <config.cfg|config.properties> | -stripe-shape <[name/]hostname[:port]|hostname[:port]|...>) [-cluster-name <cluster-name>] [-restrict] [-license-file <license-file>] [-restart-wait-time <restart-wait-time>] [-restart-delay <restart-delay>]")
 public class ActivateCommand extends RestartCommand {
 
   @Parameter(names = {"-connect-to"}, description = "Node to connect to", converter = HostPortConverter.class)
@@ -51,7 +51,7 @@ public class ActivateCommand extends RestartCommand {
   // config-tool -cluster-name tc-cluster -stripe node-1-1:9410|node-1-2,node-2-1:9410|node-2-2
   // config-tool -cluster-name tc-cluster -stripe node-1-1:9410|node-1-2 -stripe node-2-1:9410|node-2-2
   // config-tool -cluster-name tc-cluster -stripe stripe1/node-1-1:9410|node-1-2,stripe2/node-2-1:9410|node-2-2
-  @Parameter(names = {"-stripe"}, description = "Stripe", converter = ShapeConverter.class)
+  @Parameter(names = {"-stripe-shape", "-stripe"}, description = "Stripe shape", converter = ShapeConverter.class)
   private List<Map.Entry<Collection<HostPort>, String>> shape = Collections.emptyList();
 
   @Parameter(names = {"-license-file"}, description = "License file", converter = PathConverter.class)

--- a/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/deprecated/DeprecatedAttachCommand.java
+++ b/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/deprecated/DeprecatedAttachCommand.java
@@ -66,10 +66,21 @@ public class DeprecatedAttachCommand extends Command {
   public void run() {
     action.setOperationType(operationType);
     action.setDestinationHostPort(destinationHostPort);
+
     action.setForce(force);
-    action.setSourceHostPort(sourceHostPort);
     action.setRestartWaitTime(restartWaitTime);
     action.setRestartDelay(restartDelay);
+
+    switch (operationType) {
+      case NODE:
+        action.setSourceHostPort(sourceHostPort);
+        break;
+      case STRIPE:
+        action.setStripeFromSource(sourceHostPort);
+        break;
+      default:
+        throw new AssertionError();
+    }
 
     action.run();
   }

--- a/dynamic-config/cli/dynamic-config-cli-api/src/main/java/org/terracotta/dynamic_config/cli/api/command/AttachAction.java
+++ b/dynamic-config/cli/dynamic-config-cli-api/src/main/java/org/terracotta/dynamic_config/cli/api/command/AttachAction.java
@@ -19,11 +19,14 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terracotta.common.struct.Measure;
 import org.terracotta.common.struct.TimeUnit;
+import org.terracotta.common.struct.Tuple2;
 import org.terracotta.dynamic_config.api.model.Cluster;
 import org.terracotta.dynamic_config.api.model.FailoverPriority;
 import org.terracotta.dynamic_config.api.model.Node;
 import org.terracotta.dynamic_config.api.model.Node.Endpoint;
+import org.terracotta.dynamic_config.api.model.NodeContext;
 import org.terracotta.dynamic_config.api.model.Stripe;
+import org.terracotta.dynamic_config.api.model.UID;
 import org.terracotta.dynamic_config.api.model.nomad.NodeAdditionNomadChange;
 import org.terracotta.dynamic_config.api.model.nomad.StripeAdditionNomadChange;
 import org.terracotta.dynamic_config.api.model.nomad.TopologyNomadChange;
@@ -31,11 +34,14 @@ import org.terracotta.dynamic_config.api.service.NameGenerator;
 import org.terracotta.inet.HostPort;
 
 import java.util.Collection;
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Objects;
 
 import static java.lang.System.lineSeparator;
+import static java.util.Collections.singleton;
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toSet;
 import static org.terracotta.dynamic_config.api.model.FailoverPriority.Type.CONSISTENCY;
 import static org.terracotta.dynamic_config.cli.api.converter.OperationType.NODE;
 import static org.terracotta.dynamic_config.cli.api.converter.OperationType.STRIPE;
@@ -49,18 +55,45 @@ public class AttachAction extends TopologyAction {
 
   protected Measure<TimeUnit> restartWaitTime = Measure.of(120, TimeUnit.SECONDS);
   protected Measure<TimeUnit> restartDelay = Measure.of(2, TimeUnit.SECONDS);
-  protected HostPort sourceHostPort;
 
   // list of new nodes to add with their backup topology
-  protected final Map<Endpoint, Cluster> newOnlineNodes = new LinkedHashMap<>();
-
-  protected Endpoint source;
-  protected Cluster sourceCluster;
+  protected final Map<Endpoint, NodeContext> sources = new LinkedHashMap<>();
   protected Stripe addedStripe;
+  protected String optionalStripeName;
   protected Node addedNode;
 
   public void setSourceHostPort(HostPort sourceHostPort) {
-    this.sourceHostPort = sourceHostPort;
+    this.sources.clear();
+    getUpcomingNodeContext(sourceHostPort).accept(sources::put);
+  }
+
+  /**
+   * For each node acting as a direct source for the command, we connect to the node
+   * to determine the endpoint and fetch its topology
+   */
+  public void setStripeFromShape(Collection<HostPort> sourceHostPorts, String optionalStripeName) {
+    this.sources.clear();
+    sourceHostPorts.forEach(hostPort -> getUpcomingNodeContext(hostPort).accept(sources::put));
+    this.optionalStripeName = optionalStripeName != null ? optionalStripeName : sources.values().stream()
+        .map(nodeContext -> nodeContext.getCluster().getStripeByNode(nodeContext.getNodeUID()).get().getName())
+        .filter(Objects::nonNull)
+        .findFirst()
+        .orElse(null);
+  }
+
+  /**
+   * For a node part of a stripe, we connect to the node to get the stripe topology, then we
+   * fetch all the nodes of this stripe
+   */
+  public void setStripeFromSource(HostPort sourceStripeHostPort) {
+    final Tuple2<Endpoint, NodeContext> context = getUpcomingNodeContext(sourceStripeHostPort);
+    final Stripe stripe = context.t2.getStripe();
+    this.optionalStripeName = stripe.getName();
+    this.sources.clear();
+    stripe.getNodes()
+        .forEach(node -> sources.put(
+            node.determineEndpoint(context.t1),
+            new NodeContext(context.t2.getCluster(), node.getUID())));
   }
 
   public void setRestartWaitTime(Measure<TimeUnit> restartWaitTime) {
@@ -75,11 +108,16 @@ public class AttachAction extends TopologyAction {
   protected void validate() {
     super.validate();
 
-    source = getEndpoint(sourceHostPort);
-    sourceCluster = getUpcomingCluster(source);
+    if (operationType == NODE) {
+      if (sources.size() > 1) {
+        throw new UnsupportedOperationException("Cannot attach more than 1 node at a time");
+      }
+    }
 
-    if (destination.getNodeUID().equals(source.getNodeUID())) {
-      throw new IllegalArgumentException("The destination and the source endpoints must not be the same");
+    for (Endpoint source : sources.keySet()) {
+      if (destination.getNodeUID().equals(source.getNodeUID())) {
+        throw new IllegalArgumentException("The destination and the source endpoints must not be the same");
+      }
     }
 
     // we prevent attaching nodes if some nodes must be restarted
@@ -90,13 +128,15 @@ public class AttachAction extends TopologyAction {
           "Impossible to do any topology change. Node: " + endpoint + " is waiting to be restarted to apply some pending changes. Please refer to the Troubleshooting Guide for more help.");
     }
 
-    Collection<Endpoint> destinationPeers = destinationCluster.determineEndpoints(destination);
-    if (destinationPeers.contains(source)) {
-      throw new IllegalArgumentException("Source node: " + source + " is already part of cluster: " + destinationCluster.toShapeString());
-    }
+    for (Endpoint source : sources.keySet()) {
+      Collection<Endpoint> destinationPeers = destinationCluster.determineEndpoints(destination);
+      if (destinationPeers.contains(source)) {
+        throw new IllegalArgumentException("Source node: " + source + " is already part of cluster: " + destinationCluster.toShapeString());
+      }
 
-    if (isActivated(source)) {
-      throw new IllegalArgumentException("Source node: " + source + " cannot be attached since it is part of an existing cluster with name: " + getRuntimeCluster(source).getName());
+      if (isActivated(source)) {
+        throw new IllegalArgumentException("Source node: " + source + " cannot be attached since it is part of an existing cluster with name: " + getRuntimeCluster(source).getName());
+      }
     }
 
     /*
@@ -114,53 +154,66 @@ public class AttachAction extends TopologyAction {
      */
     Stripe destinationStripe = destinationCluster.getStripeByNode(destination.getNodeUID()).get();
     if (operationType == NODE) {
-      validateLogOrFail(
-          () -> sourceCluster.getNodeCount() == 1,
-          "Source node: " + source + " is part of a stripe containing more than 1 nodes. " +
-              "It must be detached first before being attached to a new stripe. " +
-              "Please refer to the Troubleshooting Guide for more help.");
-      
-      FailoverPriority failoverPriority = destinationCluster.getFailoverPriority().orElse(null);
-      if (failoverPriority != null && failoverPriority.getType() == CONSISTENCY) {
-        int voterCount = failoverPriority.getVoters();
-        int nodeCount = destinationStripe.getNodes().size();
-        int sum = voterCount + nodeCount;
-        if (sum % 2 != 0) {
-          LOGGER.warn(lineSeparator() +
-              "===================================================================================" + lineSeparator() +
-              "IMPORTANT: The sum (" + sum + ") of voter count (" + voterCount + ") and number of nodes " +
-              "(" + nodeCount + ") in this stripe " + lineSeparator() +
-              "is an odd number, which will become even with the addition of node " + source + "." + lineSeparator() +
-              "An even-numbered configuration is more likely to experience split-brain situations." + lineSeparator() +
-              "===================================================================================" + lineSeparator());
+      for (Map.Entry<Endpoint, NodeContext> entry : sources.entrySet()) {
+        Endpoint source = entry.getKey();
+        Cluster sourceCluster = entry.getValue().getCluster();
+
+        validateLogOrFail(
+            () -> sourceCluster.getNodeCount() == 1,
+            "Source node: " + source + " is part of a stripe containing more than 1 nodes. " +
+                "It must be detached first before being attached to a new stripe. " +
+                "Please refer to the Troubleshooting Guide for more help.");
+
+        FailoverPriority failoverPriority = destinationCluster.getFailoverPriority().orElse(null);
+        if (failoverPriority != null && failoverPriority.getType() == CONSISTENCY) {
+          int voterCount = failoverPriority.getVoters();
+          int nodeCount = destinationStripe.getNodes().size();
+          int sum = voterCount + nodeCount;
+          if (sum % 2 != 0) {
+            LOGGER.warn(lineSeparator() +
+                "===================================================================================" + lineSeparator() +
+                "IMPORTANT: The sum (" + sum + ") of voter count (" + voterCount + ") and number of nodes " +
+                "(" + nodeCount + ") in this stripe " + lineSeparator() +
+                "is an odd number, which will become even with the addition of node " + source + "." + lineSeparator() +
+                "An even-numbered configuration is more likely to experience split-brain situations." + lineSeparator() +
+                "===================================================================================" + lineSeparator());
+          }
         }
       }
     }
 
     if (operationType == STRIPE) {
-      validateLogOrFail(
-          () -> sourceCluster.getStripeCount() == 1,
-          "Source stripe from node: " + source + " is part of a cluster containing more than 1 stripes. " +
-              "It must be detached first before being attached to a new cluster. " +
-              "Please refer to the Troubleshooting Guide for more help.");
-    }
+      for (Map.Entry<Endpoint, NodeContext> entry : sources.entrySet()) {
+        Endpoint source = entry.getKey();
+        Cluster sourceCluster = entry.getValue().getCluster();
+        validateLogOrFail(
+            () -> sourceCluster.getStripeCount() == 1,
+            "Source stripe from node: " + source + " is part of a cluster containing more than 1 stripes. " +
+                "It must be detached first before being attached to a new cluster. " +
+                "Please refer to the Troubleshooting Guide for more help.");
+      }
 
-    // make sure nodes to attach are online
-    // building the list of nodes
-    if (operationType == NODE) {
-      // we attach only a node
-      newOnlineNodes.put(source, sourceCluster);
-    } else {
-      // we attach a whole stripe
-      sourceCluster.getStripeByNode(source.getNodeUID()).get().getNodes().stream()
-          .map(node -> node.determineEndpoint(source))
-          .forEach(endpoint -> newOnlineNodes.put(endpoint, getUpcomingCluster(endpoint)));
+      // we can attach stripes in 2 ways:
+      // 1. by providing -stripe parameter and point to a stripe (its nodes will be discovered)
+      // 2. by providing -stripe-shape and pointing to some nodes alone, and the stripe will be formed
+      // In all cases, we must verify that the list of sources we have contains all the nodes of all the known stripes.
+      // In case 2), nodes are supposed to be alone in their own stripes and in case 1) all the sources should be part of the targeted stripe.
+      Collection<UID> allNodesUID = sources.keySet().stream().map(Endpoint::getNodeUID).collect(toSet());
+      for (Map.Entry<Endpoint, NodeContext> entry : sources.entrySet()) {
+        final Collection<UID> nodesInStripe = entry.getValue().getStripe().getNodes().stream().map(Node::getUID).collect(toSet());
+        nodesInStripe.removeAll(allNodesUID);
+        if (!nodesInStripe.isEmpty()) {
+          throw new IllegalArgumentException("Source node: " + entry.getKey() + " points to a stripe with more than one node and the following nodes were not marked to be attached: " + toString(nodesInStripe));
+        }
+      }
     }
 
     switch (operationType) {
       case NODE: {
-        addedNode = sourceCluster.getNode(source.getNodeUID()).get().clone();
-        addedNode.setUID(destinationCluster.newUID());
+        // we only support 1 node for attach at the moment
+        addedNode = sources.values().iterator().next().getNode()
+            .clone()
+            .setUID(destinationCluster.newUID());
 
         if (destinationClusterActivated) {
           NameGenerator.assignFriendlyNodeName(destinationCluster, destinationStripe, addedNode);
@@ -168,9 +221,15 @@ public class AttachAction extends TopologyAction {
         break;
       }
       case STRIPE: {
-        addedStripe = sourceCluster.getStripeByNode(source.getNodeUID()).get().clone();
-        addedStripe.setUID(destinationCluster.newUID());
-        addedStripe.getNodes().forEach(n -> n.setUID(destinationCluster.newUID()));
+        addedStripe = new Stripe()
+            .setUID(destinationCluster.newUID())
+            .setName(optionalStripeName)
+            .setNodes(sources.values()
+                .stream()
+                .map(NodeContext::getNode)
+                .map(Node::clone)
+                .map(node -> node.setUID(destinationCluster.newUID()))
+                .collect(toList()));
 
         if (destinationClusterActivated) {
           NameGenerator.assignFriendlyNames(destinationCluster, addedStripe);
@@ -223,7 +282,7 @@ public class AttachAction extends TopologyAction {
 
   @Override
   protected void onNomadChangeReady(TopologyNomadChange nomadChange) {
-    setUpcomingCluster(newOnlineNodes.keySet(), nomadChange.getCluster());
+    setUpcomingCluster(sources.keySet(), nomadChange.getCluster());
   }
 
   @Override
@@ -231,10 +290,10 @@ public class AttachAction extends TopologyAction {
     Cluster result = nomadChange.getCluster();
     switch (operationType) {
       case NODE:
-        activateNodes(newOnlineNodes.keySet(), result, null, restartDelay, restartWaitTime);
+        activateNodes(sources.keySet(), result, null, restartDelay, restartWaitTime);
         break;
       case STRIPE:
-        activateStripe(newOnlineNodes.keySet(), result, destination, restartDelay, restartWaitTime);
+        activateStripe(sources.keySet(), result, destination, restartDelay, restartWaitTime);
         break;
       default:
         throw new UnsupportedOperationException(operationType.name());
@@ -247,10 +306,10 @@ public class AttachAction extends TopologyAction {
         "The node/stripe information may still be added to the destination cluster: you will need to run the diagnostic / export command to check the state of the transaction." + lineSeparator() +
         "The node/stripe to attach won't be activated and restarted, and their topology will be rolled back to their initial value."
     );
-    newOnlineNodes.forEach((endpoint, cluster) -> {
+    sources.forEach((endpoint, nodeContext) -> {
       try {
         output.info("Rollback topology of node: {}", endpoint);
-        setUpcomingCluster(Collections.singletonList(endpoint), cluster);
+        setUpcomingCluster(singleton(endpoint), nodeContext.getCluster());
       } catch (RuntimeException e) {
         LOGGER.warn("Unable to rollback configuration on node: {}. Error: {}", endpoint, e.getMessage(), e);
       }
@@ -260,7 +319,6 @@ public class AttachAction extends TopologyAction {
 
   @Override
   protected Collection<Endpoint> getAllOnlineSourceNodes() {
-    return newOnlineNodes.keySet();
+    return sources.keySet();
   }
-
 }

--- a/dynamic-config/cli/dynamic-config-cli-api/src/main/java/org/terracotta/dynamic_config/cli/api/command/RemoteAction.java
+++ b/dynamic-config/cli/dynamic-config-cli-api/src/main/java/org/terracotta/dynamic_config/cli/api/command/RemoteAction.java
@@ -386,9 +386,7 @@ public abstract class RemoteAction implements Runnable {
 
   protected final Cluster getRuntimeCluster(HostPort expectedOnlineNode) {
     LOGGER.trace("getRuntimeCluster({})", expectedOnlineNode);
-    try (DiagnosticService diagnosticService = diagnosticServiceProvider.fetchDiagnosticService(expectedOnlineNode.createInetSocketAddress())) {
-      return diagnosticService.getProxy(TopologyService.class).getRuntimeNodeContext().getCluster();
-    }
+    return getRuntimeNodeContext(expectedOnlineNode).t2.getCluster();
   }
 
   /**
@@ -415,9 +413,22 @@ public abstract class RemoteAction implements Runnable {
    */
   protected final Endpoint getEndpoint(HostPort expectedOnlineNode) {
     LOGGER.trace("getEndpoint({})", expectedOnlineNode);
+    return getRuntimeNodeContext(expectedOnlineNode).t1;
+  }
+
+  protected final Tuple2<Endpoint, NodeContext> getRuntimeNodeContext(HostPort expectedOnlineNode) {
+    LOGGER.trace("NodeContext({})", expectedOnlineNode);
     try (DiagnosticService diagnosticService = diagnosticServiceProvider.fetchDiagnosticService(expectedOnlineNode.createInetSocketAddress())) {
-      Node node = diagnosticService.getProxy(TopologyService.class).getRuntimeNodeContext().getNode();
-      return node.determineEndpoint(expectedOnlineNode);
+      final NodeContext nodeContext = diagnosticService.getProxy(TopologyService.class).getRuntimeNodeContext();
+      return Tuple2.tuple2(nodeContext.getNode().determineEndpoint(expectedOnlineNode), nodeContext);
+    }
+  }
+
+  protected final Tuple2<Endpoint, NodeContext> getUpcomingNodeContext(HostPort expectedOnlineNode) {
+    LOGGER.trace("NodeContext({})", expectedOnlineNode);
+    try (DiagnosticService diagnosticService = diagnosticServiceProvider.fetchDiagnosticService(expectedOnlineNode.createInetSocketAddress())) {
+      final NodeContext nodeContext = diagnosticService.getProxy(TopologyService.class).getUpcomingNodeContext();
+      return Tuple2.tuple2(nodeContext.getNode().determineEndpoint(expectedOnlineNode), nodeContext);
     }
   }
 

--- a/dynamic-config/cli/dynamic-config-cli-api/src/test/java/org/terracotta/dynamic_config/cli/api/command/AttachActionTest.java
+++ b/dynamic-config/cli/dynamic-config-cli-api/src/test/java/org/terracotta/dynamic_config/cli/api/command/AttachActionTest.java
@@ -166,7 +166,7 @@ public class AttachActionTest extends TopologyActionTest<AttachAction> {
     when(topologyServiceMock("localhost", 9411).isActivated()).thenReturn(true);
 
     AttachAction command = newCommand();
-    command.setSourceHostPort(HostPort.create("localhost", 9411));
+    command.setStripeFromSource(HostPort.create("localhost", 9411));
     command.setOperationType(STRIPE);
     command.setDestinationHostPort(HostPort.create("localhost", 9410));
 
@@ -181,7 +181,7 @@ public class AttachActionTest extends TopologyActionTest<AttachAction> {
     when(topologyServiceMock("localhost", 9411).getUpcomingNodeContext()).thenReturn(nodeContext);
 
     AttachAction command = newCommand();
-    command.setSourceHostPort(HostPort.create("localhost", 9411));
+    command.setStripeFromSource(HostPort.create("localhost", 9411));
     command.setOperationType(STRIPE);
     command.setDestinationHostPort(HostPort.create("localhost", 9410));
 
@@ -199,7 +199,7 @@ public class AttachActionTest extends TopologyActionTest<AttachAction> {
     DynamicConfigService mock11 = dynamicConfigServiceMock("localhost", 9411);
 
     AttachAction command = newCommand();
-    command.setSourceHostPort(HostPort.create("localhost", 9411));
+    command.setStripeFromSource(HostPort.create("localhost", 9411));
     command.setOperationType(STRIPE);
     command.setDestinationHostPort(HostPort.create("localhost", 9410));
     command.run();

--- a/dynamic-config/model/src/main/java/org/terracotta/dynamic_config/api/model/Node.java
+++ b/dynamic-config/model/src/main/java/org/terracotta/dynamic_config/api/model/Node.java
@@ -601,8 +601,7 @@ public class Node implements Cloneable, PropertyHolder {
       this.hostPort = requireNonNull(hostPort);
     }
 
-    // keep package local
-    EndpointType getEndpointType() {
+    public EndpointType getEndpointType() {
       return endpointType;
     }
 

--- a/dynamic-config/model/src/main/java/org/terracotta/dynamic_config/api/model/Stripe.java
+++ b/dynamic-config/model/src/main/java/org/terracotta/dynamic_config/api/model/Stripe.java
@@ -19,6 +19,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.terracotta.dynamic_config.api.service.Props;
 import org.terracotta.inet.HostPort;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
@@ -30,6 +31,7 @@ import java.util.stream.Stream;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toCollection;
+import static java.util.stream.Collectors.toList;
 
 
 public class Stripe implements Cloneable, PropertyHolder {
@@ -179,5 +181,13 @@ public class Stripe implements Cloneable, PropertyHolder {
 
   public Optional<Node> findReachableNode(HostPort hostPort) {
     return nodes.stream().filter(node -> node.isReachableWith(hostPort)).findFirst();
+  }
+
+  public Collection<Node.Endpoint> determineEndpoints(Node.Endpoint initiator) {
+    return determineEndpoints(initiator.getEndpointType());
+  }
+
+  public Collection<Node.Endpoint> determineEndpoints(EndpointType endpointType) {
+    return getNodes().stream().map(node -> node.determineEndpoint(endpointType)).collect(toList());
   }
 }

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/AttachCommand2x2IT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/AttachCommand2x2IT.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.dynamic_config.system_tests.activated;
+
+import org.junit.Test;
+import org.terracotta.dynamic_config.test_support.ClusterDefinition;
+import org.terracotta.dynamic_config.test_support.DynamicConfigIT;
+
+import java.util.stream.Stream;
+
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.terracotta.angela.client.support.hamcrest.AngelaMatchers.containsOutput;
+import static org.terracotta.angela.client.support.hamcrest.AngelaMatchers.successful;
+
+/**
+ * @author Mathieu Carbou
+ */
+@ClusterDefinition(stripes = 2, nodesPerStripe = 2)
+public class AttachCommand2x2IT extends DynamicConfigIT {
+
+  @Test
+  public void test_attach_stripe_shape() {
+    assertThat(
+        configTool("activate", "-cluster-name", "my-cluster", "-stripe-shape", getNodeHostPort(1, 1) + "|" + getNodeHostPort(1, 2)),
+        allOf(successful(), containsOutput("came back up")));
+
+    waitForActive(1);
+    waitForPassives(1);
+
+    assertThat(configTool("attach", "-to-cluster", getNodeHostPort(1, 1).toString(), "-stripe-shape", getNodeHostPort(2, 1) + "|" + getNodeHostPort(2, 2)), is(successful()));
+
+    Stream.of(getNodePort(1, 1), getNodePort(1, 2), getNodePort(2, 1), getNodePort(2, 2)).forEach(port -> {
+      assertThat(getUpcomingCluster("localhost", port).getNodeCount(), is(equalTo(4)));
+      assertThat(getUpcomingCluster("localhost", port).getStripeCount(), is(equalTo(2)));
+    });
+  }
+
+  @Test
+  public void test_attach_stripe_shape_named() {
+    assertThat(
+        configTool("activate", "-cluster-name", "my-cluster", "-stripe-shape", "stripe1/" + getNodeHostPort(1, 1) + "|" + getNodeHostPort(1, 2)),
+        allOf(successful(), containsOutput("came back up")));
+
+    waitForActive(1);
+    waitForPassives(1);
+
+    assertThat(configTool("attach", "-to-cluster", getNodeHostPort(1, 1).toString(), "-stripe-shape", "stripe2/" + getNodeHostPort(2, 1) + "|" + getNodeHostPort(2, 2)), is(successful()));
+
+    Stream.of(getNodePort(1, 1), getNodePort(1, 2), getNodePort(2, 1), getNodePort(2, 2)).forEach(port -> {
+      assertThat(getUpcomingCluster("localhost", port).getNodeCount(), is(equalTo(4)));
+      assertThat(getUpcomingCluster("localhost", port).getStripeCount(), is(equalTo(2)));
+      assertThat(getUpcomingCluster("localhost", port).getStripes().get(0).getName(), is(equalTo("stripe1")));
+      assertThat(getUpcomingCluster("localhost", port).getStripes().get(1).getName(), is(equalTo("stripe2")));
+    });
+  }
+
+}

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activation/ActivateCommand1x2IT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activation/ActivateCommand1x2IT.java
@@ -53,7 +53,7 @@ public class ActivateCommand1x2IT extends DynamicConfigIT {
   @Test
   public void test_fast_activation_1x1() {
     assertThat(
-        configTool("activate", "-cluster-name", "my-cluster", "-stripe", getNodeHostPort(1, 1).toString()),
+        configTool("activate", "-cluster-name", "my-cluster", "-stripe-shape", getNodeHostPort(1, 1).toString()),
         allOf(successful(), containsOutput("No license specified for activation"), containsOutput("came back up")));
 
     waitForActive(1);
@@ -68,7 +68,7 @@ public class ActivateCommand1x2IT extends DynamicConfigIT {
   @Test
   public void test_fast_activation_1x1_with_stripe_name() {
     assertThat(
-        configTool("activate", "-cluster-name", "my-cluster", "-stripe", "foo/" + getNodeHostPort(1, 1)),
+        configTool("activate", "-cluster-name", "my-cluster", "-stripe-shape", "foo/" + getNodeHostPort(1, 1)),
         allOf(successful(), containsOutput("No license specified for activation"), containsOutput("came back up")));
 
     waitForActive(1);
@@ -84,7 +84,7 @@ public class ActivateCommand1x2IT extends DynamicConfigIT {
   @Test
   public void test_fast_activation_1x2() {
     assertThat(
-        configTool("activate", "-cluster-name", "my-cluster", "-stripe", getNodeHostPort(1, 1) + "|" + getNodeHostPort(1, 2)),
+        configTool("activate", "-cluster-name", "my-cluster", "-stripe-shape", getNodeHostPort(1, 1) + "|" + getNodeHostPort(1, 2)),
         allOf(successful(), containsOutput("No license specified for activation"), containsOutput("came back up")));
 
     waitForActive(1);
@@ -100,7 +100,7 @@ public class ActivateCommand1x2IT extends DynamicConfigIT {
   @Test
   public void test_fast_activation_1x2_with_stripe_name() {
     assertThat(
-        configTool("activate", "-cluster-name", "my-cluster", "-stripe", "foo/" + getNodeHostPort(1, 1) + "|" + getNodeHostPort(1, 2)),
+        configTool("activate", "-cluster-name", "my-cluster", "-stripe-shape", "foo/" + getNodeHostPort(1, 1) + "|" + getNodeHostPort(1, 2)),
         allOf(successful(), containsOutput("No license specified for activation"), containsOutput("came back up")));
 
     waitForActive(1);
@@ -119,7 +119,7 @@ public class ActivateCommand1x2IT extends DynamicConfigIT {
     assertThat(configTool("attach", "-d", "localhost:" + getNodePort(), "-s", "localhost:" + getNodePort(1, 2)), is(successful()));
 
     assertThat(
-        configTool("activate", "-cluster-name", "my-cluster", "-stripe", getNodeHostPort(1, 1).toString()),
+        configTool("activate", "-cluster-name", "my-cluster", "-stripe-shape", getNodeHostPort(1, 1).toString()),
         allOf(not(successful()), containsOutput("already contains a topology with 2 nodes or more so it cannot be used in a fast activation")));
   }
 
@@ -128,7 +128,7 @@ public class ActivateCommand1x2IT extends DynamicConfigIT {
     assertThat(configTool("set", "-connect-to", "localhost:" + getNodePort(1, 2), "-setting", "client-reconnect-window=1s"), is(successful()));
 
     assertThat(
-        configTool("activate", "-cluster-name", "my-cluster", "-stripe", getNodeHostPort(1, 1) + "|" + getNodeHostPort(1, 2)),
+        configTool("activate", "-cluster-name", "my-cluster", "-stripe-shape", getNodeHostPort(1, 1) + "|" + getNodeHostPort(1, 2)),
         allOf(not(successful()), containsOutput("Host: " + getNodeHostPort(1, 2) + " has been started with cluster settings:")));
   }
 

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activation/ActivateCommand2x2IT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activation/ActivateCommand2x2IT.java
@@ -36,8 +36,8 @@ public class ActivateCommand2x2IT extends DynamicConfigIT {
   public void test_fast_activation_2x2() {
     assertThat(
         configTool("activate", "-cluster-name", "my-cluster",
-            "-stripe", getNodeHostPort(1, 1) + "|" + getNodeHostPort(1, 2),
-            "-stripe", getNodeHostPort(2, 1) + "|" + getNodeHostPort(2, 2)),
+            "-stripe-shape", getNodeHostPort(1, 1) + "|" + getNodeHostPort(1, 2),
+            "-stripe-shape", getNodeHostPort(2, 1) + "|" + getNodeHostPort(2, 2)),
         allOf(successful(), containsOutput("No license specified for activation"), containsOutput("came back up")));
 
     waitForActive(1);
@@ -56,7 +56,7 @@ public class ActivateCommand2x2IT extends DynamicConfigIT {
   @Test
   public void test_fast_activation_2x2_comma() {
     assertThat(
-        configTool("activate", "-cluster-name", "my-cluster", "-stripe", getNodeHostPort(1, 1) + "|" + getNodeHostPort(1, 2) + "," + getNodeHostPort(2, 1) + "|" + getNodeHostPort(2, 2)),
+        configTool("activate", "-cluster-name", "my-cluster", "-stripe-shape", getNodeHostPort(1, 1) + "|" + getNodeHostPort(1, 2) + "," + getNodeHostPort(2, 1) + "|" + getNodeHostPort(2, 2)),
         allOf(successful(), containsOutput("No license specified for activation"), containsOutput("came back up")));
 
     waitForActive(1);
@@ -76,8 +76,8 @@ public class ActivateCommand2x2IT extends DynamicConfigIT {
   public void test_fast_activation_2x2_with_stripe_name() {
     assertThat(
         configTool("activate", "-cluster-name", "my-cluster",
-            "-stripe", "foo/" + getNodeHostPort(1, 1) + "|" + getNodeHostPort(1, 2),
-            "-stripe", "bar/" + getNodeHostPort(2, 1) + "|" + getNodeHostPort(2, 2)),
+            "-stripe-shape", "foo/" + getNodeHostPort(1, 1) + "|" + getNodeHostPort(1, 2),
+            "-stripe-shape", "bar/" + getNodeHostPort(2, 1) + "|" + getNodeHostPort(2, 2)),
         allOf(successful(), containsOutput("No license specified for activation"), containsOutput("came back up")));
 
     waitForActive(1);
@@ -99,8 +99,8 @@ public class ActivateCommand2x2IT extends DynamicConfigIT {
   public void test_fast_activation_2x2_with_duplicate_stripe_name() {
     assertThat(
         configTool("activate", "-cluster-name", "my-cluster",
-            "-stripe", "foo/" + getNodeHostPort(1, 1) + "|" + getNodeHostPort(1, 2),
-            "-stripe", "foo/" + getNodeHostPort(2, 1) + "|" + getNodeHostPort(2, 2)),
+            "-stripe-shape", "foo/" + getNodeHostPort(1, 1) + "|" + getNodeHostPort(1, 2),
+            "-stripe-shape", "foo/" + getNodeHostPort(2, 1) + "|" + getNodeHostPort(2, 2)),
         allOf(not(successful()), containsOutput("Found duplicate stripe name: foo")));
   }
 }

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/diagnostic/AttachCommand2x2IT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/diagnostic/AttachCommand2x2IT.java
@@ -19,6 +19,8 @@ import org.junit.Test;
 import org.terracotta.dynamic_config.test_support.ClusterDefinition;
 import org.terracotta.dynamic_config.test_support.DynamicConfigIT;
 
+import java.util.stream.Stream;
+
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
@@ -74,5 +76,26 @@ public class AttachCommand2x2IT extends DynamicConfigIT {
 
     assertThat(getUpcomingCluster("localhost", getNodePort(2, 1)).getNodeCount(), is(equalTo(3)));
     assertThat(getUpcomingCluster("localhost", getNodePort(2, 1)).getStripeCount(), is(equalTo(2)));
+  }
+
+  @Test
+  public void test_attach_stripe_shape() {
+    assertThat(configTool("attach", "-to-cluster", getNodeHostPort(1, 1).toString(), "-stripe-shape", getNodeHostPort(2, 1) + "|" + getNodeHostPort(2, 2)), is(successful()));
+
+    Stream.of(getNodePort(1, 1), getNodePort(2, 1), getNodePort(2, 2)).forEach(port -> {
+      assertThat(getUpcomingCluster("localhost", port).getNodeCount(), is(equalTo(3)));
+      assertThat(getUpcomingCluster("localhost", port).getStripeCount(), is(equalTo(2)));
+    });
+  }
+
+  @Test
+  public void test_attach_stripe_shape_named() {
+    assertThat(configTool("attach", "-to-cluster", getNodeHostPort(1, 1).toString(), "-stripe-shape", "stripe2/" + getNodeHostPort(2, 1) + "|" + getNodeHostPort(2, 2)), is(successful()));
+
+    Stream.of(getNodePort(1, 1), getNodePort(2, 1), getNodePort(2, 2)).forEach(port -> {
+      assertThat(getUpcomingCluster("localhost", port).getNodeCount(), is(equalTo(3)));
+      assertThat(getUpcomingCluster("localhost", port).getStripeCount(), is(equalTo(2)));
+      assertThat(getUpcomingCluster("localhost", port).getStripes().get(1).getName(), is(equalTo("stripe2")));
+    });
   }
 }


### PR DESCRIPTION
This is the introduction of the `-stripe-shape` parameter to be able to attach a new stripe to a cluster (activated or not) in one shot without having to prepare the topology first by attaching new nodes one by one.

The stripe is formed dynamically thanks to the list of nodes (and eventually stripe name) passed to the cli.

Required for the Kube Operator.