### PR TITLE
Fix lock/unlock commands to consider relay nodes

### DIFF
--- a/dynamic-config/cli/api/src/main/java/org/terracotta/dynamic_config/cli/api/command/ConfigurationMutationAction.java
+++ b/dynamic-config/cli/api/src/main/java/org/terracotta/dynamic_config/cli/api/command/ConfigurationMutationAction.java
@@ -161,14 +161,7 @@ public abstract class ConfigurationMutationAction extends ConfigurationAction {
       // Filter out relay nodes from onlineNodes, they are not contacted to apply configuration changes at runtime
       // onlineRelayNodes will contain the list of relay nodes we will automatically restart
       // to sync configuration changes during passive sync
-      final Set<Endpoint> onlineRelayNodes = new HashSet<>();
-      onlineNodes.entrySet().removeIf(entry -> {
-        if (entry.getValue().isRelay()) {
-          onlineRelayNodes.add(entry.getKey());
-          return true;
-        }
-        return false;
-      });
+      final Collection<Endpoint> onlineRelayNodes = removeRelayNodes(onlineNodes);
 
       // cluster is active, we need to run a nomad change and eventually a restart
 

--- a/dynamic-config/cli/api/src/main/java/org/terracotta/dynamic_config/cli/api/command/LockUnlockConfigAction.java
+++ b/dynamic-config/cli/api/src/main/java/org/terracotta/dynamic_config/cli/api/command/LockUnlockConfigAction.java
@@ -49,6 +49,9 @@ public abstract class LockUnlockConfigAction extends RemoteAction {
       throw new IllegalStateException("The cluster is not fully activated: a lock or unlock operation can only be performed on an activated cluster.");
     }
 
+    // Remove Relay nodes from the list: they do not take part of nomad tx
+    removeRelayNodes(onlineNodes);
+
     // validate that all the online nodes are either actives or passives
     ensureNodesAreEitherActiveOrPassive(onlineNodes);
 

--- a/dynamic-config/cli/api/src/main/java/org/terracotta/dynamic_config/cli/api/command/RemoteAction.java
+++ b/dynamic-config/cli/api/src/main/java/org/terracotta/dynamic_config/cli/api/command/RemoteAction.java
@@ -67,6 +67,7 @@ import java.time.Duration;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.EnumSet;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -671,6 +672,18 @@ public abstract class RemoteAction implements Runnable {
 
   protected final LinkedHashMap<Endpoint, LogicalServerState> filterOnlineNodes(Map<Endpoint, LogicalServerState> nodes) {
     return filter(nodes, (addr, state) -> !state.isUnknown() && !state.isUnreacheable());
+  }
+
+  protected final Collection<Endpoint> removeRelayNodes(Map<Endpoint, LogicalServerState> onlineNodes) {
+    final Collection<Endpoint> onlineRelayNodes = new HashSet<>(onlineNodes.size() / 3);
+    onlineNodes.entrySet().removeIf(entry -> {
+      if (entry.getValue().isRelay()) {
+        onlineRelayNodes.add(entry.getKey());
+        return true;
+      }
+      return false;
+    });
+    return onlineRelayNodes;
   }
 
   protected final <K> LinkedHashMap<K, LogicalServerState> filter(Map<K, LogicalServerState> nodes, BiPredicate<K, LogicalServerState> predicate) {

--- a/dynamic-config/testing/integration-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/LockConfigWithRelayIT.java
+++ b/dynamic-config/testing/integration-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/LockConfigWithRelayIT.java
@@ -31,6 +31,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 import static org.terracotta.angela.client.support.hamcrest.AngelaMatchers.containsOutput;
 import static org.terracotta.angela.client.support.hamcrest.AngelaMatchers.successful;
 
@@ -56,6 +57,24 @@ public class LockConfigWithRelayIT extends DynamicConfigIT {
       throw new AssertionError("lock failed");
     }
     unlock();
+
+    // active and passive nodes are part of the DC transaction
+    waitUntil(() -> configTool("log", "-s", "localhost:" + getNodePort(1, 1)),
+      allOf(is(successful()),
+        containsOutput("Locking the config by 'platform (dynamic-scale)'"),
+        containsOutput("Unlocking the config (forced=false)")));
+
+    // but relay nodes are not
+    waitUntil(() -> configTool("log", "-s", "localhost:" + getNodePort(1, 2)),
+      allOf(is(successful()),
+        not(containsOutput("Locking the config by 'platform (dynamic-scale)'")),
+        not(containsOutput("Unlocking the config (forced=false)"))));
+
+    stopNode(1, 2);
+    startNode(1, 2);
+    waitForPassiveRelay(1, 2);
+
+    // after a restart though they have synced the config from active and have the append log entries
     waitUntil(() -> configTool("log", "-s", "localhost:" + getNodePort(1, 2)),
       allOf(is(successful()),
         containsOutput("Locking the config by 'platform (dynamic-scale)'"),


### PR DESCRIPTION
This PR filters out the relay nodes from the online nodes to contact for the Nomad TX when doing a lock and unlock.

This change fixed LockConfigWithRelayIT.

But this change also leads to a question... Should relay nodes be restarted after a lock and unlock command ? And if yes, what is the impact of having some nodes currently restarting when the lock/unlock was part of a sequence of DC operations ?

I think we can leave them as-is, since they are not part of any Nomad TX, they do not need to be locked.