### PR TITLE
TDB-19412: Wire core security operations into the security logging

### DIFF
--- a/dynamic-config/testing/integration-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/SecurityLog1x2IT.java
+++ b/dynamic-config/testing/integration-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/SecurityLog1x2IT.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright Terracotta, Inc.
+ * Copyright IBM Corp. 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.dynamic_config.system_tests.activated;
+
+import org.junit.Test;
+import org.terracotta.angela.client.filesystem.RemoteFile;
+import org.terracotta.angela.common.tcconfig.TerracottaServer;
+import org.terracotta.dynamic_config.test_support.ClusterDefinition;
+import org.terracotta.dynamic_config.test_support.DynamicConfigIT;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.endsWith;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.startsWith;
+import static org.terracotta.angela.client.support.hamcrest.AngelaMatchers.containsOutput;
+import static org.terracotta.angela.client.support.hamcrest.AngelaMatchers.successful;
+
+@ClusterDefinition(nodesPerStripe = 2, autoActivate = true)
+public class SecurityLog1x2IT extends DynamicConfigIT {
+  @Test
+  public void test_security_logs() {
+    waitUntil(
+      () -> configTool("set", "-connect-to", "localhost:" + getNodePort(1, 1), "-setting", "security-log-dir=logs/security", "-auto-restart"),
+      is(successful()));
+
+    for (int i = 1; i <= 2; i++) {
+      final int nodeId = i;
+
+      waitUntil(
+        () -> configTool("get", "-connect-to", "localhost:" + getNodePort(1, nodeId), "-setting", "security-log-dir", "-runtime"),
+        containsOutput("security-log-dir=logs/security"));
+
+      TerracottaServer node = getNode(1, nodeId);
+      List<RemoteFile> logFiles = angela.tsa().browse(node, Paths.get("logs", "security").toString()).list();
+      assertThat(logFiles, hasSize(1));
+      assertThat(logFiles.get(0).getName(), startsWith("terracotta-security-log-"));
+      assertThat(logFiles.get(0).getName(), endsWith(".log"));
+
+      try {
+        angela.tsa()
+          .browse(node, Paths.get("logs", "security").toString())
+          .downloadTo(Paths.get("build"));
+
+        Path logFile = Paths.get("build", logFiles.get(0).getName());
+        String content = Files.readString(logFile);
+        Files.delete(logFile);
+
+        assertThat(content, containsString("client connection open event: buffer=com.tc.net.core.ClearTextSocketEndpoint"));
+        assertThat(content, containsString("client connection close event: buffer=com.tc.net.core.ClearTextSocketEndpoint"));
+        assertThat(content, containsString("diagnostic handshake started: clientAddress="));
+        assertThat(content, containsString("server node joined: nodeId=NodeID["));
+
+      } catch (IOException e) {
+        throw new UncheckedIOException(e);
+      }
+    }
+  }
+}

--- a/security/logger/server/services/src/main/java/org/terracotta/security/logger/SecurityLoggerServiceProvider.java
+++ b/security/logger/server/services/src/main/java/org/terracotta/security/logger/SecurityLoggerServiceProvider.java
@@ -17,6 +17,7 @@
 package org.terracotta.security.logger;
 
 import com.tc.classloader.BuiltinService;
+import com.tc.spi.Guardian;
 import org.terracotta.entity.PlatformConfiguration;
 import org.terracotta.entity.ServiceConfiguration;
 import org.terracotta.entity.ServiceProvider;
@@ -24,6 +25,11 @@ import org.terracotta.entity.ServiceProviderConfiguration;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static java.util.stream.Collectors.joining;
 
 @BuiltinService
 public class SecurityLoggerServiceProvider implements ServiceProvider {
@@ -37,23 +43,63 @@ public class SecurityLoggerServiceProvider implements ServiceProvider {
 
   @Override
   public <T> T getService(long consumerID, ServiceConfiguration<T> configuration) {
+    // provides SecurityLogger interface to other plugins
     if (configuration.getServiceType() == SecurityLogger.class) {
-      Collection<SecurityLogger> loggers = platformConfiguration.getExtendedConfiguration(SecurityLogger.class);
-      if (loggers.size() != 1) {
-        throw new IllegalStateException("Multiple or no instance found of " + SecurityLogger.class);
-      }
-      return configuration.getServiceType().cast(loggers.iterator().next());
+      return configuration.getServiceType().cast(findSecurityLogger().orElse(SecurityLogger.NOOP));
     }
+
+    // provide Guardian implementation to core
+    if (consumerID == 0 && configuration.getServiceType() == Guardian.class) {
+      return configuration.getServiceType().cast(new Guardian() {
+        private final AtomicReference<SecurityLogger> cachedLogger = new AtomicReference<>();
+
+        @Override
+        public boolean validate(Op op, Properties properties) {
+          if (op == Op.SECURITY_OP) {
+            Object message = properties.remove("id");
+            if (message != null) {
+              SecurityLogger securityLogger = this.cachedLogger.get();
+              // The following code within the if block is just to trigger a new search for the logger until it is found.
+              // It will be found later once SecurityLoggerExtension is loaded and has registered a security logger implementation
+              if (securityLogger == null) {
+                securityLogger = findSecurityLogger()
+                  .filter(logger -> this.cachedLogger.compareAndSet(null, logger))
+                  .orElseGet(this.cachedLogger::get);
+              }
+              // securityLogger will be null until SecurityLoggerExtension is loaded and has registered a security logger implementation
+              if (securityLogger != null) {
+                String context = properties.stringPropertyNames().stream().sorted().map(key -> key + "=" + properties.getProperty(key)).collect(joining(", "));
+                if (context.isEmpty()) {
+                  securityLogger.log(message.toString());
+                } else {
+                  securityLogger.log("{}: {}", message, context);
+                }
+              }
+            }
+          }
+          return true;
+        }
+      });
+    }
+
     throw new UnsupportedOperationException(configuration.getServiceType().getName());
   }
 
   @Override
   public Collection<Class<?>> getProvidedServiceTypes() {
-    return List.of(SecurityLogger.class);
+    return List.of(SecurityLogger.class, Guardian.class);
   }
 
   @Override
   public void prepareForSynchronization() {
     // no-op
+  }
+
+  private Optional<SecurityLogger> findSecurityLogger() {
+    Collection<SecurityLogger> loggers = platformConfiguration.getExtendedConfiguration(SecurityLogger.class);
+    if (loggers.size() != 1) {
+      throw new IllegalStateException("Multiple instances found for " + SecurityLogger.class);
+    }
+    return loggers.stream().findAny();
   }
 }


### PR DESCRIPTION
This PR implements the Guardian core service to receive security operation logs and forward them to the security log file.

Also added a IT test: `SecurityLog1x2IT` that can be run to see the content of the security log:

<img width="453" height="528" alt="image" src="https://github.com/user-attachments/assets/13e7b2a0-7010-49a3-8945-63d482bad9e4" />
