### PR TITLE
[5.11] TDB-20032: Fix Lock and Unlock commands

### DIFF
--- a/dynamic-config/cli/api/src/main/java/org/terracotta/dynamic_config/cli/api/command/LockConfigAction.java
+++ b/dynamic-config/cli/api/src/main/java/org/terracotta/dynamic_config/cli/api/command/LockConfigAction.java
@@ -1,6 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
- * Copyright IBM Corp. 2024, 2025
+ * Copyright IBM Corp. 2024, 2026
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,23 +16,11 @@
  */
 package org.terracotta.dynamic_config.cli.api.command;
 
-import org.terracotta.diagnostic.model.LogicalServerState;
-import org.terracotta.dynamic_config.api.model.Cluster;
 import org.terracotta.dynamic_config.api.model.LockContext;
-import org.terracotta.dynamic_config.api.model.Node.Endpoint;
-import org.terracotta.inet.HostPort;
 
-import java.util.LinkedHashMap;
-import java.util.Map;
+public class LockConfigAction extends LockUnlockConfigAction {
 
-public class LockConfigAction extends RemoteAction {
-
-  private HostPort node;
   private String lockContext;
-
-  public void setNode(HostPort node) {
-    this.node = node;
-  }
 
   public void setLockContext(String lockContext) {
     this.lockContext = lockContext;
@@ -40,10 +28,7 @@ public class LockConfigAction extends RemoteAction {
 
   @Override
   public final void run() {
-    Map<Endpoint, LogicalServerState> allNodes = findRuntimePeersStatus(node);
-    LinkedHashMap<Endpoint, LogicalServerState> onlineNodes = filterOnlineNodes(allNodes);
-    Cluster cluster = getRuntimeCluster(node);
-    String token = lock(cluster, onlineNodes, LockContext.from(lockContext));
-    output.out("Config lock with token: " + token);
+    super.run();
+    lock(cluster, onlineNodes, LockContext.from(lockContext));
   }
 }

--- a/dynamic-config/cli/api/src/main/java/org/terracotta/dynamic_config/cli/api/command/LockUnlockConfigAction.java
+++ b/dynamic-config/cli/api/src/main/java/org/terracotta/dynamic_config/cli/api/command/LockUnlockConfigAction.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright Terracotta, Inc.
+ * Copyright IBM Corp. 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.dynamic_config.cli.api.command;
+
+import org.terracotta.diagnostic.model.LogicalServerState;
+import org.terracotta.dynamic_config.api.model.Cluster;
+import org.terracotta.dynamic_config.api.model.Node.Endpoint;
+import org.terracotta.inet.HostPort;
+
+import java.util.Map;
+
+public abstract class LockUnlockConfigAction extends RemoteAction {
+
+  protected HostPort node;
+  protected boolean force;
+
+  protected Map<Endpoint, LogicalServerState> onlineNodes;
+  protected Cluster cluster;
+
+  public void setForce(boolean force) {
+    this.force = force;
+  }
+
+  public void setNode(HostPort node) {
+    this.node = node;
+  }
+
+  @Override
+  public void run() {
+    cluster = getRuntimeCluster(node);
+    onlineNodes = findOnlineRuntimePeers(node);
+
+    boolean allOnlineNodesActivated = areAllNodesActivated(onlineNodes.keySet());
+    if (!allOnlineNodesActivated) {
+      throw new IllegalStateException("The cluster is not fully activated: a lock or unlock operation can only be performed on an activated cluster.");
+    }
+
+    // validate that all the online nodes are either actives or passives
+    ensureNodesAreEitherActiveOrPassive(onlineNodes);
+
+    ensureActivesAreAllOnline(cluster, onlineNodes);
+
+    if (requiresAllNodesAlive()) {
+      // Check passive nodes as well if the setting requires all nodes to be online
+      ensurePassivesAreAllOnline(cluster, onlineNodes);
+    }
+  }
+
+  protected boolean requiresAllNodesAlive() {
+    // By default, we require all nodes to be up to allow a DC change: the consensus system needs all nodes to be able to vote and prepare the change.
+    // This will also solve any potential partitioned config to happen (or loosing a change if a failover happens just after),
+    // in the case a nomad change is prepared at the same time a passive is synchronizing the DC configuration from active server.
+    // This can be overridden by the user if he knows what he is doing with: -force
+    return !force;
+  }
+}

--- a/dynamic-config/cli/api/src/main/java/org/terracotta/dynamic_config/cli/api/command/RemoteAction.java
+++ b/dynamic-config/cli/api/src/main/java/org/terracotta/dynamic_config/cli/api/command/RemoteAction.java
@@ -342,6 +342,7 @@ public abstract class RemoteAction implements Runnable {
       nomadManager = ((LockAwareNomadManager<NodeContext>) nomadManager).getUnderlying();
     }
     this.nomadManager = new LockAwareNomadManager<>(lockContext.getToken(), nomadManager);
+    output.out("Config locked with token: " + lockContext.getToken());
     return lockContext.getToken();
   }
 

--- a/dynamic-config/cli/api/src/main/java/org/terracotta/dynamic_config/cli/api/command/TopologyAction.java
+++ b/dynamic-config/cli/api/src/main/java/org/terracotta/dynamic_config/cli/api/command/TopologyAction.java
@@ -1,6 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
- * Copyright IBM Corp. 2024, 2025
+ * Copyright IBM Corp. 2024, 2026
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -117,7 +117,6 @@ public abstract class TopologyAction extends RemoteAction {
     if (mustLock) {
       // if we need to lock the operation, lock it first
       createdLockToken = lock(destinationCluster, destinationOnlineNodes, LockTag.OWNER_PLATFORM, buildLockTag());
-      output.out("Config lock with token: " + createdLockToken);
       destinationCluster = getUpcomingCluster(destination);
     }
     // then we run the scale task. In case of error, we unlock, but only if we placed a lock

--- a/dynamic-config/cli/api/src/main/java/org/terracotta/dynamic_config/cli/api/command/UnlockConfigAction.java
+++ b/dynamic-config/cli/api/src/main/java/org/terracotta/dynamic_config/cli/api/command/UnlockConfigAction.java
@@ -1,6 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
- * Copyright IBM Corp. 2024, 2025
+ * Copyright IBM Corp. 2024, 2026
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,27 +16,10 @@
  */
 package org.terracotta.dynamic_config.cli.api.command;
 
-import org.terracotta.diagnostic.model.LogicalServerState;
-import org.terracotta.dynamic_config.api.model.Cluster;
-import org.terracotta.dynamic_config.api.model.Node.Endpoint;
-import org.terracotta.inet.HostPort;
-
-import java.util.LinkedHashMap;
-import java.util.Map;
-
-public class UnlockConfigAction extends RemoteAction {
-
-  private HostPort node;
-
-  public void setNode(HostPort node) {
-    this.node = node;
-  }
-
+public class UnlockConfigAction extends LockUnlockConfigAction {
   @Override
   public final void run() {
-    Map<Endpoint, LogicalServerState> allNodes = findRuntimePeersStatus(node);
-    LinkedHashMap<Endpoint, LogicalServerState> onlineNodes = filterOnlineNodes(allNodes);
-    Cluster cluster = getRuntimeCluster(node);
+    super.run();
     unlock(cluster, onlineNodes);
   }
 }

--- a/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/LockConfigCommand.java
+++ b/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/LockConfigCommand.java
@@ -1,6 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
- * Copyright IBM Corp. 2024, 2025
+ * Copyright IBM Corp. 2024, 2026
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,6 +35,9 @@ public class LockConfigCommand extends Command {
   @Parameter(names = {"-lock-context"}, description = "Lock context", required = true)
   String lockContext;
 
+  @Parameter(names = {"-force"}, description = "Force the operation", hidden = true)
+  boolean force;
+
   @Inject
   public LockConfigAction action;
 
@@ -50,6 +53,7 @@ public class LockConfigCommand extends Command {
   public void run() {
     action.setNode(node);
     action.setLockContext(lockContext);
+    action.setForce(force);
 
     action.run();
   }

--- a/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/SetCommand.java
+++ b/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/SetCommand.java
@@ -1,6 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
- * Copyright IBM Corp. 2024, 2025
+ * Copyright IBM Corp. 2024, 2026
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,7 +45,7 @@ public class SetCommand extends RestartCommand {
   boolean autoRestart = false;
 
   @Parameter(names = {"-force"}, description = "Force the operation", hidden = true)
-  protected boolean force;
+  boolean force;
 
   @Inject
   public SetAction action;

--- a/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/UnlockConfigCommand.java
+++ b/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/UnlockConfigCommand.java
@@ -1,6 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
- * Copyright IBM Corp. 2024, 2025
+ * Copyright IBM Corp. 2024, 2026
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,6 +32,9 @@ public class UnlockConfigCommand extends Command {
   @Parameter(names = {"-connect-to"}, description = "Node to connect to", required = true, converter = HostPortConverter.class)
   HostPort node;
 
+  @Parameter(names = {"-force"}, description = "Force the operation", hidden = true)
+  boolean force;
+
   @Inject
   public UnlockConfigAction action;
 
@@ -46,6 +49,7 @@ public class UnlockConfigCommand extends Command {
   @Override
   public void run() {
     action.setNode(node);
+    action.setForce(force);
 
     action.run();
   }

--- a/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/UnsetCommand.java
+++ b/dynamic-config/cli/config-tool/src/main/java/org/terracotta/dynamic_config/cli/config_tool/parsing/UnsetCommand.java
@@ -1,6 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
- * Copyright IBM Corp. 2024, 2025
+ * Copyright IBM Corp. 2024, 2026
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,7 +45,7 @@ public class UnsetCommand extends RestartCommand {
   boolean autoRestart = false;
 
   @Parameter(names = {"-force"}, description = "Force the operation", hidden = true)
-  protected boolean force;
+  boolean force;
 
   @Inject
   public UnsetAction action;

--- a/dynamic-config/testing/integration-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/LockConfigIT.java
+++ b/dynamic-config/testing/integration-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/LockConfigIT.java
@@ -1,6 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
- * Copyright IBM Corp. 2024, 2025
+ * Copyright IBM Corp. 2024, 2026
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -103,7 +103,7 @@ public class LockConfigIT extends DynamicConfigIT {
 
     // we lock the configuration
     // but not all nodes are there
-    if (!lock()) {
+    if (!lock(true)) {
       throw new AssertionError("lock failed");
     }
 
@@ -140,7 +140,13 @@ public class LockConfigIT extends DynamicConfigIT {
   }
 
   private boolean lock() {
-    ToolExecutionResult result = invokeWithoutToken("lock-config", "-s", "localhost:" + getNodePort(), "--lock-context", lockContext.toString());
+    return lock(false);
+  }
+
+  private boolean lock(boolean force) {
+    ToolExecutionResult result = force ?
+      invokeWithoutToken("lock-config", "-connect-to", "localhost:" + getNodePort(), "-lock-context", lockContext.toString(), "-force"):
+      invokeWithoutToken("lock-config", "-connect-to", "localhost:" + getNodePort(), "-lock-context", lockContext.toString());
     if (result.getExitStatus() != 0) {
       for (String line : result.getOutput()) {
         System.out.println("LOCK FAIL:" + line);

--- a/dynamic-config/testing/integration-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/Scaling2x1IT.java
+++ b/dynamic-config/testing/integration-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/Scaling2x1IT.java
@@ -1,6 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
- * Copyright IBM Corp. 2024, 2025
+ * Copyright IBM Corp. 2024, 2026
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -81,19 +81,19 @@ public class Scaling2x1IT extends DynamicConfigIT {
   public void test_rolledBackScaleOut() {
     // attach
     final ToolExecutionResult attach = configTool("attach", "-lock", "-to-cluster", getNodeHostPort(1, 1).toString(), "-stripe-shape", getNodeHostPort(2, 1).toString());
-    assertThat(attach, allOf(is(successful()), containsOutput("Config lock with token: ")));
+    assertThat(attach, allOf(is(successful()), containsOutput("Config locked with token: ")));
 
     final String token = attach.getOutput()
         .stream()
-        .filter(line -> line.startsWith("Config lock with token: "))
-        .map(line -> line.substring("Config lock with token: ".length()))
+        .filter(line -> line.startsWith("Config locked with token: "))
+        .map(line -> line.substring("Config locked with token: ".length()))
         .findFirst()
         .get();
 
     // simulated re-balancing failure: detach + marker + unlock
     assertThat(configTool("-lock-token", token, "detach", "-from-cluster", getNodeHostPort(1, 1).toString(), "-stripe", getNodeHostPort(2, 1).toString()), is(successful()));
     final LockContext marker = new LockContext(token, OWNER_PLATFORM, DENY_SCALE_OUT);
-    assertThat(configTool("-lock-token", token, "lock-config", "-connect-to", getNodeHostPort(1, 1).toString(), "-lock-context", marker.toString()), allOf(is(successful()), containsOutput("Config lock with token: " + token)));
+    assertThat(configTool("-lock-token", token, "lock-config", "-connect-to", getNodeHostPort(1, 1).toString(), "-lock-context", marker.toString()), allOf(is(successful()), containsOutput("Config locked with token: " + token)));
     assertThat(configTool("-lock-token", token, "unlock-config", "-connect-to", getNodeHostPort(1, 1).toString()), is(successful()));
 
     // verify that scale out is not allowed anymore
@@ -140,9 +140,9 @@ public class Scaling2x1IT extends DynamicConfigIT {
     final String token = UUID.randomUUID().toString();
     final UID stripeUID = getUpcomingCluster(1, 1).getStripes().get(1).getUID();
     final LockContext lock = new LockContext(token, OWNER_PLATFORM, SCALE_IN_PREFIX + stripeUID);
-    assertThat(configTool("lock-config", "-connect-to", getNodeHostPort(1, 1).toString(), "-lock-context", lock.toString()), allOf(is(successful()), containsOutput("Config lock with token: " + token)));
+    assertThat(configTool("lock-config", "-connect-to", getNodeHostPort(1, 1).toString(), "-lock-context", lock.toString()), allOf(is(successful()), containsOutput("Config locked with token: " + token)));
     final LockContext marker = new LockContext(token, OWNER_PLATFORM, DENY_SCALE_OUT);
-    assertThat(configTool("-lock-token", token, "lock-config", "-connect-to", getNodeHostPort(1, 1).toString(), "-lock-context", marker.toString()), allOf(is(successful()), containsOutput("Config lock with token: " + token)));
+    assertThat(configTool("-lock-token", token, "lock-config", "-connect-to", getNodeHostPort(1, 1).toString(), "-lock-context", marker.toString()), allOf(is(successful()), containsOutput("Config locked with token: " + token)));
     assertThat(configTool("-lock-token", token, "unlock-config", "-connect-to", getNodeHostPort(1, 1).toString()), is(successful()));
 
     // verify that we scale in is not allowed anymore


### PR DESCRIPTION
This PR fixes several issues in the `lock` and `unlock` commands.

1. **Missing validation to check that the cluster is fully activated**. This validation was not there so it was possible to trigger a `lock` or `unlock` command on a non activated cluster (or partial) which would lead to a cryptic Nomad error for the user

2. **Missing validation about online nodes**: `lock` and `unlock` commands were allowed as long as actives were up. They were not checking the states of passive servers. This problems can cause a mismatch configuration under certain cases and a loss of append log entries in case of an unfortunate failover.

3. **Fixed a typo** in the user displayed message

Note: point 2 was solved already for `set` / `unset` commands (mutative operations on the append log) but the fix was not ported to `lock` and `unlock` commands, which are also mutative operations on the append log.

Also, like we did for `set` / `unset`, a **hidden** `-force` option was added to the `lock` and `unlock` commands exactly like it was also done for the `set` / `unset` commands in order to bypass this validation and still be able to force a `lock` or `unlock` if some passive nodes are down and if the user knows what he is doing.