### PR TITLE
Fix broken platform-layout following previous kit layout refactorings

### DIFF
--- a/layout/pom.xml
+++ b/layout/pom.xml
@@ -148,6 +148,15 @@
       <artifactId>dynamic-config-cli-config-tool</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.terracotta.dynamic-config</groupId>
+      <artifactId>dynamic-config-api-json</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+    </dependency>
 
     <!--
       tools/voter/lib

--- a/layout/src/main/assembly/platform-layout.xml
+++ b/layout/src/main/assembly/platform-layout.xml
@@ -120,17 +120,29 @@
     <dependencySet>
       <outputDirectory>tools/lib</outputDirectory>
       <includes>
-        <include>org.terracotta:terracotta-utilities-tools</include>
-        <include>org.terracotta.common:common-inet-support</include>
-        <include>org.terracotta.common:common-structures</include>
-        <include>org.terracotta.common:common-json-support</include>
-        <include>org.terracotta.common:common-nomad</include>
-        <include>org.terracotta.common:output-service</include>
-        <include>com.google.code.gson:gson</include>
-        <include>com.beust:jcommander</include>
         <include>ch.qos.logback:logback-classic</include>
         <include>ch.qos.logback:logback-core</include>
+        <include>com.beust:jcommander</include>
+        <include>com.google.code.gson:gson</include>
         <include>org.slf4j:slf4j-api</include>
+        <include>org.terracotta:terracotta-utilities-tools</include>
+        <include>org.terracotta.common:common-inet-support</include>
+        <include>org.terracotta.common:common-json-support</include>
+        <include>org.terracotta.common:common-nomad</include>
+        <include>org.terracotta.common:common-structures</include>
+        <include>org.terracotta.common:output-service</include>
+        <include>org.terracotta.diagnostic:diagnostic-client</include>
+        <include>org.terracotta.diagnostic:diagnostic-common</include>
+        <include>org.terracotta.diagnostic:diagnostic-model</include>
+        <include>org.terracotta.dynamic-config:dynamic-config-api</include>
+        <include>org.terracotta.dynamic-config:dynamic-config-api-json</include>
+        <include>org.terracotta.dynamic-config:dynamic-config-model</include>
+        <include>org.terracotta.dynamic-config.cli:dynamic-config-cli-api</include>
+        <include>org.terracotta.dynamic-config.cli:dynamic-config-cli-config-tool</include>
+        <include>org.terracotta.dynamic-config.cli:dynamic-config-cli-support</include>
+        <include>org.terracotta.dynamic-config.entities:dynamic-config-nomad-entity-client</include>
+        <include>org.terracotta.dynamic-config.entities:dynamic-config-nomad-entity-common</include>
+        <include>org.terracotta.internal:client-runtime</include>
       </includes>
     </dependencySet>
 
@@ -138,24 +150,6 @@
       <outputDirectory>tools/voter/lib</outputDirectory>
       <includes>
         <include>org.terracotta:voter</include>
-      </includes>
-    </dependencySet>
-
-    <dependencySet>
-      <outputDirectory>tools/lib</outputDirectory>
-      <includes>
-        <include>org.terracotta.internal:client-runtime</include>
-        <include>org.terracotta.dynamic-config.cli:dynamic-config-cli-config-tool</include>
-        <include>org.terracotta.dynamic-config.cli:dynamic-config-cli-api</include>
-        <include>org.terracotta.dynamic-config.cli:dynamic-config-cli-support</include>
-        <include>org.terracotta.dynamic-config:dynamic-config-model</include>
-        <include>org.terracotta.dynamic-config:dynamic-config-api</include>
-        <include>org.terracotta.dynamic-config:dynamic-config-json</include>
-        <include>org.terracotta.dynamic-config.entities:dynamic-config-nomad-entity-common</include>
-        <include>org.terracotta.dynamic-config.entities:dynamic-config-nomad-entity-client</include>
-        <include>org.terracotta.diagnostic:diagnostic-client</include>
-        <include>org.terracotta.diagnostic:diagnostic-common</include>
-        <include>org.terracotta.diagnostic:diagnostic-model</include>
       </includes>
     </dependencySet>
 


### PR DESCRIPTION
This change does not impact downstream project and adds to the platform kit used for testing the missing libraries

For example, the following commands were failing with class not found:

`./kit/target/platform-kit-5.10-SNAPSHOT/platform-kit-5.10-SNAPSHOT/tools/bin/config-tool.sh --help`

`./kit/target/platform-kit-5.10-SNAPSHOT/platform-kit-5.10-SNAPSHOT/tools/voter/bin/start-tc-voter.sh -connect-to localhost:941`
@[mathieucarbou-ibm](https://github.com/Terracotta-OSS/terracotta-platform/commits?author=mathieucarbou-ibm)
mathieucarbou-ibm committed 1 minute ago