### PR TITLE
[5.10] TDB-20178: Skip restart when node collection is empty

### DIFF
--- a/dynamic-config/cli/dynamic-config-cli-api/src/main/java/org/terracotta/dynamic_config/cli/api/command/ConfigurationMutationAction.java
+++ b/dynamic-config/cli/dynamic-config-cli-api/src/main/java/org/terracotta/dynamic_config/cli/api/command/ConfigurationMutationAction.java
@@ -1,6 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
- * Copyright IBM Corp. 2024, 2025
+ * Copyright IBM Corp. 2024, 2026
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -315,20 +315,28 @@ public abstract class ConfigurationMutationAction extends ConfigurationAction {
     // If not, the restart will throw.
     // This is required because next step is to restart the remaining nodes...
     // Which are active, so we have to ensure that a passive not will be there to take over the active role
-    LOGGER.info("Restarting non active nodes: {}...", toString(others));
-    restartNodesIfPassives(
-        others,
-        Duration.ofMillis(restartWaitTime.getQuantity(TimeUnit.MILLISECONDS)),
-        Duration.ofMillis(restartDelay.getQuantity(TimeUnit.MILLISECONDS)),
-        EnumSet.of(ACTIVE, ACTIVE_RECONNECTING, PASSIVE));
+    if (!others.isEmpty()) {
+      LOGGER.info("Restarting non active nodes: {}...", toString(others));
+      restartNodesIfPassives(
+          others,
+          Duration.ofMillis(restartWaitTime.getQuantity(TimeUnit.MILLISECONDS)),
+          Duration.ofMillis(restartDelay.getQuantity(TimeUnit.MILLISECONDS)),
+          EnumSet.of(ACTIVE, ACTIVE_RECONNECTING, PASSIVE));
+    } else {
+      LOGGER.info("No non active nodes to restart");
+    }
 
     // Restarting actives. This will trigger failovers and active will restart as passives.
-    LOGGER.info("Restarting active nodes: {}...", toString(actives));
-    restartNodesIfActives(
-        actives,
-        Duration.ofMillis(restartWaitTime.getQuantity(TimeUnit.MILLISECONDS)),
-        Duration.ofMillis(restartDelay.getQuantity(TimeUnit.MILLISECONDS)),
-        EnumSet.of(ACTIVE, ACTIVE_RECONNECTING, PASSIVE));
+    if (!actives.isEmpty()) {
+      LOGGER.info("Restarting active nodes: {}...", toString(actives));
+      restartNodesIfActives(
+          actives,
+          Duration.ofMillis(restartWaitTime.getQuantity(TimeUnit.MILLISECONDS)),
+          Duration.ofMillis(restartDelay.getQuantity(TimeUnit.MILLISECONDS)),
+          EnumSet.of(ACTIVE, ACTIVE_RECONNECTING, PASSIVE));
+    } else {
+      LOGGER.info("No active nodes to restart");
+    }
 
     // let's check if some nodes were not restarted because their state has changed from the last time we got their state
     concat(actives.stream(), others.stream())

--- a/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/SetCommand2x3IT.java
+++ b/dynamic-config/testing/system-tests/src/test/java/org/terracotta/dynamic_config/system_tests/activated/SetCommand2x3IT.java
@@ -1,6 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
- * Copyright IBM Corp. 2024, 2025
+ * Copyright IBM Corp. 2024, 2026
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,7 @@ import static java.util.function.Predicate.isEqual;
 import static java.util.stream.IntStream.rangeClosed;
 import static java.util.stream.Stream.concat;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.both;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertFalse;
@@ -53,6 +54,23 @@ public class SetCommand2x3IT extends DynamicConfigIT {
     ).toArray(String[]::new);
 
     assertThat(configTool(cli), both(is(successful())).and(containsOutput("Restart required for nodes:")));
+
+    for (int s = 1; s <= 2; s++) {
+      for (int n = 1; n <= 3; n++) {
+        assertFalse(usingTopologyService(s, n, TopologyService::mustBeRestarted));
+      }
+    }
+  }
+
+  @Test
+  public void testAutoRestartWithPassivesOnly() {
+    int[] passives = waitForNPassives(1, 2);
+
+    // Apply configuration changes to only passive nodes with auto-restart
+    assertThat(configTool("set", "-auto-restart", "-connect-to", "localhost:" + getNodePort(2, 1),
+      "-setting", "stripe.1.node." + passives[0] + ".tc-properties.foo=bar",
+      "-setting", "stripe.1.node." + passives[1] + ".tc-properties.foo=bar"
+    ), is(allOf(successful(), containsOutput("Restart required for nodes:"))));
 
     for (int s = 1; s <= 2; s++) {
       for (int n = 1; n <= 3; n++) {


### PR DESCRIPTION
- Auto-restart fails when configuration changes are applied only to passive nodes (no active nodes require restart)

Cherry pick of https://github.com/Terracotta-OSS/terracotta-platform/pull/1281