### PR TITLE
Add Release GitHub workflow which builds, signs and deploys to Sonatype upon creation of a GitHub release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,33 @@
+name: Release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout latest code
+        uses: actions/checkout@v3
+
+      - name: "Setup JDK 17"
+        uses: actions/setup-java@v4
+        with:
+          distribution: "temurin"
+          java-version: 17
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Sign
+        run: ./gradlew assemble signMavenJavaPublication signDistributionPublication
+        env:
+          GPG_SIGNING_KEY: ${{ secrets.GPG_SIGNING_KEY }}
+          GPG_SIGNING_PASSPHRASE: ${{ secrets.GPG_SIGNING_PASSPHRASE }}
+
+      - name: Publish
+        run: ./gradlew publish closeSonatypeStagingRepository
+        env:
+          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}

--- a/build.gradle
+++ b/build.gradle
@@ -32,8 +32,8 @@ dependencyCheck {
 nexusPublishing {
   repositories {
     sonatype {
-      username = sonatypeUser
-      password = sonatypePwd
+      username = System.getenv("SONATYPE_USERNAME") ?: sonatypeUser
+      password = System.getenv("SONATYPE_PASSWORD") ?: sonatypePwd
     }
   }
   // Sonatype is often very slow in these operations:

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
-# Project version (default unless overridden, see build.gradle)
-defaultVersion = 5.11-SNAPSHOT
+# Next version that is going to be released
+defaultVersion = 5.11.0
 
 # Terracotta libs
 terracottaAngelaVersion = 3.3.40


### PR DESCRIPTION
This PR adds a GitHub workflow which will build and sign and deploy to Maven Central.

## How to use

1. When a developper wants to make a release, he needs to update the version `defaultVersion = 5.11.0` to the next one, for example `defaultVersion = 5.11.1`
2. Then he goes to the GitHub release tab (https://github.com/Terracotta-OSS/terracotta-platform/releases) to create a new release: `v5.11.1`
3. The workflow will trigger and deploy to central

Note: this would be possible to source the version to release from the tag, for example if we create `v5.11.1` release, then `defaultVersion` would be set to `5.11.1` when building. I did not implement that... 
It is better to keep consistency between the tag content and what gets deployed on Sonatype, meaning that if the gradle.properties defaultVersion is 1.2.3, then 1.2.3 should be deployed, regardless of the tag value. In our project, there is a match to make between the project content and sonatype but we do not need to make a match between the tag value and sonatype (although this is what we must aim for).

## How to configure

4 secrets have to be created:

- `GPG_SIGNING_KEY`
- `GPG_SIGNING_PASSPHRASE`
- `SONATYPE_USERNAME`
- `SONATYPE_PASSWORD`

To generate GPG secrets (armor key), the command is: `gpg --export-secret-keys --armor <key-id>`

## Some ref for GH release event

- https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#release
- https://docs.github.com/en/webhooks/webhook-events-and-payloads?actionType=released#release

## Is it secure ?

Secrets are only set on environments running gradle command, so external github actions cannot access them.
To expose a secret to a build log output, a developper would need to raise a PR which is outputting the value of these 4 environment variables, then have the PR reviewed and merged by a colleague, and then have the right to trigger a release.

I think that the PR review process plus the permissions about who can create a release are both helping keep the secrets safe.