### PR TITLE
Switched from Nexus to Artifactory for deployment

### DIFF
--- a/build-logic/build.gradle
+++ b/build-logic/build.gradle
@@ -12,6 +12,7 @@ dependencies {
   api 'com.github.spotbugs.snom:spotbugs-gradle-plugin:6.0.27'
   api 'org.unbroken-dome.gradle-plugins:gradle-xjc-plugin:2.0.0'
   api 'org.owasp:dependency-check-gradle:8.4.3'
+  api 'org.jfrog.buildinfo:build-info-extractor-gradle:5.2.5'
 
   implementation 'org.terracotta:terracotta-utilities-tools:0.0.16'
 

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,6 @@ import org.terracotta.build.conventions.BaseConvention
 plugins {
   id 'org.owasp.dependencycheck'
   id 'org.terracotta.build.convention.base'
-  id 'io.github.gradle-nexus.publish-plugin'
 }
 
 gradle.includedBuilds.forEach { includedBuild ->
@@ -26,20 +25,6 @@ dependencyCheck {
   skipConfigurations += ['checkstyle', 'spotbugs', 'asciidoctor']
   analyzers {
     assemblyEnabled = false // no .NET here, prevent warnings
-  }
-}
-
-nexusPublishing {
-  repositories {
-    sonatype {
-      username = sonatypeUser
-      password = sonatypePwd
-    }
-  }
-  // Sonatype is often very slow in these operations:
-  transitionCheckOptions {
-      delayBetween = Duration.ofSeconds((findProperty("delayBetweenRetriesInSeconds") ?: "10") as int)
-      maxRetries = (findProperty("numberOfRetries") ?: "100") as int
   }
 }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,7 +1,6 @@
 pluginManagement {
   plugins {
     id 'biz.aQute.bnd.builder' version '7.1.0'
-    id 'io.github.gradle-nexus.publish-plugin' version '1.3.0'
     id 'org.asciidoctor.jvm.convert' version '4.0.4'
     id 'org.asciidoctor.jvm.gems' version '4.0.4'
     id 'org.owasp.dependencycheck' version '8.4.3'


### PR DESCRIPTION
Switched from Nexus to Artifactory for deployment.

Tested with:

`gw --stacktrace --info publish`

and

`gw --stacktrace --info :platform-layout:publish`

to verify that the layout distribution is also deployed.
