### PR TITLE
[5.9] Prevent further scale in/out process when a previous one failed, independently of the lock/unlock state of the config

### DIFF
--- a/dynamic-config/api/src/main/java/org/terracotta/dynamic_config/api/service/TopologyService.java
+++ b/dynamic-config/api/src/main/java/org/terracotta/dynamic_config/api/service/TopologyService.java
@@ -69,6 +69,11 @@ public interface TopologyService {
    */
   boolean hasIncompleteChange();
 
+  boolean isScalingDenied();
+
+
+  boolean isLocked();
+
   /**
    * Get the current installed license information if any
    */

--- a/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/AttachCommand.java
+++ b/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/AttachCommand.java
@@ -55,6 +55,12 @@ public class AttachCommand extends RestartCommand {
   @Parameter(names = {"-force"}, description = "Force the operation", hidden = true)
   protected boolean force;
 
+  @Parameter(names = {"-lock"}, description = "Create a lock before executing the Nomad operation", hidden = true)
+  protected boolean lock;
+
+  @Parameter(names = {"-unlock"}, description = "Unlock after executing the Nomad operation", hidden = true)
+  protected boolean unlock;
+
   @Inject
   public final AttachAction action;
 
@@ -110,6 +116,8 @@ public class AttachCommand extends RestartCommand {
     }
 
     action.setForce(force);
+    action.setLock(lock);
+    action.setUnlock(unlock);
     action.setRestartWaitTime(getRestartWaitTime());
     action.setRestartDelay(getRestartDelay());
 

--- a/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/DetachCommand.java
+++ b/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/DetachCommand.java
@@ -55,6 +55,12 @@ public class DetachCommand extends Command {
   @Parameter(names = {"-force"}, description = "Force the operation", hidden = true)
   protected boolean force;
 
+  @Parameter(names = {"-lock"}, description = "Create a lock before executing the Nomad operation", hidden = true)
+  protected boolean lock;
+
+  @Parameter(names = {"-unlock"}, description = "Unlock after executing the Nomad operation", hidden = true)
+  protected boolean unlock;
+
   @Inject
   public final DetachAction action;
 
@@ -89,6 +95,8 @@ public class DetachCommand extends Command {
       action.setSourceIdentifier(sourceNodeIdentifier);
     }
     action.setForce(force);
+    action.setUnlock(unlock);
+    action.setLock(lock);
     action.setStopWaitTime(stopWaitTime);
     action.setStopDelay(stopDelay);
 

--- a/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/RepairCommand.java
+++ b/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/RepairCommand.java
@@ -33,8 +33,8 @@ public class RepairCommand extends Command {
   @Parameter(names = {"-connect-to"}, description = "Node to connect to", required = true, converter = HostPortConverter.class)
   HostPort node;
 
-  @Parameter(names = {"-force"}, description = "Repair action to force: commit, rollback, reset, unlock", converter = RepairActionConverter.class, hidden = true)
-  RepairMethod forcedRepairMethod;
+  @Parameter(names = {"-force"}, description = "Repair action to force: commit, rollback, reset, unlock, allow_scale_out", converter = RepairActionConverter.class, hidden = true)
+  RepairMethod repairMethod = RepairMethod.AUTO;
 
   @Inject
   public final RepairAction action;
@@ -50,7 +50,7 @@ public class RepairCommand extends Command {
   @Override
   public void run() {
     action.setNode(node);
-    action.setForcedRepairAction(forcedRepairMethod);
+    action.repairMethod(repairMethod);
 
     action.run();
   }

--- a/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/deprecated/DeprecatedRepairCommand.java
+++ b/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/deprecated/DeprecatedRepairCommand.java
@@ -34,7 +34,7 @@ public class DeprecatedRepairCommand extends Command {
   HostPort node;
 
   @Parameter(names = {"-f"}, description = "Repair action to force: commit, rollback, reset, unlock", converter = RepairActionConverter.class)
-  RepairMethod forcedRepairMethod;
+  RepairMethod forcedRepairMethod = RepairMethod.AUTO;
 
   @Inject
   public final RepairAction action;
@@ -50,7 +50,7 @@ public class DeprecatedRepairCommand extends Command {
   @Override
   public void run() {
     action.setNode(node);
-    action.setForcedRepairAction(forcedRepairMethod);
+    action.repairMethod(forcedRepairMethod);
 
     action.run();
   }

--- a/dynamic-config/cli/dynamic-config-cli-api/src/main/java/org/terracotta/dynamic_config/cli/api/command/LockConfigAction.java
+++ b/dynamic-config/cli/dynamic-config-cli-api/src/main/java/org/terracotta/dynamic_config/cli/api/command/LockConfigAction.java
@@ -42,6 +42,7 @@ public class LockConfigAction extends RemoteAction {
     Map<Endpoint, LogicalServerState> allNodes = findRuntimePeersStatus(node);
     LinkedHashMap<Endpoint, LogicalServerState> onlineNodes = filterOnlineNodes(allNodes);
     Cluster cluster = getRuntimeCluster(node);
-    lock(cluster, onlineNodes, LockContext.from(lockContext));
+    String token = lock(cluster, onlineNodes, LockContext.from(lockContext));
+    output.out("Config lock with token: " + token);
   }
 }

--- a/dynamic-config/cli/dynamic-config-cli-api/src/main/java/org/terracotta/dynamic_config/cli/api/converter/RepairMethod.java
+++ b/dynamic-config/cli/dynamic-config-cli-api/src/main/java/org/terracotta/dynamic_config/cli/api/converter/RepairMethod.java
@@ -21,7 +21,9 @@ public enum RepairMethod {
   COMMIT,
   ROLLBACK,
   RESET,
-  UNLOCK;
+  UNLOCK,
+  ALLOW_SCALING,
+  AUTO;
 
   @Override
   public String toString() {

--- a/dynamic-config/cli/dynamic-config-cli-api/src/main/java/org/terracotta/dynamic_config/cli/api/nomad/LockAwareNomadManager.java
+++ b/dynamic-config/cli/dynamic-config-cli-api/src/main/java/org/terracotta/dynamic_config/cli/api/nomad/LockAwareNomadManager.java
@@ -61,4 +61,8 @@ public class LockAwareNomadManager<T> implements NomadManager<T> {
   public NomadManager<T> getUnderlying() {
     return underlying;
   }
+
+  public String getLockToken() {
+    return lockToken;
+  }
 }

--- a/dynamic-config/cli/dynamic-config-cli-api/src/test/java/org/terracotta/dynamic_config/cli/api/command/AttachActionTest.java
+++ b/dynamic-config/cli/dynamic-config-cli-api/src/test/java/org/terracotta/dynamic_config/cli/api/command/AttachActionTest.java
@@ -26,6 +26,7 @@ import org.terracotta.dynamic_config.api.model.RawPath;
 import org.terracotta.dynamic_config.api.model.Stripe;
 import org.terracotta.dynamic_config.api.model.Testing;
 import org.terracotta.dynamic_config.api.service.DynamicConfigService;
+import org.terracotta.dynamic_config.api.service.NomadChangeInfo;
 import org.terracotta.inet.HostPort;
 
 import java.io.IOException;
@@ -82,6 +83,12 @@ public class AttachActionTest extends TopologyActionTest<AttachAction> {
   @Before
   public void setUp() throws Exception {
     super.setUp();
+
+    when(topologyServiceMock("localhost", 9410).isScalingDenied()).thenReturn(false);
+    when(topologyServiceMock("localhost", 9411).isScalingDenied()).thenReturn(false);
+
+    when(topologyServiceMock("localhost", 9410).getChangeHistory()).thenReturn(new NomadChangeInfo[0]);
+    when(topologyServiceMock("localhost", 9411).getChangeHistory()).thenReturn(new NomadChangeInfo[0]);
 
     when(topologyServiceMock("localhost", 9410).getUpcomingNodeContext()).thenReturn(nodeContext0);
     when(topologyServiceMock("localhost", 9411).getUpcomingNodeContext()).thenReturn(nodeContext1);

--- a/dynamic-config/cli/dynamic-config-cli-api/src/test/java/org/terracotta/dynamic_config/cli/api/command/DetachActionTest.java
+++ b/dynamic-config/cli/dynamic-config-cli-api/src/test/java/org/terracotta/dynamic_config/cli/api/command/DetachActionTest.java
@@ -92,6 +92,11 @@ public class DetachActionTest extends TopologyActionTest<DetachAction> {
   public void setUp() throws Exception {
     super.setUp();
 
+    when(topologyServiceMock(node1_1.getInternalHostPort()).isScalingDenied()).thenReturn(false);
+    when(topologyServiceMock(node1_2.getInternalHostPort()).isScalingDenied()).thenReturn(false);
+    when(topologyServiceMock(node2_1.getInternalHostPort()).isScalingDenied()).thenReturn(false);
+    when(topologyServiceMock(node2_2.getInternalHostPort()).isScalingDenied()).thenReturn(false);
+
     when(topologyServiceMock(node1_1.getInternalHostPort()).getUpcomingNodeContext()).thenReturn(new NodeContext(cluster, node1_1.getUID()));
     when(topologyServiceMock(node1_1.getInternalHostPort()).getRuntimeNodeContext()).thenReturn(new NodeContext(cluster, node1_1.getUID()));
     when(topologyServiceMock(node1_1.getInternalHostPort()).isActivated()).thenReturn(false);

--- a/dynamic-config/model/src/main/java/org/terracotta/dynamic_config/api/model/LockTag.java
+++ b/dynamic-config/model/src/main/java/org/terracotta/dynamic_config/api/model/LockTag.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.dynamic_config.api.model;
+
+/**
+ * @author Mathieu Carbou
+ */
+public class LockTag {
+
+  // tags when locking before an operation
+  public static final String SCALE_OUT_PREFIX = "dynamic-scale:adding:";
+  public static final String SCALE_IN_PREFIX = "dynamic-scale:removing:";
+  public static final String NODE_ADD_PREFIX = "node:adding:";
+  public static final String NODE_DEL_PREFIX = "node:removing:";
+
+  // tags used to prevent further scale operation
+  public static final String DENY_SCALE_OUT = "dynamic-scale:adding:deny";
+  public static final String DENY_SCALE_IN = "dynamic-scale:removing:deny";
+
+  // tags used to allow retrying a previously failed operation
+  public static final String ALLOW_SCALING = "dynamic-scale:allow";
+
+  // owner tags
+  public static final String OWNER_PLATFORM = "platform";
+}

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/DetachCommand2x1IT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/DetachCommand2x1IT.java
@@ -19,10 +19,8 @@ import org.junit.Test;
 import org.terracotta.dynamic_config.test_support.ClusterDefinition;
 import org.terracotta.dynamic_config.test_support.DynamicConfigIT;
 
-import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.terracotta.angela.client.support.hamcrest.AngelaMatchers.containsOutput;
-import static org.terracotta.angela.client.support.hamcrest.AngelaMatchers.successful;
 
 /**
  * @author Mathieu Carbou
@@ -58,6 +56,6 @@ public class DetachCommand2x1IT extends DynamicConfigIT {
 
     assertThat(
         configTool("detach", "-t", "stripe", "-d", "localhost:" + getNodePort(1, 1), "-s", "localhost:" + getNodePort(2, 1)),
-        is(successful()));
+        containsOutput("Scaling operation cannot be performed. Please refer to the Troubleshooting Guide for more help."));
   }
 }

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/RepairCommand1x2IT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/RepairCommand1x2IT.java
@@ -64,7 +64,7 @@ public class RepairCommand1x2IT extends DynamicConfigIT {
     waitForPassive(1, passiveId);
 
     // wait until we can really connect to the passive and see it has an incomplete change
-    // this is because he passive will restart after sync
+    // this is because the passive will restart after sync
     waitUntil(() -> usingTopologyService(1, activeId, TopologyService::hasIncompleteChange), is(true));
     waitUntil(() -> usingTopologyService(1, passiveId, TopologyService::hasIncompleteChange), is(true));
 

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/Scaling2x1IT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/Scaling2x1IT.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.dynamic_config.system_tests.activated;
+
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.terracotta.angela.common.ToolExecutionResult;
+import org.terracotta.dynamic_config.api.model.LockContext;
+import org.terracotta.dynamic_config.api.model.UID;
+import org.terracotta.dynamic_config.test_support.ClusterDefinition;
+import org.terracotta.dynamic_config.test_support.DynamicConfigIT;
+
+import java.util.UUID;
+
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.terracotta.angela.client.support.hamcrest.AngelaMatchers.containsOutput;
+import static org.terracotta.angela.client.support.hamcrest.AngelaMatchers.successful;
+import static org.terracotta.dynamic_config.api.model.LockTag.DENY_SCALE_OUT;
+import static org.terracotta.dynamic_config.api.model.LockTag.OWNER_PLATFORM;
+import static org.terracotta.dynamic_config.api.model.LockTag.SCALE_IN_PREFIX;
+
+/**
+ * @author Mathieu Carbou
+ */
+@ClusterDefinition(stripes = 2, nodesPerStripe = 1)
+@Ignore
+public class Scaling2x1IT extends DynamicConfigIT {
+
+  @Before
+  public void setUp() {
+    assertThat(
+        configTool("activate", "-cluster-name", "my-cluster", "-stripe-shape", getNodeHostPort(1, 1).toString()),
+        allOf(successful(), containsOutput("came back up")));
+
+    waitForActive(1);
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  public void test_normalAttachDetach() {
+    assertThat(configTool("attach", "-lock", "-unlock", "-to-cluster", getNodeHostPort(1, 1).toString(), "-stripe-shape", getNodeHostPort(2, 1).toString()), is(successful()));
+
+    assertThat(configTool("diagnostic", "-connect-to", getNodeHostPort(1, 1).toString(), "-output-format", "json"),
+        allOf(
+            successful(),
+            containsOutput("\"stripes\" : 2"),
+            containsOutput("\"configLocked\" : false"),
+            containsOutput("\"manualInterventionRequired\" : false"),
+            containsOutput("\"readyForTopologyChange\" : true"),
+            containsOutput(" \"scalingDenied\" : false")
+        ));
+
+    assertThat(configTool("detach", "-lock", "-unlock", "-from-cluster", getNodeHostPort(1, 1).toString(), "-stripe", getNodeHostPort(2, 1).toString()), is(successful()));
+
+    assertThat(configTool("diagnostic", "-connect-to", getNodeHostPort(1, 1).toString(), "-output-format", "json"),
+        allOf(
+            successful(),
+            containsOutput("\"stripes\" : 1"),
+            containsOutput("\"configLocked\" : false"),
+            containsOutput("\"manualInterventionRequired\" : false"),
+            containsOutput("\"readyForTopologyChange\" : true"),
+            containsOutput(" \"scalingDenied\" : false")
+        ));
+  }
+
+  @Test
+  public void test_rolledBackScaleOut() {
+    // attach
+    final ToolExecutionResult attach = configTool("attach", "-lock", "-to-cluster", getNodeHostPort(1, 1).toString(), "-stripe-shape", getNodeHostPort(2, 1).toString());
+    assertThat(attach, allOf(is(successful()), containsOutput("Config lock with token: ")));
+
+    final String token = attach.getOutput()
+        .stream()
+        .filter(line -> line.startsWith("Config lock with token: "))
+        .map(line -> line.substring("Config lock with token: ".length()))
+        .findFirst()
+        .get();
+
+    // simulated re-balancing failure: detach + marker + unlock
+    assertThat(configTool("-lock-token", token, "detach", "-from-cluster", getNodeHostPort(1, 1).toString(), "-stripe", getNodeHostPort(2, 1).toString()), is(successful()));
+    final LockContext marker = new LockContext(token, OWNER_PLATFORM, DENY_SCALE_OUT);
+    assertThat(configTool("-lock-token", token, "lock-config", "-connect-to", getNodeHostPort(1, 1).toString(), "-lock-context", marker.toString()), allOf(is(successful()), containsOutput("Config lock with token: " + token)));
+    assertThat(configTool("-lock-token", token, "unlock-config", "-connect-to", getNodeHostPort(1, 1).toString()), is(successful()));
+
+    // verify that scale out is not allowed anymore
+    assertThat(configTool("diagnostic", "-connect-to", getNodeHostPort(1, 1).toString(), "-output-format", "json"),
+        allOf(
+            successful(),
+            containsOutput("\"stripes\" : 1"),
+            containsOutput("\"configLocked\" : false"),
+            containsOutput("\"manualInterventionRequired\" : false"),
+            containsOutput("\"readyForTopologyChange\" : true"),
+            containsOutput(" \"scalingDenied\" : true")
+        ));
+
+    // allow scale out
+    assertThat(configTool("repair", "-force", "allow_scaling", "-connect-to", getNodeHostPort(1, 1).toString()), is(successful()));
+
+    // verify that scale out is now allowed
+    assertThat(configTool("diagnostic", "-connect-to", getNodeHostPort(1, 1).toString(), "-output-format", "json"),
+        allOf(
+            successful(),
+            containsOutput("\"stripes\" : 1"),
+            containsOutput("\"configLocked\" : false"),
+            containsOutput("\"manualInterventionRequired\" : false"),
+            containsOutput("\"readyForTopologyChange\" : true"),
+            containsOutput(" \"scalingDenied\" : false")
+        ));
+  }
+
+  @Test
+  public void test_rolledBackScaleIn() {
+    // create 2x1
+    assertThat(configTool("attach", "-to-cluster", getNodeHostPort(1, 1).toString(), "-stripe-shape", getNodeHostPort(2, 1).toString()), is(successful()));
+    assertThat(configTool("diagnostic", "-connect-to", getNodeHostPort(1, 1).toString(), "-output-format", "json"),
+        allOf(
+            successful(),
+            containsOutput("\"stripes\" : 2"),
+            containsOutput("\"configLocked\" : false"),
+            containsOutput("\"manualInterventionRequired\" : false"),
+            containsOutput("\"readyForTopologyChange\" : true"),
+            containsOutput(" \"scalingDenied\" : false")
+        ));
+
+    // we simulate a failed detach: lock-marker-unlock
+    final String token = UUID.randomUUID().toString();
+    final UID stripeUID = getUpcomingCluster(1, 1).getStripes().get(1).getUID();
+    final LockContext lock = new LockContext(token, OWNER_PLATFORM, SCALE_IN_PREFIX + stripeUID);
+    assertThat(configTool("lock-config", "-connect-to", getNodeHostPort(1, 1).toString(), "-lock-context", lock.toString()), allOf(is(successful()), containsOutput("Config lock with token: " + token)));
+    final LockContext marker = new LockContext(token, OWNER_PLATFORM, DENY_SCALE_OUT);
+    assertThat(configTool("-lock-token", token, "lock-config", "-connect-to", getNodeHostPort(1, 1).toString(), "-lock-context", marker.toString()), allOf(is(successful()), containsOutput("Config lock with token: " + token)));
+    assertThat(configTool("-lock-token", token, "unlock-config", "-connect-to", getNodeHostPort(1, 1).toString()), is(successful()));
+
+    // verify that we scale in is not allowed anymore
+    assertThat(configTool("diagnostic", "-connect-to", getNodeHostPort(1, 1).toString(), "-output-format", "json"),
+        allOf(
+            successful(),
+            containsOutput("\"stripes\" : 2"),
+            containsOutput("\"configLocked\" : false"),
+            containsOutput("\"manualInterventionRequired\" : false"),
+            containsOutput("\"readyForTopologyChange\" : true"),
+            containsOutput(" \"scalingDenied\" : true")
+        ));
+
+    // allow scale in
+    assertThat(configTool("repair", "-force", "allow_scaling", "-connect-to", getNodeHostPort(1, 1).toString()), is(successful()));
+
+    // verify that scale in is now allowed
+    assertThat(configTool("diagnostic", "-connect-to", getNodeHostPort(1, 1).toString(), "-output-format", "json"),
+        allOf(
+            successful(),
+            containsOutput("\"stripes\" : 2"),
+            containsOutput("\"configLocked\" : false"),
+            containsOutput("\"manualInterventionRequired\" : false"),
+            containsOutput("\"readyForTopologyChange\" : true"),
+            containsOutput(" \"scalingDenied\" : false")
+        ));
+  }
+
+}


### PR DESCRIPTION
### Overview

- Introduced some validations to prevent scale in/out operation to be performed if one failed previously
- Introduced a repair mode for the user to allow the operation to proceed with `config-tool repair -force allow_scaling`
- Refactored the lock/unlock logic in attach and detach to correctly catch exceptions and add markers to deny any further scale in/out in case of errors
- Introduced some flags in the diagnostic output to show if scale in/out process is allowed or not
- Refactored the inheritance logic for attach and detach between OSS and EE to consolidate the lock/unlock/marker logic at one place and only let EE override the difference in behaviour

### Scale in flow

**detach command (CLI)**

1. validation: fails if we find: a `deny scale in` marker
2. `lock`
3. trigger rebalancing
    - on failure:
        * try to place a marker `deny scale in` to prevent replaying the detach
        * try to `unlock`

**on rebalancing success (server-side)**

1. `detach` the stripe
2. `unlock` on nomad tx success

**on rebalancing failure (server-side)**

1. place a `deny scale in` marker
2. `unlock`

### Scale out flow

**attach command (CLI)**

1. validations
    - fails if we find: a `deny scale out` marker
3. `lock`
4. `attach`
    - on failure:
        * try to place a marker `deny scale out` to prevent replaying the attach
        * try to `unlock`
        * in any case, either a marker is placed or the config is kept locked
6. trigger rebalancing on nomad success
    - on failure:
        * config is kept locked

**on rebalancing success (server-side)**

1. `unlock`

**on rebalancing failure (server-side)**

1. TRY `detach`
2. FINALLY place a `deny scale out` marker
3. FINALLY `unlock`

### Why adding a marker if the `attach` or `detach` CLI fails ?

Because attach and detach are triggering 2 Nomad tx to lock and unlock (discovery/prepare/commit) and replaying would cause 2 problems:
- un-necessary append-log entries would fill the append-log
- un-necessary nomad transactions triggered would increase the chance to collide with a concurrent user transaction which aims are doing a valid config change or repair

### Repairing

We can re-allow a scale op to be retried by running:

`config-tool repair -force allow_scaling`