### PR TITLE
Add support for GPG signing of deployable artifacts with signMavenJavaPublication task

### DIFF
--- a/build-logic/src/main/java/org/terracotta/build/conventions/DeployConvention.java
+++ b/build-logic/src/main/java/org/terracotta/build/conventions/DeployConvention.java
@@ -1,6 +1,11 @@
 package org.terracotta.build.conventions;
 
+import java.util.Optional;
+
 import org.gradle.api.Project;
+import org.gradle.api.publish.PublishingExtension;
+import org.gradle.plugins.signing.SigningExtension;
+import org.gradle.plugins.signing.SigningPlugin;
 import org.terracotta.build.plugins.DeployPlugin;
 
 /**
@@ -17,5 +22,24 @@ public class DeployConvention implements ConventionPlugin<Project, DeployPlugin>
   public void apply(Project project) {
     project.getPlugins().apply(BaseConvention.class);
     project.getPlugins().apply(DeployPlugin.class);
+    project.getPlugins().apply(SigningPlugin.class);
+
+    final String gpgSigningKey = Optional.ofNullable(System.getenv("GPG_SIGNING_KEY"))
+        .orElse(project.hasProperty("gpgSigningKey") ? project.property("gpgSigningKey").toString() : null);
+    final String gpgSigningPassphrase = Optional.ofNullable(System.getenv("GPG_SIGNING_PASSPHRASE")).orElse(
+        project.hasProperty("gpgSigningPassphrase") ? project.property("gpgSigningPassphrase").toString() : null);
+
+    if (gpgSigningKey != null && gpgSigningPassphrase != null) {
+      project.afterEvaluate(p -> {
+        p.getExtensions().configure(PublishingExtension.class, publishing -> {
+          if (!publishing.getPublications().isEmpty()) {
+            project.getExtensions().configure(SigningExtension.class, signing -> {
+              signing.useInMemoryPgpKeys(gpgSigningKey, gpgSigningPassphrase);
+              signing.sign(publishing.getPublications());
+            });
+          }
+        });
+      });
+    }
   }
 }


### PR DESCRIPTION
This PR updates the new `DeployConvention` to add support for GPG signing.

## How it works

jars can be signed with: 

```bash
> gw assemble signMavenJavaPublication signDistributionPublication
```

## How to configure

1. Export the GPG secret key as base64 with `gpg --export-secret-keys --armor <key-id>`

2. **For CI**: Configure the GPG armor key and passphrase as secrets to allow passing them in `GPG_SIGNING_KEY` and `GPG_SIGNING_PASSPHRASE` environment variables

3. An alternative option is to pass them through gradle properties:

```properties
gpgSigningKey = -----BEGIN PGP PRIVATE KEY BLOCK-----\n\
\n\
lIYEZ8jC2hYJKwYBBAHaRw8BAQdAoF87CdBIKC7k0Qs3Ai9Wsg+QrvmQhbXZ9seb\n\
[...]
akUBAO30AEyZztjK5f4V6NDmuZB3UQgAcgmnMYouXn1zhKcA\n\
=AeWI\n\
-----END PGP PRIVATE KEY BLOCK-----
gpgSigningPassphrase = <passphrase>
 ```
