### PR TITLE
Update Maven coordinates

### DIFF
--- a/client-message-tracker/build.gradle
+++ b/client-message-tracker/build.gradle
@@ -6,6 +6,6 @@ plugins {
 
 deploy {
   groupId = 'org.terracotta'
-  artifactId = 'client-message-tracker'
+  artifactId = 'terracotta-client-message-tracker'
   name = 'Client Message Tracker Server Plugin'
 }

--- a/common/inet/build.gradle
+++ b/common/inet/build.gradle
@@ -9,7 +9,7 @@ dependencies {
 }
 
 deploy {
-  groupId = 'org.terracotta.common'
-  artifactId = 'common-inet-support'
+  groupId = 'org.terracotta'
+  artifactId = 'terracotta-inet'
   name = 'Inet Utilities'
 }

--- a/common/json/build.gradle
+++ b/common/json/build.gradle
@@ -10,8 +10,8 @@ dependencies {
 }
 
 deploy {
-  groupId = 'org.terracotta.common'
-  artifactId = 'common-json-support'
+  groupId = 'org.terracotta'
+  artifactId = 'terracotta-json'
   name = 'JSON Support'
 }
 

--- a/common/nomad/build.gradle
+++ b/common/nomad/build.gradle
@@ -9,7 +9,7 @@ dependencies {
 }
 
 deploy {
-  groupId = 'org.terracotta.common'
-  artifactId = 'common-nomad'
+  groupId = 'org.terracotta'
+  artifactId = 'terracotta-nomad'
   name = 'Nomad'
 }

--- a/common/output-service/build.gradle
+++ b/common/output-service/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 deploy {
-  groupId = 'org.terracotta.common'
-  artifactId = 'output-service'
+  groupId = 'org.terracotta'
+  artifactId = 'terracotta-output-service'
   name = 'Output Service'
 }

--- a/common/runnel/build.gradle
+++ b/common/runnel/build.gradle
@@ -6,6 +6,6 @@ plugins {
 
 deploy {
   groupId = 'org.terracotta'
-  artifactId = 'runnel'
+  artifactId = 'terracotta-runnel'
   name = 'Runnel'
 }

--- a/common/sanskrit/build.gradle
+++ b/common/sanskrit/build.gradle
@@ -12,7 +12,7 @@ dependencies {
 }
 
 deploy {
-  groupId = 'org.terracotta.common'
-  artifactId = 'common-sanskrit'
+  groupId = 'org.terracotta'
+  artifactId = 'terracotta-sanskrit'
   name = 'Sanskrit'
 }

--- a/common/structures/build.gradle
+++ b/common/structures/build.gradle
@@ -9,7 +9,7 @@ dependencies {
 }
 
 deploy {
-  groupId = 'org.terracotta.common'
-  artifactId = 'common-structures'
+  groupId = 'org.terracotta'
+  artifactId = 'terracotta-structures'
   name = 'Structures'
 }

--- a/common/test-utilities/build.gradle
+++ b/common/test-utilities/build.gradle
@@ -10,7 +10,7 @@ dependencies {
 }
 
 deploy {
-  groupId = 'org.terracotta.common'
-  artifactId = 'common-test-utilities'
+  groupId = 'org.terracotta'
+  artifactId = 'terracotta-test-utilities'
   name = 'Test Utilities'
 }

--- a/communicator/client/build.gradle
+++ b/communicator/client/build.gradle
@@ -10,7 +10,7 @@ dependencies {
 }
 
 deploy {
-  groupId = 'org.terracotta.voltron.communicator'
-  artifactId = 'communicator-support-client'
+  groupId = 'org.terracotta'
+  artifactId = 'terracotta-communicator-client'
   name = 'Communicator Client API'
 }

--- a/communicator/common/build.gradle
+++ b/communicator/common/build.gradle
@@ -9,6 +9,6 @@ dependencies {
 }
 
 deploy {
-  groupId = 'org.terracotta.voltron.communicator'
-  artifactId = 'communicator-support-common'
+  groupId = 'org.terracotta'
+  artifactId = 'terracotta-communicator-common'
 }

--- a/communicator/server/build.gradle
+++ b/communicator/server/build.gradle
@@ -10,7 +10,7 @@ dependencies {
 }
 
 deploy {
-  groupId = 'org.terracotta.voltron.communicator'
-  artifactId = 'communicator-support-server'
+  groupId = 'org.terracotta'
+  artifactId = 'terracotta-communicator-server'
   name = 'Communicator Server API'
 }

--- a/diagnostic/client/build.gradle
+++ b/diagnostic/client/build.gradle
@@ -13,7 +13,7 @@ dependencies {
 }
 
 deploy {
-  groupId = 'org.terracotta.diagnostic'
-  artifactId = 'diagnostic-client'
+  groupId = 'org.terracotta'
+  artifactId = 'terracotta-diagnostic-client'
   name = 'Diagnostic Client'
 }

--- a/diagnostic/common/build.gradle
+++ b/diagnostic/common/build.gradle
@@ -11,6 +11,6 @@ dependencies {
 }
 
 deploy {
-  groupId = 'org.terracotta.diagnostic'
-  artifactId = 'diagnostic-common'
+  groupId = 'org.terracotta'
+  artifactId = 'terracotta-diagnostic-common'
 }

--- a/diagnostic/model/build.gradle
+++ b/diagnostic/model/build.gradle
@@ -9,7 +9,7 @@ dependencies {
 }
 
 deploy {
-  groupId = 'org.terracotta.diagnostic'
-  artifactId = 'diagnostic-model'
+  groupId = 'org.terracotta'
+  artifactId = 'terracotta-diagnostic-model'
   name = 'Diagnostic Model'
 }

--- a/diagnostic/server/api/build.gradle
+++ b/diagnostic/server/api/build.gradle
@@ -11,7 +11,7 @@ dependencies {
 }
 
 deploy {
-  groupId = 'org.terracotta.diagnostic'
-  artifactId = 'diagnostic-service-api'
+  groupId = 'org.terracotta'
+  artifactId = 'terracotta-diagnostic-server-api'
   name = 'Diagnostic Server API'
 }

--- a/diagnostic/server/services/build.gradle
+++ b/diagnostic/server/services/build.gradle
@@ -12,7 +12,7 @@ dependencies {
 }
 
 deploy {
-  groupId = 'org.terracotta.diagnostic'
-  artifactId = 'diagnostic-service'
+  groupId = 'org.terracotta'
+  artifactId = 'terracotta-diagnostic-server-services'
   name = 'Diagnostic Server Plugin'
 }

--- a/dynamic-config/api/build.gradle
+++ b/dynamic-config/api/build.gradle
@@ -15,7 +15,7 @@ dependencies {
 }
 
 deploy {
-  groupId = 'org.terracotta.dynamic-config'
-  artifactId = 'dynamic-config-api'
+  groupId = 'org.terracotta'
+  artifactId = 'terracotta-dynamic-config-api'
   name = 'Dynamic Config API'
 }

--- a/dynamic-config/cli/api/build.gradle
+++ b/dynamic-config/cli/api/build.gradle
@@ -15,7 +15,7 @@ dependencies {
 }
 
 deploy {
-  groupId = 'org.terracotta.dynamic-config.cli'
-  artifactId = 'dynamic-config-cli-api'
+  groupId = 'org.terracotta'
+  artifactId = 'terracotta-dynamic-config-cli-api'
   name = 'Dynamic Config CLI API'
 }

--- a/dynamic-config/cli/config-tool/build.gradle
+++ b/dynamic-config/cli/config-tool/build.gradle
@@ -20,7 +20,7 @@ tool {
 }
 
 deploy {
-  groupId = 'org.terracotta.dynamic-config.cli'
-  artifactId = 'dynamic-config-cli-config-tool'
+  groupId = 'org.terracotta'
+  artifactId = 'terracotta-dynamic-config-cli-config-tool'
   name = 'Dynamic Config config-tool CLI'
 }

--- a/dynamic-config/cli/jcommander/build.gradle
+++ b/dynamic-config/cli/jcommander/build.gradle
@@ -13,7 +13,7 @@ dependencies {
 }
 
 deploy {
-  groupId = 'org.terracotta.dynamic-config.cli'
-  artifactId = 'dynamic-config-cli-support'
+  groupId = 'org.terracotta'
+  artifactId = 'terracotta-dynamic-config-cli-jcommander'
   name = 'Dynamic Config CLI JCommander Support'
 }

--- a/dynamic-config/cli/upgrade-tool-oss/build.gradle
+++ b/dynamic-config/cli/upgrade-tool-oss/build.gradle
@@ -14,7 +14,7 @@ dependencies {
 }
 
 deploy {
-  groupId = 'org.terracotta.dynamic-config.cli'
-  artifactId = 'upgrade-tools-oss'
+  groupId = 'org.terracotta'
+  artifactId = 'terracotta-dynamic-config-cli-upgrade-tool-oss'
   name = 'Dynamic Config CLI upgrade-tool (OSS)'
 }

--- a/dynamic-config/cli/upgrade-tool/build.gradle
+++ b/dynamic-config/cli/upgrade-tool/build.gradle
@@ -25,6 +25,6 @@ dependencies {
 }
 
 deploy {
-  groupId = 'org.terracotta.dynamic-config.cli'
-  artifactId = 'dynamic-config-cli-upgrade-tools'
+  groupId = 'org.terracotta'
+  artifactId = 'terracotta-dynamic-config-cli-upgrade-tool'
 }

--- a/dynamic-config/entities/management/server/build.gradle
+++ b/dynamic-config/entities/management/server/build.gradle
@@ -10,7 +10,7 @@ dependencies {
 }
 
 deploy {
-  groupId = 'org.terracotta.dynamic-config.entities'
-  artifactId = 'dynamic-config-management-entity-server'
+  groupId = 'org.terracotta'
+  artifactId = 'terracotta-dynamic-config-entities-management-server'
   name = 'Dynamic Config Management Entity'
 }

--- a/dynamic-config/entities/nomad/client/build.gradle
+++ b/dynamic-config/entities/nomad/client/build.gradle
@@ -10,7 +10,7 @@ dependencies {
 }
 
 deploy {
-  groupId = 'org.terracotta.dynamic-config.entities'
-  artifactId = 'dynamic-config-nomad-entity-client'
+  groupId = 'org.terracotta'
+  artifactId = 'terracotta-dynamic-config-entities-nomad-client'
   name = 'Dynamic Config Nomad Entity Client'
 }

--- a/dynamic-config/entities/nomad/common/build.gradle
+++ b/dynamic-config/entities/nomad/common/build.gradle
@@ -11,6 +11,6 @@ dependencies {
 }
 
 deploy {
-  groupId = 'org.terracotta.dynamic-config.entities'
-  artifactId = 'dynamic-config-nomad-entity-common'
+  groupId = 'org.terracotta'
+  artifactId = 'terracotta-dynamic-config-entities-nomad-common'
 }

--- a/dynamic-config/entities/nomad/server/build.gradle
+++ b/dynamic-config/entities/nomad/server/build.gradle
@@ -10,7 +10,7 @@ dependencies {
 }
 
 deploy {
-  groupId = 'org.terracotta.dynamic-config.entities'
-  artifactId = 'dynamic-config-nomad-entity-server'
+  groupId = 'org.terracotta'
+  artifactId = 'terracotta-dynamic-config-entities-nomad-server'
   name = 'Dynamic Config Nomad Entity'
 }

--- a/dynamic-config/entities/topology/client/build.gradle
+++ b/dynamic-config/entities/topology/client/build.gradle
@@ -10,7 +10,7 @@ dependencies {
 }
 
 deploy {
-  groupId = 'org.terracotta.dynamic-config.entities'
-  artifactId = 'dynamic-config-topology-entity-client'
+  groupId = 'org.terracotta'
+  artifactId = 'terracotta-dynamic-config-entities-topology-client'
   name = 'Dynamic Config Topology Entity Client'
 }

--- a/dynamic-config/entities/topology/common/build.gradle
+++ b/dynamic-config/entities/topology/common/build.gradle
@@ -11,6 +11,6 @@ dependencies {
 }
 
 deploy {
-  groupId = 'org.terracotta.dynamic-config.entities'
-  artifactId = 'dynamic-config-topology-entity-common'
+  groupId = 'org.terracotta'
+  artifactId = 'terracotta-dynamic-config-entities-topology-common'
 }

--- a/dynamic-config/entities/topology/server/build.gradle
+++ b/dynamic-config/entities/topology/server/build.gradle
@@ -10,7 +10,7 @@ dependencies {
 }
 
 deploy {
-  groupId = 'org.terracotta.dynamic-config.entities'
-  artifactId = 'dynamic-config-topology-entity-server'
+  groupId = 'org.terracotta'
+  artifactId = 'terracotta-dynamic-config-entities-topology-server'
   name = 'Dynamic Config Topology Entity'
 }

--- a/dynamic-config/json/build.gradle
+++ b/dynamic-config/json/build.gradle
@@ -10,7 +10,7 @@ dependencies {
 }
 
 deploy {
-  groupId = 'org.terracotta.dynamic-config'
-  artifactId = 'dynamic-config-json'
+  groupId = 'org.terracotta'
+  artifactId = 'terracotta-dynamic-config-json'
   name = 'Dynamic Config Json Modules'
 }

--- a/dynamic-config/model/build.gradle
+++ b/dynamic-config/model/build.gradle
@@ -20,7 +20,7 @@ sourceSets {
 }
 
 deploy {
-  groupId = 'org.terracotta.dynamic-config'
-  artifactId = 'dynamic-config-model'
+  groupId = 'org.terracotta'
+  artifactId = 'terracotta-dynamic-config-model'
   name = 'Dynamic Config Model'
 }

--- a/dynamic-config/repository/build.gradle
+++ b/dynamic-config/repository/build.gradle
@@ -17,7 +17,7 @@ dependencies {
 }
 
 deploy {
-  groupId = 'org.terracotta.dynamic-config.server'
-  artifactId = 'dynamic-config-configuration-repository'
+  groupId = 'org.terracotta'
+  artifactId = 'terracotta-dynamic-config-repository'
   name = 'Dynamic Config Repository'
 }

--- a/dynamic-config/server/api/build.gradle
+++ b/dynamic-config/server/api/build.gradle
@@ -10,7 +10,7 @@ dependencies {
 }
 
 deploy {
-  groupId = 'org.terracotta.dynamic-config.server'
-  artifactId = 'dynamic-config-server-api'
+  groupId = 'org.terracotta'
+  artifactId = 'terracotta-dynamic-config-server-api'
   name = 'Dynamic Config Server API'
 }

--- a/dynamic-config/server/config-provider/build.gradle
+++ b/dynamic-config/server/config-provider/build.gradle
@@ -21,7 +21,7 @@ dependencies {
 }
 
 deploy {
-  groupId = 'org.terracotta.dynamic-config.server'
-  artifactId = 'dynamic-config-configuration-provider'
+  groupId = 'org.terracotta'
+  artifactId = 'terracotta-dynamic-config-server-configuration-provider'
   name = 'Dynamic Config Server Configuration Provider'
 }

--- a/dynamic-config/server/services/build.gradle
+++ b/dynamic-config/server/services/build.gradle
@@ -12,7 +12,7 @@ dependencies {
 }
 
 deploy {
-  groupId = 'org.terracotta.dynamic-config.server'
-  artifactId = 'dynamic-config-services'
+  groupId = 'org.terracotta'
+  artifactId = 'terracotta-dynamic-config-server-services'
   name = 'Dynamic Config Server Plugin'
 }

--- a/dynamic-config/testing/entity/build.gradle
+++ b/dynamic-config/testing/entity/build.gradle
@@ -10,7 +10,7 @@ dependencies {
 }
 
 deploy {
-  groupId = 'org.terracotta.dynamic-config.testing'
-  artifactId = 'dynamic-config-testing-entity'
+  groupId = 'org.terracotta'
+  artifactId = 'terracotta-dynamic-config-testing-entity'
   name = 'Dynamic Config Test Entity'
 }

--- a/dynamic-config/testing/galvan/build.gradle
+++ b/dynamic-config/testing/galvan/build.gradle
@@ -17,6 +17,6 @@ dependencies {
 
 deploy {
   groupId = 'org.terracotta'
-  artifactId = 'galvan-platform-support'
+  artifactId = 'terracotta-dynamic-config-testing-galvan'
   name = 'Platform Galvan Support'
 }

--- a/dynamic-config/testing/support/build.gradle
+++ b/dynamic-config/testing/support/build.gradle
@@ -18,7 +18,7 @@ dependencies {
 }
 
 deploy {
-  groupId = 'org.terracotta.dynamic-config.testing'
-  artifactId = 'dynamic-config-testing-support'
+  groupId = 'org.terracotta'
+  artifactId = 'terracotta-dynamic-config-testing-support'
   name = 'Dynamic Config Testing Support'
 }

--- a/healthchecker/client/build.gradle
+++ b/healthchecker/client/build.gradle
@@ -12,6 +12,6 @@ dependencies {
 
 deploy {
   groupId = 'org.terracotta'
-  artifactId = 'healthchecker-client'
+  artifactId = 'terracotta-healthchecker-client'
   name = 'Healthchecker Entity Client'
 }

--- a/healthchecker/common/build.gradle
+++ b/healthchecker/common/build.gradle
@@ -10,5 +10,5 @@ dependencies {
 
 deploy {
   groupId = 'org.terracotta'
-  artifactId = 'healthchecker-common'
+  artifactId = 'terracotta-healthchecker-common'
 }

--- a/healthchecker/server/build.gradle
+++ b/healthchecker/server/build.gradle
@@ -10,6 +10,6 @@ dependencies {
 
 deploy {
   groupId = 'org.terracotta'
-  artifactId = 'healthchecker-server'
+  artifactId = 'terracotta-healthchecker-server'
   name = 'Healthchecker Entity'
 }

--- a/lease/client/build.gradle
+++ b/lease/client/build.gradle
@@ -14,6 +14,6 @@ dependencies {
 
 deploy {
   groupId = 'org.terracotta'
-  artifactId = 'lease-entity-client'
+  artifactId = 'terracotta-lease-client'
   name = 'Lease Entity Client'
 }

--- a/lease/common/build.gradle
+++ b/lease/common/build.gradle
@@ -12,5 +12,5 @@ dependencies {
 
 deploy {
   groupId = 'org.terracotta'
-  artifactId = 'lease-common'
+  artifactId = 'terracotta-lease-common'
 }

--- a/lease/server/build.gradle
+++ b/lease/server/build.gradle
@@ -25,6 +25,6 @@ dependencies {
 
 deploy {
   groupId = 'org.terracotta'
-  artifactId = 'lease-entity-server'
+  artifactId = 'terracotta-lease-server'
   name = 'Lease Entity'
 }

--- a/lease/testing/integration-tests/build.gradle
+++ b/lease/testing/integration-tests/build.gradle
@@ -13,6 +13,6 @@ dependencies {
 
 deploy {
   groupId = 'org.terracotta'
-  artifactId = 'lease-system-test'
+  artifactId = 'terracotta-lease-testing-integration-tests'
   name = 'Lease System tests'
 }

--- a/lease/testing/passthrough/build.gradle
+++ b/lease/testing/passthrough/build.gradle
@@ -11,6 +11,6 @@ dependencies {
 
 deploy {
   groupId = 'org.terracotta'
-  artifactId = 'passthrough-leased-connection-api'
+  artifactId = 'terracotta-lease-testing-passthrough'
   name = 'Lease Passthrough Support'
 }

--- a/management/entities/nms-agent/client/build.gradle
+++ b/management/entities/nms-agent/client/build.gradle
@@ -12,7 +12,7 @@ dependencies {
 }
 
 deploy {
-  groupId = 'org.terracotta.management'
-  artifactId = 'nms-agent-entity'
+  groupId = 'org.terracotta'
+  artifactId = 'terracotta-management-entities-nms-agent-entity'
   name = 'NMS Agent Entity Client'
 }

--- a/management/entities/nms-agent/common/build.gradle
+++ b/management/entities/nms-agent/common/build.gradle
@@ -10,6 +10,6 @@ dependencies {
 }
 
 deploy {
-  groupId = 'org.terracotta.management'
-  artifactId = 'nms-agent-entity-common'
+  groupId = 'org.terracotta'
+  artifactId = 'terracotta-management-entities-nms-agent-common'
 }

--- a/management/entities/nms-agent/server/build.gradle
+++ b/management/entities/nms-agent/server/build.gradle
@@ -12,7 +12,7 @@ dependencies {
 }
 
 deploy {
-  groupId = 'org.terracotta.management'
-  artifactId = 'nms-agent-entity-server'
+  groupId = 'org.terracotta'
+  artifactId = 'terracotta-management-entities-nms-agent-server'
   name = 'NMS Agent Entity'
 }

--- a/management/entities/nms/client/build.gradle
+++ b/management/entities/nms/client/build.gradle
@@ -11,7 +11,7 @@ dependencies {
 }
 
 deploy {
-  groupId = 'org.terracotta.management'
-  artifactId = 'nms-entity-client'
+  groupId = 'org.terracotta'
+  artifactId = 'terracotta-management-entities-nms-client'
   name = 'NMS Entity Client'
 }

--- a/management/entities/nms/common/build.gradle
+++ b/management/entities/nms/common/build.gradle
@@ -10,6 +10,6 @@ dependencies {
 }
 
 deploy {
-  groupId = 'org.terracotta.management'
-  artifactId = 'nms-entity-common'
+  groupId = 'org.terracotta'
+  artifactId = 'terracotta-management-entities-nms-common'
 }

--- a/management/entities/nms/server/build.gradle
+++ b/management/entities/nms/server/build.gradle
@@ -13,7 +13,7 @@ dependencies {
 }
 
 deploy {
-  groupId = 'org.terracotta.management'
-  artifactId = 'nms-entity-server'
+  groupId = 'org.terracotta'
+  artifactId = 'terracotta-management-entities-nms-server'
   name = 'NMS Entity'
 }

--- a/management/model/build.gradle
+++ b/management/model/build.gradle
@@ -12,7 +12,7 @@ dependencies {
 }
 
 deploy {
-  groupId = 'org.terracotta.management'
-  artifactId = 'management-model'
+  groupId = 'org.terracotta'
+  artifactId = 'terracotta-management-model'
   name = 'Management Model'
 }

--- a/management/registry/build.gradle
+++ b/management/registry/build.gradle
@@ -11,7 +11,7 @@ dependencies {
 }
 
 deploy {
-  groupId = 'org.terracotta.management'
-  artifactId = 'management-registry'
+  groupId = 'org.terracotta'
+  artifactId = 'terracotta-management-registry'
   name = 'Management Registry'
 }

--- a/management/sequence-generator/build.gradle
+++ b/management/sequence-generator/build.gradle
@@ -14,7 +14,7 @@ test {
 }
 
 deploy {
-  groupId = 'org.terracotta.management'
-  artifactId = 'sequence-generator'
+  groupId = 'org.terracotta'
+  artifactId = 'terracotta-management-sequence-generator'
   name = 'Management Sequence Generator'
 }

--- a/management/server/api/build.gradle
+++ b/management/server/api/build.gradle
@@ -11,7 +11,7 @@ dependencies {
 }
 
 deploy {
-  groupId = 'org.terracotta.management'
-  artifactId = 'monitoring-service-api'
+  groupId = 'org.terracotta'
+  artifactId = 'terracotta-management-server-api'
   name = 'Monitoring Server API'
 }

--- a/management/server/services/build.gradle
+++ b/management/server/services/build.gradle
@@ -12,7 +12,7 @@ dependencies {
 }
 
 deploy {
-  groupId = 'org.terracotta.management'
-  artifactId = 'monitoring-service'
+  groupId = 'org.terracotta'
+  artifactId = 'terracotta-management-server-services'
   name = 'Monitoring Server Plugin'
 }

--- a/management/testing/entity/build.gradle
+++ b/management/testing/entity/build.gradle
@@ -25,7 +25,7 @@ dependencies {
 }
 
 deploy {
-  groupId = 'org.terracotta.management.testing'
-  artifactId = 'sample-entity'
+  groupId = 'org.terracotta'
+  artifactId = 'terracotta-management-testing-entity'
   name = 'Management Test Entity'
 }

--- a/management/testing/examples/build.gradle
+++ b/management/testing/examples/build.gradle
@@ -12,7 +12,7 @@ dependencies {
 }
 
 deploy {
-  groupId = 'org.terracotta.management'
-  artifactId = 'management-examples'
+  groupId = 'org.terracotta'
+  artifactId = 'terracotta-management-testing-examples'
   name = 'Management Examples'
 }

--- a/platform-base/build.gradle
+++ b/platform-base/build.gradle
@@ -6,6 +6,6 @@ plugins {
 
 deploy {
   groupId = 'org.terracotta'
-  artifactId = 'platform-base'
+  artifactId = 'terracotta-platform-base'
   name = 'ServerInfo Server Plugin'
 }

--- a/platform-layout/build.gradle.kts
+++ b/platform-layout/build.gradle.kts
@@ -192,7 +192,7 @@ publishing {
     register<MavenPublication>("distribution") {
       artifact(tasks.distZip)
       artifact(tasks.distTar)
-      groupId = "org.terracotta.distributions"
+      groupId = "org.terracotta"
       artifactId = "terracotta-platform-layout"
       pom {
         name = "Terracotta platform layout"

--- a/resources/data-root/build.gradle
+++ b/resources/data-root/build.gradle
@@ -30,6 +30,6 @@ dependencies {
 
 deploy {
   groupId = 'org.terracotta'
-  artifactId = 'data-root-resource'
+  artifactId = 'terracotta-resources-data-root'
   name = 'Data Root Server Resource'
 }

--- a/resources/offheap/build.gradle
+++ b/resources/offheap/build.gradle
@@ -29,6 +29,6 @@ dependencies {
 
 deploy {
   groupId = 'org.terracotta'
-  artifactId = 'offheap-resource'
+  artifactId = 'terracotta-resources-offheap'
   name = 'Offheap Server Resource'
 }

--- a/voltron-proxy/client/build.gradle
+++ b/voltron-proxy/client/build.gradle
@@ -10,7 +10,7 @@ dependencies {
 }
 
 deploy {
-  groupId = 'org.terracotta.voltron.proxy'
-  artifactId = 'voltron-proxy-client'
+  groupId = 'org.terracotta'
+  artifactId = 'terracotta-voltron-proxy-client'
   name = 'Voltron Proxy Client'
 }

--- a/voltron-proxy/common/build.gradle
+++ b/voltron-proxy/common/build.gradle
@@ -10,6 +10,6 @@ dependencies {
 }
 
 deploy {
-  groupId = 'org.terracotta.voltron.proxy'
-  artifactId = 'voltron-proxy-common'
+  groupId = 'org.terracotta'
+  artifactId = 'terracotta-voltron-proxy-common'
 }

--- a/voltron-proxy/server/build.gradle
+++ b/voltron-proxy/server/build.gradle
@@ -13,7 +13,7 @@ dependencies {
 }
 
 deploy {
-  groupId = 'org.terracotta.voltron.proxy'
-  artifactId = 'voltron-proxy-server'
+  groupId = 'org.terracotta'
+  artifactId = 'terracotta-voltron-proxy-server'
   name = 'Voltron Proxy Server'
 }

--- a/voter/build.gradle
+++ b/voter/build.gradle
@@ -25,6 +25,6 @@ tool {
 
 deploy {
   groupId = 'org.terracotta'
-  artifactId = 'voter'
+  artifactId = 'terracotta-voter'
   name = 'Voter CLI'
 }


### PR DESCRIPTION
This PR updates all maven coordinates as is:

- everything under `org.terracotta`
- all artifact names prefixed by `terracotta-*`
- artifact names match the folder structure

This helps organizing our libraries in the kit / layout and avoids naming conflicts.

![image](https://github.com/user-attachments/assets/86d4298b-1854-4b1b-a0eb-143c529a1037)
![image](https://github.com/user-attachments/assets/fbc791ae-3b02-4c3a-9368-ecd4dda058b2)
