### PR TITLE
Fix wrong dependency scope that should be api since exposed in OffHeapResourcesProvider class

### DIFF
--- a/resources/offheap/build.gradle
+++ b/resources/offheap/build.gradle
@@ -20,7 +20,7 @@ dependencies {
   xmlApi "org.terracotta.internal:tc-config-parser:$terracottaConfigVersion"
   xmlApi "org.terracotta:tcconfig-schema:$terracottaConfigVersion"
 
-  implementation project(':common:structures')
+  api project(':common:structures')
 
   xmlXjcEpisodes "org.terracotta:tcconfig-schema:$terracottaConfigVersion"
 }


### PR DESCRIPTION
Saw this little issue when integrating in EE