### PR TITLE
Introduced a validation to prevent further scale out operation when a previous one was rolled back

### DIFF
--- a/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/RepairCommand.java
+++ b/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/RepairCommand.java
@@ -33,8 +33,8 @@ public class RepairCommand extends Command {
   @Parameter(names = {"-connect-to"}, description = "Node to connect to", required = true, converter = HostPortConverter.class)
   HostPort node;
 
-  @Parameter(names = {"-force"}, description = "Repair action to force: commit, rollback, reset, unlock", converter = RepairActionConverter.class, hidden = true)
-  RepairMethod forcedRepairMethod;
+  @Parameter(names = {"-force"}, description = "Repair action to force: commit, rollback, reset, unlock, allow_scale_out", converter = RepairActionConverter.class, hidden = true)
+  RepairMethod forcedRepairMethod = RepairMethod.NONE;
 
   @Inject
   public final RepairAction action;

--- a/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/deprecated/DeprecatedRepairCommand.java
+++ b/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/deprecated/DeprecatedRepairCommand.java
@@ -34,7 +34,7 @@ public class DeprecatedRepairCommand extends Command {
   HostPort node;
 
   @Parameter(names = {"-f"}, description = "Repair action to force: commit, rollback, reset, unlock", converter = RepairActionConverter.class)
-  RepairMethod forcedRepairMethod;
+  RepairMethod forcedRepairMethod = RepairMethod.NONE;
 
   @Inject
   public final RepairAction action;

--- a/dynamic-config/cli/dynamic-config-cli-api/src/main/java/org/terracotta/dynamic_config/cli/api/command/AttachAction.java
+++ b/dynamic-config/cli/dynamic-config-cli-api/src/main/java/org/terracotta/dynamic_config/cli/api/command/AttachAction.java
@@ -206,6 +206,12 @@ public class AttachAction extends TopologyAction {
           throw new IllegalArgumentException("Source node: " + entry.getKey() + " points to a stripe with more than one node and the following nodes were not marked to be attached: " + toString(nodesInStripe));
         }
       }
+
+      validateLogOrFail(
+          () -> isScaleOutAllowed(destinationOnlineNodes),
+          "A previous scale out operation has failed and the stripe was detached. " +
+              "Before executing another scale out operation, please inspect the issue and run: " +
+              "'config-tool repair -force allow_scale_out' to allow further scale out operations.");
     }
 
     switch (operationType) {

--- a/dynamic-config/cli/dynamic-config-cli-api/src/main/java/org/terracotta/dynamic_config/cli/api/command/DiagnosticAction.java
+++ b/dynamic-config/cli/dynamic-config-cli-api/src/main/java/org/terracotta/dynamic_config/cli/api/command/DiagnosticAction.java
@@ -307,19 +307,24 @@ public class DiagnosticAction extends RemoteAction {
 
     // some aggregated states (i.e. useful for tools like Kube operator)
 
+    // manual intervention required
+    final boolean manualInterventionRequired = !nodesPendingRestart.isEmpty() // restart required
+        || (EnumSet.of(INCONSISTENT, PARTITIONED, ALL_PREPARED, ONLINE_PREPARED, PARTIALLY_PREPARED, PARTIALLY_COMMITTED, PARTIALLY_ROLLED_BACK).contains(analyzer.getState())) // a change is in progress or needs to be repaired
+        || (!onlineActivatedNodes.isEmpty() && states.getOrDefault(ACTIVE, 0L) + states.getOrDefault(ACTIVE_RECONNECTING, 0L) != cluster.getStripeCount()) // missing active ?
+        || !Collections.disjoint(EnumSet.of(ACTIVE_SUSPENDED, PASSIVE_SUSPENDED, START_SUSPENDED), states.keySet());
+    map.put("manualInterventionRequired", manualInterventionRequired); // some nodes have disallowed states
+
     // ready for a topology change ?
-    map.put("readyForTopologyChange", !lockContext.isPresent() // config not locked
+    final boolean readyForTopologyChange = !manualInterventionRequired
+        && !lockContext.isPresent() // config not locked
         && (EnumSet.of(ALL_ACCEPTING, ONLINE_ACCEPTING).contains(analyzer.getState())) // nomad is accepting changes, with or without some offline nodes
         && nodesPendingRestart.isEmpty() // no pending restart
         && onlineActivatedNodes.size() == onlineNodes.size() // all online nodes are activated
         && (states.getOrDefault(ACTIVE, 0L) + states.getOrDefault(ACTIVE_RECONNECTING, 0L) == cluster.getStripeCount()) // 1 active per stripe
-        && DefaultNomadManager.ALLOWED.containsAll(states.keySet())); // all nodes have allowed states
+        && DefaultNomadManager.ALLOWED.containsAll(states.keySet());
+    map.put("readyForTopologyChange", readyForTopologyChange); // all nodes have allowed states
 
-    // manual intervention required
-    map.put("manualInterventionRequired", !nodesPendingRestart.isEmpty() // restart required
-        || (EnumSet.of(INCONSISTENT, PARTITIONED, ALL_PREPARED, ONLINE_PREPARED, PARTIALLY_PREPARED, PARTIALLY_COMMITTED, PARTIALLY_ROLLED_BACK).contains(analyzer.getState())) // a change is in progress or needs to be repaired
-        || (!onlineActivatedNodes.isEmpty() && states.getOrDefault(ACTIVE, 0L) + states.getOrDefault(ACTIVE_RECONNECTING, 0L) != cluster.getStripeCount()) // missing active ?
-        || !Collections.disjoint(EnumSet.of(ACTIVE_SUSPENDED, PASSIVE_SUSPENDED, START_SUSPENDED), states.keySet())); // some nodes have disallowed states
+    map.put("scaleOutAllowed", readyForTopologyChange && isScaleOutAllowed(onlineNodes));
 
     Map<String, Object> topology = new LinkedHashMap<>();
     map.put("cluster", topology);

--- a/dynamic-config/cli/dynamic-config-cli-api/src/main/java/org/terracotta/dynamic_config/cli/api/converter/RepairMethod.java
+++ b/dynamic-config/cli/dynamic-config-cli-api/src/main/java/org/terracotta/dynamic_config/cli/api/converter/RepairMethod.java
@@ -21,7 +21,12 @@ public enum RepairMethod {
   COMMIT,
   ROLLBACK,
   RESET,
-  UNLOCK;
+  UNLOCK,
+
+  // allow to perform again a scale out operation when previous one was rolled back
+  ALLOW_SCALE_OUT,
+
+  NONE;
 
   @Override
   public String toString() {

--- a/dynamic-config/cli/dynamic-config-cli-api/src/test/java/org/terracotta/dynamic_config/cli/api/command/AttachActionTest.java
+++ b/dynamic-config/cli/dynamic-config-cli-api/src/test/java/org/terracotta/dynamic_config/cli/api/command/AttachActionTest.java
@@ -26,6 +26,7 @@ import org.terracotta.dynamic_config.api.model.RawPath;
 import org.terracotta.dynamic_config.api.model.Stripe;
 import org.terracotta.dynamic_config.api.model.Testing;
 import org.terracotta.dynamic_config.api.service.DynamicConfigService;
+import org.terracotta.dynamic_config.api.service.NomadChangeInfo;
 import org.terracotta.inet.HostPort;
 
 import java.io.IOException;
@@ -82,6 +83,9 @@ public class AttachActionTest extends TopologyActionTest<AttachAction> {
   @Before
   public void setUp() throws Exception {
     super.setUp();
+
+    when(topologyServiceMock("localhost", 9410).getChangeHistory()).thenReturn(new NomadChangeInfo[0]);
+    when(topologyServiceMock("localhost", 9411).getChangeHistory()).thenReturn(new NomadChangeInfo[0]);
 
     when(topologyServiceMock("localhost", 9410).getUpcomingNodeContext()).thenReturn(nodeContext0);
     when(topologyServiceMock("localhost", 9411).getUpcomingNodeContext()).thenReturn(nodeContext1);


### PR DESCRIPTION
Once user fixed the problem, he can allow further scale out operation to be done by executing: `config-tool repair -force allow_scale_out`
