### PR TITLE
Change log level in LeaseMaintainerFactory from INFO to DEBUG

### DIFF
--- a/lease/client/src/main/java/org/terracotta/lease/LeaseMaintainerFactory.java
+++ b/lease/client/src/main/java/org/terracotta/lease/LeaseMaintainerFactory.java
@@ -16,6 +16,8 @@
  */
 package org.terracotta.lease;
 
+import java.util.Properties;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terracotta.connection.Connection;
@@ -23,9 +25,6 @@ import org.terracotta.connection.entity.EntityRef;
 import org.terracotta.exception.EntityNotFoundException;
 import org.terracotta.exception.EntityNotProvidedException;
 import org.terracotta.exception.EntityVersionMismatchException;
-
-import java.util.Properties;
-
 import static org.terracotta.lease.LeaseEntityConstants.ENTITY_NAME;
 import static org.terracotta.lease.LeaseEntityConstants.ENTITY_VERSION;
 
@@ -42,7 +41,7 @@ public class LeaseMaintainerFactory {
    * @return the LeaseMaintainer that will maintain leases on the connection
    */
   public static LeaseMaintainer createLeaseMaintainer(Connection connection) {
-    LOGGER.info("Creating LeaseMaintainer for connection: " + connection);
+    LOGGER.debug("Creating LeaseMaintainer for connection: " + connection);
     ProxyLeaseReconnectListener leaseReconnectListener = new ProxyLeaseReconnectListener();
     LeaseAcquirer leaseAcquirer = getLeaseAcquirer(connection, leaseReconnectListener);
 


### PR DESCRIPTION
# PR: Change log level in LeaseMaintainerFactory from INFO to DEBUG

Fixes #468

In adding my name to the list of publishers, I agree to the current contributor agreement 
as referred to here: https://github.com/terracotta-oss/contributing/blob/main/CONTRIBUTING.md.
I also agree to follow all of the responsibilities and policies pertaining to being a project
"Publisher", as listed in the same document.

## Changes
- Changed log level in `LeaseMaintainerFactory.createLeaseMaintainer()` from INFO to DEBUG
- Reordered imports to follow project conventions (moved java.util.Properties before org.slf4j imports)

## Why
The creation of a LeaseMaintainer is a common operation that doesn't need to be logged at INFO level in normal operation. Changing to DEBUG level reduces log noise while still providing the information when needed for troubleshooting.

## Testing
No functional changes, only logging level adjustment. Verified that the log message appears when debug logging is enabled and doesn't appear with default logging levels.