### PR TITLE
Adding support for line continuation

### DIFF
--- a/dynamic-config/model/src/main/java/org/terracotta/dynamic_config/api/model/Setting.java
+++ b/dynamic-config/model/src/main/java/org/terracotta/dynamic_config/api/model/Setting.java
@@ -507,7 +507,7 @@ public enum Setting {
           // tuple.t2 != null
           // complete reset of all entries
           node.setTcProperties(emptyMap());
-          Stream.of(tuple.t2.split(",")).map(kv -> kv.split(":")).forEach(kv -> node.putTcProperty(kv[0], kv[1]));
+          Stream.of(tuple.t2.split(",")).map(kv -> kv.split(":")).forEach(kv -> node.putTcProperty(kv[0].trim(), kv[1].trim()));
         } else {
           // tuple.t1 != null && tuple.t2 != null
           node.putTcProperty(tuple.t1, tuple.t2);

--- a/dynamic-config/model/src/test/java/org/terracotta/dynamic_config/api/service/ConfigPropertiesTranslatorTest.java
+++ b/dynamic-config/model/src/test/java/org/terracotta/dynamic_config/api/service/ConfigPropertiesTranslatorTest.java
@@ -28,6 +28,7 @@ import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
 import java.util.Arrays;
+import java.util.Map;
 import java.util.Properties;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
@@ -628,6 +629,42 @@ public class ConfigPropertiesTranslatorTest {
 
     // these clusters need to be identical
     assertEquals(clusterFromPropertiesFile, clusterFromConfigFile);
+  }
+
+  @Test
+  public void test_cluster_from_cfg_properties() throws URISyntaxException {
+    Cluster cluster = new ClusterFactory().create(Paths.get(getClass().getResource("/tc-config.cfg").toURI()));
+    assertThat(cluster.getStripes().get(0).getNodeCount(), is(4));
+    for (int i = 0; i < 4; i++) {
+      Map<String, String> properties = cluster.getStripes().get(0).getNodes().get(i).getTcProperties().get();
+      assert(properties != null);
+      assertThat(properties.size(), is(25));
+      assertThat(properties.get("prop-01"), is("true"));
+      assertThat(properties.get("prop-02"), is("5000"));
+      assertThat(properties.get("prop-03"), is("1000"));
+      assertThat(properties.get("prop-04"), is("3"));
+      assertThat(properties.get("prop-05"), is("true"));
+      assertThat(properties.get("prop-06"), is("2"));
+      assertThat(properties.get("prop-07"), is("5"));
+      assertThat(properties.get("prop-08"), is("true"));
+      assertThat(properties.get("prop-09"), is("5000"));
+      assertThat(properties.get("prop-10"), is("1000"));
+      assertThat(properties.get("prop-11"), is("3"));
+      assertThat(properties.get("prop-12"), is("true"));
+      assertThat(properties.get("prop-13"), is("2"));
+      assertThat(properties.get("prop-14"), is("5"));
+      assertThat(properties.get("prop-15"), is("true"));
+      assertThat(properties.get("prop-16"), is("5000"));
+      assertThat(properties.get("prop-17"), is("1000"));
+      assertThat(properties.get("prop-18"), is("3"));
+      assertThat(properties.get("prop-19"), is("true"));
+      assertThat(properties.get("prop-20"), is("2"));
+      assertThat(properties.get("prop-21"), is("5"));
+      assertThat(properties.get("prop-22"), is("true"));
+      assertThat(properties.get("prop-23"), is("15000"));
+      assertThat(properties.get("prop-24"), is("true"));
+      assertThat(properties.get("prop-25"), is("15000"));
+    }
   }
 
   private Reader getReader(String[] params) {

--- a/dynamic-config/model/src/test/resources/tc-config.cfg
+++ b/dynamic-config/model/src/test/resources/tc-config.cfg
@@ -1,0 +1,85 @@
+#
+# Copyright Terracotta, Inc.
+# Copyright IBM Corp. 2024, 2025
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+cluster-name=mycluster
+# comment
+stripe-names=stripeA
+stripeA:node-names=A,B,C,D
+
+tc-properties= \
+\
+prop-01:true,\
+# comment1
+# comment2\
+prop-02 : 5000,\
+prop-03:          1000,\   
+prop-04 :3,\
+\   
+ \
+
+  \
+prop-05  :  true,\
+prop-06:2,      \   
+prop-07:5,\
+#\
+prop-08:true,\
+prop-09:5000,       \ 
+prop-10:1000,\
+        \
+      # comment3\
+      prop-11:3,\
+      prop-12:true ,\
+      prop-13:2,\
+      prop-14:5,\
+      prop-15:true,\
+          prop-16:5000,\
+          prop-17:1000,\
+          prop-18:3,\
+          prop-19:true,\
+              prop-20:2  ,  \
+              prop-21:5  ,  \
+prop-22:true,\
+prop-23:15000,\
+prop-24:true,\
+prop-25:15000
+
+A:data-dirs=main:/opt/webmethods/10.11/Terracotta/server-data
+A:port=9410
+# comment
+A:group-port=9430
+A:hostname=A
+A:log-dir=/opt/webmethods/10.11/terracotta/server-logs
+
+B:data-dirs=main:/opt/webmethods/10.11/Terracotta/server-data
+B:port=9410
+B:group-port=9430
+#
+B:hostname=B
+B:log-dir=/opt/webmethods/10.11/terracotta/server-logs
+
+C:data-dirs=main:/opt/webmethods/10.11/Terracotta/server-data
+C:port=9410
+C:group-port=9430
+C:hostname=C
+C:log-dir=/opt/webmethods/10.11/terracotta/server-logs
+
+D:data-dirs=main:/opt/webmethods/10.11/Terracotta/server-data
+D:port=9410
+D:group-port=9430
+D:hostname=D
+D:log-dir=/opt/webmethods/10.11/terracotta/server-logs
+#
+#


### PR DESCRIPTION
Prior to this change, the newer .cfg file format did not support line continuation, which is supported with the original .properties format.  This deficiency was noticed whenever a tc-properties setting possessed several entries and everything had to be entered on a single line, which made it difficult to clearly identify each property.  This change now allows each property to be continued on separate line.
