### PR TITLE
Fixes AttachCommandWithMultipleVoter1x3IT

### DIFF
--- a/voter/src/main/java/org/terracotta/voter/ClientVoterManager.java
+++ b/voter/src/main/java/org/terracotta/voter/ClientVoterManager.java
@@ -58,6 +58,8 @@ public interface ClientVoterManager {
   
   long generation();
   
+  long lastVotedGeneration();
+  
   void zombie();
 
   boolean isConnected();

--- a/voter/src/main/java/org/terracotta/voter/ClientVoterManagerImpl.java
+++ b/voter/src/main/java/org/terracotta/voter/ClientVoterManagerImpl.java
@@ -40,6 +40,7 @@ public class ClientVoterManagerImpl implements ClientVoterManager {
 
   private volatile boolean voting = false;
   private volatile long generation = INVALID_VOTER_RESPONSE;
+  private volatile long lastVotedGeneration = INVALID_VOTER_RESPONSE;
 
   public ClientVoterManagerImpl(String hostPort) {
     this.hostPort = hostPort;
@@ -124,7 +125,11 @@ public class ClientVoterManagerImpl implements ClientVoterManager {
       throw new RuntimeException("not currently voting");
     }
     String result = processInvocation(diagnostics.invokeWithArg(MBEAN_NAME, "vote", id + ":" + generation));
-    return Long.parseLong(result);
+    long value = Long.parseLong(result);
+    if (value == HEARTBEAT_RESPONSE) {
+      lastVotedGeneration = generation;
+    }
+    return value;
   }
 
   @Override
@@ -203,6 +208,11 @@ public class ClientVoterManagerImpl implements ClientVoterManager {
   public long generation() {
     return generation;
   }
+  
+  @Override
+  public long lastVotedGeneration() {
+    return lastVotedGeneration;
+  }  
 
   @Override
   public void zombie() {

--- a/voter/src/main/java/org/terracotta/voter/VotingGroup.java
+++ b/voter/src/main/java/org/terracotta/voter/VotingGroup.java
@@ -228,7 +228,7 @@ public class VotingGroup implements AutoCloseable {
           // if the owner is voting, this voter must zombie, cannot vote in this generation
           mgr.zombie();
         }
-      } else if (mgr.generation() > voteOwner.generation()) {
+      } else if (mgr.generation() > voteOwner.lastVotedGeneration()) {
         voteOwner.zombie();
         long result = mgr.vote(id);
         setVoteOwner(mgr);

--- a/voter/src/test/java/org/terracotta/voter/VotingGroupTest.java
+++ b/voter/src/test/java/org/terracotta/voter/VotingGroupTest.java
@@ -417,6 +417,11 @@ public class VotingGroupTest {
     }
 
     @Override
+    public long lastVotedGeneration() {
+      return 0L;
+    }
+
+    @Override
     public boolean register(String id) throws TimeoutException {
       return connected;
     }


### PR DESCRIPTION
Due to the way inline servers are shutdown.  The voter can receive the new generation but not have time to vote.  If the voter never votes for the current owner the current voter can be zombies and a new voter can take over.